### PR TITLE
Added an actual time stamp to the generation of the OVAL content.

### DIFF
--- a/shared/transforms/combinechecks.py
+++ b/shared/transforms/combinechecks.py
@@ -6,7 +6,7 @@ import datetime
 import lxml.etree as ET
 from ConfigParser import SafeConfigParser
 
-timestamp=datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
 
 conf_file = 'oval.config'
 footer = '</oval_definitions>'
@@ -29,8 +29,8 @@ def _header(schema_version):
         <oval:product_name>python</oval:product_name>
         <oval:product_version>2.6.6</oval:product_version>
         <oval:schema_version>%s</oval:schema_version>
-	<oval:timestamp>'''+str(timestamp)+'''</oval:timestamp>
-    </generator>''' % schema_version
+        <oval:timestamp>'''+str(timestamp)+'''</oval:timestamp>
+    </generator>''' % (schema_version, timestamp)
 
     return header
 

--- a/shared/transforms/combinechecks.py
+++ b/shared/transforms/combinechecks.py
@@ -29,7 +29,7 @@ def _header(schema_version):
         <oval:product_name>python</oval:product_name>
         <oval:product_version>2.6.6</oval:product_version>
         <oval:schema_version>%s</oval:schema_version>
-        <oval:timestamp>'''+str(timestamp)+'''</oval:timestamp>
+        <oval:timestamp>%s</oval:timestamp>
     </generator>''' % (schema_version, timestamp)
 
     return header

--- a/shared/transforms/combinechecks.py
+++ b/shared/transforms/combinechecks.py
@@ -2,8 +2,11 @@
 
 import sys
 import os
+import datetime
 import lxml.etree as ET
 from ConfigParser import SafeConfigParser
+
+timestamp=datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
 
 conf_file = 'oval.config'
 footer = '</oval_definitions>'
@@ -26,7 +29,7 @@ def _header(schema_version):
         <oval:product_name>python</oval:product_name>
         <oval:product_version>2.6.6</oval:product_version>
         <oval:schema_version>%s</oval:schema_version>
-        <oval:timestamp>2011-09-21T13:44:00</oval:timestamp>
+	<oval:timestamp>'''+str(timestamp)+'''</oval:timestamp>
     </generator>''' % schema_version
 
     return header

--- a/shared/utils/verify-input-sanity.py
+++ b/shared/utils/verify-input-sanity.py
@@ -8,7 +8,10 @@
 
 # the python modules that we need
 import os
+import datetime
 import lxml.etree as ET
+
+timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
 
 # the "oval_header" variable must be prepended to the body of the check to form
 # valid XML
@@ -29,8 +32,8 @@ oval_header = '''<?xml version="1.0" encoding="UTF-8"?>
         <oval:product_name>testcheck.py</oval:product_name>
         <oval:product_version>0.0.1</oval:product_version>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2011-09-23T13:44:00</oval:timestamp>
-    </generator>'''
+        <oval:timestamp>%s</oval:timestamp>
+    </generator>''' % (timestamp)
 
 # the "oval_footer" variable must be appended to the body of the check to form
 # valid XML


### PR DESCRIPTION
This change replaces the time stamp in the header of the OVAL file generated with an actual time stamp of when the file was actually generated.