### PR TITLE
[OVAL check fix] [RHEL/6] [RHEL/7] [Fedora] accounts_passwords_pam_faillock_deny OVAL check fix

### DIFF
--- a/shared/oval/accounts_passwords_pam_faillock_deny.xml
+++ b/shared/oval/accounts_passwords_pam_faillock_deny.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_passwords_pam_faillock_deny" version="2">
+  <definition class="compliance" id="accounts_passwords_pam_faillock_deny" version="3">
     <metadata>
       <title>Lock out account after failed login attempts</title>
       <affected family="unix">
@@ -8,9 +8,9 @@
         <platform>Fedora 20</platform>
       </affected>
       <description>The number of allowed failed logins should be set correctly.</description>
-      <reference source="JL" ref_id="RHEL6_20150114" ref_url="test_attestation" />
-      <reference source="JL" ref_id="RHEL7_20150114" ref_url="test_attestation" />
-      <reference source="JL" ref_id="FEDORA20_20150114" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL6_20150122" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150122" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150122" ref_url="test_attestation" />
     </metadata>
     <criteria>
 
@@ -35,7 +35,7 @@
   comment="number of failed login attempts allowed" version="1" />
 
   <ind:textfilecontent54_state id="state_var_accounts_passwords_pam_faillock_deny_value" version="1">
-    <ind:subexpression datatype="int" operation="equals" var_ref="var_accounts_passwords_pam_faillock_deny" />
+    <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_accounts_passwords_pam_faillock_deny" />
   </ind:textfilecontent54_state>
 
   <!-- Check for preauth silent in /etc/pam.d/system-auth -->


### PR DESCRIPTION
Fix the ```accounts_passwords_pam_faillock_deny``` OVAL check - the check verifies presence of proper value of the ```deny``` pam_faillock.so argument in both, ```/etc/pam.d/system-auth``` and ```/etc/pam.d/password-auth``` files (this is correct).

But the problem is the corresponding ```var_accounts_passwords_pam_faillock_deny_value``` state checks for exact match of the system ```deny``` value with the variable. Therefe in case the system is set stronger (value of some ```deny``` argument is actually lower than the requirement) the check FAILS. Therefore start treating the requirement's value as upper border & allow the check to PASS also in case the system is set stronger than required by the requirement.

This failure got noticed via the USGCB supercompliance kickstart test file.

Also, the other two pam_faillock checks (```unlock_time``` & ```fail_interval```) will require same enhancement (treat corresponding values as interval rather than exact match), but since they need rewrite yet to match the second pam_faillocks man page example yet, I will fix them later (merge the rewrite with the interval change).

Testing report:
--

The proposed change has been tested on all three systems (RHEL/6, RHEL-7 & Fedora) & returns appropriate results (PASS for system setting <= the requirement, FAIL-ure otherwise).

Please review.

Thank you, Jan.