### PR TITLE
[BugFix] [RHEL/7] Drop duplicate </ocil> tag to fix mismatched tag make warning

### DIFF
--- a/RHEL/7/input/system/accounts/banners.xml
+++ b/RHEL/7/input/system/accounts/banners.xml
@@ -133,7 +133,6 @@ To ensure the login warning banner text is locked and cannot be changed by a use
 <pre>$ grep banner-message-enable /etc/dconf/db/gdm.d/locks/*</pre>
 If properly configured, the output should be <tt>/org/gnome/login-screen/banner-message-text</tt>.
 </ocil>
-</ocil>
 <rationale>
 An appropriate warning message reinforces policy awareness during the logon
 process and facilitates possible legal action against attackers.


### PR DESCRIPTION
Issuing ```make``` on current RHEL/7 content displays the following warning:
```
input/system/accounts/banners.xml:136: parser error : Opening and ending tag mismatch: Rule line 117 and ocil
</ocil>
       ^
input/system/accounts/banners.xml:144: parser error : Opening and ending tag mismatch: Group line 79 and Rule
</Rule>
       ^
input/system/accounts/banners.xml:148: parser error : Extra content at the end of the document
<Rule id="dconf_gnome_disable_user_list">
^
```

This change fixes it (more of the warning fixes tomorrow).

Please review.

Thank you, Jan.