### PR TITLE
Added support scripts.

### DIFF
--- a/shared/transforms/stats.sh
+++ b/shared/transforms/stats.sh
@@ -1,0 +1,68 @@
+if [ -e input/auxiliary/stig_overlay.xml ]; then
+	XCCDF_FILE=`find references -name \*xccdf.xml 2>/dev/null`
+	if [ -e "$XCCDF_FILE" ]; then
+		grep "<version>" $XCCDF_FILE | sed -e 's/.*<version>//' -e 's/<\/version>.*//' -e 's/ .*//g' | grep -v ^[0-9] | sort -u > xccdfchecks.out
+		cat xccdfchecks.out | while read CHECK; do
+			if [ "`grep -c $CHECK input/auxiliary/stig_overlay.xml`" = "0" ]; then
+				echo "$CHECK" >> stigtochecksnotfound.out
+			fi
+		done
+	fi
+	grep "ruleid" input/auxiliary/stig_overlay.xml | grep -v 'ownerid="SRG' | sed 's/.*<overlay //g' | awk '{ print $3"|"$2 }' | cut -d'"' -f2,4 | sed 's/\"/\|/' | while read ENTRY; do
+		STIG_ID=`echo $ENTRY | cut -d"|" -f1`
+		CHECK_ID=`echo $ENTRY | cut -d"|" -f2`
+		if [ "$(echo $CHECK_ID | egrep -c '^(XXXX|unmet_)')" != "0" ]; then
+			echo "$STIG_ID" >> nochecks.out
+		elif [ "$(echo $CHECK_ID | egrep -c '^(met_)')" != "0" ]; then
+			echo "$STIG_ID|$CHECK_ID" >> inherentchecks.out
+		else
+			echo "$STIG_ID|$CHECK_ID" >> checks.out
+		fi
+		if [ -e "$XCCDF_FILE" ]; then
+			if [ "`grep -c ${STIG_ID} xccdfchecks.out`" != "0" ]; then
+				echo "$STIG_ID|$CHECK_ID" >> checkstostigfound.out
+			else
+				echo "$STIG_ID|$CHECK_ID" >> checkstostignotfound.out
+			fi
+		fi
+	done
+	if [ -e checks.out ]; then
+		cat checks.out | cut -d "|" -f2 | sort -u | while read ENTRY; do
+			if [ ! -e "input/checks/${ENTRY}.xml" ] && [ ! -e "${SHARED}/oval/${ENTRY}.xml" ]; then
+				echo "${ENTRY}" >> missingchecks.out
+			else
+				echo "${ENTRY}" >> foundchecks.out
+			fi
+			if [ ! -e "input/fixes/bash/${ENTRY}.sh" ] && [ ! -e "${SHARED}/fixes/bash/${ENTRY}.xml" ]; then
+				echo "${ENTRY}" >> missingfixes.out
+			else
+				echo "${ENTRY}" >> foundfixes.out
+			fi
+		done
+	fi
+
+	echo -e "\nSTIG INTEGRATION SUMMARY:\n\n"
+	if [ -e "$XCCDF_FILE" ]; then
+		echo -e "TOTAL XCCDF STIG REQUIREMENTS: `grep -c ^ xccdfchecks.out`\n"
+	fi
+	echo -e "TOTAL SSG STIG REQUIREMENTS: `grep "ruleid" input/auxiliary/stig_overlay.xml | grep -v 'ownerid="SRG' | grep -c ^`\n"
+	if [ -e "foundchecks.out" ]; then
+		echo -e "TOTAL SSG STIG CHECKS: `grep -c ^ foundchecks.out`\n"
+	else
+		echo -e "TOTAL SSG STIG CHECKS: 0\n"
+	fi
+	if [ -e "foundfixes.out" ]; then
+		echo -e "TOTAL SSG STIG FIXES: `grep -c ^ foundfixes.out`\n"
+	else
+		echo -e "TOTAL SSG STIG FIXES: 0\n"
+	fi
+	if [ -e checkstostignotfound.out ] && [ ! -z checkstostignotfound.out ]; then
+		echo -e "\nSSG STIG REQUIREMENTS NOT FOUND IN XCCDF STIG: `grep -c ^ checkstostignotfound.out`\n"
+		cat checkstostignotfound.out
+	fi
+	if [ -e stigtochecksnotfound.out ] && [ ! -z stigtochecksnotfound.out ]; then
+		echo -e "\nXCCDF STIG REQUIREMENTS NOT FOUND IN SSG STIG: `grep -c ^ stigtochecksnotfound.out`\n"
+		cat stigtochecksnotfound.out
+	fi
+	rm -f *.out
+fi

--- a/shared/transforms/stig_refs.sh
+++ b/shared/transforms/stig_refs.sh
@@ -1,0 +1,61 @@
+# For this to work, you need to:
+# 1) Download the latest STIG, 
+# 2) Extract the xccdf file into the root project folder (i.e. RHEL\5), 
+# 3) Run this script from that same project folder.
+if [ -e input/auxiliary/stig_overlay.xml ]; then
+	XCCDF_FILE=`find references -name \*xccdf.xml 2>/dev/null`
+	if [ -e "$XCCDF_FILE" ]; then
+		grep "<Group " $XCCDF_FILE | sed -e 's/.*<Group id="//' -e 's/">.*//' | sort -u > xccdfchecks.out
+		RULES="$(grep -c ^ xccdfchecks.out)"
+		LINE=1
+		cat xccdfchecks.out | while read VKEY; do
+			echo "Processing rule ${LINE} of ${RULES}"
+			STIG_ID=$(awk "/<Group id=\"${VKEY}\"/,/<\/Group/" $XCCDF_FILE | grep "<version>" | sed -e "s/.*<version>//" -e "s/<\/version>.*//")
+			CCI=$(awk "/<Group id=\"${VKEY}\"/,/<\/Group/" $XCCDF_FILE | grep -i '<ident.*cci' | cut -d'>' -f2 | cut -d'<' -f1 | sed ':a;N;$!ba;s/\n/,/g' | sed 's/[cC][cC][iI]-[0]*//g')
+			CCE=$(awk "/<Group id=\"${VKEY}\"/,/<\/Group/" $XCCDF_FILE | grep -i '<ident.*cce' | cut -d'>' -f2 | cut -d'<' -f1 | sed ':a;N;$!ba;s/\n/,/g' | sed 's/[cC][cC][eE]-//g')
+			SEVERITY=$(awk "/<Group id=\"${VKEY}\"/,/<\/Group/" $XCCDF_FILE |  grep 'severity=' | sed -e 's/.*severity="//' -e 's/".*//')
+			SVKEY=$(awk "/<Group id=\"${VKEY}\"/,/<\/Group/" $XCCDF_FILE | grep -i 'Rule id=' | sed -e 's/.*Rule id="SV-//' -e 's/r[0-9].*//')
+			VRELEASE=$(awk "/<Group id=\"${VKEY}\"/,/<\/Group/" $XCCDF_FILE | grep -i 'Rule id=' | sed -e 's/.*Rule id="SV-[0-9]*//' -e 's/r\([0-9]\).*/\1/')
+			IACONTROLS=$(awk "/<Group id=\"${VKEY}\"/,/<\/Group/" $XCCDF_FILE | grep "&lt;IAControls&gt;" | sed -e 's/.*&lt;IAControls&gt;//' -e 's/&.*//' -e 's/,[ ]*/,/g')
+			TITLE=$(awk "/<Group id=\"${VKEY}\"/,/<\/Group/" $XCCDF_FILE | awk "/<Rule /,/<\/Rule>/" | grep '<title>' | sed -e "s/.*<title>//" -e "s/<\/title>.*//")
+			RULE_ID=$(grep "<overlay.*ownerid=\"${STIG_ID}\"" input/auxiliary/stig_overlay.xml | sed -e 's/.*ruleid="//' -e 's/".*//')
+			echo "${VKEY}|${STIG_ID}|${CCI}|${CCE}|${SEVERITY}|${SVKEY}|${VRELEASE}|${IACONTROLS}|${TITLE}|${RULE_ID}"
+			sed -i -e "/<overlay.*ownerid=\"${STIG_ID}\"/,/<\/overlay>/s/disa=\"[0-9]*\"/disa=\"$(echo ${CCI} | cut -d"," -f1)\"/" -e "/<overlay.*ownerid=\"${STIG_ID}\"/,/<\/overlay>/s/severity=\"[a-z]*\"/severity=\"${SEVERITY}\"/" -e "/<overlay.*ownerid=\"${STIG_ID}\"/,/<\/overlay>/s/VKey=\"[0-9]*\"/VKey=\"$(echo ${VKEY}|sed 's/[vV]-//')\"/" -e "/<overlay.*ownerid=\"${STIG_ID}\"/,/<\/overlay>/s/SVKey=\"[0-9]*\"/SVKey=\"${SVKEY}\"/" -e "/<overlay.*ownerid=\"${STIG_ID}\"/,/<\/overlay>/s/VRelease=\"[0-9]*\"/VRelease=\"${VRELEASE}\"/" -e "\|<overlay.*ownerid=\"${STIG_ID}\"|,\|</overlay>|s|<title>.*</title>|<title>${TITLE}</title>|" input/auxiliary/stig_overlay.xml
+			if [ "$(grep -R "<Rule id=\"${RULE_ID}\"" input/services input/system 2>/dev/null| grep -c ^)" != 0 ]; then
+				grep -R "<Rule id=\"${RULE_ID}\"" input/services input/system 2>/dev/null | cut -d: -f1 | uniq | while read FILE; do
+					# SEVERITY
+					sed -i -e "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/s/severity=\"[a-z]*\"/severity=\"${SEVERITY}\"/" ${FILE}
+					# CCE
+					if [ ! -z "${CCE}" ]; then
+						if [ "$(awk "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/" ${FILE} | grep -c "<ident ")" = "0" ]; then
+							sed -i "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/s/\(<\/Rule>\)/<ident cce=\"${CCE}\" \/>\n\1/" ${FILE}
+						elif [ "$(awk "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/" ${FILE} | grep "<ident " | grep -c "cce=")" = "0" ]; then
+							sed -i "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/s/\(<ident .*\)\/>/\1 cce=\"${CCE}\" \/>/" ${FILE}
+						else
+							sed -i "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/s/\(<ident .*\)cce=\"[a-zA-Z0-9-_.]*\"/\1cce=\"${CCE}\"/" ${FILE}
+						fi
+					fi
+					# STIG ID
+					if [ ! -z "${STIG_ID}" ]; then
+						if [ "$(awk "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/" ${FILE} | grep -c "<ident ")" = "0" ]; then
+							sed -i "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/s/\(<\/Rule>\)/<ident stig=\"${STIG_ID}\" \/>\n\1/" ${FILE}
+						elif [ "$(awk "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/" ${FILE} | grep "<ident " | grep -c "stig=")" = "0" ]; then
+							sed -i "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/s/\(<ident .*\)\/>/\1 stig=\"${STIG_ID}\" \/>/" ${FILE}
+						else
+							sed -i "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/s/\(<ident .*\)stig=\"[a-zA-Z0-9-_.]*\"/\1cce=\"${STIG_ID}\"/" ${FILE}
+						fi
+					fi
+					# CCI
+					# IA CONTROL
+					if [ "$(awk "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/" ${FILE} | grep -c "<ref ")" != "0" ]; then
+						sed -i "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/s/<ref .*/<ref nist=\"${IACONTROLS}\" disa=\"${CCI}\" \/>/" ${FILE}
+					else
+						sed -i "/<Rule id=\"${RULE_ID}\"/,/<\/Rule>/s/\(<\/Rule>\)/<ref nist=\"${IACONTROLS}\" disa=\"${CCI}\" \/>\n\1/" ${FILE}
+					fi
+				done
+			fi
+			LINE="$(expr ${LINE} + 1)"
+		done
+	fi
+	rm -f *.out
+fi


### PR DESCRIPTION
- Added a change to 'RHEL/6/transforms/shorthand2xccdf.xslt' to allow the 'ident' field to support a STIG ID.
- Ran the shared/transforms/stig_refs.sh script to update all STIG references in the RHEL6 content.
- Added the latest RHEL6 STIG XCCDF document for comparison.