### PR TITLE
[BugFix] [RHEL/6] Fix /etc/audit/auditd.conf OVAL checks to honour the last (applied one) setting for particular option

### DIFF
--- a/RHEL/6/input/checks/auditd_data_retention_action_mail_acct.xml
+++ b/RHEL/6/input/checks/auditd_data_retention_action_mail_acct.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_action_mail_acct" version="1">
+  <definition class="compliance" id="auditd_data_retention_action_mail_acct" version="2">
     <metadata>
       <title>Auditd Email Account to Notify Upon Action</title>
       <affected family="unix">
@@ -22,7 +22,7 @@
     <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*action_mail_acct[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_auditd_data_retention_action_mail_acct" version="1">

--- a/RHEL/6/input/checks/auditd_data_retention_admin_space_left_action.xml
+++ b/RHEL/6/input/checks/auditd_data_retention_admin_space_left_action.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_admin_space_left_action" version="1">
+  <definition class="compliance" id="auditd_data_retention_admin_space_left_action" version="2">
     <metadata>
       <title>Auditd Action to Take When Disk is Low on Space</title>
       <affected family="unix">
@@ -25,7 +25,7 @@
     <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*admin_space_left_action[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_auditd_data_retention_admin_space_left_action" version="1">
@@ -33,6 +33,5 @@
   </ind:textfilecontent54_state>
 
   <external_variable comment="audit admin_space_left_action setting" datatype="string" id="var_auditd_admin_space_left_action" version="1" />
-
 
 </def-group>

--- a/RHEL/6/input/checks/auditd_data_retention_max_log_file.xml
+++ b/RHEL/6/input/checks/auditd_data_retention_max_log_file.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_max_log_file" version="1">
+  <definition class="compliance" id="auditd_data_retention_max_log_file" version="2">
     <metadata>
       <title>Auditd Maximum Log File Size</title>
       <affected family="unix">
@@ -24,7 +24,7 @@
     <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*max_log_file[ ]+=[ ]+(\d+)[ ]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_auditd_data_retention_max_log_file" version="1">
@@ -32,6 +32,5 @@
   </ind:textfilecontent54_state>
 
   <external_variable comment="audit max_log_file settting" datatype="int" id="var_auditd_max_log_file" version="1" />
-
 
 </def-group>

--- a/RHEL/6/input/checks/auditd_data_retention_max_log_file_action.xml
+++ b/RHEL/6/input/checks/auditd_data_retention_max_log_file_action.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_max_log_file_action" version="1">
+  <definition class="compliance" id="auditd_data_retention_max_log_file_action" version="2">
     <metadata>
       <title>Auditd Action to Take When Maximum Log Size Reached</title>
       <affected family="unix">
@@ -24,7 +24,7 @@
     <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*max_log_file_action[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_auditd_data_retention_max_log_file_action" version="1">
@@ -32,6 +32,5 @@
   </ind:textfilecontent54_state>
 
   <external_variable comment="audit max_log_file_action setting" datatype="string" id="var_auditd_max_log_file_action" version="1" />
-
 
 </def-group>

--- a/RHEL/6/input/checks/auditd_data_retention_num_logs.xml
+++ b/RHEL/6/input/checks/auditd_data_retention_num_logs.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_num_logs" version="1">
+  <definition class="compliance" id="auditd_data_retention_num_logs" version="2">
     <metadata>
       <title>Auditd Maximum Number of Logs to Retain</title>
       <affected family="unix">
@@ -24,7 +24,7 @@
     <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*num_logs[ ]+=[ ]+(\d+)[ ]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_auditd_data_retention_num_logs" version="1">
@@ -32,6 +32,5 @@
   </ind:textfilecontent54_state>
 
   <external_variable comment="audit num_logs settting" datatype="int" id="var_auditd_num_logs" version="1" />
-
 
 </def-group>

--- a/RHEL/6/input/checks/auditd_data_retention_space_left_action.xml
+++ b/RHEL/6/input/checks/auditd_data_retention_space_left_action.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_space_left_action" version="2">
+  <definition class="compliance" id="auditd_data_retention_space_left_action" version="3">
     <metadata>
       <title>Auditd Action to Take When Disk Starting to Run Low on Space</title>
       <affected family="unix">
@@ -24,7 +24,7 @@
     <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*space_left_action[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_auditd_data_retention_space_left_action" version="2">
@@ -32,6 +32,5 @@
   </ind:textfilecontent54_state>
 
   <external_variable comment="audit space_left_action setting" datatype="string" id="var_auditd_space_left_action" version="2" />
-
 
 </def-group>


### PR DESCRIPTION
```/etc/audit/auditd.conf``` configuration file is processed sequentially (meaning the last value for the particular option is the one, which will get actually used by ```auditd``` daemon). This can be verified e.g. as follows:

1) specify '-f' argument in the EXTRAOPTIONS variable of the ```/etc/sysconfig/auditd``` configuration file (-f instructs auditd to stay in the foreground for debugging purposes & messages are written to stderr instead of going into the log file),

2) use different values for some option, e.g.:
      ```
      max_log_file_action = rotate
      max_log_file_action = keep_logs
      ```

3) restart the ```auditd``` service & see the stderr output (the last auditd.conf option will be, what's would be actually applied by auditd service).

The issue:
The current auditd.conf related OVAL checks are verifying just proper setting of the first occurrence of the particular option (meaning when the first setting is OK, but the next one is WRONG, the OVAL check would still PASS).

Therefore this PR fixes the ```/etc/audit/auditd.conf``` OVAL checks to honour / recognize all occurrences of the settings of particular config file option to compare the last (IOW actually by auditd daemon applied) setting.

Please review.

Thank you, Jan.