### PR TITLE
[Enhancement] [RHEL/6] [RHEL/7] Update audit_rules_privileged_commands XCCDF find command syntax and add RHEL-6 remediation

### DIFF
--- a/RHEL/6/input/fixes/bash/audit_rules_privileged_commands.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_privileged_commands.sh
@@ -4,12 +4,32 @@ readonly AUDIT_RULES='/etc/audit/audit.rules'
 # Obtain the list of SUID/SGID binaries on the particular system into PRIVILEGED_BINARIES array
 PRIVILEGED_BINARIES=($(find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null))
 
+# Keep list of SUID/SGID binaries that have been already handled within some previous iteration
+declare -a SBINARIES_TO_SKIP=()
+
 # For each found binary from that list...
 for SBINARY in ${PRIVILEGED_BINARIES[@]}
 do
 
-    # Define base rule pattern for this binary to search existing audit.rules' content for match
-    BASE_RULE="-a always,exit -F path=${SBINARY} -F perm=.* -F auid>=500 -F auid!=4294967295 -k privileged"
+    # Replace possible slash '/' character in SBINARY definition so we could use it in sed expressions below
+    SBINARY_ESC=${SBINARY//$'/'/$'\/'}
+
+    # Check if this SBINARY wasn't already handled in some of the previous iterations
+    if [[ $(sed -ne "/$SBINARY_ESC/p" <<< ${SBINARIES_TO_SKIP[@]}) ]]
+    then
+        # If so, don't process it second time & go to process next SBINARY
+        continue
+    fi
+
+    # Search existing audit.rule's content for match. Match criteria:
+    # * existing rule is for the same SUID/SGID binary we are currently processing (but
+    #   can contain multiple -F path= elements covering multiple SUID/SGID binaries)
+    # * existing rule contains all arguments from expected rule form (though can contain
+    #   them in arbitrary order)
+    BASE_SEARCH=$(sed -e "/-a always,exit/!d" -e "/-F path=${SBINARY_ESC}/!d"	\
+                      -e "/-F path=[^[:space:]]\+/!d" -e "/-F perm=.*/!d"	\
+                      -e "/-F auid>=500/!d" -e "/-F auid!=4294967295/!d"	\
+                      -e "/-k privileged/!d" $AUDIT_RULES)
 
     # Define expected rule form for this binary
     EXPECTED_RULE="-a always,exit -F path=${SBINARY} -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged"
@@ -18,18 +38,25 @@ do
     EXEC_ACCESS='x'
 
     # Search existing audit.rules content for presence of rule pattern for this binary
-    if grep -q -- "$BASE_RULE" $AUDIT_RULES
+    if [[ $BASE_SEARCH ]]
     then
 
         # Current /etc/audit/audit.rules already contains rule for this binary =>
-        # Load it's exact form into CONCRETE_RULE variable for further processing
-        CONCRETE_RULE=$(cat $AUDIT_RULES | grep -- "$BASE_RULE")
+        # Store the exact form of found rule for this binary for further processing
+        CONCRETE_RULE=$BASE_SEARCH
 
-        # Separate that rule into three sections using hash '#'
+        # Select all other SUID/SGID binaries possibly also present in the found rule
+        IFS=$'\n' HANDLED_SBINARIES=($(grep -o -e "-F path=[^[:space:]]\+" <<< $CONCRETE_RULE))
+        IFS=$' ' HANDLED_SBINARIES=(${HANDLED_SBINARIES[@]//-F path=/})
+
+        # Merge the list of such SUID/SGID binaries found in this iteration with global list ignoring duplicates
+        SBINARIES_TO_SKIP=($(for i in "${SBINARIES_TO_SKIP[@]}" "${HANDLED_SBINARIES[@]}"; do echo $i; done | sort -du))
+
+        # Separate CONCRETE_RULE into three sections using hash '#'
         # sign as a delimiter around rule's permission section borders
         CONCRETE_RULE=$(echo $CONCRETE_RULE | sed -n "s/\(.*\)\+\(-F perm=[rwax]\+\)\+/\1#\2#/p")
 
-        # Split that rule into head, perm, and tail sections using hash '#' delimiter
+        # Split CONCRETE_RULE into head, perm, and tail sections using hash '#' delimiter
         IFS=$'#' read RULE_HEAD RULE_PERM RULE_TAIL <<<  "$CONCRETE_RULE"
 
         # Extract already present exact access type [r|w|x|a] from rule's permission section

--- a/RHEL/6/input/fixes/bash/audit_rules_privileged_commands.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_privileged_commands.sh
@@ -1,0 +1,58 @@
+
+readonly AUDIT_RULES='/etc/audit/audit.rules'
+
+# Obtain the list of SUID/SGID binaries on the particular system into PRIVILEGED_BINARIES array
+PRIVILEGED_BINARIES=($(find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null))
+
+# For each found binary from that list...
+for SBINARY in ${PRIVILEGED_BINARIES[@]}
+do
+
+    # Define base rule pattern for this binary to search existing audit.rules' content for match
+    BASE_RULE="-a always,exit -F path=${SBINARY} -F perm=.* -F auid>=500 -F auid!=4294967295 -k privileged"
+
+    # Define expected rule form for this binary
+    EXPECTED_RULE="-a always,exit -F path=${SBINARY} -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged"
+
+    # Require execute access type to be set for existing audit rule
+    EXEC_ACCESS='x'
+
+    # Search existing audit.rules content for presence of rule pattern for this binary
+    if grep -q -- "$BASE_RULE" $AUDIT_RULES
+    then
+
+        # Current /etc/audit/audit.rules already contains rule for this binary =>
+        # Load it's exact form into CONCRETE_RULE variable for further processing
+        CONCRETE_RULE=$(cat $AUDIT_RULES | grep -- "$BASE_RULE")
+
+        # Separate that rule into three sections using hash '#'
+        # sign as a delimiter around rule's permission section borders
+        CONCRETE_RULE=$(echo $CONCRETE_RULE | sed -n "s/\(.*\)\+\(-F perm=[rwax]\+\)\+/\1#\2#/p")
+
+        # Split that rule into head, perm, and tail sections using hash '#' delimiter
+        IFS=$'#' read RULE_HEAD RULE_PERM RULE_TAIL <<<  "$CONCRETE_RULE"
+
+        # Extract already present exact access type [r|w|x|a] from rule's permission section
+        ACCESS_TYPE=${RULE_PERM//-F perm=/}
+
+        # Verify current permission access type(s) for rule contain 'x' (execute) permission
+        if ! grep -q "$EXEC_ACCESS" <<< "$ACCESS_TYPE"
+        then
+
+            # If not, append the 'x' (execute) permission to the existing access type bits
+            ACCESS_TYPE="$ACCESS_TYPE$EXEC_ACCESS"
+            # Reconstruct the permissions section for the rule
+            NEW_RULE_PERM="-F perm=$ACCESS_TYPE"
+            # Update existing rule in /etc/audit/audit.rules with the new permission section
+            sed -i "s#${RULE_HEAD}\(.*\)${RULE_TAIL}#${RULE_HEAD}${NEW_RULE_PERM}${RULE_TAIL}#" $AUDIT_RULES
+
+        fi
+
+    else
+
+        # Current /etc/audit/audit.rules content doesn't contain expected rule for this
+        # SUID/SGID binary yet => append it
+        echo $EXPECTED_RULE >> $AUDIT_RULES
+    fi
+
+done

--- a/RHEL/6/input/system/auditing.xml
+++ b/RHEL/6/input/system/auditing.xml
@@ -1157,19 +1157,25 @@ these events could serve as evidence of potential system compromise.</rationale>
 <title>Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands</title>
 <description>At a minimum the audit system should collect the
 execution of privileged commands for all users and root.
-To find the relevant setuid / setgid programs, run the following command for each local partition <i>PART</i>:
-<pre>$ sudo find <i>PART</i> -xdev -type f -perm -4000 -o -perm -2000 2>/dev/null</pre>
-Then, for each setuid / setgid program on the system, add a line of the following form to
-<tt>/etc/audit/audit.rules</tt>, where <i>SETUID_PROG_PATH</i> is the full path to each setuid / setgid program
+To find the relevant setuid / setgid programs, run the following command
+for each local partition <i>PART</i>:
+<pre>$ sudo find <i>PART</i> -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null</pre>
+Then, for each setuid / setgid program on the system, add a line of the
+following form to <tt>/etc/audit/audit.rules</tt>, where
+<i>SETUID_PROG_PATH</i> is the full path to each setuid / setgid program
 in the list:
 <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged</pre>
 </description>
 <ocil clause="that is not the case">
-To verify that auditing of privileged command use is configured, run the following command for each local partition <i>PART</i> to find relevant setuid / setgid programs:
-<pre>$ sudo find <i>PART</i> -xdev -type f -perm -4000 -o -perm -2000 2>/dev/null</pre>
-Run the following command to verify entries in the audit rules for all programs found with the previous command:
+To verify that auditing of privileged command use is configured, run the
+following command for each local partition <i>PART</i> to find relevant
+setuid / setgid programs:
+<pre>$ sudo find <i>PART</i> -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null</pre>
+Run the following command to verify entries in the audit rules for all programs
+found with the previous command:
 <pre>$ sudo grep path /etc/audit/audit.rules</pre>
-It should be the case that all relevant setuid / setgid programs have a line in the audit rules.
+It should be the case that all relevant setuid / setgid programs have a line
+in the audit rules.
 </ocil>
 <rationale>Privileged programs are subject to escalation-of-privilege attacks,
 which attempt to subvert their normal role of providing some necessary but

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -1158,19 +1158,25 @@ these events could serve as evidence of potential system compromise.</rationale>
 <title>Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands</title>
 <description>At a minimum the audit system should collect the
 execution of privileged commands for all users and root.
-To find the relevant setuid / setgid programs:
-<pre>$ sudo find / -xdev -type f -perm -4000 -o -perm -2000 2>/dev/null</pre>
-Then, for each setuid / setgid program on the system, add a line of the following form to
-<tt>/etc/audit/audit.rules</tt>, where <i>SETUID_PROG_PATH</i> is the full path to each setuid / setgid program
+To find the relevant setuid / setgid programs, run the following command
+for each local partition <i>PART</i>:
+<pre>$ sudo find <i>PART</i> -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null</pre>
+Then, for each setuid / setgid program on the system, add a line of the
+following form to <tt>/etc/audit/audit.rules</tt>, where
+<i>SETUID_PROG_PATH</i> is the full path to each setuid / setgid program
 in the list:
 <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged</pre>
 </description>
 <ocil clause="it is not the case">
-To verify that auditing of privileged command use is configured, run the following command to find relevant setuid / setgid programs:
-<pre>$ sudo find / -xdev -type f -perm -4000 -o -perm -2000 2>/dev/null</pre>
-Run the following command to verify entries in the audit rules for all programs found with the previous command:
+To verify that auditing of privileged command use is configured, run the
+following command for each local partition <i>PART</i> to find relevant
+setuid / setgid programs:
+<pre>$ sudo find <i>PART</i> -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null</pre>
+Run the following command to verify entries in the audit rules for all programs
+found with the previous command:
 <pre>$ sudo grep path /etc/audit/audit.rules</pre>
-It should be the case that all relevant setuid / setgid programs have a line in the audit rules.
+It should be the case that all relevant setuid / setgid programs have a line
+in the audit rules.
 </ocil>
 <rationale>Privileged programs are subject to escalation-of-privilege attacks,
 which attempt to subvert their normal role of providing some necessary but


### PR DESCRIPTION
This proposal does the following:
* 1) Updates audit_rules_privileged_commands description (for both RHEL-6 & RHEL-7) according to hint in:
   [1] https://lists.fedorahosted.org/pipermail/scap-security-guide/2014-July/005798.html

to when searching for SUID/SGID binaries on the system the underlying ```find``` command not to include also SGID directories
* 2) Unifies the XCCDF rule description to match in RHEL-6 & RHEL-7 (current RHEL-6 version is using <PARTITION> syntax, while RHEL-7 was using just '/' to search the root partition). Updated the RHEL-7 description to use the RHEL-6's one's form

* 3) Adds RHEL-6 remediation for audit_rules_privileged_commands rule

Please review.

Thank you, Jan.