### PR TITLE
sed breaks symlinks

### DIFF
--- a/shared/fixes/bash/enable_selinux_bootloader.sh
+++ b/shared/fixes/bash/enable_selinux_bootloader.sh
@@ -1,2 +1,2 @@
-sed -i "s/selinux=0//gI" /etc/grub.conf
-sed -i "s/enforcing=0//gI" /etc/grub.conf
+sed -i --follow-symlinks "s/selinux=0//gI" /etc/grub.conf
+sed -i --follow-symlinks "s/enforcing=0//gI" /etc/grub.conf


### PR DESCRIPTION
sed 4.2.1 in RHEL6 breaks symlinks unless --follow-symlinks is passed

el6 kernel updates modify /etc/grub.conf when installed, but will never be booted because /boot/grub/grub.conf is used for boot time config

Either add --follow-symlinks, or modify /boot/grub/grub.conf directly.