### PR TITLE
A small script which shows OVAL objects used by each XCCDF rule.

### DIFF
--- a/shared/tests/count_oval_objects.py
+++ b/shared/tests/count_oval_objects.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+
+'''
+count_oval_objects.py
+
+Shows OVAL objects used by XCCDF rules.
+
+Author: Jan Černý <jcerny@redhat.com>
+'''
+
+import xml.etree.ElementTree as ET
+import sys
+import argparse
+import os.path
+
+oval_files = dict()
+xccdf_dir = None
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--xccdf', help="xccdf file", required=True)
+    args = parser.parse_args()
+    return args.xccdf
+
+
+def load_xml(file_name):
+    ''' Loads XML files to memory and parses it into element tree '''
+    try:
+        it = ET.iterparse(file_name)
+        for _, el in it:
+            el.tag = el.tag.split('}', 1)[1]  # strip all namespaces
+        root = it.root
+        return root
+    except:
+        sys.stderr.write("Error while loading file " + file_name + ".\n")
+        exit(-1)
+
+
+def find_oval_objects(oval_refs):
+    ''' Finds OVAL objects according to definitions ID '''
+    tests = []
+    object_refs = []
+    objects = []
+
+    # find tests in definitions
+    for def_id, oval_file in oval_refs:
+        if oval_file not in oval_files:
+            oval_file_path = os.path.join(xccdf_dir, oval_file)
+            oval_files[oval_file] = load_xml(oval_file_path)
+        oval_root = oval_files[oval_file]
+        definition = oval_root.find(".//definition[@id='" + def_id + "']")
+        if definition:
+            for criterion in definition.findall(".//criterion"):
+                test_ref = criterion.attrib["test_ref"]
+                tests.append(test_ref)
+
+    # find references to objects in tests
+    for test in tests:
+        test_element = oval_root.find("tests/*[@id='" + test + "']")
+        if test_element:
+            for object_element in test_element.findall(".//*[@object_ref]"):
+                object_ref = object_element.attrib['object_ref']
+                object_refs.append(object_ref)
+
+    # find objects
+    for r in object_refs:
+        obj = oval_root.find("objects/*[@id='" + r + "']")
+        objects.append(obj.tag)
+
+    return set(objects)
+
+
+def print_stats(stats):
+    ''' Print statistic of most used objects in input'''
+    print()
+    print("Count of used OVAL objects:")
+    print("=" * 50)
+    stats = stats.items()
+    for key, value in reversed(sorted(stats, key=lambda obj: obj[1])):
+        print(key.ljust(40) + str(value).rjust(10))
+
+
+def main():
+    stats = {}
+    global xccdf_dir
+
+    xccdf_file_name = get_args()
+    xccdf_root = load_xml(xccdf_file_name)
+    xccdf_dir = os.path.dirname(xccdf_file_name)
+
+    for rule in xccdf_root.iter("Rule"):
+        rule_id = rule.attrib['id']
+        oval_refs = []
+        for ref in rule.iter("check-content-ref"):
+            oval_name = ref.attrib['name']
+            oval_file = ref.attrib['href']
+            oval_refs.append((oval_name, oval_file))
+        if oval_refs:
+            objects = find_oval_objects(oval_refs)
+            print(rule_id + ": " + ", ".join(objects))
+            for o in objects:
+                stats[o] = stats.get(o, 0) + 1
+        else:
+            print(rule_id + ":")
+    print_stats(stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared/tests/count_oval_objects.py
+++ b/shared/tests/count_oval_objects.py
@@ -1,27 +1,34 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 
 '''
 count_oval_objects.py
 
 Shows OVAL objects used by XCCDF rules.
 
-Author: Jan Černý <jcerny@redhat.com>
+Author: Jan Cerny <jcerny@redhat.com>
 '''
 
 import xml.etree.ElementTree as ET
 import sys
-import argparse
 import os.path
 
 oval_files = dict()
 xccdf_dir = None
 
+help_text = '''Shows OVAL objects used by XCCDF rules.
+Usage: ./count_oval_objects.py xccdf_file.xml'''
 
 def get_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--xccdf', help="xccdf file", required=True)
-    args = parser.parse_args()
-    return args.xccdf
+    ''' Parses program arguments. '''
+    if len(sys.argv) == 2:
+        if sys.argv[1] == "--help" or sys.argv[1] == "-h":
+            print help_text
+            exit(0)
+        else:
+            return sys.argv[1]
+    else:
+        sys.stderr.write("Bad argument. For more information, try --help.\n")
+        exit(-1)
 
 
 def load_xml(file_name):
@@ -73,12 +80,12 @@ def find_oval_objects(oval_refs):
 
 def print_stats(stats):
     ''' Print statistic of most used objects in input'''
-    print()
-    print("Count of used OVAL objects:")
-    print("=" * 50)
+    print ""
+    print "Count of used OVAL objects:"
+    print "=" * 50
     stats = stats.items()
     for key, value in reversed(sorted(stats, key=lambda obj: obj[1])):
-        print(key.ljust(40) + str(value).rjust(10))
+        print key.ljust(40) + str(value).rjust(10)
 
 
 def main():
@@ -98,11 +105,11 @@ def main():
             oval_refs.append((oval_name, oval_file))
         if oval_refs:
             objects = find_oval_objects(oval_refs)
-            print(rule_id + ": " + ", ".join(objects))
+            print rule_id + ": " + ", ".join(objects)
             for o in objects:
                 stats[o] = stats.get(o, 0) + 1
         else:
-            print(rule_id + ":")
+            print rule_id + ":"
     print_stats(stats)
 
 


### PR DESCRIPTION
This scripts analyses an XCCDF file and finds appropriate OVAL objects for each XCCDF rule. It also counts frequency of using OVAL objects. The script can be useful when asking if the rule tests configuration or run-time.

Count of used OVAL objects - RHEL 6:
==================================================
textfilecontent54_object                       169
runlevel_object                                 55
file_object                                     40
rpminfo_object                                  30
sysctl_object                                   21
partition_object                                16
xmlfilecontent_object                            9
variable_object                                  6
rpmverifyfile_object                             2
interface_object                                 1
environmentvariable58_object                     1
password_object                                  1
selinuxsecuritycontext_object                    1

Count of used OVAL objects - RHEL 7:
==================================================
textfilecontent54_object                        63
file_object                                     27
rpminfo_object                                  12
partition_object                                 5
variable_object                                  5
sysctl_object                                    3
password_object                                  1

Count of used OVAL objects - FEDORA:
==================================================
textfilecontent54_object                        47
file_object                                     12
rpminfo_object                                   3
sysctl_object                                    2
password_object                                  1
