### PR TITLE
updates for accounts_passwords_pam_faillock_unlock_time

### DIFF
--- a/Fedora/input/system/accounts/pam.xml
+++ b/Fedora/input/system/accounts/pam.xml
@@ -535,7 +535,7 @@ situations.
 <ref nist="AC-7(b)" disa="47" />
 </Rule>
 
-<Rule id="accounts_passwords_pam_fail_interval" severity="medium">
+<Rule id="accounts_passwords_pam_faillock_interval" severity="medium">
 <title>Set Interval For Counting Failed Password Attempts</title>
 <description>
 Utilizing <tt>pam_faillock.so</tt>, the <tt>fail_interval</tt> directive configures the system to lock out accounts after a number of incorrect login
@@ -555,7 +555,7 @@ For each file, the output should show <tt>fail_interval=&lt;interval-in-seconds&
 Locking out user accounts after a number of incorrect attempts within a
 specific period of time prevents direct password guessing attacks.
 </rationale>
-<!--oval id="accounts_passwords_pam_fail_interval" value="var_accounts_passwords_pam_faillock_fail_interval"/-->
+<!--oval id="accounts_passwords_pam_faillock_interval" value="var_accounts_passwords_pam_faillock_fail_interval"/-->
 <ref nist="AC-7(a)" disa="1452" />
 </Rule>
 

--- a/RHEL/6/input/auxiliary/stig_overlay.xml
+++ b/RHEL/6/input/auxiliary/stig_overlay.xml
@@ -1017,7 +1017,7 @@
 		<VMSinfo VKey="38592" SVKey="50393" VRelease="3" />
 		<title>The system must require administrator action to unlock an account locked by excessive failed login attempts.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="accounts_passwords_pam_fail_interval" ownerid="RHEL-06-000357" disa="1452" severity="medium">
+	<overlay owner="disastig" ruleid="accounts_passwords_pam_faillock_interval" ownerid="RHEL-06-000357" disa="1452" severity="medium">
 		<VMSinfo VKey="38501" SVKey="50302" VRelease="3" />
 		<title>The system must disable accounts after excessive login failures within a 15-minute interval.</title>
 	</overlay>

--- a/RHEL/6/input/checks/accounts_passwords_pam_faillock_interval.xml
+++ b/RHEL/6/input/checks/accounts_passwords_pam_faillock_interval.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_passwords_pam_fail_interval" version="2">
+  <definition class="compliance" id="accounts_passwords_pam_faillock_interval" version="2">
     <metadata>
       <title>Lock out account after failed login attempts</title>
       <affected family="unix">

--- a/RHEL/6/input/fixes/bash/accounts_passwords_pam_faillock_interval.sh
+++ b/RHEL/6/input/fixes/bash/accounts_passwords_pam_faillock_interval.sh
@@ -1,0 +1,36 @@
+source ./templates/support.sh
+populate var_accounts_passwords_pam_faillock_interval
+
+AUTH_FILES[0]="/etc/pam.d/system-auth"
+AUTH_FILES[1]="/etc/pam.d/password-auth"
+
+for pamFile in "${AUTH_FILES[@]}"
+do
+	
+	# pam_faillock.so already present?
+	if grep -q "^auth.*pam_faillock.so.*" $pamFile; then
+
+		# pam_faillock.so present, interval directive present?
+		if grep -q "^auth.*[default=die].*pam_faillock.so.*authfail.*interval=" $pamFile; then
+
+			# both pam_faillock.so & interval present, just correct interval directive value
+			sed -i --follow-symlink "s/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\(interval *= *\).*/\1\2$var_accounts_passwords_pam_faillock_interval/" $pamFile
+			sed -i --follow-symlink "s/\(^auth.*[default=die].*pam_faillock.so.*authfail.*\)\(interval *= *\).*/\1\2$var_accounts_passwords_pam_faillock_interval/" $pamFile
+
+		# pam_faillock.so present, but interval directive not yet
+		else
+
+			# append correct interval value to appropriate places
+			sed -i --follow-symlink "/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ interval=$var_accounts_passwords_pam_faillock_interval/" $pamFile
+			sed -i --follow-symlink "/^auth.*[default=die].*pam_faillock.so.*authfail.*/ s/$/ interval=$var_accounts_passwords_pam_faillock_interval/" $pamFile
+		fi
+
+	# pam_faillock.so not present yet
+	else
+
+		# insert pam_faillock.so preauth & authfail rows with proper value of the 'interval' option
+		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent interval=$var_accounts_passwords_pam_faillock_interval" $pamFile
+		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail interval=$var_accounts_passwords_pam_faillock_interval" $pamFile
+		sed -i --follow-symlink "/^account.*required.*pam_unix.so/i account     required      pam_faillock.so" $pamFile
+	fi
+done

--- a/RHEL/6/input/fixes/bash/accounts_passwords_pam_faillock_interval.sh
+++ b/RHEL/6/input/fixes/bash/accounts_passwords_pam_faillock_interval.sh
@@ -1,5 +1,5 @@
 source ./templates/support.sh
-populate var_accounts_passwords_pam_faillock_interval
+populate var_accounts_passwords_pam_faillock_fail_interval
 
 AUTH_FILES[0]="/etc/pam.d/system-auth"
 AUTH_FILES[1]="/etc/pam.d/password-auth"
@@ -14,23 +14,23 @@ do
 		if grep -q "^auth.*[default=die].*pam_faillock.so.*authfail.*interval=" $pamFile; then
 
 			# both pam_faillock.so & interval present, just correct interval directive value
-			sed -i --follow-symlink "s/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\(interval *= *\).*/\1\2$var_accounts_passwords_pam_faillock_interval/" $pamFile
-			sed -i --follow-symlink "s/\(^auth.*[default=die].*pam_faillock.so.*authfail.*\)\(interval *= *\).*/\1\2$var_accounts_passwords_pam_faillock_interval/" $pamFile
+			sed -i --follow-symlink "s/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\(interval *= *\).*/\1\2$var_accounts_passwords_pam_faillock_fail_interval/" $pamFile
+			sed -i --follow-symlink "s/\(^auth.*[default=die].*pam_faillock.so.*authfail.*\)\(interval *= *\).*/\1\2$var_accounts_passwords_pam_faillock_fail_interval/" $pamFile
 
 		# pam_faillock.so present, but interval directive not yet
 		else
 
 			# append correct interval value to appropriate places
-			sed -i --follow-symlink "/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ interval=$var_accounts_passwords_pam_faillock_interval/" $pamFile
-			sed -i --follow-symlink "/^auth.*[default=die].*pam_faillock.so.*authfail.*/ s/$/ interval=$var_accounts_passwords_pam_faillock_interval/" $pamFile
+			sed -i --follow-symlink "/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ interval=$var_accounts_passwords_pam_faillock_fail_interval/" $pamFile
+			sed -i --follow-symlink "/^auth.*[default=die].*pam_faillock.so.*authfail.*/ s/$/ interval=$var_accounts_passwords_pam_faillock_fail_interval/" $pamFile
 		fi
 
 	# pam_faillock.so not present yet
 	else
 
 		# insert pam_faillock.so preauth & authfail rows with proper value of the 'interval' option
-		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent interval=$var_accounts_passwords_pam_faillock_interval" $pamFile
-		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail interval=$var_accounts_passwords_pam_faillock_interval" $pamFile
+		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent interval=$var_accounts_passwords_pam_faillock_fail_interval" $pamFile
+		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail interval=$var_accounts_passwords_pam_faillock_fail_interval" $pamFile
 		sed -i --follow-symlink "/^account.*required.*pam_unix.so/i account     required      pam_faillock.so" $pamFile
 	fi
 done

--- a/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
+++ b/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
@@ -64,7 +64,7 @@ for production deployment.</description>
 <select idref="deactivate_wireless_interfaces" selected="true" />
 <select idref="accounts_passwords_pam_faillock_unlock_time" selected="false" />
 <select idref="accounts_passwords_pam_faillock_deny" selected="false" />
-<select idref="accounts_passwords_pam_fail_interval" selected="false" />
+<select idref="accounts_passwords_pam_faillock_interval" selected="false" />
 <select idref="dhcp_server_deny_bootp" selected="true" />
 <select idref="dhcp_server_deny_decline" selected="true" />
 <select idref="dhcp_server_disable_ddns" selected="true" />

--- a/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
+++ b/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
@@ -79,7 +79,7 @@
 <refine-value idref="var_accounts_passwords_pam_faillock_deny" selector="3"/>
 <refine-value idref="var_accounts_passwords_pam_faillock_fail_interval" selector="900" />
 <select idref="accounts_passwords_pam_faillock_deny" selected="true" />
-<select idref="accounts_passwords_pam_fail_interval" selected="true" />
+<select idref="accounts_passwords_pam_faillock_interval" selected="true" />
 
 <!--	AC-7(b)
      	FISMA Refine: Locks until admin action

--- a/RHEL/6/input/profiles/nist-CL-IL-AL.xml
+++ b/RHEL/6/input/profiles/nist-CL-IL-AL.xml
@@ -166,7 +166,7 @@ assurance."</description>
 
 <!-- AC-7(a) -->
 <select idref="accounts_passwords_pam_faillock_deny" selected="true" />
-<select idref="accounts_passwords_pam_fail_interval" selected="true" />
+<select idref="accounts_passwords_pam_faillock_interval" selected="true" />
 
 <!-- AC-7(b) -->
 <select idref="accounts_passwords_pam_faillock_unlock_time" selected="true" />

--- a/RHEL/6/input/profiles/stig-rhel6-server-upstream.xml
+++ b/RHEL/6/input/profiles/stig-rhel6-server-upstream.xml
@@ -95,7 +95,7 @@ upstream project homepage is https://fedorahosted.org/scap-security-guide/.
 
 <select idref="accounts_passwords_pam_faillock_unlock_time" selected="true" />
 <refine-value idref="var_accounts_passwords_pam_faillock_unlock_time" selector="604800"/>
-<select idref="accounts_passwords_pam_fail_interval" selected="true" />
+<select idref="accounts_passwords_pam_faillock_interval" selected="true" />
 <refine-value idref="var_accounts_passwords_pam_faillock_fail_interval" selector="900"/>
 
 <!-- from inherited Rule, accounts_password_pam_unix_remember -->

--- a/RHEL/6/input/system/accounts/pam.xml
+++ b/RHEL/6/input/system/accounts/pam.xml
@@ -554,7 +554,7 @@ situations.
 <ref nist="AC-7(b)" disa="47" />
 </Rule>
 
-<Rule id="accounts_passwords_pam_fail_interval" severity="medium">
+<Rule id="accounts_passwords_pam_faillock_interval" severity="medium">
 <title>Set Interval For Counting Failed Password Attempts</title>
 <description>
 Utilizing <tt>pam_faillock.so</tt>, the <tt>fail_interval</tt> directive configures the system to lock out accounts after a number of incorrect login
@@ -579,7 +579,7 @@ Locking out user accounts after a number of incorrect attempts within a
 specific period of time prevents direct password guessing attacks.
 </rationale>
 <ident cce="27215-3"  stig="RHEL-06-000357" />
-<oval id="accounts_passwords_pam_fail_interval" value="var_accounts_passwords_pam_faillock_fail_interval"/>
+<oval id="accounts_passwords_pam_faillock_interval" value="var_accounts_passwords_pam_faillock_fail_interval"/>
 <ref nist="AC-7(a)" disa="1452" />
 </Rule>
 

--- a/RHEL/7/input/auxiliary/stig_overlay.xml
+++ b/RHEL/7/input/auxiliary/stig_overlay.xml
@@ -1004,7 +1004,7 @@
 		<VMSinfo VKey="38592" SVKey="50393" VRelease="1" />
 		<title>The system must require administrator action to unlock an account locked by excessive failed login attempts.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="accounts_passwords_pam_fail_interval" ownerid="RHEL-06-000357" disa="1452" severity="medium">
+	<overlay owner="disastig" ruleid="accounts_passwords_pam_faillock_interval" ownerid="RHEL-06-000357" disa="1452" severity="medium">
 		<VMSinfo VKey="38501" SVKey="50302" VRelease="2" />
 		<title>The system must disable accounts after excessive login failures within a 15-minute interval.</title>
 	</overlay>

--- a/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
@@ -31,7 +31,7 @@
 <select idref="accounts_password_pam_minlen" selected="true" />
 <select idref="accounts_password_pam_difok" selected="true" />
 <select idref="accounts_minimum_age_login_defs" selected="true" />
-<select idref="accounts_passwords_pam_fail_interval" selected="true" />
+<select idref="accounts_passwords_pam_faillock_interval" selected="true" />
 <select idref="accounts_passwords_pam_faillock_deny" selected="true" />
 
 </Profile>

--- a/RHEL/7/input/profiles/usgcb-rhel7-server.xml
+++ b/RHEL/7/input/profiles/usgcb-rhel7-server.xml
@@ -29,7 +29,7 @@
 <select idref="accounts_password_pam_minlen" selected="true" />
 <select idref="accounts_password_pam_difok" selected="true" />
 <select idref="accounts_minimum_age_login_defs" selected="true" />
-<select idref="accounts_passwords_pam_fail_interval" selected="true" />
+<select idref="accounts_passwords_pam_faillock_interval" selected="true" />
 <select idref="accounts_passwords_pam_faillock_deny" selected="true" />
 
 </Profile>

--- a/RHEL/7/input/system/accounts/pam.xml
+++ b/RHEL/7/input/system/accounts/pam.xml
@@ -568,7 +568,7 @@ situations.
 <ref nist="AC-7(b)" disa="47" />
 </Rule>
 
-<Rule id="accounts_passwords_pam_fail_interval" severity="medium">
+<Rule id="accounts_passwords_pam_faillock_interval" severity="medium">
 <title>Set Interval For Counting Failed Password Attempts</title>
 <description>
 Utilizing <tt>pam_faillock.so</tt>, the <tt>fail_interval</tt> directive configures the system to lock out accounts after a number of incorrect login
@@ -595,7 +595,7 @@ Locking out user accounts after a number of incorrect attempts within a
 specific period of time prevents direct password guessing attacks.
 </rationale>
 <ident cce="26763-3" />
-<oval id="accounts_passwords_pam_fail_interval" value="var_accounts_passwords_pam_faillock_fail_interval"/>
+<oval id="accounts_passwords_pam_faillock_interval" value="var_accounts_passwords_pam_faillock_fail_interval"/>
 <ref nist="AC-7(a)" disa="44" srg="21" />
 </Rule>
 


### PR DESCRIPTION
- Updated XCCDF naming to follow other faillocks (https://github.com/OpenSCAP/scap-security-guide/commit/f6a61f793f82ce636a4e074cd5323e87c1ea0979)
- Updated OVAL name (https://github.com/OpenSCAP/scap-security-guide/commit/f6a61f793f82ce636a4e074cd5323e87c1ea0979)
- Added remediation using @iankko 's template (https://github.com/OpenSCAP/scap-security-guide/commit/adcc8cf9a30b09c2c5ff25d86ffa86612ea76242)