### PR TITLE
[shared] Modify OVAL check for accounts_passwords_pam_faillock_deny rule

### DIFF
--- a/shared/oval/accounts_passwords_pam_faillock_deny.xml
+++ b/shared/oval/accounts_passwords_pam_faillock_deny.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_passwords_pam_faillock_deny" version="1">
+  <definition class="compliance" id="accounts_passwords_pam_faillock_deny" version="2">
     <metadata>
       <title>Lock out account after failed login attempts</title>
       <affected family="unix">
@@ -8,80 +8,100 @@
         <platform>Fedora 20</platform>
       </affected>
       <description>The number of allowed failed logins should be set correctly.</description>
-      <reference source="swells" ref_id="20131025" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL6_20150114" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150114" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150114" ref_url="test_attestation" />
     </metadata>
     <criteria>
-      <criterion comment="pam_faillock.so authfail deny value set in system-auth" test_ref="test_accounts_passwords_pam_faillock_authfail_deny_system-auth" />
-      <criterion comment="pam_faillock.so authfail deny value set in password-auth" test_ref="test_accounts_passwords_pam_faillock_authfail_deny_password-auth" />
-      <criterion comment="pam_faillock.so authsucc deny value set in password-auth" test_ref="test_accounts_passwords_pam_faillock_authsucc_deny_system-auth" />
-      <criterion comment="pam_faillock.so authsucc deny value set in password-auth" test_ref="test_accounts_passwords_pam_faillock_authsucc_deny_password-auth" />
+
+      <criterion test_ref="test_accounts_passwords_pam_faillock_authfail_deny_system-auth"
+      comment="pam_faillock.so authfail deny value set in system-auth" />
+      <criterion test_ref="test_accounts_passwords_pam_faillock_account_phase_system-auth"
+      comment="pam_faillock.so set in account phase of system-auth" />
+      <criterion test_ref="test_accounts_passwords_pam_faillock_authfail_deny_password-auth"
+      comment="pam_faillock.so authfail deny value set in password-auth" />
+      <criterion test_ref="test_accounts_passwords_pam_faillock_account_phase_password-auth"
+      comment="pam_faillock.so set in account phase of password-auth" />
+
     </criteria>
   </definition>
 
-  <!-- check for authfail deny in system-auth -->
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check maximum failed login attempts allowed in /etc/pam.d/system-auth (authfail)" id="test_accounts_passwords_pam_faillock_authfail_deny_system-auth" version="1">
+  <!-- Specify required external variable & create corresponding state from it -->
+  <external_variable id="var_accounts_passwords_pam_faillock_deny" datatype="int"
+  comment="number of failed login attempts allowed" version="1" />
+
+  <ind:textfilecontent54_state id="state_var_accounts_passwords_pam_faillock_deny_value" version="1">
+    <ind:subexpression datatype="int" operation="equals" var_ref="var_accounts_passwords_pam_faillock_deny" />
+  </ind:textfilecontent54_state>
+
+  <!-- Check for authfail deny in /etc/pam.d/system-auth -->
+  <ind:textfilecontent54_test id="test_accounts_passwords_pam_faillock_authfail_deny_system-auth"
+  check="all" check_existence="all_exist"
+  comment="Check maximum failed login attempts allowed in /etc/pam.d/system-auth (authfail)" version="1">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_authfail_deny_system-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_authfail_deny_system-auth" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_authfail_deny_system-auth" version="1">
+    <!-- Read whole /etc/pam.d/system-auth content as single line so we can verify existing order of PAM modules -->
+    <ind:behaviors singleline="true" />
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+authfail.*deny=([0-9]*).*$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <!-- Since order of PAM modules matters ensure pam_faillock.so in auth section is listed right after pam_unix.so auth row -->
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]+[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+deny=([0-9]+)[^\n]*[\n]</ind:pattern>
+    <!-- Check only the first instance -->
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- check for authfail deny in password-auth -->
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check maximum failed login attempts allowed in /etc/pam.d/password-auth (authsucc)" id="test_accounts_passwords_pam_faillock_authfail_deny_password-auth" version="1">
+  <!-- Check for pam_faillock.so present in account phase of /etc/pam.d/system-auth -->
+  <ind:textfilecontent54_test id="test_accounts_passwords_pam_faillock_account_phase_system-auth"
+  check="all" check_existence="all_exist"
+  comment="Check if pam_faillock_so is called in account phase of /etc/pam.d/system-auth" version="1" >
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_account_phase_system-auth" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_account_phase_system-auth" version="1">
+    <!-- Read whole /etc/pam.d/system-auth content as single line so we can verify existing order of PAM modules -->
+    <ind:behaviors singleline="true" />
+    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <!-- Since order of PAM modules matters ensure pam_faillock.so in account section is listed right before pam_unix.so account row -->
+    <ind:pattern operation="pattern match">[\n][\s]*account[\s]+required[\s]+pam_faillock\.so[^\n]*[\n][\s]*account[\s]+required[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
+    <!-- Check only the first instance -->
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Check for authfail deny in /etc/pam.d/password-auth -->
+  <ind:textfilecontent54_test id="test_accounts_passwords_pam_faillock_authfail_deny_password-auth"
+  check="all" check_existence="all_exist"
+  comment="Check maximum failed login attempts allowed in /etc/pam.d/password-auth (authfail)" version="1">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_authfail_deny_password-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_authfail_deny_password-auth" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_authfail_deny_password-auth" version="1">
+    <!-- Read whole /etc/pam.d/system-auth content as single line so we can verify existing order of PAM modules -->
+    <ind:behaviors singleline="true" />
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:sufficient)|(?:\[default=die\]))\s+pam_faillock\.so\s+authfail.*deny=([0-9]*).*$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <!-- Since order of PAM modules matters ensure pam_faillock.so in auth section is listed right after pam_unix.so auth row -->
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]+[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+deny=([0-9]+)[^\n]*[\n]</ind:pattern>
+    <!-- Check only the first instance -->
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- check for authsucc deny in system-auth -->
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check maximum failed login attempts allowed in /etc/pam.d/system-auth (authsucc)" id="test_accounts_passwords_pam_faillock_authsucc_deny_system-auth" version="1">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_authsucc_deny_system-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_authsucc_deny_system-auth" />
+  <!-- Check for pam_faillock.so present in account phase of /etc/pam.d/password-auth -->
+  <ind:textfilecontent54_test id="test_accounts_passwords_pam_faillock_account_phase_password-auth"
+  check="all" check_existence="all_exist"
+  comment="Check if pam_faillock_so is called in account phase of /etc/pam.d/password-auth" version="1" >
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_account_phase_password-auth" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_authsucc_deny_system-auth" version="1">
-    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+authsucc.*deny=([0-9]*).*$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <!-- check for authsucc deny in password-auth -->
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check maximum failed login attempts allowed in /etc/pam.d/password-auth (authsucc)" id="test_accounts_passwords_pam_faillock_authsucc_deny_password-auth" version="1">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_authsucc_deny_password-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_authsucc_deny_password-auth" />
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_authsucc_deny_password-auth" version="1">
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_account_phase_password-auth" version="1">
+    <!-- Read whole /etc/pam.d/system-auth content as single line so we can verify existing order of PAM modules -->
+    <ind:behaviors singleline="true" />
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:sufficient)|(?:\[default=die\]))\s+pam_faillock\.so\s+authsucc.*deny=([0-9]*).*$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <!-- Since order of PAM modules matters ensure pam_faillock.so in account section is listed right before pam_unix.so account row -->
+    <ind:pattern operation="pattern match">[\n][\s]*account[\s]+required[\s]+pam_faillock\.so[^\n]*[\n][\s]*account[\s]+required[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
+    <!-- Check only the first instance -->
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- state placeholders -->
-  <ind:textfilecontent54_state id="state_accounts_passwords_pam_faillock_authfail_deny_system-auth" version="1">
-    <ind:subexpression datatype="int" operation="equals" var_ref="var_accounts_passwords_pam_faillock_deny" />
-  </ind:textfilecontent54_state>
-
-  <ind:textfilecontent54_state id="state_accounts_passwords_pam_faillock_authfail_deny_password-auth" version="1">
-    <ind:subexpression datatype="int" operation="equals" var_ref="var_accounts_passwords_pam_faillock_deny" />
-  </ind:textfilecontent54_state>
-
-  <ind:textfilecontent54_state id="state_accounts_passwords_pam_faillock_authsucc_deny_system-auth" version="1">
-    <ind:subexpression datatype="int" operation="equals" var_ref="var_accounts_passwords_pam_faillock_deny" />
-  </ind:textfilecontent54_state>
-
-  <ind:textfilecontent54_state id="state_accounts_passwords_pam_faillock_authsucc_deny_password-auth" version="1">
-    <ind:subexpression datatype="int" operation="equals" var_ref="var_accounts_passwords_pam_faillock_deny" />
-  </ind:textfilecontent54_state>
-
-  <external_variable comment="number of failed login attempts allowed" datatype="int" id="var_accounts_passwords_pam_faillock_deny" version="1" />
 </def-group>


### PR DESCRIPTION
Fix OVAL check for accounts_passwords_pam_faillock_deny rule to require exact setting from second example of ```pam_faillock(8)``` manual page instead of to require incorrect setting listed at:
&nbsp; &nbsp; [1] https://access.redhat.com/solutions/62949

Further details:
The current OVAL check implementation is based on configuration as documented at:
&nbsp; &nbsp; [1] https://access.redhat.com/solutions/62949

We have previously checked this setting / configuration with PAM faillock PAM module maintainer and according to their opinion the recommendation listed at [1] is wrong (it's not possible to extract just interesting bits from pam_faillock.so(8) manual page example and use them in arbitrary order [since order of PAM modules is also crucial for proper work of the setting]).

Following the suggestion from the developer to rather base on the second example from the ```pam_faillock(8)``` manual page, we have implemented ```shared``` https://github.com/OpenSCAP/scap-security-guide/commit/c404af9fe74dff397f8c46e4d5c5ac4dbabef740 remediation script for this rule.

See also details in https://github.com/OpenSCAP/scap-security-guide/issues/304 for explanation why currently used pam_faillock.so deny OVAL check is wrong & why it should be based on the second ```pam_faillock.so(8)``` example instead.

This patch / PR proposal is just completion / applying the same settings expectations to the underlying OVAL check too.

Testing report:
--
The proposed change has been tested on all three products (RHEL-6, RHEL-7 & Fedora 20) & works fine / works as expected.

Please review.

Thank you, Jan.