### PR TITLE
Update list of Fedora CPEs

### DIFF
--- a/Fedora/input/guide.xml
+++ b/Fedora/input/guide.xml
@@ -35,8 +35,9 @@ quality, reliability, or any other characteristic.</notice>
 trademarks or trademarks of Red Hat, Inc. in the United States and other
 countries. All other names are registered trademarks or trademarks of their
 respective companies.</rear-matter>
+<platform idref="cpe:/o:fedoraproject:fedora:23" />
+<platform idref="cpe:/o:fedoraproject:fedora:22" />
 <platform idref="cpe:/o:fedoraproject:fedora:21" />
 <platform idref="cpe:/o:fedoraproject:fedora:20" />
-<platform idref="cpe:/o:fedoraproject:fedora:19" />
 <version>0.0.4</version>
 </Benchmark>


### PR DESCRIPTION
Fedora 19 is end-of-live. Fedora 22 has been branched. Fedora 23 is now
rawhide.