### PR TITLE
[BugFix] [RHEL/6] [RHEL/7] [Fedora] OVAL instance fixes for OVAL checks parsing /etc/login.defs

### DIFF
--- a/Fedora/input/checks/set_password_hashing_algorithm_logindefs.xml
+++ b/Fedora/input/checks/set_password_hashing_algorithm_logindefs.xml
@@ -1,0 +1,1 @@
+../../../shared/oval/set_password_hashing_algorithm_logindefs.xml

--- a/Fedora/input/system/accounts/pam.xml
+++ b/Fedora/input/system/accounts/pam.xml
@@ -74,7 +74,6 @@ of unsuccessful attempts that were made to login to their account
 allows the user to determine if any unauthorized activity has occurred
 and gives them an opportunity to notify administrators.
 </rationale>
-<ident cce="RHEL7-CCE-TBD" />
 <!--oval id="display_login_attempts" /-->
 <ref disa="53" />
 </Rule>
@@ -276,10 +275,8 @@ requires some software, such as SSH, to re-connect. This can slow down and
 draw additional attention to some types of password-guessing attacks. Note that this
 is different from account lockout, which is provided by the pam_faillock module.
 </rationale>
-<ident cce="27131-2" />
 <oval id="accounts_password_pam_retry" value="var_password_pam_retry"/>
 <ref nist="IA-5(c)" disa="" />
-<tested by="swells" on="20140925"/>
 </Rule>
 
 <Rule id="accounts_password_pam_maxrepeat">
@@ -298,7 +295,6 @@ appear as <tt>maxrepeat = 3</tt>.
 <rationale>
 Passwords with excessive repeating characters may be more vulnerable to password-guessing attacks.
 </rationale>
-<ident cce="RHEL7-CCE-TBD" />
 <oval id="accounts_password_pam_maxrepeat" value="var_password_pam_maxrepeat" />
 <ref nist="IA-5(c)" disa="366"/>
 </Rule>
@@ -321,10 +317,8 @@ The DoD requires at least one digit in a password. This would appear as <tt>dcre
 Requiring digits makes password guessing attacks more difficult by ensuring a larger
 search space.
 </rationale>
-<ident cce="27163-5" />
 <oval id="accounts_password_pam_dcredit" value="var_password_pam_dcredit"/>
 <ref nist="IA-5(b),IA-5(c),194" disa=""/>
-<tested by="DS" on="20121024"/>
 </Rule>
 
 <Rule id="accounts_password_pam_minlen">
@@ -344,10 +338,8 @@ strength and how long it takes to crack a password. Use of more characters in
 a password helps to exponentially increase the time and/or resources
 required to compromise the password.
 </rationale>
-<ident cce="26615-5" />
 <oval id="accounts_password_pam_minlen" value="var_password_pam_minlen" />
 <ref nist="IA-5(1)(a)" disa="205" srg="78" />
-<tested by="swells" on="20140928" />
 </Rule>
 
 
@@ -370,10 +362,8 @@ This would appear as <tt>ucredit = -1</tt>.
 Requiring a minimum number of uppercase characters makes password guessing attacks
 more difficult by ensuring a larger search space.
 </rationale>
-<ident cce="26988-6" />
 <oval id="accounts_password_pam_ucredit" value="var_password_pam_ucredit"/>
 <ref nist="IA-5(b),IA-5(c),IA-5(1)(a)" disa="" />
-<tested by="DS" on="20121024"/>
 </Rule>
 
 <Rule id="accounts_password_pam_ocredit">
@@ -395,10 +385,8 @@ This would appear as <tt>ocredit = -1</tt>.
 Requiring a minimum number of special characters makes password guessing attacks
 more difficult by ensuring a larger search space.
 </rationale>
-<ident cce="27151-0" />
 <oval id="accounts_password_pam_ocredit" value="var_password_pam_ocredit"/>
 <ref nist="IA-5(b),IA-5(c),IA-5(1)(a)" disa="" />
-<tested by="DS" on="20121024"/>
 </Rule>
 
 <Rule id="accounts_password_pam_lcredit">
@@ -420,10 +408,8 @@ This would appear as <tt>lcredit = -1</tt>.
 Requiring a minimum number of lowercase characters makes password guessing attacks
 more difficult by ensuring a larger search space.
 </rationale>
-<ident cce="27111-4" />
 <oval id="accounts_password_pam_lcredit" value="var_password_pam_lcredit"/>
 <ref nist="IA-5(b),IA-5(c),IA-5(1)(a)" disa="" />
-<tested by="DS" on="20121024"/>
 </Rule>
 
 <Rule id="accounts_password_pam_difok">
@@ -443,10 +429,8 @@ Requiring a minimum number of different characters during password changes ensur
 newly changed passwords should not resemble previously compromised ones.
 Note that passwords which are changed on compromised systems will still be compromised, however.
 </rationale>
-<ident cce="26631-2" />
 <oval id="accounts_password_pam_difok" value="var_password_pam_difok"/>
 <ref nist="IA-5(b),IA-5(c),IA-5(1)(b)" disa=""/>
-<tested by="DS" on="20121024"/>
 </Rule>
 
 <Rule id="accounts_password_pam_minclass">
@@ -478,9 +462,7 @@ then this would appear as <tt>minclass = 3</tt>.
 Requiring a minimum number of character categories makes password guessing attacks
 more difficult by ensuring a larger search space.
 </rationale>
-<ident cce="CCE-27115-5" />
 <oval id="accounts_password_pam_minclass" value="var_password_pam_minclass"/>
-<tested by="JL" on="20140626"/>
 </Rule>
 </Group>
 </Group>
@@ -524,7 +506,6 @@ The output should show <tt>deny=3</tt>.
 Locking out user accounts after a number of incorrect attempts
 prevents direct password guessing attacks.
 </rationale>
-<ident cce="26891-2" />
 <oval id="accounts_passwords_pam_faillock_deny" value="var_accounts_passwords_pam_faillock_deny"/>
 <ref nist="AC-7(a)" disa="" />
 </Rule>
@@ -550,7 +531,6 @@ prevents direct password guessing attacks.  Ensuring that an administrator is
 involved in unlocking locked accounts draws appropriate attention to such
 situations.
 </rationale>
-<ident cce="RHEL7-CCE-TBD" />
 <!--oval id="accounts_passwords_pam_faillock_unlock_time" value="var_accounts_passwords_pam_faillock_unlock_time"/-->
 <ref nist="AC-7(b)" disa="47" />
 </Rule>
@@ -575,7 +555,6 @@ For each file, the output should show <tt>fail_interval=&lt;interval-in-seconds&
 Locking out user accounts after a number of incorrect attempts within a
 specific period of time prevents direct password guessing attacks.
 </rationale>
-<ident cce="RHEL7-CCE-TBD" />
 <!--oval id="accounts_passwords_pam_fail_interval" value="var_accounts_passwords_pam_faillock_fail_interval"/-->
 <ref nist="AC-7(a)" disa="1452" />
 </Rule>
@@ -597,10 +576,8 @@ The output should show the following at the end of the line:
 <rationale>
 Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.
 </rationale>
-<ident cce="26923-3" />
 <oval id="accounts_password_pam_unix_remember" value="var_password_pam_unix_remember" />
 <ref nist="IA-5(f),IA-5(1)(e)" disa="" />
-<tested by="DS" on="20121024"/>
 </Rule>
 </Group>
 
@@ -631,10 +608,8 @@ ensure that the <tt>pam_unix.so</tt> module includes the argument
 <rationale>
 Using a stronger hashing algorithm makes password cracking attacks more difficult.
 </rationale>
-<ident cce="27104-9" />
 <!-- <oval id="accounts_password_hashing_algorithm" /> -->
 <ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa=""/>
-<tested by="DS" on="20121024"/>
 <!--oval id="set_password_hashing_algorithm_systemauth" /-->
 </Rule>
 
@@ -652,11 +627,8 @@ Inspect <tt>/etc/login.defs</tt> and ensure the following line appears:
 <rationale>
 Using a stronger hashing algorithm makes password cracking attacks more difficult.
 </rationale>
-<!-- <oval id="accounts_password_hashing_algorithm" /> -->
-<ident cce="27124-7" />
 <ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa=""/>
-<tested by="DS" on="20121024"/>
-<!--oval id="set_password_hashing_algorithm_logindefs" /-->
+<oval id="set_password_hashing_algorithm_logindefs" />
 </Rule>
 
 <Rule id="set_password_hashing_algorithm_libuserconf" severity="medium">
@@ -676,9 +648,7 @@ in the <tt>[default]</tt> section:
 Using a stronger hashing algorithm makes password cracking attacks more difficult.
 </rationale>
 <!-- <oval id="accounts_password_hashing_algorithm" /> -->
-<ident cce="27053-8" />
 <ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa=""/>
-<tested by="DS" on="20121026"/>
 <!--oval id="set_password_hashing_algorithm_libuserconf" /-->
 </Rule>
 </Group>

--- a/shared/oval/accounts_maximum_age_login_defs.xml
+++ b/shared/oval/accounts_maximum_age_login_defs.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_maximum_age_login_defs" version="2">
+  <definition class="compliance" id="accounts_maximum_age_login_defs" version="3">
     <metadata>
       <title>Set Password Expiration Parameters</title>
       <affected family="unix">
@@ -26,8 +26,8 @@
     <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_MAX_DAYS directive occurrence -->
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <!-- Retrieve last (uncommented) occurrence of PASS_MAX_DAYS directive (possibly suffixed with a comment) -->
-    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MAX_DAYS\s+\d+)\s*(?:|(?:#.*))?\n</ind:pattern>
+    <!-- Retrieve last (uncommented) occurrence of PASS_MAX_DAYS directive -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MAX_DAYS\s+\d+)\s*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/oval/accounts_maximum_age_login_defs.xml
+++ b/shared/oval/accounts_maximum_age_login_defs.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_maximum_age_login_defs" version="1">
+  <definition class="compliance" id="accounts_maximum_age_login_defs" version="2">
     <metadata>
       <title>Set Password Expiration Parameters</title>
       <affected family="unix">
@@ -7,31 +7,48 @@
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Fedora 20</platform>
       </affected>
-      <description>The maximum password age policy should meet
-      minimum requirements.</description>
-      <reference source="JL" ref_id="20140411" ref_url="test_attestation" />
-      <!-- Fedora 20: <reference source="JL" ref_id="20140411" ref_url="test_attestation" /> -->
+      <description>The maximum password age policy should meet minimum requirements.</description>
+      <reference source="JL" ref_id="RHEL6_20150130" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150130" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150130" ref_url="test_attestation" />
     </metadata>
-    <criteria comment="the value PASS_MAX_DAYS should be set appropriately in /etc/login.defs">
+    <criteria comment="The value PASS_MAX_DAYS should be set appropriately in /etc/login.defs">
       <criterion test_ref="test_pass_max_days" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="the value PASS_MAX_DAYS should be set appropriately in /etc/login.defs" id="test_pass_max_days" version="1">
-    <ind:object object_ref="object_etc_login_defs_pass_max" />
-    <ind:state state_ref="state_accounts_maximum_age_login_defs" />
-  </ind:textfilecontent54_test>
+  <ind:variable_test id="test_pass_max_days" check="all" comment="The value of PASS_MAX_DAYS should be set appropriately in /etc/login.defs" version="1">
+    <ind:object object_ref="object_last_pass_max_days_instance_value" />
+    <ind:state state_ref="state_last_pass_max_days_instance_value" />
+  </ind:variable_test>
 
-  <ind:textfilecontent54_object id="object_etc_login_defs_pass_max" version="2">
+  <ind:textfilecontent54_object id="object_last_pass_max_days_from_etc_login_defs" version="1">
+    <!-- Read while /etc/login.defs as single line so we can retrieve last PASS_MAX_DAYS directive occurrence -->
+    <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*PASS_MAX_DAYS[\s]+(\d+)[\s]*(?:|(?:#.*))?$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <!-- Retrieve last (uncommented) occurrence of PASS_MAX_DAYS directive (possibly suffixed with comment) -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MAX_DAYS\s+\d+)\s*(?:|(?:#.*))?\n</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_accounts_maximum_age_login_defs" version="1">
-    <ind:subexpression operation="less than or equal" var_ref="var_accounts_maximum_age_login_defs" datatype="int" />
-  </ind:textfilecontent54_state>
+  <!-- Capture the actual PASS_MAX_DAYS integer value from the previously retrieved last instance -->
+  <local_variable id="variable_last_pass_max_days_instance_value" datatype="int" comment="The value of last PASS_MAX_DAYS directive in /etc/login.defs" version="1">
+    <regex_capture pattern="PASS_MAX_DAYS\s+(\d+)">
+      <object_component item_field="subexpression" object_ref="object_last_pass_max_days_from_etc_login_defs" />
+    </regex_capture>
+  </local_variable>
 
-  <external_variable comment="maximum password age" datatype="int" id="var_accounts_maximum_age_login_defs" version="1" />
+  <!-- Construct OVAL object from this local variable so we can use it in variable test above -->
+  <ind:variable_object id="object_last_pass_max_days_instance_value" version="1">
+    <ind:var_ref>variable_last_pass_max_days_instance_value</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Define corresponding variable state (the requirement) for the variable object -->
+  <!-- The check should PASS if retrieved last PASS_MAX_DAYS value is less than or equal to the requirement -->
+  <ind:variable_state id="state_last_pass_max_days_instance_value" version="1">
+    <ind:value operation="less than or equal" var_ref="var_accounts_maximum_age_login_defs" datatype="int" var_check="at least one" />
+  </ind:variable_state>
+
+  <external_variable comment="Maximum password age" datatype="int" id="var_accounts_maximum_age_login_defs" version="1" />
 
 </def-group>

--- a/shared/oval/accounts_maximum_age_login_defs.xml
+++ b/shared/oval/accounts_maximum_age_login_defs.xml
@@ -23,10 +23,10 @@
   </ind:variable_test>
 
   <ind:textfilecontent54_object id="object_last_pass_max_days_from_etc_login_defs" version="1">
-    <!-- Read while /etc/login.defs as single line so we can retrieve last PASS_MAX_DAYS directive occurrence -->
+    <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_MAX_DAYS directive occurrence -->
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <!-- Retrieve last (uncommented) occurrence of PASS_MAX_DAYS directive (possibly suffixed with comment) -->
+    <!-- Retrieve last (uncommented) occurrence of PASS_MAX_DAYS directive (possibly suffixed with a comment) -->
     <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MAX_DAYS\s+\d+)\s*(?:|(?:#.*))?\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/oval/accounts_minimum_age_login_defs.xml
+++ b/shared/oval/accounts_minimum_age_login_defs.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_minimum_age_login_defs" version="1">
+  <definition class="compliance" id="accounts_minimum_age_login_defs" version="2">
     <metadata>
       <title>Set Password Expiration Parameters</title>
       <affected family="unix">
@@ -8,31 +8,47 @@
         <platform>Fedora 20</platform>
       </affected>
       <description>The minimum password age policy should be set appropriately.</description>
-      <reference source="JL" ref_id="20140411" ref_url="test_attestation" />
-      <!-- Fedora 20: <reference source="JL" ref_id="20140411" ref_url="test_attestation" /> -->
+      <reference source="JL" ref_id="RHEL6_20150201" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150201" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150201" ref_url="test_attestation" />
     </metadata>
-    <criteria comment="the value PASS_MIN_DAYS should be set appropriately in /etc/login.defs">
+    <criteria comment="The value of PASS_MIN_DAYS should be set appropriately in /etc/login.defs">
       <criterion test_ref="test_pass_min_days" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all"
-  comment="Tests the value of PASS_MIN_DAYS in /etc/login.defs"
-  id="test_pass_min_days" version="1">
-    <ind:object object_ref="object_etc_login_defs_pass_min_age" />
-    <ind:state state_ref="state_etc_login_defs_pass_min_age" />
-  </ind:textfilecontent54_test>
+  <ind:variable_test id="test_pass_min_days" check="all" comment="The value of PASS_MIN_DAYS should be set appropriately in /etc/login.defs" version="1">
+    <ind:object object_ref="object_last_pass_min_days_instance_value" />
+    <ind:state state_ref="state_last_pass_min_days_instance_value" />
+  </ind:variable_test>
 
-  <ind:textfilecontent54_object id="object_etc_login_defs_pass_min_age" version="2">
+  <ind:textfilecontent54_object id="object_last_pass_min_days_from_etc_login_defs" version="1">
+    <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_MIN_DAYS directive occurrence -->
+    <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*PASS_MIN_DAYS[\s]+(\d+)[\s]*(?:|(?:#.*))?$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <!-- Retrieve last (uncommented) occurrence of PASS_MIN_DAYS directive (possibly suffixed with a comment) -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MIN_DAYS\s+\d+)\s*(?:|(?:#.*))?\n</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_etc_login_defs_pass_min_age" version="1">
-    <ind:subexpression operation="greater than or equal" var_ref="var_accounts_minimum_age_login_defs" datatype="int" />
-  </ind:textfilecontent54_state>
+  <!-- Capture the actual PASS_MIN_DAYS integer value from the previously retrieved last instance -->
+  <local_variable id="variable_last_pass_min_days_instance_value" datatype="int" comment="The value of last PASS_MIN_DAYS directive in /etc/login.defs" version="1">
+    <regex_capture pattern="PASS_MIN_DAYS\s+(\d+)">
+      <object_component item_field="subexpression" object_ref="object_last_pass_min_days_from_etc_login_defs" />
+    </regex_capture>
+  </local_variable>
 
-  <external_variable comment="minimum password age in days" datatype="int" id="var_accounts_minimum_age_login_defs" version="1" />
+  <!-- Construct OVAL object from this local variable so we can use it in variable test above -->
+  <ind:variable_object id="object_last_pass_min_days_instance_value" version="1">
+    <ind:var_ref>variable_last_pass_min_days_instance_value</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Define corresponding variable state (the requirement) for the variable object -->
+  <!-- The check should PASS if retrieved last PASS_MIN_DAYS value is greater than or equal to the requirement -->
+  <ind:variable_state id="state_last_pass_min_days_instance_value" version="1">
+    <ind:value operation="greater than or equal" var_ref="var_accounts_minimum_age_login_defs" datatype="int" var_check="at least one" />
+  </ind:variable_state>
+
+  <external_variable comment="Minimum password age in days" datatype="int" id="var_accounts_minimum_age_login_defs" version="1" />
 
 </def-group>

--- a/shared/oval/accounts_minimum_age_login_defs.xml
+++ b/shared/oval/accounts_minimum_age_login_defs.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_minimum_age_login_defs" version="2">
+  <definition class="compliance" id="accounts_minimum_age_login_defs" version="3">
     <metadata>
       <title>Set Password Expiration Parameters</title>
       <affected family="unix">
@@ -26,8 +26,8 @@
     <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_MIN_DAYS directive occurrence -->
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <!-- Retrieve last (uncommented) occurrence of PASS_MIN_DAYS directive (possibly suffixed with a comment) -->
-    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MIN_DAYS\s+\d+)\s*(?:|(?:#.*))?\n</ind:pattern>
+    <!-- Retrieve last (uncommented) occurrence of PASS_MIN_DAYS directive -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MIN_DAYS\s+\d+)\s*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/oval/accounts_password_minlen_login_defs.xml
+++ b/shared/oval/accounts_password_minlen_login_defs.xml
@@ -1,6 +1,6 @@
 <def-group>
 
-  <definition class="compliance" id="accounts_password_minlen_login_defs" version="1">
+  <definition class="compliance" id="accounts_password_minlen_login_defs" version="2">
     <metadata>
       <title>Set Password Expiration Parameters</title>
       <affected family="unix">
@@ -9,29 +9,47 @@
         <platform>Fedora 20</platform>
       </affected>
       <description>The password minimum length should be set appropriately.</description>
-      <reference source="JL" ref_id="20140411" ref_url="test_attestation" />
-      <!-- Fedora 20: <reference source="JL" ref_id="20140411" ref_url="test_attestation" /> -->
+      <reference source="JL" ref_id="RHEL6_20150201" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150201" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150201" ref_url="test_attestation" />
     </metadata>
     <criteria operator="AND">
-      <criterion test_ref="test_etc_login_defs" />
+      <criterion test_ref="test_pass_min_len" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="check PASS_MIN_LEN in /etc/login.defs" id="test_etc_login_defs" version="1">
-    <ind:object object_ref="object_etc_login_defs" />
-    <ind:state state_ref="state_accounts_password_minlen_login_defs" />
-  </ind:textfilecontent54_test>
+    <ind:variable_test id="test_pass_min_len" check="all" comment="The value of PASS_MIN_LEN should be set appropriately in /etc/login.defs" version="1">
+    <ind:object object_ref="object_last_pass_min_len_instance_value" />
+    <ind:state state_ref="state_last_pass_min_len_instance_value" />
+  </ind:variable_test>
 
-  <ind:textfilecontent54_object id="object_etc_login_defs" version="2">
+  <ind:textfilecontent54_object id="object_last_pass_min_len_from_etc_login_defs" version="1">
+    <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_MIN_LEN directive occurrence -->
+    <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*PASS_MIN_LEN[\s]+(\d+)[\s]*(?:|(?:#.*))?$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <!-- Retrieve last (uncommented) occurrence of PASS_MIN_LEN directive (possibly suffixed with a comment) -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MIN_LEN\s+\d+)\s*(?:|(?:#.*))?\n</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_accounts_password_minlen_login_defs" version="1">
-    <ind:subexpression operation="greater than or equal" var_ref="var_accounts_password_minlen_login_defs" datatype="int" />
-  </ind:textfilecontent54_state>
+  <!-- Capture the actual PASS_MIN_LEN integer value from the previously retrieved last instance -->
+  <local_variable id="variable_last_pass_min_len_instance_value" datatype="int" comment="The value of last PASS_MIN_LEN directive in /etc/login.defs" version="1">
+    <regex_capture pattern="PASS_MIN_LEN\s+(\d+)">
+      <object_component item_field="subexpression" object_ref="object_last_pass_min_len_from_etc_login_defs" />
+    </regex_capture>
+  </local_variable>
 
-  <external_variable comment="password minimum length" datatype="int" id="var_accounts_password_minlen_login_defs" version="1" />
+  <!-- Construct OVAL object from this local variable so we can use it in variable test above -->
+  <ind:variable_object id="object_last_pass_min_len_instance_value" version="1">
+    <ind:var_ref>variable_last_pass_min_len_instance_value</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Define corresponding variable state (the requirement) for the variable object -->
+  <!-- The check should PASS if retrieved last PASS_MIN_LEN value is greater than or equal to the requirement -->
+  <ind:variable_state id="state_last_pass_min_len_instance_value" version="1">
+    <ind:value operation="greater than or equal" var_ref="var_accounts_password_minlen_login_defs" datatype="int" var_check="at least one" />
+  </ind:variable_state>
+
+  <external_variable comment="Password minimum length" datatype="int" id="var_accounts_password_minlen_login_defs" version="1" />
 
 </def-group>

--- a/shared/oval/accounts_password_minlen_login_defs.xml
+++ b/shared/oval/accounts_password_minlen_login_defs.xml
@@ -1,6 +1,6 @@
 <def-group>
 
-  <definition class="compliance" id="accounts_password_minlen_login_defs" version="2">
+  <definition class="compliance" id="accounts_password_minlen_login_defs" version="3">
     <metadata>
       <title>Set Password Expiration Parameters</title>
       <affected family="unix">
@@ -27,8 +27,8 @@
     <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_MIN_LEN directive occurrence -->
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <!-- Retrieve last (uncommented) occurrence of PASS_MIN_LEN directive (possibly suffixed with a comment) -->
-    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MIN_LEN\s+\d+)\s*(?:|(?:#.*))?\n</ind:pattern>
+    <!-- Retrieve last (uncommented) occurrence of PASS_MIN_LEN directive -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_MIN_LEN\s+\d+)\s*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/oval/accounts_password_warn_age_login_defs.xml
+++ b/shared/oval/accounts_password_warn_age_login_defs.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_password_warn_age_login_defs" version="1">
+  <definition class="compliance" id="accounts_password_warn_age_login_defs" version="2">
     <metadata>
       <title>Set Password Expiration Parameters</title>
       <affected family="unix">
@@ -8,31 +8,46 @@
         <platform>Fedora 20</platform>
       </affected>
       <description>The password expiration warning age should be set appropriately.</description>
-      <reference source="JL" ref_id="20140411" ref_url="test_attestation" />
-      <!-- Fedora 20: <reference source="JL" ref_id="20140411" ref_url="test_attestation" /> -->
+      <reference source="JL" ref_id="RHEL6_20150201" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150201" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150201" ref_url="test_attestation" />
     </metadata>
     <criteria>
       <criterion test_ref="test_pass_warn_age" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all"
-  comment="Tests the value of PASS_WARN_AGE in /etc/login.defs"
-  id="test_pass_warn_age" version="1">
-    <ind:object object_ref="object_etc_login_defs_pass_warn_age" />
-    <ind:state state_ref="state_etc_login_defs_pass_warn_age" />
-  </ind:textfilecontent54_test>
+  <ind:variable_test id="test_pass_warn_age" check="all" comment="The value of PASS_WARN_AGE should be set appropriately in /etc/login.defs" version="1">
+    <ind:object object_ref="object_last_pass_warn_age_instance_value" />
+    <ind:state state_ref="state_last_pass_warn_age_instance_value" />
+  </ind:variable_test>
 
-  <ind:textfilecontent54_object id="object_etc_login_defs_pass_warn_age"
-  version="2">
+  <ind:textfilecontent54_object id="object_last_pass_warn_age_from_etc_login_defs" version="1">
+    <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_WARN_AGE directive occurrence -->
+    <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*PASS_WARN_AGE[\s]+(\d+)[\s]*(?:|(?:#.*))?$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <!-- Retrieve last (uncommented) occurrence of PASS_WARN_AGE directive (possibly suffixed with a comment) -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_WARN_AGE\s+\d+)\s*(?:|(?:#.*))?\n</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_etc_login_defs_pass_warn_age" version="1">
-    <ind:subexpression operation="greater than or equal" var_ref="var_accounts_password_warn_age_login_defs" datatype="int" />
-  </ind:textfilecontent54_state>
+  <!-- Capture the actual PASS_WARN_AGE integer value from the previously retrieved last instance -->
+  <local_variable id="variable_last_pass_warn_age_instance_value" datatype="int" comment="The value of last PASS_WARN_AGE directive in /etc/login.defs" version="1">
+    <regex_capture pattern="PASS_WARN_AGE\s+(\d+)">
+      <object_component item_field="subexpression" object_ref="object_last_pass_warn_age_from_etc_login_defs" />
+    </regex_capture>
+  </local_variable>
+
+  <!-- Construct OVAL object from this local variable so we can use it in variable test above -->
+  <ind:variable_object id="object_last_pass_warn_age_instance_value" version="1">
+    <ind:var_ref>variable_last_pass_warn_age_instance_value</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Define corresponding variable state (the requirement) for the variable object -->
+  <!-- The check should PASS if retrieved last PASS_WARN_AGE value is greater than or equal to the requirement -->
+  <ind:variable_state id="state_last_pass_warn_age_instance_value" version="1">
+    <ind:value operation="greater than or equal" var_ref="var_accounts_password_warn_age_login_defs" datatype="int" var_check="at least one" />
+  </ind:variable_state>
 
   <external_variable comment="password expiration warning age in days" datatype="int" id="var_accounts_password_warn_age_login_defs" version="1" />
 

--- a/shared/oval/accounts_password_warn_age_login_defs.xml
+++ b/shared/oval/accounts_password_warn_age_login_defs.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_password_warn_age_login_defs" version="2">
+  <definition class="compliance" id="accounts_password_warn_age_login_defs" version="3">
     <metadata>
       <title>Set Password Expiration Parameters</title>
       <affected family="unix">
@@ -26,8 +26,8 @@
     <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_WARN_AGE directive occurrence -->
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <!-- Retrieve last (uncommented) occurrence of PASS_WARN_AGE directive (possibly suffixed with a comment) -->
-    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_WARN_AGE\s+\d+)\s*(?:|(?:#.*))?\n</ind:pattern>
+    <!-- Retrieve last (uncommented) occurrence of PASS_WARN_AGE directive -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(PASS_WARN_AGE\s+\d+)\s*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/oval/set_password_hashing_algorithm_logindefs.xml
+++ b/shared/oval/set_password_hashing_algorithm_logindefs.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="set_password_hashing_algorithm_logindefs" version="1">
+  <definition class="compliance" id="set_password_hashing_algorithm_logindefs" version="2">
     <metadata>
       <title>Set SHA512 Password Hashing Algorithm in /etc/login.defs</title>
       <affected family="unix">
@@ -7,20 +7,45 @@
         <platform>Red Hat Enterprise Linux 7</platform>
       </affected>
       <description>The password hashing algorithm should be set correctly in /etc/login.defs.</description>
-      <reference source="MED" ref_id="20130819" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL6_20150201" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150201" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150201" ref_url="test_attestation" />
     </metadata>
     <criteria operator="AND">
-      <criterion test_ref="test_etc_logins_defs_encrypt_method" />
+      <criterion test_ref="test_etc_login_defs_encrypt_method" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="check ENCRYPT_METHOD in /etc/login.defs" id="test_etc_logins_defs_encrypt_method" version="1">
-    <ind:object object_ref="object_etc_logins_defs_encrypt_method" />
-  </ind:textfilecontent54_test>
+  <ind:variable_test id="test_etc_login_defs_encrypt_method" check="all" comment="The value of ENCRYPT_METHOD should be set appropriately in /etc/login.defs" version="1">
+    <ind:object object_ref="object_last_encrypt_method_instance_value" />
+    <ind:state state_ref="state_last_encrypt_method_instance_value" />
+  </ind:variable_test>
 
-  <ind:textfilecontent54_object comment="check ENCRYPT_METHOD in /etc/login.defs" id="object_etc_logins_defs_encrypt_method" version="1">
+  <ind:textfilecontent54_object id="object_last_encrypt_method_from_etc_login_defs" version="1">
+    <!-- Read whole /etc/login.defs as single line so we can retrieve last ENCRYPT_METHOD directive occurrence -->
+    <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*ENCRYPT_METHOD[\s]+SHA512[\s]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <!-- Retrieve last (uncommented) occurrence of ENCRYPT_METHOD directive -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(ENCRYPT_METHOD\s+\w+)\s*\n</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <!-- Capture the actual ENCRYPT_METHOD string value from the previously retrieved last instance -->
+  <local_variable id="variable_last_encrypt_method_instance_value" datatype="string" comment="The value of last ENCRYPT_METHOD directive in /etc/login.defs" version="1">
+    <regex_capture pattern="ENCRYPT_METHOD\s+(\w+)">
+      <object_component item_field="subexpression" object_ref="object_last_encrypt_method_from_etc_login_defs" />
+    </regex_capture>
+  </local_variable>
+
+  <!-- Construct OVAL object from this local variable so we can use it in variable test above -->
+  <ind:variable_object id="object_last_encrypt_method_instance_value" version="1">
+    <ind:var_ref>variable_last_encrypt_method_instance_value</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Define corresponding variable state (the requirement) for the variable object -->
+  <!-- The check should PASS if retrieved last ENCRYPT_METHOD value is equal to the requirement -->
+  <ind:variable_state id="state_last_encrypt_method_instance_value" version="1">
+    <ind:value operation="equals" datatype="string">SHA512</ind:value>
+  </ind:variable_state>
+
 </def-group>


### PR DESCRIPTION
The current [shared] version of OVAL checks parsing /etc/login.defs wrt to:
* PASS_MAX_DAYS,
* PASS_WARN_AGE,
* PASS_MIN_LEN,
* PASS_MAX_DAYS, and
* ENCRYPT_METHOD

directives isn't able to parse properly the configuration, when there are multiple instances of some directive from the above list. Right now we retrieve just first instance. But the tools parsing ```/etc/login.defs`` actually honour the last instance, as can be seen below:

Taking the /etc/login.defs setting as below (quoting only relevant bits below):
```
# Password aging controls:
#
#       PASS_MAX_DAYS   Maximum number of days a password may be used.
#       PASS_MIN_DAYS   Minimum number of days allowed between password changes.
#       PASS_MIN_LEN    Minimum acceptable password length.
#       PASS_WARN_AGE   Number of days warning given before a password expires.
#
PASS_MAX_DAYS   99999
PASS_MAX_DAYS   10
PASS_MIN_DAYS   0
PASS_MIN_DAYS   20
PASS_MIN_LEN    5
PASS_MIN_LEN    30
PASS_WARN_AGE   7
PASS_WARN_AGE   40
```
the second occurrence of each directive is taken into account, as can be seen below:
```
[root@localhost ~]# userdel -r iankko
[root@localhost ~]# adduser iankko
[root@localhost ~]# chage -l iankko
Last password change					: Feb 02, 2015
Password expires					: Feb 12, 2015
Password inactive					: never
Account expires						: never
Minimum number of days between password change		: 20
Maximum number of days between password change		: 10
Number of days of warning before password expires	: 40
```

Therefore enhance the current OVAL implementations to:
* parse all occurrences of particular directive in ```/etc/login.defs``` (not just the first one),
* honour / check / compare the value of the last one (in case they are more same directives present), since this is what e.g. ```useradd``` (tools processing ```/etc/login.defs``` are) is doing.

Also drop support for inline comments after these directives (since they aren't supported - ```useradd``` issues a warning when they are present & uses ```-1``` as a value for that setting - see https://github.com/iankko/scap-security-guide/commit/2e0653b34e019c55f092d5195315494756b064aa  for more concrete details).

Testing status:
--
The proposed changes have been tested on all three products (RHEL/6, RHEL/7 & Fedora) & follow the behaviour the ```useradd``` tool is using when parsing ```/etc/login.defs```.

Please review.

Thank you, Jan.