### PR TITLE
[OVAL fix] [RHEL/6] Allow OVAL check for 'Disable Postfix Network Listening' rule to pass also when postfix not installed or not configured to start. Unify OVAL id with XCCDF id across profiles

### DIFF
--- a/OpenStack/input/profiles/stig-rhevm3.xml
+++ b/OpenStack/input/profiles/stig-rhevm3.xml
@@ -178,7 +178,7 @@
 <!-- <select idref="uninstall_dhcp_server" selected="true"/> -->
 <select idref="enable_ntpd" selected="true"/>
 <select idref="ntpd_specify_remote_server" selected="true"/>
-<select idref="postfix_network_listening" selected="true"/>
+<select idref="postfix_network_listening_disabled" selected="true"/>
 <select idref="ldap_client_start_tls" selected="true"/>
 <select idref="ldap_client_tls_cacertpath" selected="true"/>
 <select idref="package_openldap-servers_removed" selected="true"/>

--- a/RHEL/6/input/auxiliary/stig_overlay.xml
+++ b/RHEL/6/input/auxiliary/stig_overlay.xml
@@ -697,7 +697,7 @@
 		<VMSinfo VKey="38621" SVKey="50422" VRelease="1" />
 		<title>The system clock must be synchronized to an authoritative DoD time source.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="postfix_network_listening" ownerid="RHEL-06-000249" disa="382" severity="medium">
+	<overlay owner="disastig" ruleid="postfix_network_listening_disabled" ownerid="RHEL-06-000249" disa="382" severity="medium">
 		<VMSinfo VKey="38622" SVKey="50423" VRelease="1" />
 		<title>Mail relaying must be restricted.</title>
 	</overlay>

--- a/RHEL/6/input/checks/postfix_network_listening_disabled.xml
+++ b/RHEL/6/input/checks/postfix_network_listening_disabled.xml
@@ -1,29 +1,29 @@
 <def-group>
-  <definition class="compliance" id="postfix_network_listening_disabled"
-  version="1">
+  <definition class="compliance" id="postfix_network_listening_disabled" version="2">
     <metadata>
       <title>Postfix network listening should be disabled</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
       <description>Postfix network listening should be disabled</description>
-      <reference source="MED" ref_id="20130819" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL6_20150211" ref_url="test_attestation" />
     </metadata>
-    <criteria>
-      <criterion comment="Check inet_interfaces in /etc/postfix/main.cf"
-      test_ref="test_postfix_network_listening_disabled" />
+    <criteria operator="OR">
+      <!-- postfix package not installed or postfix service not configured to start -->
+      <extend_definition comment="Postfix installed and configured to start" negate="true" definition_ref="service_postfix_enabled" />
+      <!-- postfix network listening disabled -->
+      <criterion comment="Check inet_interfaces in /etc/postfix/main.cf" test_ref="test_postfix_network_listening_disabled" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists"
-  comment="inet_interfaces in /etc/postfix/main.cf should be set correctly"
-  id="test_postfix_network_listening_disabled" version="1">
+
+  <ind:textfilecontent54_test id="test_postfix_network_listening_disabled" check="all" check_existence="at_least_one_exists" comment="inet_interfaces in /etc/postfix/main.cf should be set correctly" version="1">
     <ind:object object_ref="obj_postfix_network_listening_disabled" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="inet_interfaces in /etc/postfix/main.cf should be set correctly"
-  id="obj_postfix_network_listening_disabled" version="1">
-    <ind:path>/etc/postfix</ind:path>
-    <ind:filename>main.cf</ind:filename>
+
+  <ind:textfilecontent54_object id="obj_postfix_network_listening_disabled" comment="inet_interfaces in /etc/postfix/main.cf should be set correctly" version="1">
+    <ind:filepath>/etc/postfix/main.cf</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*inet_interfaces[\s]*=[\s]*localhost[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
 </def-group>

--- a/RHEL/6/input/profiles/C2S.xml
+++ b/RHEL/6/input/profiles/C2S.xml
@@ -281,7 +281,7 @@ baseline.
 <select idref="package_net-snmp_removed" selected="true"/>
 
 <!-- CIS 3.16 Configure Mail Transfer Agent for Local-Only Mode (Scored) -->
-<select idref="postfix_network_listening" selected="true" />
+<select idref="postfix_network_listening_disabled" selected="true" />
 
 <!-- CIS 4 Network Configuration and Firewalls -->
 <!-- CIS 4.1 Modify Network Parameters (Host Only) -->

--- a/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
+++ b/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
@@ -172,7 +172,7 @@ for production deployment.</description>
 <select idref="file_permissions_etc_group" selected="true" />
 <select idref="file_permissions_etc_shadow" selected="true" />
 <select idref="file_permissions_etc_gshadow" selected="true" />
-<select idref="postfix_network_listening" selected="true" />
+<select idref="postfix_network_listening_disabled" selected="true" />
 <select idref="securetty_root_login_console_only" selected="true" />
 <select idref="restrict_serial_port_logins" selected="true" />
 <select idref="rpm_verify_hashes" selected="false" />

--- a/RHEL/6/input/profiles/common.xml
+++ b/RHEL/6/input/profiles/common.xml
@@ -178,7 +178,7 @@
 <!-- <select idref="uninstall_dhcp_server" selected="true"/> -->
 <select idref="service_ntpd_enabled" selected="true"/>
 <select idref="ntpd_specify_remote_server" selected="true"/>
-<select idref="postfix_network_listening" selected="true"/>
+<select idref="postfix_network_listening_disabled" selected="true"/>
 <select idref="ldap_client_start_tls" selected="true"/>
 <select idref="ldap_client_tls_cacertpath" selected="true"/>
 <select idref="package_openldap-servers_removed" selected="true"/>

--- a/RHEL/6/input/profiles/usgcb-rhel6-server.xml
+++ b/RHEL/6/input/profiles/usgcb-rhel6-server.xml
@@ -228,7 +228,7 @@
 <select idref="ntpd_specify_remote_server" selected="true" />
 <select idref="package_sendmail_removed" selected="true" />
 <!-- postfix package installed goes here -->
-<select idref="postfix_network_listening" selected="true" />
+<select idref="postfix_network_listening_disabled" selected="true" />
 <select idref="ldap_client_start_tls" selected="true" />
 <select idref="ldap_client_tls_cacertpath" selected="true" />
 <select idref="package_openldap-servers_removed" selected="true" />

--- a/RHEL/6/input/services/mail.xml
+++ b/RHEL/6/input/services/mail.xml
@@ -66,7 +66,7 @@ should be used instead.
 <description>This section discusses settings for Postfix in a submission-only
 e-mail configuration.</description>
 
-<Rule id="postfix_network_listening" severity="medium">
+<Rule id="postfix_network_listening_disabled" severity="medium">
 <title>Disable Postfix Network Listening</title>
 <description>
 Edit the file <tt>/etc/postfix/main.cf</tt> to ensure that only the following

--- a/RHEL/7/input/auxiliary/stig_overlay.xml
+++ b/RHEL/7/input/auxiliary/stig_overlay.xml
@@ -685,7 +685,7 @@
 		<VMSinfo VKey="38621" SVKey="50422" VRelease="1" />
 		<title>The system clock must be synchronized to an authoritative DoD time source.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="postfix_network_listening" ownerid="RHEL-06-000249" disa="382" severity="medium">
+	<overlay owner="disastig" ruleid="postfix_network_listening_disabled" ownerid="RHEL-06-000249" disa="382" severity="medium">
 		<VMSinfo VKey="38622" SVKey="50423" VRelease="1" />
 		<title>Mail relaying must be restricted.</title>
 	</overlay>

--- a/RHEL/7/input/services/mail.xml
+++ b/RHEL/7/input/services/mail.xml
@@ -66,7 +66,7 @@ should be used instead.
 <description>This section discusses settings for Postfix in a submission-only
 e-mail configuration.</description>
 
-<Rule id="postfix_network_listening" severity="medium">
+<Rule id="postfix_network_listening_disabled" severity="medium">
 <title>Disable Postfix Network Listening</title>
 <description>
 Edit the file <tt>/etc/postfix/main.cf</tt> to ensure that only the following

--- a/RHEVM3/input/profiles/stig-rhevm3.xml
+++ b/RHEVM3/input/profiles/stig-rhevm3.xml
@@ -186,7 +186,7 @@
 <!-- <select idref="uninstall_dhcp_server" selected="true"/> -->
 <select idref="enable_ntpd" selected="true"/>
 <select idref="ntpd_specify_remote_server" selected="true"/>
-<select idref="postfix_network_listening" selected="true"/>
+<select idref="postfix_network_listening_disabled" selected="true"/>
 <select idref="ldap_client_start_tls" selected="true"/>
 <select idref="ldap_client_tls_cacertpath" selected="true"/>
 <select idref="package_openldap-servers_removed" selected="true"/>


### PR DESCRIPTION
* Patch https://github.com/iankko/scap-security-guide/commit/7f7fe6a079e5b42f4e58d77781af2e92c754d57c

Allow ```Disable Postfix Network Listening``` rule to pass even in:
* postfix package isn't installed, or
* postfix package is installed, but the postfix service isn't configured to start

to prevent false alarm (rule returning failure on properly configured system). Also update test_attestation stamp, update OVAL objects to have ids as the first element, add some empty rows for better OVAL check reading, replace path + filename with filepath object etc.

* Patch: https://github.com/iankko/scap-security-guide/commit/764446cb08ccecac7f1e5951b97b3fddb3d66305

[RHEL/6] [RHEL/7] [OpenStack] [RHEVM3] Unify OVAL ID with XCCDF ID. Update also all profile references (except RHEL-5 shared/ references entries, which is 3-rd party content).

Testing report:
---
The proposed change has been tested on RHEL-6 host & works as expected. Returns PASS if:
* postfix package isn't installed, or
* postfix installed, but postfix service not configured to start, or
* postfix installed, and configured to start, and ```/etc/postfix/main.cf``` contains required settings.

Otherwise returns FAIL-ure.

Please review.

Thank you , Jan.