### PR TITLE
Make CPE Dictionary not compulsory.

### DIFF
--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -70,8 +70,6 @@ dist: guide content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
-	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
-	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 
 eval-common: content
 	oscap xccdf eval --profile common $(OUT)/$(ID)-$(PROD)-xccdf.xml


### PR DESCRIPTION
Addressing failing `make` that I have broken previously. As I did not
noticed because I haven't run `make clean`.

Sorry for missing this out. :-(