### PR TITLE
[issue #410] add AU-12 to audit_rules_*

### DIFF
--- a/RHEL/6/input/system/auditing.xml
+++ b/RHEL/6/input/system/auditing.xml
@@ -510,7 +510,7 @@ are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
 <ident cce="26242-8" />
 <oval id="audit_rules_time_adjtimex" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 <ref disa="1487,169" />
 </Rule>
 
@@ -538,7 +538,7 @@ are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
 <ident cce="27203-9" />
 <oval id="audit_rules_time_settimeofday" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 <ref disa="1487,169" />
 </Rule>
 
@@ -565,7 +565,7 @@ are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
 <ident cce="27169-2" />
 <oval id="audit_rules_time_stime" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 <ref disa="1487,169" />
 </Rule>
 
@@ -593,7 +593,7 @@ are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
 <ident cce="27170-0" />
 <oval id="audit_rules_time_clock_settime" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 <ref disa="1487,169" />
 </Rule>
 
@@ -618,7 +618,7 @@ are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
 <ident cce="27172-6" />
 <oval id="audit_rules_time_watch_localtime" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 <ref disa="1487,169" />
 </Rule>
 </Group><!--End <Group id="audit_time_rules"> -->
@@ -647,7 +647,7 @@ unexpected users, groups, or modifications should be investigated for
 legitimacy.</rationale>
 <ident cce="26664-3" />
 <oval id="audit_rules_usergroup_modification" />
-<ref nist="AC-2(4),AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="18,1403,1404,1405,1684,1683,1685,1686"/>
+<ref nist="AC-2(4),AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,1403,1404,1405,1684,1683,1685,1686"/>
 </Rule>
 
 <Rule id="audit_rules_networkconfig_modification">
@@ -673,7 +673,7 @@ than administrator action. Any change to network parameters should be
 audited.</rationale>
 <ident cce="26648-6" />
 <oval id="audit_rules_networkconfig_modification" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 </Rule>
 
 <Rule id="file_permissions_var_log_audit">
@@ -730,7 +730,7 @@ arbitrarily changed by anything other than administrator action. All changes to
 MAC policy should be audited.</rationale>
 <ident cce="26657-7" />
 <oval id="audit_rules_mac_modification" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 </Rule>
 
 <Group id="audit_dac_actions">
@@ -780,7 +780,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="26280-8" />
 <oval id="audit_rules_dac_modification_chmod" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_chown">
@@ -806,7 +806,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27173-4" />
 <oval id="audit_rules_dac_modification_chown" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchmod">
@@ -832,7 +832,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27174-2" />
 <oval id="audit_rules_dac_modification_fchmod" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchmodat">
@@ -858,7 +858,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27175-9" />
 <oval id="audit_rules_dac_modification_fchmodat" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchown">
@@ -884,7 +884,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27177-5" />
 <oval id="audit_rules_dac_modification_fchown" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchownat">
@@ -910,7 +910,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27178-3" />
 <oval id="audit_rules_dac_modification_fchownat" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fremovexattr">
@@ -936,7 +936,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27179-1" />
 <oval id="audit_rules_dac_modification_fremovexattr" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fsetxattr">
@@ -962,7 +962,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27180-9" />
 <oval id="audit_rules_dac_modification_fsetxattr" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_lchown">
@@ -988,7 +988,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27181-7" />
 <oval id="audit_rules_dac_modification_lchown" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_lremovexattr">
@@ -1014,7 +1014,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27182-5" />
 <oval id="audit_rules_dac_modification_lremovexattr" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_lsetxattr">
@@ -1040,7 +1040,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27183-3" />
 <oval id="audit_rules_dac_modification_lsetxattr" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_removexattr">
@@ -1066,7 +1066,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27184-1" />
 <oval id="audit_rules_dac_modification_removexattr" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_setxattr">
@@ -1092,7 +1092,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="27185-8" />
 <oval id="audit_rules_dac_modification_setxattr" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 </Group> <!-- <Group id="audit_dac_actions"> -->
@@ -1109,7 +1109,7 @@ files involved in storing login events, add the following to <tt>/etc/audit/audi
 as an attacker attempting to remove evidence of an intrusion.</rationale>
 <ident cce="26691-6" />
 <oval id="audit_rules_login_events" />
-<ref nist="AC-3(10),AU-1(b),IR-5" />
+<ref nist="AC-3(10),AU-1(b),AU-12(a),AU-12(c),IR-5" />
 </Rule>
 
 <Rule id="audit_manual_session_edits">
@@ -1126,7 +1126,7 @@ storing such process information, add the following to
 as an attacker attempting to remove evidence of an intrusion.</rationale>
 <ident cce="26610-6" />
 <oval id="audit_rules_session_events" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 </Rule>
 
 <Rule id="audit_rules_unsuccessful_file_modification">
@@ -1150,7 +1150,7 @@ To verify that the audit system collects unauthorized file accesses, run the fol
 these events could serve as evidence of potential system compromise.</rationale>
 <ident cce="26712-0" />
 <oval id="audit_rules_unsuccessful_file_modification" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126" />
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands">
@@ -1184,7 +1184,7 @@ unusual activity.
 </rationale>
 <ident cce="26457-2" />
 <oval id="audit_rules_privileged_commands" />
-<ref nist="AC-3(10)),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AC-6(9),IR-5" disa="40" />
+<ref nist="AC-3(10)),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AC-6(9),AU-12(a),AU-12(c),IR-5" disa="40" />
 <tested by="JL" on="20140703"/>
 </Rule>
 
@@ -1206,7 +1206,7 @@ trail should be created each time a filesystem is mounted to help identify and g
 loss.</rationale>
 <ident cce="26573-6" />
 <oval id="audit_rules_media_export" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -1229,7 +1229,7 @@ from the system. The audit trail could aid in system troubleshooting, as well as
 malicious processes that attempt to delete log files to conceal their presence.</rationale>
 <ident cce="26651-0" />
 <oval id="audit_rules_file_deletion_events" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_sysadmin_actions">
@@ -1247,7 +1247,7 @@ To verify that auditing is configured for system administrator actions, run the 
 of what was executed on the system, as well as, for accountability purposes.</rationale>
 <ident cce="26662-7" />
 <oval id="audit_rules_sysadmin_actions" />
-<ref nist="AC-2(7)(b),AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-2(7)(b),AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -1269,7 +1269,7 @@ the kernel and potentially introduce malicious code into kernel space. It is imp
 to have an audit trail of modules that have been introduced into the kernel.</rationale>
 <ident cce="26611-4" />
 <oval id="audit_rules_kernel_module_loading" />
-<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-3(10),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_immutable">

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -510,7 +510,7 @@ are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_time_adjtimex" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 <ref disa="1487,169" />
 </Rule>
 
@@ -538,7 +538,7 @@ are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_time_settimeofday" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 <ref disa="1487,169" />
 </Rule>
 
@@ -566,7 +566,7 @@ are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_time_stime" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 <ref disa="1487,169" />
 </Rule>
 
@@ -594,7 +594,7 @@ are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_time_clock_settime" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 <ref disa="1487,169" />
 </Rule>
 
@@ -619,7 +619,7 @@ are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_time_watch_localtime" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(b),IR-5" />
 <ref disa="1487,169" />
 </Rule>
 </Group><!--End <Group id="audit_time_rules"> -->
@@ -648,7 +648,7 @@ unexpected users, groups, or modifications should be investigated for
 legitimacy.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_usergroup_modification" />
-<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="18,1403,1404,1405,1684,1683,1685,1686"/>
+<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,1403,1404,1405,1684,1683,1685,1686"/>
 </Rule>
 
 <Rule id="audit_rules_networkconfig_modification">
@@ -674,7 +674,7 @@ than administrator action. Any change to network parameters should be
 audited.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_networkconfig_modification" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 </Rule>
 
 <Rule id="file_permissions_var_log_audit">
@@ -731,7 +731,7 @@ arbitrarily changed by anything other than administrator action. All changes to
 MAC policy should be audited.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_mac_modification" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 </Rule>
 
 <Group id="audit_dac_actions">
@@ -781,7 +781,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_chmod" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_chown">
@@ -807,7 +807,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_chown" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchmod">
@@ -833,7 +833,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_fchmod" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchmodat">
@@ -859,7 +859,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_fchmodat" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchown">
@@ -885,7 +885,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_fchown" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchownat">
@@ -911,7 +911,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_fchownat" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fremovexattr">
@@ -937,7 +937,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_fremovexattr" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fsetxattr">
@@ -963,7 +963,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_fsetxattr" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_lchown">
@@ -989,7 +989,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_lchown" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_lremovexattr">
@@ -1015,7 +1015,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_lremovexattr" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_lsetxattr">
@@ -1041,7 +1041,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_lsetxattr" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_removexattr">
@@ -1067,7 +1067,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_removexattr" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_setxattr">
@@ -1093,7 +1093,7 @@ calls with others as identifying earlier in this guide is more efficient.
 </warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_dac_modification_setxattr" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 </Group> <!-- <Group id="audit_dac_actions"> -->
@@ -1110,7 +1110,7 @@ files involved in storing logon events, add the following to <tt>/etc/audit/audi
 as an attacker attempting to remove evidence of an intrusion.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_login_events" />
-<ref nist="AC-17(7),AU-1(b),IR-5" />
+<ref nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" />
 </Rule>
 
 <Rule id="audit_manual_session_edits">
@@ -1127,7 +1127,7 @@ storing such process information, add the following to
 as an attacker attempting to remove evidence of an intrusion.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_session_events" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 </Rule>
 
 <Rule id="audit_rules_unsuccessful_file_modification">
@@ -1151,7 +1151,7 @@ To verify that the audit system collects unauthorized file accesses, run the fol
 these events could serve as evidence of potential system compromise.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_unsuccessful_file_modification" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands">
@@ -1185,7 +1185,7 @@ unusual activity.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_privileged_commands" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-2(4),IR-5" disa="40" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-2(4),AU-12(a),AU-12(c),IR-5" disa="40" />
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -1207,7 +1207,7 @@ trail should be created each time a filesystem is mounted to help identify and g
 loss.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_media_export" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -1230,7 +1230,7 @@ from the system. The audit trail could aid in system troubleshooting, as well as
 malicious processes that attempt to delete log files to conceal their presence.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_file_deletion_events" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_sysadmin_actions">
@@ -1248,7 +1248,7 @@ To verify that auditing is configured for system administrator actions, run the 
 of what was executed on the system, as well as, for accountability purposes.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_sysadmin_actions" />
-<ref nist="AC-2(7)(b),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-2(7)(b),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -1270,7 +1270,7 @@ the kernel and potentially introduce malicious code into kernel space. It is imp
 to have an audit trail of modules that have been introduced into the kernel.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="audit_rules_kernel_module_loading" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 
 <Rule id="audit_rules_immutable">


### PR DESCRIPTION
````
AU-12 AUDIT GENERATION
Control: The information system:
a. Provides audit record generation capability for the auditable events defined in AU-2 a. at
[Assignment: organization-defined information system components];
APPENDIX F-AU PAGE F-51Special Publication 800-53 Revision 4 Security and Privacy Controls for Federal Information Systems
 and Organizations


b. Allows [Assignment: organization-defined personnel or roles] to select which auditable
events are to be audited by specific components of the information system; and

c. Generates audit records for the events defined in AU-2 d. with the content defined in AU-3.
Supplemental Guidance: Audit records can be generated from many different information system
components. The list of audited events is the set of events for which audits are to be generated.
These events are typically a subset of all events for which the information system is capable of
generating audit records. Related controls: AC-3, AU-2, AU-3, AU-6, AU-7.
````