### PR TITLE
[Enhancement] [RHEL/6] Add testing kickstarts for USGCB supercompliance & subcompliance

### DIFF
--- a/RHEL/6/tests/kickstart/test-usgcb-subcompliance-ks.cfg
+++ b/RHEL/6/tests/kickstart/test-usgcb-subcompliance-ks.cfg
@@ -1,0 +1,141 @@
+# SCAP Security Guide subcompliance USGCB profile testing kickstart
+# for Red Hat Enterprise Linux 6 Server
+# Version 0.0.1
+# Date: 2015-01-16
+
+# Disclaimer:
+# The sole purpose of this kickstart file is testing if the USGCB
+# profile content for Red Hat Enterprise Linux 6 returns appropriate
+# results also at system configured to weaker settings than those
+# required by the United States Government Configuration Baseline (USGCB).
+#
+# IT IS NOT INTENDED FOR APPLICATION IN PRODUCTION ENVIRONMENT.
+#
+# In case of any doubt check the mailing list:
+#
+#	 scap-security-guide@lists.fedorahosted.org
+#
+# EXPECTED TEST RESULT: All rules below should FAIL
+
+# Perform basic settings
+# Install new system
+install
+# Set system language
+lang en_US.UTF-8
+# Set system keyboard type
+keyboard us
+# Configure network information
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+
+# Install USGCB profile compliant system based on SCAP Security Guide's RHEL-6 kickstart
+%include https://raw.githubusercontent.com/OpenSCAP/scap-security-guide/master/RHEL/6/kickstart/usgcb-server-with-gui-ks.cfg
+
+%post
+
+# Configure the previously installed USGCB compliant system to use weaker settings
+
+### Weaker permissions checks on selected files ###
+# USGCB /etc/group requirement:				0644
+# => use 777 mode as weaker setting
+chmod 777 /etc/group
+
+# USGCB /etc/passwd requirement:			0644
+# => use 777 mode as weaker setting
+chmod 777 /etc/passwd
+
+# USGCB /boot/grub/grub.conf requirement:		0600
+# => use 777 mode as weaker setting
+chmod 777 /boot/grub/grub.conf
+
+### Weaker umask settings ###
+# USGCB /etc/init.d/functions umask requirement:	022 or 027
+# => use 012 as weaker setting
+sed -i "s/umask[[:space:]]\+[[:digit:]]\+/umask 012/g" /etc/init.d/functions
+
+# USGCB /etc/bashrc umask requirement:			077
+# => use 012 as weaker setting
+sed -i "s/umask[[:space:]]\+[[:digit:]]\+/umask 012/g" /etc/bashrc
+
+# USGCB /etc/csh.cshrc umask requirement:		077
+# => use 012 as weaker setting
+sed -i "s/umask[[:space:]]\+[[:digit:]]\+/umask 012/g" /etc/csh.cshrc
+
+# USGCB /etc/profile umask requirement:			077
+# => use 012 as weaker setting
+sed -i "s/umask[[:space:]]\+[[:digit:]]\+/umask 012/g" /etc/profile
+
+# USGCB /etc/login.defs UMASK requirement:		077
+# => use 012 as weaker setting
+sed -i "s/^UMASK[[:space:]]\+[[:digit:]]\+/UMASK 012/g" /etc/login.defs
+
+### Disable core dumps ###
+# USGCB /etc/security/limits.conf core requirement:	0
+# => set 100 as weaker setting
+sed -i "s/.*core.*/\*\tsoft\tcore\t100/g" /etc/security/limits.conf
+
+### Weaker password /etc/login.defs settings ###
+# USGCB /etc/login.defs PASS_MIN_LEN requirement:	12 or more
+# => use 10 as weaker setting
+sed -i "s/^PASS_MIN_LEN[[:space:]]\+[[:digit:]]\+/PASS_MIN_LEN 10/g" /etc/login.defs
+
+# USGCB /etc/login.defs PASS_MAX_DAYS requirement:	60 or less
+# => use 100 as weaker setting
+sed -i "s/^PASS_MAX_DAYS[[:space:]]\+[[:digit:]]\+/PASS_MAX_DAYS 100/g" /etc/login.defs
+
+# USGCB /etc/login.defs PASS_WARN_AGE requirement:	14 or more
+# => use 10 as weaker setting
+sed -i "s/^PASS_WARN_AGE[[:space:]]\+[[:digit:]]\+/PASS_WARN_AGE 10/g" /etc/login.defs
+
+# Weaker password PAM pam_cracklib.so settings
+# USGCB /etc/pam.d/system-auth retry requirement:	3 or less
+# => use 10 as weaker setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.* \)retry=[[:digit:]]\+/\1retry=10/g" /etc/pam.d/system-auth
+
+# USGCB /etc/pam.d/system-auth dcredit requirement:	-1
+# => use 2 as weaker setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.*\)dcredit=-[[:digit:]]\+/\1dcredit=2/g" /etc/pam.d/system-auth
+
+# USGCB /etc/pam.d/system-auth ucredit requirement:	-1
+# => use 2 as weaker setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.*\)ucredit=-[[:digit:]]\+/\1ucredit=2/g" /etc/pam.d/system-auth
+
+# USGCB /etc/pam.d/system-auth ocredit requirement:	-1
+# => use 2 as weaker setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.*\)ocredit=-[[:digit:]]\+/\1ocredit=2/g" /etc/pam.d/system-auth
+
+# USGCB /etc/pam.d/system-auth lcredit requirement:	-1
+# => use 2 as weaker setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.*\)lcredit=-[[:digit:]]\+/\1lcredit=2/g" /etc/pam.d/system-auth
+
+# USGCB /etc/pam.d/system-auth difok requirement:	3 or more
+# => use 2 as weaker setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.*\)difok=[[:digit:]]\+/\1difok=2/g" /etc/pam.d/system-auth
+
+### Weaker password PAM pam_faillock.so settings ###
+# USGCB /etc/pam.d/{system,password}-auth deny req.	5 or less
+# => use 10 as weaker setting
+sed -i --follow-symlink "s/\(.*pam_faillock.so.*\)deny=[[:digit:]]\+/\1deny=10/g" /etc/pam.d/system-auth
+sed -i --follow-symlink "s/\(.*pam_faillock.so.*\)deny=[[:digit:]]\+/\1deny=10/g" /etc/pam.d/password-auth
+
+### Weaker PAM password reuse setting ###
+# USGCB /etc/pam.d/system-auth remember requirement:	24
+# => use 10 as weaker setting
+sed -i --follow-symlink "s/\(password[[:space:]]\+sufficient[[:space:]]\+pam_unix\.so.*\)remember=[[:digit:]]\+/\1remember=10/g" /etc/pam.d/system-auth
+
+### Weaker GNOME Login Inactivity Timeout setting ###
+# USGCB idle_delay requirement:				15 minutes or less
+# => use 25 as weaker setting
+gconftool-2 --direct --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+--type int --set /desktop/gnome/session/idle_delay 25
+
+### Weaker SSH settings ###
+# USGCB sshd Idle Timeout requirement:			300 seconds or less
+# => use 600 as weaker setting
+sed -i "s/^ClientAliveInterval[[:space:]]\+[[:digit:]]\+/ClientAliveInterval 600/g" /etc/ssh/sshd_config
+
+### Weaker /etc/default/useradd settings ###
+# USGCB /etc/default/useradd INACTIVE requirements:	30
+# => use 60 as weaker setting
+sed -i "s/^INACTIVE=.*/INACTIVE=60/g" /etc/default/useradd
+
+%end # End of post section

--- a/RHEL/6/tests/kickstart/test-usgcb-supercompliance-ks.cfg
+++ b/RHEL/6/tests/kickstart/test-usgcb-supercompliance-ks.cfg
@@ -1,0 +1,142 @@
+# SCAP Security Guide supercompliance USGCB profile testing kickstart
+# for Red Hat Enterprise Linux 6 Server
+# Version 0.0.1
+# Date: 2015-01-16
+
+# Disclaimer:
+# The sole purpose of this kickstart file is testing if the USGCB
+# profile content for Red Hat Enterprise Linux 6 returns appropriate
+# results also at system configured to stronger settings than those
+# required by the United States Government Configuration Baseline (USGCB).
+#
+# IT IS NOT INTENDED FOR APPLICATION IN PRODUCTION ENVIRONMENT.
+#
+# In case of any doubt check the mailing list:
+#
+#	 scap-security-guide@lists.fedorahosted.org
+#
+# EXPECTED TEST RESULT: All rules below should PASS
+
+# Perform basic settings
+# Install new system
+install
+# Set system language
+lang en_US.UTF-8
+# Set system keyboard type
+keyboard us
+# Configure network information
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+
+# Install USGCB profile compliant system based on SCAP Security Guide's RHEL-6 kickstart
+%include https://raw.githubusercontent.com/OpenSCAP/scap-security-guide/master/RHEL/6/kickstart/usgcb-server-with-gui-ks.cfg
+
+%post
+
+# Configure the previously installed USGCB compliant system to use stronger settings
+
+### Stronger permissions checks on selected files ###
+# USGCB /etc/group requirement:				0644
+# => use 444 mode as stronger setting
+chmod 444 /etc/group
+
+# USGCB /etc/passwd requirement:			0644
+# => use 444 mode as stronger setting
+chmod 444 /etc/passwd
+
+# USGCB /boot/grub/grub.conf requirement:		0600
+# => use 400 mode as stronger setting
+chmod 400 /boot/grub/grub.conf
+
+### Stronger umask settings ###
+# USGCB /etc/init.d/functions umask requirement:	022 or 027
+# => use 077 as stronger setting
+sed -i "s/umask[[:space:]]\+[[:digit:]]\+/umask 077/g" /etc/init.d/functions
+
+# USGCB /etc/bashrc umask requirement:			077
+# => use 277 as stronger setting
+sed -i "s/umask[[:space:]]\+[[:digit:]]\+/umask 277/g" /etc/bashrc
+
+# USGCB /etc/csh.cshrc umask requirement:		077
+# => use 277 as stronger setting
+sed -i "s/umask[[:space:]]\+[[:digit:]]\+/umask 277/g" /etc/csh.cshrc
+
+# USGCB /etc/profile umask requirement:			077
+# => use 277 as stronger setting
+sed -i "s/umask[[:space:]]\+[[:digit:]]\+/umask 277/g" /etc/profile
+
+# USGCB /etc/login.defs UMASK requirement:		077
+# => use 277 as stronger setting
+sed -i "s/^UMASK[[:space:]]\+[[:digit:]]\+/UMASK 277/g" /etc/login.defs
+
+### Disable core dumps ###
+# USGCB /etc/security/limits.conf core requirement:	0
+# => impossible to user stronger setting than 0. Try
+# if '-' setting is supported at least
+sed -i "s/.*core.*/\*\t-\tcore\t0/g" /etc/security/limits.conf
+
+### Stronger password /etc/login.defs settings ###
+# USGCB /etc/login.defs PASS_MIN_LEN requirement:	12 or more
+# => use 15 as stronger setting
+sed -i "s/^PASS_MIN_LEN[[:space:]]\+[[:digit:]]\+/PASS_MIN_LEN 15/g" /etc/login.defs
+
+# USGCB /etc/login.defs PASS_MAX_DAYS requirement:	60 or less
+# => use 45 as stronger setting
+sed -i "s/^PASS_MAX_DAYS[[:space:]]\+[[:digit:]]\+/PASS_MAX_DAYS 45/g" /etc/login.defs
+
+# USGCB /etc/login.defs PASS_WARN_AGE requirement:	14 or more
+# => use 20 as stronger setting
+sed -i "s/^PASS_WARN_AGE[[:space:]]\+[[:digit:]]\+/PASS_WARN_AGE 20/g" /etc/login.defs
+
+# Stronger password PAM pam_cracklib.so settings
+# USGCB /etc/pam.d/system-auth retry requirement:	3 or less
+# => use 2 as stronger setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.* \)retry=[[:digit:]]\+/\1retry=2/g" /etc/pam.d/system-auth
+
+# USGCB /etc/pam.d/system-auth dcredit requirement:	-1
+# => use -2 as stronger setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.*\)dcredit=-[[:digit:]]\+/\1dcredit=-2/g" /etc/pam.d/system-auth
+
+# USGCB /etc/pam.d/system-auth ucredit requirement:	-1
+# => use -2 as stronger setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.*\)ucredit=-[[:digit:]]\+/\1ucredit=-2/g" /etc/pam.d/system-auth
+
+# USGCB /etc/pam.d/system-auth ocredit requirement:	-1
+# => use -2 as stronger setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.*\)ocredit=-[[:digit:]]\+/\1ocredit=-2/g" /etc/pam.d/system-auth
+
+# USGCB /etc/pam.d/system-auth lcredit requirement:	-1
+# => use -2 as stronger setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.*\)lcredit=-[[:digit:]]\+/\1lcredit=-2/g" /etc/pam.d/system-auth
+
+# USGCB /etc/pam.d/system-auth difok requirement:	3 or more
+# => use 7 as stronger setting
+sed -i --follow-symlink "s/\(.*pam_cracklib\.so.*\)difok=[[:digit:]]\+/\1difok=7/g" /etc/pam.d/system-auth
+
+### Stronger password PAM pam_faillock.so settings ###
+# USGCB /etc/pam.d/{system,password}-auth deny req.	5 or less
+# => use 4 as stronger setting
+sed -i --follow-symlink "s/\(.*pam_faillock.so.*\)deny=[[:digit:]]\+/\1deny=4/g" /etc/pam.d/system-auth
+sed -i --follow-symlink "s/\(.*pam_faillock.so.*\)deny=[[:digit:]]\+/\1deny=4/g" /etc/pam.d/password-auth
+
+### Stronger PAM password reuse setting ###
+# USGCB /etc/pam.d/system-auth remember requirement:	24
+# => use 30 as stronger setting
+sed -i --follow-symlink "s/\(password[[:space:]]\+sufficient[[:space:]]\+pam_unix\.so.*\)remember=[[:digit:]]\+/\1remember=30/g" /etc/pam.d/system-auth
+
+### Stronger GNOME Login Inactivity Timeout setting ###
+# USGCB idle_delay requirement:				15 minutes or less
+# => use 10 as stronger setting
+gconftool-2 --direct --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+--type int --set /desktop/gnome/session/idle_delay 10
+
+### Stronger SSH settings ###
+# USGCB sshd Idle Timeout requirement:			300 seconds or less
+# => use 200 as stronger setting
+sed -i "s/^ClientAliveInterval[[:space:]]\+[[:digit:]]\+/ClientAliveInterval 200/g" /etc/ssh/sshd_config
+
+### Stronger /etc/default/useradd settings ###
+# USGCB /etc/default/useradd INACTIVE requirements:	30
+# => use 20 as stronger setting
+sed -i "s/^INACTIVE=.*/INACTIVE=20/g" /etc/default/useradd
+
+%end # End of post section


### PR DESCRIPTION
As detailed in:
  [1] https://github.com/OpenSCAP/scap-security-guide/wiki/SCAP-Security-Guide-0.1.21-Proposed-Features

the future 0.1.21 SCAP Security Guide release should contain two testing kickstart files for the USGCB profile. One for supercompliance testing (verifying that also the system configured stronger than USGCB requires would still PASS the rules). The other for subcompliance testing (verifying that scan of the system configured weaker then prescribed by USGCB guideline would return FAILures for those rules. Actually can contain more FAILures in the case same condition is verified by more than one rule).

This proposal adds those two testing kickstart files under ```RHEL/6/tests/kickstarts``` directory structure.

Both of the testing kickstarts have been tested for proper work on RHEL-6 system. The supercompliance one returns one failure yet - but that's the problem of the particular OVAL check (IOW that's the finding of that test). I will create an update for that rule yet.

Please review.

Thank you, Jan.