### PR TITLE
new remediation: accounts_passwords_pam_faillock_unlock_time.sh

### DIFF
--- a/RHEL/6/input/fixes/bash/accounts_passwords_pam_faillock_unlock_time.sh
+++ b/RHEL/6/input/fixes/bash/accounts_passwords_pam_faillock_unlock_time.sh
@@ -1,0 +1,36 @@
+source ./templates/support.sh
+populate var_accounts_passwords_pam_faillock_unlock_time
+
+AUTH_FILES[0]="/etc/pam.d/system-auth"
+AUTH_FILES[1]="/etc/pam.d/password-auth"
+
+for pamFile in "${AUTH_FILES[@]}"
+do
+	
+	# pam_faillock.so already present?
+	if grep -q "^auth.*pam_faillock.so.*" $pamFile; then
+
+		# pam_faillock.so present, unlock_time directive present?
+		if grep -q "^auth.*[default=die].*pam_faillock.so.*authfail.*unlock_time=" $pamFile; then
+
+			# both pam_faillock.so & unlock_time present, just correct unlock_time directive value
+			sed -i --follow-symlink "s/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\(unlock_time *= *\).*/\1\2$var_accounts_passwords_pam_faillock_unlock_time/" $pamFile
+			sed -i --follow-symlink "s/\(^auth.*[default=die].*pam_faillock.so.*authfail.*\)\(unlock_time *= *\).*/\1\2$var_accounts_passwords_pam_faillock_unlock_time/" $pamFile
+
+		# pam_faillock.so present, but unlock_time directive not yet
+		else
+
+			# append correct unlock_time value to appropriate places
+			sed -i --follow-symlink "/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ unlock_time=$var_accounts_passwords_pam_faillock_unlock_time/" $pamFile
+			sed -i --follow-symlink "/^auth.*[default=die].*pam_faillock.so.*authfail.*/ s/$/ unlock_time=$var_accounts_passwords_pam_faillock_unlock_time/" $pamFile
+		fi
+
+	# pam_faillock.so not present yet
+	else
+
+		# insert pam_faillock.so preauth & authfail rows with proper value of the 'unlock_time' option
+		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent unlock_time=$var_accounts_passwords_pam_faillock_unlock_time" $pamFile
+		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail unlock_time=$var_accounts_passwords_pam_faillock_unlock_time" $pamFile
+		sed -i --follow-symlink "/^account.*required.*pam_unix.so/i account     required      pam_faillock.so" $pamFile
+	fi
+done


### PR DESCRIPTION
added remediation for accounts_passwords_pam_faillock_unlock_time.sh, using @iankko 's template from accounts_passwords_pam_faillock_deny

````
$ cp accounts_passwords_pam_faillock_deny.sh accounts_passwords_pam_faillock_unlock_time.sh
$ sed -i 's/accounts_passwords_pam_faillock_deny/accounts_passwords_pam_faillock_unlock_time/g' accounts_passwords_pam_faillock_unlock_time.sh
$ sed -i 's/deny/unlock_time/g' accounts_passwords_pam_faillock_unlock_time.sh
````