### PR TITLE
[RHEL/7] Add initial firewalld XCCDF section

### DIFF
--- a/RHEL/7/input/guide.xslt
+++ b/RHEL/7/input/guide.xslt
@@ -87,6 +87,7 @@
       <xsl:apply-templates select="document('system/network/kernel.xml')" />
       <xsl:apply-templates select="document('system/network/wireless.xml')" />
       <xsl:apply-templates select="document('system/network/ipv6.xml')" />
+      <xsl:apply-templates select="document('system/network/firewalld.xml')" />
       <xsl:apply-templates select="document('system/network/iptables.xml')" />
       <xsl:apply-templates select="document('system/network/ssl.xml')" />
       <xsl:apply-templates select="document('system/network/uncommon.xml')" />

--- a/RHEL/7/input/system/network/firewalld.xml
+++ b/RHEL/7/input/system/network/firewalld.xml
@@ -1,0 +1,110 @@
+<Group id="network-firewalld">
+<title>firewalld</title>
+<description>The dynamic firewall daemon <tt>firewalld</tt> provides a
+dynamically managed firewall with support for network “zones” to assign
+a level of trust to a network and its associated connections and interfaces.
+It has support for IPv4 and IPv6 firewall settings. It supports Ethernet
+bridges and has a separation of runtime and permanent configuration options.
+It also has an interface for services or applications to add firewall rules
+directly.
+<br/>
+A graphical configuration tool, <tt>firewall-config</tt>, is used to configure
+<tt>firewalld</tt>, which in turn uses <tt>iptables</tt> tool to communicate
+with <tt>Netfilter</tt> in the kernel which implements packet filtering.
+<br/>
+The firewall service provided by <tt>firewalld</tt> is dynamic rather than
+static because changes to the configuration can be made at anytime and are
+immediately implemented. There is no need to save or apply the changes. No
+unintended disruption of existing network connections occurs as no part of
+the firewall has to be reloaded.
+</description>
+
+<Group id="firewalld_activation">
+<title>Inspect and Activate Default firewalld Rules</title>
+<description>Firewalls can be used to separate networks into different zones
+based on the level of trust the user has decided to place on the devices and
+traffic within that network. <tt>NetworkManager</tt> informs firewalld to which
+zone an interface belongs. An interface's assigned zone can be changed by
+<tt>NetworkManager</tt> or via the <tt>firewall-config</tt> tool.
+<br/>
+The zone settings in <tt>/etc/firewalld/</tt> are a range of preset settings
+which can be quickly applied to a network interface. These are the zones
+provided by firewalld sorted according to the default trust level of the
+zones from untrusted to trusted:
+<ul>
+<li><tt>drop</tt><br /><p>Any incoming network packets are dropped, there is no
+reply. Only outgoing network connections are possible.</p></li>
+<li><tt>block</tt><br /><p>Any incoming network connections are rejected with an
+<tt>icmp-host-prohibited</tt> message for IPv4 and <tt>icmp6-adm-prohibited</tt>
+for IPv6. Only network connections initiated from within the system are
+possible.</p></li>
+<li><tt>public</tt><br /><p>For use in public areas. You do not trust the other
+computers on the network to not harm your computer. Only selected incoming
+connections are accepted.</p></li>
+<li><tt>external</tt><br /><p>For use on external networks with masquerading enabled
+especially for routers. You do not trust the other computers on the network to
+not harm your computer. Only selected incoming connections are accepted.</p></li>
+<li><tt>dmz</tt><br /><p>For computers in your demilitarized zone that are
+publicly-accessible with limited access to your internal network. Only selected
+incoming connections are accepted.</p></li>
+<li><tt>work</tt><br /><p>For use in work areas. You mostly trust the other computers
+on networks to not harm your computer. Only selected incoming connections are
+accepted.</p></li>
+<li><tt>home</tt><br /><p>For use in home areas. You mostly trust the other computers
+on networks to not harm your computer. Only selected incoming connections are
+accepted.</p></li>
+<li><tt>internal</tt><br /><p>For use on internal networks. You mostly trust the
+other computers on the networks to not harm your computer. Only selected
+incoming connections are accepted.</p></li>
+<li><tt>trusted</tt><br /><p>All network connections are accepted.</p></li>
+</ul>
+<br/>
+It is possible to designate one of these zones to be the default zone. When
+interface connections are added to <tt>NetworkManager</tt>, they are assigned
+to the default zone. On installation, the default zone in firewalld is set to
+be the public zone.
+<br/>
+To find out all the settings of a zone, for example the <tt>public zone,</tt>
+enter the following command as root:
+<pre># firewall-cmd --zone=public --list-all</pre>
+Example output of this command might look like the following:
+<pre>
+# firewall-cmd --zone=public --list-all
+public
+  interfaces:
+  services: mdns dhcpv6-client ssh
+  ports:
+  forward-ports:
+  icmp-blocks: source-quench
+</pre>
+To view the network zones currently active, enter the following command as root:
+<pre># firewall-cmd --get-service</pre>
+The following listing displays the result of this command on common Red Hat
+Enterprise Linux 7 Server system:
+<pre>
+# firewall-cmd --get-service
+amanda-client bacula bacula-client dhcp dhcpv6 dhcpv6-client dns ftp high-availability http https imaps ipp ipp-client ipsec kerberos kpasswd ldap ldaps libvirt libvirt-tls mdns mountd ms-wbt mysql nfs ntp openvpn pmcd pmproxy pmwebapi pmwebapis pop3s postgresql proxy-dhcp radius rpc-bind samba samba-client smtp ssh telnet tftp tftp-client transmission-client vnc-server wbem-https
+</pre>
+Finally to view the network zones that will be active after the next firewalld
+service reload, enter the following command as root:
+<pre># firewall-cmd --get-service --permanent</pre>
+</description>
+
+<Rule id="service_firewalld_enabled" severity="medium">
+<title>Verify firewalld Enabled</title>
+<description>
+<service-enable-macro service="firewalld" />
+</description>
+<ocil><service-enable-check-macro service="firewalld" /></ocil>
+<rationale>
+The dynamic firewall daemon <tt>firewalld</tt> provides a dynamically managed
+firewall with support for network “zones”, Ethernet bridges, and has a
+separation of runtime and permanent configuration options. It has support for
+both IPv4 and IPv6 firewall settings.
+</rationale>
+<ident cce="RHEL7-CCE-TBD" />
+<!--<oval id="service_firewalld_enabled" />-->
+</Rule>
+</Group><!--<Group id="firewalld_activation">-->
+
+</Group>


### PR DESCRIPTION
Initial firewalld dedicated XCCDF section based on information from:
[1] https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Using_Firewalls.html
and
[2] https://fedoraproject.org/wiki/FirewallD

Please review.

Thank you.
Jan