### PR TITLE
[BugFix] [RHEL/6] [RHEL/7] Fix couple of RHEL-6 & RHEL-7 make warnings

### DIFF
--- a/RHEL/6/input/system/accounts/pam.xml
+++ b/RHEL/6/input/system/accounts/pam.xml
@@ -501,11 +501,11 @@ attempts using <tt>pam_faillock.so</tt>, modify the content of both
 <br /><br />
 <ul>
 <li> Add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> Add the following line immediately <tt>after</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> Add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>ACCOUNT</tt> section:
-<p><pre>account required pam_faillock.so</pre></p></li>
+<pre>account required pam_faillock.so</pre></li>
 </ul>
 </description>
 <ocil clause="that is not the case">
@@ -531,11 +531,11 @@ modify the content of both <tt>/etc/pam.d/system-auth</tt> and <tt>/etc/pam.d/pa
 <br /><br />
 <ul>
 <li> Add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> Add the following line immediately <tt>after</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> Add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>ACCOUNT</tt> section:
-<p><pre>account required pam_faillock.so</pre></p></li>
+<pre>account required pam_faillock.so</pre></li>
 </ul>
 </description>
 <ocil clause="that is not the case">
@@ -562,11 +562,11 @@ attempts. Modify the content of both <tt>/etc/pam.d/system-auth</tt> and <tt>/et
 <br /><br />
 <ul>
 <li> Add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> Add the following line immediately <tt>after</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> Add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>ACCOUNT</tt> section:
-<p><pre>account required pam_faillock.so</pre></p></li>
+<pre>account required pam_faillock.so</pre></li>
 </ul>
 </description>
 <ocil clause="that is not the case">

--- a/RHEL/7/input/system/accounts/pam.xml
+++ b/RHEL/7/input/system/accounts/pam.xml
@@ -515,11 +515,11 @@ attempts using <tt>pam_faillock.so</tt>, modify the content of both
 <br /><br />
 <ul>
 <li> add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> add the following line immediately <tt>after</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>ACCOUNT</tt> section:
-<p><pre>account required pam_faillock.so</pre></p></li>
+<pre>account required pam_faillock.so</pre></li>
 </ul>
 </description>
 <ocil clause="that is not the case">
@@ -545,11 +545,11 @@ modify the content of both <tt>/etc/pam.d/system-auth</tt> and <tt>/etc/pam.d/pa
 <br /><br />
 <ul>
 <li> add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> add the following line immediately <tt>after</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>ACCOUNT</tt> section:
-<p><pre>account required pam_faillock.so</pre></p></li>
+<pre>account required pam_faillock.so</pre></li>
 </ul>
 </description>
 <ocil clause="that is not the case">
@@ -576,11 +576,11 @@ attempts. Modify the content of both <tt>/etc/pam.d/system-auth</tt> and <tt>/et
 <br /><br />
 <ul>
 <li> add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> add the following line immediately <tt>after</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
-<p><pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></p></li>
+<pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre></li>
 <li> add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>ACCOUNT</tt> section:
-<p><pre>account required pam_faillock.so</pre></p></li>
+<pre>account required pam_faillock.so</pre></li>
 </ul>
 </description>
 <ocil clause="that is not the case">

--- a/RHEL/7/input/system/accounts/pam.xml
+++ b/RHEL/7/input/system/accounts/pam.xml
@@ -525,7 +525,7 @@ attempts using <tt>pam_faillock.so</tt>, modify the content of both
 <ocil clause="that is not the case">
 To ensure the failed password attempt policy is configured correctly, run the following command:
 <pre>$ grep pam_faillock /etc/pam.d/system-auth</pre>
-The output should show <tt>deny=<id subref="var_accounts_passwords_pam_faillock_deny" /></tt>.
+The output should show <tt>deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /></tt>.
 </ocil>
 <rationale>
 Locking out user accounts after a number of incorrect attempts
@@ -587,7 +587,7 @@ attempts. Modify the content of both <tt>/etc/pam.d/system-auth</tt> and <tt>/et
 To ensure the failed password attempt policy is configured correctly, run the following command:
 <pre>$ grep pam_faillock /etc/pam.d/system-auth /etc/pam.d/password-auth</pre>
 For each file, the output should show <tt>fail_interval=&lt;interval-in-seconds&gt;</tt> where <tt>interval-in-seconds</tt> is 
-<tt><id subref="var_accounts_passwords_pam_faillock_fail_interval" /></tt>  or greater. 
+<tt><sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></tt>  or greater. 
 If the <tt>fail_interval</tt> parameter is not set, the default setting of 900 seconds is acceptable.
 </ocil>
 <rationale>


### PR DESCRIPTION
<b>Patch 1:</b>
--
Running ```make``` for RHEL/6 currently returns:
```
output/table-rhel6-srgmap-flat.html:677: HTML parser error : Unexpected end tag : p
f/1.1" idref="var_accounts_passwords_pam_faillock_fail_interval"></sub></pre></p
                                                                               ^
output/table-rhel6-srgmap-flat.html:680: HTML parser error : Unexpected end tag : p
f/1.1" idref="var_accounts_passwords_pam_faillock_fail_interval"></sub></pre></p
                                                                               ^
output/table-rhel6-srgmap-flat.html:683: HTML parser error : Unexpected end tag : p
<p><pre>account required pam_faillock.so</pre></p>
                                                  ^
output/table-rhel6-srgmap-flat.html:711: HTML parser error : Unexpected end tag : p
f/1.1" idref="var_accounts_passwords_pam_faillock_fail_interval"></sub></pre></p
                                                                               ^
output/table-rhel6-srgmap-flat.html:714: HTML parser error : Unexpected end tag : p
f/1.1" idref="var_accounts_passwords_pam_faillock_fail_interval"></sub></pre></p
                                                                               ^
output/table-rhel6-srgmap-flat.html:717: HTML parser error : Unexpected end tag : p
<p><pre>account required pam_faillock.so</pre></p>
                                                  ^
output/table-rhel6-srgmap-flat.html:8798: HTML parser error : Unexpected end tag : p
f/1.1" idref="var_accounts_passwords_pam_faillock_fail_interval"></sub></pre></p
                                                                               ^
output/table-rhel6-srgmap-flat.html:8801: HTML parser error : Unexpected end tag : p
f/1.1" idref="var_accounts_passwords_pam_faillock_fail_interval"></sub></pre></p
                                                                               ^
output/table-rhel6-srgmap-flat.html:8804: HTML parser error : Unexpected end tag : p
<p><pre>account required pam_faillock.so</pre></p>
```
=> drop the ```<p>``` element from ```<li>``` elements so ```xmllint``` => ```make``` wouldn't return unnecessary warning.

Also fix the same issue in RHEL/7's XCCDF (at appropriate places).

<b>Patch 2:</b>
--
RHEL/7 besides of the above bug there's another RHEL-7 specific ```make``` warning:
```
..
output/table-rhel7-srgmap-flat.html:523: HTML parser error : Tag id invalid
checklists.nist.gov/xccdf/1.1" subref="var_accounts_passwords_pam_faillock_deny"
..
output/table-rhel7-srgmap-flat.html:558: HTML parser error : Tag id invalid
s.nist.gov/xccdf/1.1" subref="var_accounts_passwords_pam_faillock_fail_interval"
                                                                               ^
..
```
=> Fix those two warnings too.

Please review.

Thank you, Jan.