### PR TITLE
Improved logic of test "file_permissions_ungroupowned".

### DIFF
--- a/RHEL/6/input/checks/file_permissions_ungroupowned.xml
+++ b/RHEL/6/input/checks/file_permissions_ungroupowned.xml
@@ -14,13 +14,12 @@
     </criteria>
   </definition>
   <unix:file_test xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
-  check="all" comment="files with no group owner"
+  check="all" comment="files with no group owner" check_existence="none_exist"
   id="test_file_permissions_ungroupowned" version="1">
     <notes>
       <note>This will enumerate all files on local partitions</note>
     </notes>
     <unix:object object_ref="object_file_permissions_ungroupowned" />
-    <unix:state state_ref="state_file_permissions_ungroupowned" />
   </unix:file_test>
   <unix:file_state comment="Executables with suid set"
   id="state_file_permissions_ungroupowned" version="1">
@@ -35,5 +34,6 @@
     <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" />
     <unix:path>/</unix:path>
     <unix:filename operation="pattern match">.*</unix:filename>
+    <filter action="include">state_file_permissions_ungroupowned</filter>
   </unix:file_object>
 </def-group>

--- a/RHEL/6/input/checks/file_permissions_ungroupowned.xml
+++ b/RHEL/6/input/checks/file_permissions_ungroupowned.xml
@@ -21,7 +21,7 @@
     </notes>
     <unix:object object_ref="object_file_permissions_ungroupowned" />
   </unix:file_test>
-  <unix:file_state comment="Executables with suid set"
+  <unix:file_state comment="Files that are owned by a group."
   id="state_file_permissions_ungroupowned" version="1">
     <unix:group_id datatype="int" var_ref="variable_file_permissions_ungroupowned" var_check="at least one"/>
   </unix:file_state>

--- a/RHEL/6/input/checks/file_permissions_ungroupowned.xml
+++ b/RHEL/6/input/checks/file_permissions_ungroupowned.xml
@@ -10,7 +10,7 @@
     </metadata>
     <criteria>
       <criterion comment="Check all files and make sure they are owned by a group"
-      negate="true" test_ref="test_file_permissions_ungroupowned" />
+      test_ref="test_file_permissions_ungroupowned" />
     </criteria>
   </definition>
   <unix:file_test xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
@@ -23,7 +23,7 @@
   </unix:file_test>
   <unix:file_state comment="Executables with suid set"
   id="state_file_permissions_ungroupowned" version="1">
-    <unix:group_id datatype="int">0</unix:group_id>
+    <unix:group_id datatype="int" var_ref="variable_file_permissions_ungroupowned" var_check="at least one"/>
   </unix:file_state>
 
   <unix:file_object comment="all local files" id="object_file_permissions_ungroupowned" version="1">
@@ -34,6 +34,15 @@
     <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" />
     <unix:path>/</unix:path>
     <unix:filename operation="pattern match">.*</unix:filename>
-    <filter action="include">state_file_permissions_ungroupowned</filter>
+    <filter action="exclude">state_file_permissions_ungroupowned</filter>
   </unix:file_object>
+  <ind:textfilecontent54_object id="etc_group_object" version="1">
+        <ind:filepath>/etc/group</ind:filepath>
+        <ind:pattern operation="pattern match">^[^:]+:[^:]*:([\d]+):[^:]*$</ind:pattern>
+        <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+   <local_variable id="variable_file_permissions_ungroupowned" datatype="int" version="1" comment="all GIDs on the target system">
+        <object_component object_ref="etc_group_object" item_field="subexpression"/>
+   </local_variable>
 </def-group>


### PR DESCRIPTION
It does not collect all files in whole filesystem. It collects only files which have no GID.
Avoids this warning message:
<message level="warning">Object is incomplete due to memory constraints.</message>