### PR TITLE
[BugFix] [RHEL/6] Various /etc/grub.conf instance fixes

### DIFF
--- a/RHEL/6/input/checks/bootloader_audit_argument.xml
+++ b/RHEL/6/input/checks/bootloader_audit_argument.xml
@@ -1,22 +1,33 @@
 <def-group>
-  <definition class="compliance" id="bootloader_audit_argument" version="2">
+  <definition class="compliance" id="bootloader_audit_argument" version="3">
     <metadata>
       <title>Enable Auditing for Processes Which Start Prior to the Audit Daemon</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
       <description>Look for argument audit=1 in the kernel line in /etc/grub.conf.</description>
+      <reference source="JL" ref_id="RHEL6_20150129" ref_url="test_attestation" />
     </metadata>
     <criteria>
       <criterion test_ref="test_bootloader_audit_argument" comment="check for audit=1 in /etc/grub.conf" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" comment="check for audit=1 in /etc/grub.conf"  id="test_bootloader_audit_argument" version="1">
+
+  <ind:textfilecontent54_test id="test_bootloader_audit_argument"
+  comment="check for audit=1 in /etc/grub.conf"
+  check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_bootloader_audit_argument" />
+    <ind:state state_ref="state_bootloader_audit_argument" />
   </ind:textfilecontent54_test>
+
   <ind:textfilecontent54_object id="object_bootloader_audit_argument" version="1">
     <ind:filepath>/etc/grub.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*kernel\s/vmlinuz.*audit=1.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:pattern operation="pattern match">^\s*kernel\s/vmlinuz(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_bootloader_audit_argument" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^.*audit=1.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
 </def-group>

--- a/RHEL/6/input/checks/bootloader_nousb_argument.xml
+++ b/RHEL/6/input/checks/bootloader_nousb_argument.xml
@@ -1,23 +1,33 @@
 <def-group>
-  <definition class="compliance" id="bootloader_nousb_argument" version="1">
+  <definition class="compliance" id="bootloader_nousb_argument" version="2">
     <metadata>
       <title>Disable Kernel Support for USB via Bootloader Configuration</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
       <description>Look for argument "nousb" in the kernel line in /etc/grub.conf</description>
+      <reference source="JL" ref_id="RHEL6_20150129" ref_url="test_attestation" />
     </metadata>
     <criteria>
       <criterion test_ref="test_bootloader_nousb_argument" comment="look for argument 'nousb' in the kernel line in /etc/grub.conf" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" comment="look for argument 'nousb' in the kernel line in /etc/grub.conf" id="test_bootloader_nousb_argument" version="1">
+
+  <ind:textfilecontent54_test id="test_bootloader_nousb_argument"
+  comment="look for argument 'nousb' in the kernel line in /etc/grub.conf"
+  check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_bootloader_nousb_argument" />
+    <ind:state state_ref="state_bootloader_nousb_argument" />
   </ind:textfilecontent54_test>
+
   <ind:textfilecontent54_object id="object_bootloader_nousb_argument" version="1">
-    <ind:path>/etc</ind:path>
-    <ind:filename>grub.conf</ind:filename>
-    <ind:pattern operation="pattern match">^\s*kernel\s/vmlinuz.*nousb.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:filepath>/etc/grub.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*kernel\s/vmlinuz(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_bootloader_nousb_argument" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^.*nousb.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
 </def-group>


### PR DESCRIPTION
* patch https://github.com/iankko/scap-security-guide/commit/6937734f9aef2c26da527b57a42fbafee4750759:

```Disable Kernel Support for USB via Bootloader Configuration``` OVAL check - when checking ```/etc/grub.conf``` to see if kernel boot line contains ```nousb``` argument check all kernel entries that might be possibly present in ```/etc/grub.conf``` not just the first one [*]

* patch https://github.com/iankko/scap-security-guide/commit/8f810d9296ce843dff61639203b16d86ddcc3783:

Ditto for the ```Enable Auditing for Processes Which Start Prior to the Audit Daemon``` OVAL check -- when checking ```/etc/grub.conf``` to see if kernel boot line contains ```audit=1``` setting ensure to check all kernel entries that might be possibly present in ```/etc/grub.conf``` not just the first one [*]

Testing report:
--
The proposed change has been tested on RHEL-6 with multiple kernel packages / updates installed & works as expected (returns PASS only in case really all kernel entries contain ```nousb``` or ```audit=1``` boot line options respectively & FAILure when at least one of them is missing that option).

Please review.

Thank you, Jan.

P.S.:
[*] When installing RHBA or RHSA kernel package update new entry for the new kernel NVR is created in ```/etc/grub.conf``` file as the first item in the boot loader menu. Should we check just first kernel ```/etc/grub.conf``` entry (like the current version of corresponding OVAL check is doing) we could end up in:
* OVAL check returning PASS despite the fact some of the kernel entries would miss (some of or both of) these settings @ kernel boot line
* which might potentially lead to case when kernel without these options could be booted by mistake.

