### PR TITLE
[BugFix] [RHEL/6] Rewrite (RHEL-6) mount_option_no{dev,exec,suid}_removable_partitions.xml OVAL checks not to return false alerts when scanning /etc/fstab entries not belonging to removable devices / partitions

### DIFF
--- a/RHEL/6/input/checks/mount_option_nodev_removable_partitions.xml
+++ b/RHEL/6/input/checks/mount_option_nodev_removable_partitions.xml
@@ -1,57 +1,163 @@
 <def-group>
-  <definition class="compliance" id="mount_option_nodev_removable_partitions" version="1">
+  <definition class="compliance" id="mount_option_nodev_removable_partitions" version="2">
     <metadata>
       <title>Add nodev Option to Removable Media Partitions</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
-      <description>The nodev mount option prevents files from being
-      interpreted as character or block devices. Legitimate character and block
-      devices should exist in the /dev directory on the root partition or
-      within chroot jails built for system services. All other locations should not
-      allow character and block devices.</description>
+      <description>The nodev mount option prevents files from being interpreted
+      as character or block devices. Legitimate character and block devices
+      should exist in the /dev directory on the root partition or within chroot
+      jails built for system services. All other locations should not allow
+      character and block devices.</description>
+      <reference source="JL" ref_id="RHEL6_20150305" ref_url="test_attestation"/>
     </metadata>
     <criteria operator="OR">
-      <criterion test_ref="test_removable_partition_doesnt_exist" comment="check if removable partition exists" />
-      <criterion test_ref="test_nodev_removable_partition" comment="nodev on removable partition" />
-      <criterion test_ref="test_nodev_etc_fstab_removable_partition" comment="removable partition /etc/fstab" />
+      <!-- First check if specified removable partition truly exists on the system. If not, don't check /etc/fstab & runtime configuration
+           since there's no device to check against -->
+      <criterion test_ref="test_removable_partition_doesnt_exist" comment="Check if removable partition really exists on the system" />
+      <!-- Removable device exists. Check if it's CD/DVD drive. If so, verify that at least one from all of the possible its alternative
+           names in /etc/fstab & runtime configuration are configured with 'nodev' option -->
+      <criteria operator="AND">
+        <criterion test_ref="test_var_removable_partition_is_cd_dvd_drive" comment="Check if removable partition value represents CD/DVD drive" />
+        <criterion test_ref="test_nodev_etc_fstab_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'nodev' mount option in /etc/fstab" />
+        <criterion test_ref="test_nodev_runtime_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'nodev' mount option in runtime configuration" />
+      </criteria>
+      <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with 'nodev' mount option in both
+           /etc/fstab & runtime configuration -->
+      <criteria operator="AND">
+        <criterion test_ref="test_nodev_etc_fstab_not_cd_dvd_drive" comment="Check if removable partition is using 'nodev' mount option in /etc/fstab" />
+        <criterion test_ref="test_nodev_runtime_not_cd_dvd_drive" comment="Check if removable partition is using 'nodev' mount option in runtime configuration" />
+      </criteria>
     </criteria>
   </definition>
 
-  <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist" comment="check if expected removable partitions truly exist on the system" version="1">
+  <!-- First check if specified removable partition really exists on the system.
+       If not return PASS since there's nothing to check /etc/fstab & runtime settings against. -->
+  <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist" comment="Check if expected removable partitions truly exist on the system" version="1">
     <unix:object object_ref="object_removable_partition_doesnt_exist" />
   </unix:file_test>
-
-  <linux:partition_test id="test_nodev_removable_partition" check="all" check_existence="all_exist" comment="nodev on removable partition" version="1">
-    <linux:object object_ref="object_removable_partition_nodev" />
-    <linux:state state_ref="state_partition_removable_partition_nodev" />
-  </linux:partition_test>
-
-  <ind:textfilecontent54_test id="test_nodev_etc_fstab_removable_partition" check="at least one" comment="removable partition /etc/fstab" version="1">
-    <ind:object object_ref="object_etc_fstab_removable_partition_nodev" />
-    <ind:state state_ref="state_text_removable_partition_nodev" />
-  </ind:textfilecontent54_test>
 
   <unix:file_object id="object_removable_partition_doesnt_exist" version="1">
     <unix:filepath var_ref="var_removable_partition" var_check="at least one" />
   </unix:file_object>
 
-  <linux:partition_object id="object_removable_partition_nodev" version="1">
-    <linux:mount_point var_ref="var_removable_partition" />
+  <!-- Specified removable partition exists on the system. Check if it represents a CD / DVD drive -->
+  <ind:variable_test id="test_var_removable_partition_is_cd_dvd_drive" check="all" comment="Check if removable partition variable value represents CD/DVD drive" version="1">
+    <ind:object object_ref="object_var_removable_partition_is_cd_dvd_drive" />
+    <ind:state state_ref="state_var_removable_partition_is_cd_dvd_drive" />
+  </ind:variable_test>
+
+  <ind:variable_object id="object_var_removable_partition_is_cd_dvd_drive" version="1">
+    <ind:var_ref>var_removable_partition</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="state_var_removable_partition_is_cd_dvd_drive" version="1">
+    <ind:value operation="equals">/dev/cdrom</ind:value>
+  </ind:variable_state>
+
+  <!-- If specified removable partition represents CD / DVD drive, create a variable
+       holding also alternative names for CD / DVD block special device as used by udev -->
+  <constant_variable id="variable_cd_dvd_drive_alternative_names" datatype="string" comment="CD/DVD drive alternative names whitelist" version="1">
+    <value>/dev/cdrom</value>
+    <value>/dev/dvd</value>
+    <value>/dev/scd0</value>
+    <value>/dev/sr0</value>
+  </constant_variable>
+
+  <!-- For each of the CD / DVD drive alternative names create regular expression pattern
+       to be used in textfilecontent54_object below -->
+  <local_variable id="variable_cd_dvd_drive_regex_pattern" datatype="string" comment="Regular expression pattern for CD / DVD drive alternative names" version="1">
+    <concat>
+      <literal_component>^[\s]*</literal_component>
+      <variable_component var_ref="variable_cd_dvd_drive_alternative_names" />
+      <!-- Capture the mount options field (4-th column of /etc/fstab) -->
+      <literal_component>[\s]+[/\w]+[\s]+[\w]+[\s]+([^\s]+)(?:[\s]+[\d]+){2}$</literal_component>
+    </concat>
+  </local_variable>
+
+  <!-- If specified removable partition represents CD / DVD drive, use all alternative
+       names to check /etc/fstab & runtime settings -->
+  <ind:textfilecontent54_test id="test_nodev_etc_fstab_cd_dvd_drive" check="all" comment="'nodev' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
+    <ind:object object_ref="object_nodev_etc_fstab_cd_dvd_drive" />
+    <ind:state state_ref="state_nodev_etc_fstab_cd_dvd_drive" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_nodev_etc_fstab_cd_dvd_drive" version="1">
+    <ind:filepath>/etc/fstab</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string" var_ref="variable_cd_dvd_drive_regex_pattern" var_check="at least one" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_nodev_etc_fstab_cd_dvd_drive" version="1">
+    <ind:subexpression operation="pattern match" datatype="string">^.*,?nodev,?.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <linux:partition_test id="test_nodev_runtime_cd_dvd_drive" check="all" comment="'nodev' mount option used for at least one CD / DVD drive alternative names in runtime configuration" version="1">
+    <linux:object object_ref="object_nodev_runtime_cd_dvd_drive" />
+  </linux:partition_test>
+
+  <linux:partition_object id="object_nodev_runtime_cd_dvd_drive" version="1">
+    <!-- CD / DVD drive can be mounted under any mount_point. We don't know ahead its exact name.
+         => Capture all & filter out only the relevant ones via the corresponding state -->
+    <linux:mount_point operation="pattern match">^.*$</linux:mount_point>
+    <!-- Therefore from all the captured mount points select only those having
+         device set to some CD / DVD drive alternative name and simultaneously
+         having 'nodev' mount option used -->
+    <filter action="include">state_nodev_runtime_cd_dvd_drive</filter>
   </linux:partition_object>
-  <linux:partition_state id="state_partition_removable_partition_nodev" version="1">
+
+  <linux:partition_state id="state_nodev_runtime_cd_dvd_drive" version="1">
+    <linux:device datatype="string" operation="equals" var_ref="variable_cd_dvd_drive_alternative_names" var_check="at least one" />
     <linux:mount_options datatype="string" entity_check="at least one" operation="equals">nodev</linux:mount_options>
   </linux:partition_state>
 
-  <ind:textfilecontent54_object id="object_etc_fstab_removable_partition_nodev" version="1">
+  <!-- Specified removable partition exists & doesn't represent a CD/DVD drive.
+       Check if configured with 'nodev' mount option in both /etc/fstab & runtime configuration -->
+  <ind:textfilecontent54_test id="test_nodev_etc_fstab_not_cd_dvd_drive" check="at least one" check_existence="all_exist" comment="Check if removable partition is configured with 'nodev' mount option in /etc/fstab" version="1">
+    <ind:object object_ref="object_nodev_etc_fstab_not_cd_dvd_drive" />
+    <ind:state state_ref="state_nodev_etc_fstab_not_cd_dvd_drive" />
+  </ind:textfilecontent54_test>
+
+  <!-- Create regular expression pattern for the device to be used in the
+       textfilecontent54_object below -->
+  <local_variable id="variable_not_cd_dvd_drive_regex_pattern" datatype="string" comment="Regular expression pattern for removable block special device other than CD / DVD drive" version="1">
+    <concat>
+      <literal_component>^[\s]*</literal_component>
+      <variable_component var_ref="var_removable_partition" />
+      <!-- Capture the mount options field (4-th column of /etc/fstab) -->
+      <literal_component>[\s]+[/\w]+[\s]+[\w]+[\s]+([^\s]+)(?:[\s]+[\d]+){2}$</literal_component>
+    </concat>
+  </local_variable>
+
+  <ind:textfilecontent54_object id="object_nodev_etc_fstab_not_cd_dvd_drive" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*([/\w]*)\s+.*,?nodev,?.*$</ind:pattern>
-    <!-- the "not equal" operation essentially means all instances of the regexp -->
-    <ind:instance datatype="int" operation="not equal">0</ind:instance>
+    <ind:pattern operation="pattern match" datatype="string" var_ref="variable_not_cd_dvd_drive_regex_pattern" var_check="at least one" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_text_removable_partition_nodev" version="1">
-    <ind:subexpression datatype="string" var_ref="var_removable_partition" />
+
+  <ind:textfilecontent54_state id="state_nodev_etc_fstab_not_cd_dvd_drive" version="1">
+    <ind:subexpression operation="pattern match" datatype="string">^.*,?nodev,?.*</ind:subexpression>
   </ind:textfilecontent54_state>
+
+  <linux:partition_test id="test_nodev_runtime_not_cd_dvd_drive" check="all" check_existence="all_exist" comment="'nodev' mount option used for removable partition in runtime configuration" version="1">
+    <linux:object object_ref="object_nodev_runtime_not_cd_dvd_drive" />
+  </linux:partition_test>
+
+  <linux:partition_object id="object_nodev_runtime_not_cd_dvd_drive" version="1">
+    <!-- Removable partition can be mounted under any mount point. We don't know it's
+         exact name ahead => capture all & filter out only those relevant later via state -->
+    <linux:mount_point operation="pattern match">^.*$</linux:mount_point>
+    <!-- From all the captured mount points select only those having device equal
+         to 'var_removable_partition' variable value and simultaneously having
+         'nodev' mount option set -->
+    <filter action="include">state_nodev_runtime_not_cd_dvd_drive</filter>
+  </linux:partition_object>
+
+  <linux:partition_state id="state_nodev_runtime_not_cd_dvd_drive" version="1">
+    <linux:device datatype="string" operation="equals" var_ref="var_removable_partition" var_check="at least one" />
+    <linux:mount_options datatype="string" entity_check="at least one" operation="equals">nodev</linux:mount_options>
+  </linux:partition_state>
 
   <external_variable comment="removable partition" datatype="string" id="var_removable_partition" version="1" />
 

--- a/RHEL/6/input/checks/mount_option_nodev_removable_partitions.xml
+++ b/RHEL/6/input/checks/mount_option_nodev_removable_partitions.xml
@@ -32,6 +32,12 @@
     </criteria>
   </definition>
 
+  <!-- IMPORTANT NOTE: Selected OVAL entities (tests, objects, and states) are used also by the following OVAL checks:
+       * mount_option_noexec_removable_partitions.xml
+
+       therefore DON'T edit the identifiers on these entities WITHOUT editing their corresponding counterparts in those
+       referencing OVAL checks too. See the mount_option_nodev_removable_partitions.xml definition for further details -->
+
   <!-- First check if specified removable partition really exists on the system.
        If not return PASS since there's nothing to check /etc/fstab & runtime settings against. -->
   <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist" comment="Check if expected removable partitions truly exist on the system" version="1">

--- a/RHEL/6/input/checks/mount_option_nodev_removable_partitions.xml
+++ b/RHEL/6/input/checks/mount_option_nodev_removable_partitions.xml
@@ -33,10 +33,14 @@
   </definition>
 
   <!-- IMPORTANT NOTE: Selected OVAL entities (tests, objects, and states) are used also by the following OVAL checks:
-       * mount_option_noexec_removable_partitions.xml
+       * mount_option_noexec_removable_partitions.xml, and
+       * mount_option_nosuid_removable_partitions.xml.
 
-       therefore DON'T edit the identifiers on these entities WITHOUT editing their corresponding counterparts in those
-       referencing OVAL checks too. See the mount_option_nodev_removable_partitions.xml definition for further details -->
+       Therefore DON'T edit the identifiers on these entities WITHOUT editing their corresponding counterparts in those
+       referencing OVAL checks too.
+
+       See the mount_option_nodev_removable_partitions.xml and mount_option_nosuid_removable_partitions.xml definitions
+       for further details -->
 
   <!-- First check if specified removable partition really exists on the system.
        If not return PASS since there's nothing to check /etc/fstab & runtime settings against. -->

--- a/RHEL/6/input/checks/mount_option_nodev_removable_partitions.xml
+++ b/RHEL/6/input/checks/mount_option_nodev_removable_partitions.xml
@@ -32,16 +32,6 @@
     </criteria>
   </definition>
 
-  <!-- IMPORTANT NOTE: Selected OVAL entities (tests, objects, and states) are used also by the following OVAL checks:
-       * mount_option_noexec_removable_partitions.xml, and
-       * mount_option_nosuid_removable_partitions.xml.
-
-       Therefore DON'T edit the identifiers on these entities WITHOUT editing their corresponding counterparts in those
-       referencing OVAL checks too.
-
-       See the mount_option_nodev_removable_partitions.xml and mount_option_nosuid_removable_partitions.xml definitions
-       for further details -->
-
   <!-- First check if specified removable partition really exists on the system.
        If not return PASS since there's nothing to check /etc/fstab & runtime settings against. -->
   <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist" comment="Check if expected removable partitions truly exist on the system" version="1">

--- a/RHEL/6/input/checks/mount_option_noexec_removable_partitions.xml
+++ b/RHEL/6/input/checks/mount_option_noexec_removable_partitions.xml
@@ -33,20 +33,49 @@
     </criteria>
   </definition>
 
-  <!-- The following OVAL items:
+  <!-- First check if specified removable partition really exists on the system.
+       If not return PASS since there's nothing to check /etc/fstab & runtime settings against. -->
+  <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist" comment="Check if expected removable partitions truly exist on the system" version="1">
+    <unix:object object_ref="object_removable_partition_doesnt_exist" />
+  </unix:file_test>
 
-       * test_removable_partition_doesnt_exist,
-       * object_removable_partition_doesnt_exist,
-       * test_var_removable_partition_is_cd_dvd_drive,
-       * object_var_removable_partition_is_cd_dvd_drive,
-       * state_var_removable_partition_is_cd_dvd_drive,
-       * variable_cd_dvd_drive_alternative_names,
-       * variable_cd_dvd_drive_regex_pattern,
-       * variable_not_cd_dvd_drive_regex_pattern, and
-       * var_removable_partition
+  <unix:file_object id="object_removable_partition_doesnt_exist" version="1">
+    <unix:filepath var_ref="var_removable_partition" var_check="at least one" />
+  </unix:file_object>
 
-       are defined in RHEL-6's 'mount_option_nodev_removable_partitions.xml' OVAL check. We will reuse them
-       and define only those OVAL items below that (slightly) differ from 'nodev' case -->
+  <!-- Specified removable partition exists on the system. Check if it represents a CD / DVD drive -->
+  <ind:variable_test id="test_var_removable_partition_is_cd_dvd_drive" check="all" comment="Check if removable partition variable value represents CD/DVD drive" version="1">
+    <ind:object object_ref="object_var_removable_partition_is_cd_dvd_drive" />
+    <ind:state state_ref="state_var_removable_partition_is_cd_dvd_drive" />
+  </ind:variable_test>
+
+  <ind:variable_object id="object_var_removable_partition_is_cd_dvd_drive" version="1">
+    <ind:var_ref>var_removable_partition</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="state_var_removable_partition_is_cd_dvd_drive" version="1">
+    <ind:value operation="equals">/dev/cdrom</ind:value>
+  </ind:variable_state>
+
+  <!-- If specified removable partition represents CD / DVD drive, create a variable
+       holding also alternative names for CD / DVD block special device as used by udev -->
+  <constant_variable id="variable_cd_dvd_drive_alternative_names" datatype="string" comment="CD/DVD drive alternative names whitelist" version="1">
+    <value>/dev/cdrom</value>
+    <value>/dev/dvd</value>
+    <value>/dev/scd0</value>
+    <value>/dev/sr0</value>
+  </constant_variable>
+
+  <!-- For each of the CD / DVD drive alternative names create regular expression pattern
+       to be used in textfilecontent54_object below -->
+  <local_variable id="variable_cd_dvd_drive_regex_pattern" datatype="string" comment="Regular expression pattern for CD / DVD drive alternative names" version="1">
+    <concat>
+      <literal_component>^[\s]*</literal_component>
+      <variable_component var_ref="variable_cd_dvd_drive_alternative_names" />
+      <!-- Capture the mount options field (4-th column of /etc/fstab) -->
+      <literal_component>[\s]+[/\w]+[\s]+[\w]+[\s]+([^\s]+)(?:[\s]+[\d]+){2}$</literal_component>
+    </concat>
+  </local_variable>
 
   <!-- If specified removable partition represents CD / DVD drive, use all alternative
        names to check /etc/fstab & runtime settings -->
@@ -91,6 +120,17 @@
     <ind:state state_ref="state_noexec_etc_fstab_not_cd_dvd_drive" />
   </ind:textfilecontent54_test>
 
+  <!-- Create regular expression pattern for the device to be used in the
+       textfilecontent54_object below -->
+  <local_variable id="variable_not_cd_dvd_drive_regex_pattern" datatype="string" comment="Regular expression pattern for removable block special device other than CD / DVD drive" version="1">
+    <concat>
+      <literal_component>^[\s]*</literal_component>
+      <variable_component var_ref="var_removable_partition" />
+      <!-- Capture the mount options field (4-th column of /etc/fstab) -->
+      <literal_component>[\s]+[/\w]+[\s]+[\w]+[\s]+([^\s]+)(?:[\s]+[\d]+){2}$</literal_component>
+    </concat>
+  </local_variable>
+
   <ind:textfilecontent54_object id="object_noexec_etc_fstab_not_cd_dvd_drive" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
     <ind:pattern operation="pattern match" datatype="string" var_ref="variable_not_cd_dvd_drive_regex_pattern" var_check="at least one" />
@@ -119,5 +159,7 @@
     <linux:device datatype="string" operation="equals" var_ref="var_removable_partition" var_check="at least one" />
     <linux:mount_options datatype="string" entity_check="at least one" operation="equals">noexec</linux:mount_options>
   </linux:partition_state>
+
+  <external_variable comment="removable partition" datatype="string" id="var_removable_partition" version="1" />
 
 </def-group>

--- a/RHEL/6/input/checks/mount_option_noexec_removable_partitions.xml
+++ b/RHEL/6/input/checks/mount_option_noexec_removable_partitions.xml
@@ -1,60 +1,123 @@
 <def-group>
-  <definition class="compliance" id="mount_option_noexec_removable_partitions" version="1">
+  <definition class="compliance" id="mount_option_noexec_removable_partitions" version="2">
     <metadata>
       <title>Add noexec Option to Removable Media Partitions</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
-      <description>The noexec mount option prevents the direct
-      execution of binaries on the mounted filesystem. Users should not
-      be allowed to execute binaries that exist on partitions mounted
-      from removable media (such as a USB key). The noexec
-      option prevents code from being executed directly from the media
-      itself, and may therefore provide a line of defense against
-      certain types of worms or malicious code.</description>
+      <description>The noexec mount option prevents the direct execution of
+      binaries on the mounted filesystem. Users should not be allowed to
+      execute binaries that exist on partitions mounted from removable media
+      (such as a USB key). The noexec option prevents code from being executed
+      directly from the media itself, and may therefore provide a line of
+      defense against certain types of worms or malicious code.</description>
+      <reference source="JL" ref_id="RHEL6_20150305" ref_url="test_attestation"/>
     </metadata>
     <criteria operator="OR">
-      <criterion test_ref="test_removable_partition_doesnt_exist" comment="check if removable partition exists" />
-      <criterion test_ref="test_noexec_removable_partition" comment="noexec on removable partition" />
-      <criterion test_ref="test_noexec_etc_fstab_removable_partition" comment="removable partition /etc/fstab" />
+      <!-- First check if specified removable partition truly exists on the system. If not, don't check /etc/fstab & runtime configuration
+           since there's no device to check against -->
+      <criterion test_ref="test_removable_partition_doesnt_exist" comment="Check if removable partition really exists on the system" />
+      <!-- Removable device exists. Check if it's CD/DVD drive. If so, verify that at least one from all of the possible its alternative
+           names in /etc/fstab & runtime configuration are configured with 'noexec' option -->
+      <criteria operator="AND">
+        <criterion test_ref="test_var_removable_partition_is_cd_dvd_drive" comment="Check if removable partition value represents CD/DVD drive" />
+        <criterion test_ref="test_noexec_etc_fstab_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'noexec' mount option in /etc/fstab" />
+        <criterion test_ref="test_noexec_runtime_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'noexec' mount option in runtime configuration" />
+      </criteria>
+      <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with 'noexec' mount option in both
+           /etc/fstab & runtime configuration -->
+      <criteria operator="AND">
+        <criterion test_ref="test_noexec_etc_fstab_not_cd_dvd_drive" comment="Check if removable partition is using 'noexec' mount option in /etc/fstab" />
+        <criterion test_ref="test_noexec_runtime_not_cd_dvd_drive" comment="Check if removable partition is using 'noexec' mount option in runtime configuration" />
+      </criteria>
     </criteria>
   </definition>
 
-  <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist" comment="check if expected removable partitions truly exist on the system" version="1">
-    <unix:object object_ref="object_removable_partition_doesnt_exist" />
-  </unix:file_test>
+  <!-- The following OVAL items:
 
-  <linux:partition_test id="test_noexec_removable_partition" check="all" check_existence="all_exist" comment="noexec on removable partition" version="1">
-    <linux:object object_ref="object_removable_partition_noexec" />
-    <linux:state state_ref="state_noexec_removable_partition" />
-  </linux:partition_test>
+       * test_removable_partition_doesnt_exist,
+       * object_removable_partition_doesnt_exist,
+       * test_var_removable_partition_is_cd_dvd_drive,
+       * object_var_removable_partition_is_cd_dvd_drive,
+       * state_var_removable_partition_is_cd_dvd_drive,
+       * variable_cd_dvd_drive_alternative_names,
+       * variable_cd_dvd_drive_regex_pattern,
+       * variable_not_cd_dvd_drive_regex_pattern, and
+       * var_removable_partition
 
-  <ind:textfilecontent54_test id="test_noexec_etc_fstab_removable_partition" check="at least one" comment="removable partition /etc/fstab" version="1">
-    <ind:object object_ref="object_etc_fstab_removable_partition_noexec" />
-    <ind:state state_ref="state_text_noexec_removable_partition" />
+       are defined in RHEL-6's 'mount_option_nodev_removable_partitions.xml' OVAL check. We will reuse them
+       and define only those OVAL items below that (slightly) differ from 'nodev' case -->
+
+  <!-- If specified removable partition represents CD / DVD drive, use all alternative
+       names to check /etc/fstab & runtime settings -->
+  <ind:textfilecontent54_test id="test_noexec_etc_fstab_cd_dvd_drive" check="all" comment="'noexec' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
+    <ind:object object_ref="object_noexec_etc_fstab_cd_dvd_drive" />
+    <ind:state state_ref="state_noexec_etc_fstab_cd_dvd_drive" />
   </ind:textfilecontent54_test>
 
-  <unix:file_object id="object_removable_partition_doesnt_exist" version="1">
-    <unix:filepath var_ref="var_removable_partition" var_check="at least one" />
-  </unix:file_object>
+  <ind:textfilecontent54_object id="object_noexec_etc_fstab_cd_dvd_drive" version="1">
+    <ind:filepath>/etc/fstab</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string" var_ref="variable_cd_dvd_drive_regex_pattern" var_check="at least one" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
 
-  <linux:partition_object id="object_removable_partition_noexec" version="1">
-    <linux:mount_point var_ref="var_removable_partition" />
+  <ind:textfilecontent54_state id="state_noexec_etc_fstab_cd_dvd_drive" version="1">
+    <ind:subexpression operation="pattern match" datatype="string">^.*,?noexec,?.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <linux:partition_test id="test_noexec_runtime_cd_dvd_drive" check="all" comment="'noexec' mount option used for at least one CD / DVD drive alternative names in runtime configuration" version="1">
+    <linux:object object_ref="object_noexec_runtime_cd_dvd_drive" />
+  </linux:partition_test>
+
+  <linux:partition_object id="object_noexec_runtime_cd_dvd_drive" version="1">
+    <!-- CD / DVD drive can be mounted under any mount_point. We don't know ahead its exact name.
+         => Capture all & filter out only the relevant ones via the corresponding state -->
+    <linux:mount_point operation="pattern match">^.*$</linux:mount_point>
+    <!-- Therefore from all the captured mount points select only those having
+         device set to some CD / DVD drive alternative name and simultaneously
+         having 'noexec' mount option used -->
+    <filter action="include">state_noexec_runtime_cd_dvd_drive</filter>
   </linux:partition_object>
-  <linux:partition_state id="state_noexec_removable_partition" version="1">
+
+  <linux:partition_state id="state_noexec_runtime_cd_dvd_drive" version="1">
+    <linux:device datatype="string" operation="equals" var_ref="variable_cd_dvd_drive_alternative_names" var_check="at least one" />
     <linux:mount_options datatype="string" entity_check="at least one" operation="equals">noexec</linux:mount_options>
   </linux:partition_state>
 
-  <ind:textfilecontent54_object id="object_etc_fstab_removable_partition_noexec" version="1">
+  <!-- Specified removable partition exists & doesn't represent a CD/DVD drive.
+       Check if configured with 'noexec' mount option in both /etc/fstab & runtime configuration -->
+  <ind:textfilecontent54_test id="test_noexec_etc_fstab_not_cd_dvd_drive" check="at least one" check_existence="all_exist" comment="Check if removable partition is configured with 'noexec' mount option in /etc/fstab" version="1">
+    <ind:object object_ref="object_noexec_etc_fstab_not_cd_dvd_drive" />
+    <ind:state state_ref="state_noexec_etc_fstab_not_cd_dvd_drive" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_noexec_etc_fstab_not_cd_dvd_drive" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*([/\w]*)\s+.*,?noexec,?.*$</ind:pattern>
-    <!-- the "not equal" operation essentially means all instances of the regexp -->
-    <ind:instance datatype="int" operation="not equal">0</ind:instance>
+    <ind:pattern operation="pattern match" datatype="string" var_ref="variable_not_cd_dvd_drive_regex_pattern" var_check="at least one" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_text_noexec_removable_partition" version="1">
-    <ind:subexpression datatype="string" var_ref="var_removable_partition" />
+
+  <ind:textfilecontent54_state id="state_noexec_etc_fstab_not_cd_dvd_drive" version="1">
+    <ind:subexpression operation="pattern match" datatype="string">^.*,?noexec,?.*</ind:subexpression>
   </ind:textfilecontent54_state>
 
-  <external_variable comment="removable partition" datatype="string" id="var_removable_partition" version="1" />
+  <linux:partition_test id="test_noexec_runtime_not_cd_dvd_drive" check="all" check_existence="all_exist" comment="'noexec' mount option used for removable partition in runtime configuration" version="1">
+    <linux:object object_ref="object_noexec_runtime_not_cd_dvd_drive" />
+  </linux:partition_test>
+
+  <linux:partition_object id="object_noexec_runtime_not_cd_dvd_drive" version="1">
+    <!-- Removable partition can be mounted under any mount point. We don't know it's
+         exact name ahead => Capture all & filter out only those relevant later via state -->
+    <linux:mount_point operation="pattern match">^.*$</linux:mount_point>
+    <!-- From all the captured mount points select only those having device equal
+         to 'var_removable_partition' variable value and simultaneously having
+         'noexec' mount option set -->
+    <filter action="include">state_noexec_runtime_not_cd_dvd_drive</filter>
+  </linux:partition_object>
+
+  <linux:partition_state id="state_noexec_runtime_not_cd_dvd_drive" version="1">
+    <linux:device datatype="string" operation="equals" var_ref="var_removable_partition" var_check="at least one" />
+    <linux:mount_options datatype="string" entity_check="at least one" operation="equals">noexec</linux:mount_options>
+  </linux:partition_state>
 
 </def-group>

--- a/RHEL/6/input/checks/mount_option_nosuid_removable_partitions.xml
+++ b/RHEL/6/input/checks/mount_option_nosuid_removable_partitions.xml
@@ -33,20 +33,49 @@
     </criteria>
   </definition>
 
-  <!-- The following OVAL items:
+  <!-- First check if specified removable partition really exists on the system.
+       If not return PASS since there's nothing to check /etc/fstab & runtime settings against. -->
+  <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist" comment="Check if expected removable partitions truly exist on the system" version="1">
+    <unix:object object_ref="object_removable_partition_doesnt_exist" />
+  </unix:file_test>
 
-       * test_removable_partition_doesnt_exist,
-       * object_removable_partition_doesnt_exist,
-       * test_var_removable_partition_is_cd_dvd_drive,
-       * object_var_removable_partition_is_cd_dvd_drive,
-       * state_var_removable_partition_is_cd_dvd_drive,
-       * variable_cd_dvd_drive_alternative_names,
-       * variable_cd_dvd_drive_regex_pattern,
-       * variable_not_cd_dvd_drive_regex_pattern, and
-       * var_removable_partition
+  <unix:file_object id="object_removable_partition_doesnt_exist" version="1">
+    <unix:filepath var_ref="var_removable_partition" var_check="at least one" />
+  </unix:file_object>
 
-       are defined in RHEL-6's 'mount_option_nodev_removable_partitions.xml' OVAL check. We will reuse them
-       and define only those OVAL items below that (slightly) differ from 'nodev' case -->
+  <!-- Specified removable partition exists on the system. Check if it represents a CD / DVD drive -->
+  <ind:variable_test id="test_var_removable_partition_is_cd_dvd_drive" check="all" comment="Check if removable partition variable value represents CD/DVD drive" version="1">
+    <ind:object object_ref="object_var_removable_partition_is_cd_dvd_drive" />
+    <ind:state state_ref="state_var_removable_partition_is_cd_dvd_drive" />
+  </ind:variable_test>
+
+  <ind:variable_object id="object_var_removable_partition_is_cd_dvd_drive" version="1">
+    <ind:var_ref>var_removable_partition</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="state_var_removable_partition_is_cd_dvd_drive" version="1">
+    <ind:value operation="equals">/dev/cdrom</ind:value>
+  </ind:variable_state>
+
+  <!-- If specified removable partition represents CD / DVD drive, create a variable
+       holding also alternative names for CD / DVD block special device as used by udev -->
+  <constant_variable id="variable_cd_dvd_drive_alternative_names" datatype="string" comment="CD/DVD drive alternative names whitelist" version="1">
+    <value>/dev/cdrom</value>
+    <value>/dev/dvd</value>
+    <value>/dev/scd0</value>
+    <value>/dev/sr0</value>
+  </constant_variable>
+
+  <!-- For each of the CD / DVD drive alternative names create regular expression pattern
+       to be used in textfilecontent54_object below -->
+  <local_variable id="variable_cd_dvd_drive_regex_pattern" datatype="string" comment="Regular expression pattern for CD / DVD drive alternative names" version="1">
+    <concat>
+      <literal_component>^[\s]*</literal_component>
+      <variable_component var_ref="variable_cd_dvd_drive_alternative_names" />
+      <!-- Capture the mount options field (4-th column of /etc/fstab) -->
+      <literal_component>[\s]+[/\w]+[\s]+[\w]+[\s]+([^\s]+)(?:[\s]+[\d]+){2}$</literal_component>
+    </concat>
+  </local_variable>
 
   <!-- If specified removable partition represents CD / DVD drive, use all alternative
        names to check /etc/fstab & runtime settings -->
@@ -91,6 +120,17 @@
     <ind:state state_ref="state_nosuid_etc_fstab_not_cd_dvd_drive" />
   </ind:textfilecontent54_test>
 
+  <!-- Create regular expression pattern for the device to be used in the
+       textfilecontent54_object below -->
+  <local_variable id="variable_not_cd_dvd_drive_regex_pattern" datatype="string" comment="Regular expression pattern for removable block special device other than CD / DVD drive" version="1">
+    <concat>
+      <literal_component>^[\s]*</literal_component>
+      <variable_component var_ref="var_removable_partition" />
+      <!-- Capture the mount options field (4-th column of /etc/fstab) -->
+      <literal_component>[\s]+[/\w]+[\s]+[\w]+[\s]+([^\s]+)(?:[\s]+[\d]+){2}$</literal_component>
+    </concat>
+  </local_variable>
+
   <ind:textfilecontent54_object id="object_nosuid_etc_fstab_not_cd_dvd_drive" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
     <ind:pattern operation="pattern match" datatype="string" var_ref="variable_not_cd_dvd_drive_regex_pattern" var_check="at least one" />
@@ -119,5 +159,7 @@
     <linux:device datatype="string" operation="equals" var_ref="var_removable_partition" var_check="at least one" />
     <linux:mount_options datatype="string" entity_check="at least one" operation="equals">nosuid</linux:mount_options>
   </linux:partition_state>
+
+  <external_variable comment="removable partition" datatype="string" id="var_removable_partition" version="1" />
 
 </def-group>

--- a/RHEL/6/input/checks/mount_option_nosuid_removable_partitions.xml
+++ b/RHEL/6/input/checks/mount_option_nosuid_removable_partitions.xml
@@ -1,58 +1,123 @@
 <def-group>
-  <definition class="compliance" id="mount_option_nosuid_removable_partitions" version="1">
+  <definition class="compliance" id="mount_option_nosuid_removable_partitions" version="2">
     <metadata>
       <title>Add nosuid Option to Removable Media Partitions</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
       <description>The nosuid mount option prevents set-user-identifier (suid)
-      and set-group-identifier (sgid) permissions from taking effect. These permissions
-      allow users to execute binaries with the same permissions as the owner and group
-      of the file respectively. Users should not be allowed to introduce suid and guid
-      files into the system via partitions mounted from removeable media.</description>
+      and set-group-identifier (sgid) permissions from taking effect. These
+      permissions allow users to execute binaries with the same permissions as
+      the owner and group of the file respectively. Users should not be allowed
+      to introduce suid and guid files into the system via partitions mounted
+      from removeable media.</description>
+      <reference source="JL" ref_id="RHEL6_20150305" ref_url="test_attestation"/>
     </metadata>
     <criteria operator="OR">
-      <criterion test_ref="test_removable_partition_doesnt_exist" comment="check if removable partition exists" />
-      <criterion test_ref="test_nosuid_removable_partition" comment="nosuid on removable partition" />
-      <criterion test_ref="test_nosuid_etc_fstab_removable_partition" comment="removable partition /etc/fstab" />
+      <!-- First check if specified removable partition truly exists on the system. If not, don't check /etc/fstab & runtime configuration
+           since there's no device to check against -->
+      <criterion test_ref="test_removable_partition_doesnt_exist" comment="Check if removable partition really exists on the system" />
+      <!-- Removable device exists. Check if it's CD/DVD drive. If so, verify that at least one from all of the possible its alternative
+           names in /etc/fstab & runtime configuration are configured with 'nosuid' option -->
+      <criteria operator="AND">
+        <criterion test_ref="test_var_removable_partition_is_cd_dvd_drive" comment="Check if removable partition value represents CD/DVD drive" />
+        <criterion test_ref="test_nosuid_etc_fstab_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'nosuid' mount option in /etc/fstab" />
+        <criterion test_ref="test_nosuid_runtime_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'nosuid' mount option in runtime configuration" />
+      </criteria>
+      <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with 'nosuid' mount option in both
+           /etc/fstab & runtime configuration -->
+      <criteria operator="AND">
+        <criterion test_ref="test_nosuid_etc_fstab_not_cd_dvd_drive" comment="Check if removable partition is using 'nosuid' mount option in /etc/fstab" />
+        <criterion test_ref="test_nosuid_runtime_not_cd_dvd_drive" comment="Check if removable partition is using 'nosuid' mount option in runtime configuration" />
+      </criteria>
     </criteria>
   </definition>
 
-  <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist" comment="check if expected removable partitions truly exist on the system" version="1">
-    <unix:object object_ref="object_removable_partition_doesnt_exist" />
-  </unix:file_test>
+  <!-- The following OVAL items:
 
-  <linux:partition_test id="test_nosuid_removable_partition" check="all" check_existence="all_exist" comment="nosuid on removable partition" version="1">
-    <linux:object object_ref="object_removable_partition_nosuid" />
-    <linux:state state_ref="state_nosuid_removable_partitions" />
-  </linux:partition_test>
+       * test_removable_partition_doesnt_exist,
+       * object_removable_partition_doesnt_exist,
+       * test_var_removable_partition_is_cd_dvd_drive,
+       * object_var_removable_partition_is_cd_dvd_drive,
+       * state_var_removable_partition_is_cd_dvd_drive,
+       * variable_cd_dvd_drive_alternative_names,
+       * variable_cd_dvd_drive_regex_pattern,
+       * variable_not_cd_dvd_drive_regex_pattern, and
+       * var_removable_partition
 
-  <ind:textfilecontent54_test id="test_nosuid_etc_fstab_removable_partition" check="at least one" comment="removable partition /etc/fstab" version="1">
-    <ind:object object_ref="object_etc_fstab_removable_partition_nosuid" />
-    <ind:state state_ref="state_text_removable_partition_nosuid" />
+       are defined in RHEL-6's 'mount_option_nodev_removable_partitions.xml' OVAL check. We will reuse them
+       and define only those OVAL items below that (slightly) differ from 'nodev' case -->
+
+  <!-- If specified removable partition represents CD / DVD drive, use all alternative
+       names to check /etc/fstab & runtime settings -->
+  <ind:textfilecontent54_test id="test_nosuid_etc_fstab_cd_dvd_drive" check="all" comment="'nosuid' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
+    <ind:object object_ref="object_nosuid_etc_fstab_cd_dvd_drive" />
+    <ind:state state_ref="state_nosuid_etc_fstab_cd_dvd_drive" />
   </ind:textfilecontent54_test>
 
-  <unix:file_object id="object_removable_partition_doesnt_exist" version="1">
-    <unix:filepath var_ref="var_removable_partition" var_check="at least one" />
-  </unix:file_object>
+  <ind:textfilecontent54_object id="object_nosuid_etc_fstab_cd_dvd_drive" version="1">
+    <ind:filepath>/etc/fstab</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string" var_ref="variable_cd_dvd_drive_regex_pattern" var_check="at least one" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
 
-  <linux:partition_object id="object_removable_partition_nosuid" version="1">
-    <linux:mount_point var_ref="var_removable_partition" />
+  <ind:textfilecontent54_state id="state_nosuid_etc_fstab_cd_dvd_drive" version="1">
+    <ind:subexpression operation="pattern match" datatype="string">^.*,?nosuid,?.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <linux:partition_test id="test_nosuid_runtime_cd_dvd_drive" check="all" comment="'nosuid' mount option used for at least one CD / DVD drive alternative names in runtime configuration" version="1">
+    <linux:object object_ref="object_nosuid_runtime_cd_dvd_drive" />
+  </linux:partition_test>
+
+  <linux:partition_object id="object_nosuid_runtime_cd_dvd_drive" version="1">
+    <!-- CD / DVD drive can be mounted under any mount_point. We don't know ahead its exact name.
+         => Capture all & filter out only the relevant ones via the corresponding state -->
+    <linux:mount_point operation="pattern match">^.*$</linux:mount_point>
+    <!-- Therefore from all the captured mount points select only those having
+         device set to some CD / DVD drive alternative name and simultaneously
+         having 'nosuid' mount option used -->
+    <filter action="include">state_nosuid_runtime_cd_dvd_drive</filter>
   </linux:partition_object>
-  <linux:partition_state id="state_nosuid_removable_partitions" version="1">
+
+  <linux:partition_state id="state_nosuid_runtime_cd_dvd_drive" version="1">
+    <linux:device datatype="string" operation="equals" var_ref="variable_cd_dvd_drive_alternative_names" var_check="at least one" />
     <linux:mount_options datatype="string" entity_check="at least one" operation="equals">nosuid</linux:mount_options>
   </linux:partition_state>
 
-  <ind:textfilecontent54_object id="object_etc_fstab_removable_partition_nosuid" version="1">
+  <!-- Specified removable partition exists & doesn't represent a CD/DVD drive.
+       Check if configured with 'nosuid' mount option in both /etc/fstab & runtime configuration -->
+  <ind:textfilecontent54_test id="test_nosuid_etc_fstab_not_cd_dvd_drive" check="at least one" check_existence="all_exist" comment="Check if removable partition is configured with 'nosuid' mount option in /etc/fstab" version="1">
+    <ind:object object_ref="object_nosuid_etc_fstab_not_cd_dvd_drive" />
+    <ind:state state_ref="state_nosuid_etc_fstab_not_cd_dvd_drive" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_nosuid_etc_fstab_not_cd_dvd_drive" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*([/\w]*)\s+.*,?nosuid,?.*$</ind:pattern>
-    <!-- the "not equal" operation essentially means all instances of the regexp -->
-    <ind:instance datatype="int" operation="not equal">0</ind:instance>
+    <ind:pattern operation="pattern match" datatype="string" var_ref="variable_not_cd_dvd_drive_regex_pattern" var_check="at least one" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_text_removable_partition_nosuid" version="1">
-    <ind:subexpression datatype="string" var_ref="var_removable_partition" />
+
+  <ind:textfilecontent54_state id="state_nosuid_etc_fstab_not_cd_dvd_drive" version="1">
+    <ind:subexpression operation="pattern match" datatype="string">^.*,?nosuid,?.*</ind:subexpression>
   </ind:textfilecontent54_state>
 
-  <external_variable comment="removable partition" datatype="string" id="var_removable_partition" version="1" />
+  <linux:partition_test id="test_nosuid_runtime_not_cd_dvd_drive" check="all" check_existence="all_exist" comment="'nosuid' mount option used for removable partition in runtime configuration" version="1">
+    <linux:object object_ref="object_nosuid_runtime_not_cd_dvd_drive" />
+  </linux:partition_test>
+
+  <linux:partition_object id="object_nosuid_runtime_not_cd_dvd_drive" version="1">
+    <!-- Removable partition can be mounted under any mount point. We don't know it's
+         exact name ahead => capture all & filter out only those relevant later via state -->
+    <linux:mount_point operation="pattern match">^.*$</linux:mount_point>
+    <!-- From all the captured mount points select only those having device equal
+         to 'var_removable_partition' variable value and simultaneously having
+         'nosuid' mount option set -->
+    <filter action="include">state_nosuid_runtime_not_cd_dvd_drive</filter>
+  </linux:partition_object>
+
+  <linux:partition_state id="state_nosuid_runtime_not_cd_dvd_drive" version="1">
+    <linux:device datatype="string" operation="equals" var_ref="var_removable_partition" var_check="at least one" />
+    <linux:mount_options datatype="string" entity_check="at least one" operation="equals">nosuid</linux:mount_options>
+  </linux:partition_state>
 
 </def-group>


### PR DESCRIPTION
It has been reported to us that current version of:
* ```mount_option_nodev_removable_partitions.xml```,
* ```mount_option_noexec_removable_partitions.xml```, and
* ```mount_option_nosuid_removable_partitions.xml```

OVAL checks for Red Hat Enterprise Linux 6 system reports inappropriate results (false alerts) also for ```/etc/fstab``` entries / devices not representing removable media (e.g. ```/dev/shm``` to mention some example).

The problem is sourced (for the case of ```mount_option_nodev_removable_partitions.xml``` OVAL check) at:
* https://github.com/OpenSCAP/scap-security-guide/blob/master/RHEL/6/input/checks/mount_option_nodev_removable_partitions.xml#L48

due to the use of very liberal regular expression pattern (that is checking only presence of ```nodev``` option, but not restricting the check to the device / ```/etc/fstab``` entry representing removable device).

Therefore rewrite the RHEL-6 ```nodev, noexec,``` and ```nosuid``` removable media checks to:
* check if the requested removable device truly exists on the system,
* if the device represents CD/DVD drive to check only ```/dev/cdrom``` and commonly by ```udev``` recognized alternative names for this device that:
  * this device is configured with some of ```nodev, noexec, nosuid``` option (particular option for each corresponding OVAL check) in both ```/etc/fstab``` (static) and runtime configurations,
* if the device doesn't represent a CD/DVD drive (but is another type of removable block special device, like e.g. USB flash disk) that:
  * this device is configured with some of ```nodev, noexec, nosuid``` options (particular option for each corresponding OVAL check) in both ```/etc/fstab``` (static) and runtime configurations,

Testing report:
---
* ```make validate``` has been verified to (still) to work with the aforementioned change being applied on RHEL-6 system,
* all three of the commits below have been verified to work properly [*] for both cases (the CDROM drive and / or USB flash disk block special device being present on the underlying system).

Please review.

Thank you, Jan.

[*] Under work properly we understand the following results:
* requested removable device doesn't exist on the system => PASS
* requested device exists on the system & is CD/DVD drive => return PASS only in case it's configured with particular option in both static & runtime configurations,
* requested device exists on the system & isn't CD/DVD drive (IOW is some kind of other block special removable device, e.g. USB flash disk) => return PASS only in case it's configured with particular option in both static & runtime configurations,
* return FAIL otherwise

P.S.: In the future the checks could be enhanced even more:
* they to be ```templated```,
* they to be ```shared```,
* they to be split into two rules ```static vs runtime```
* they to completely get rid of ```var_removable_partition``` variable use (instead of that first scan the underlying system of present block special removable devices) & based on the scan compare static & runtime system configurations.

But since right now I can't dedicate more time to these enhancements for now (in this PR we will fix just that ```/dev/shm``` bug) & will save those enhancements for future version (another PR).
