### PR TITLE
[Enhancement] Include the necessary changes to make the content successfully validate with OVAL 5.11 version

### DIFF
--- a/RHEL/5/input/checks/rpm_verify_hashes.xml
+++ b/RHEL/5/input/checks/rpm_verify_hashes.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="rpm_verify_hashes" version="1">
+  <definition class="compliance" id="rpm_verify_hashes" version="2">
     <metadata>
       <title>Verify File Hashes with RPM</title>
       <affected family="unix">
@@ -28,6 +28,10 @@
   <linux:rpmverifyfile_object id="object_files_fail_md5_hash" version="1" comment="rpm verify of all files">
     <linux:behaviors nomd5="false"/>
     <linux:name operation="pattern match">.*</linux:name>
+    <linux:epoch operation="pattern match">.*</linux:epoch>
+    <linux:version operation="pattern match">.*</linux:version>
+    <linux:release operation="pattern match">.*</linux:release>
+    <linux:arch operation="pattern match">.*</linux:arch>
     <linux:filepath operation="pattern match">^.*bin/.*$</linux:filepath>
     <filter action="include">state_files_fail_md5_hash</filter>
   </linux:rpmverifyfile_object>

--- a/RHEL/6/input/checks/file_permissions_ungroupowned.xml
+++ b/RHEL/6/input/checks/file_permissions_ungroupowned.xml
@@ -1,6 +1,5 @@
 <def-group>
-  <definition class="compliance" id="file_permissions_ungroupowned"
-  version="1">
+  <definition class="compliance" id="file_permissions_ungroupowned" version="2">
     <metadata>
       <title>Find files unowned by a group</title>
       <affected family="unix">
@@ -16,9 +15,19 @@
   <unix:file_test xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
   check="all" comment="files with no group owner" check_existence="none_exist"
   id="test_file_permissions_ungroupowned" version="1">
+    <!-- OVAL 5.11 rc-2 within the effort to add oval-def:NotesType construct also to variables
+         moved NotesType construct to the oval-common-schema:
+         [1] https://github.com/OVALProject/Language/issues/6
+         [2] https://github.com/OVALProject/Language/commit/c34abb871ee446d9fd9e50a8ccbc8a8e2af5db20
+         But this change broke backward-compatibility as reported in:
+         [3] https://github.com/OVALProject/Language/issues/237
+         [4] http://making-security-measurable.1364806.n2.nabble.com/5-11-backwards-incompatibility-issue-Suspect-the-fix-for-issue-6-was-the-culprit-tp7586190.html
+         Therefore as a temporary workaround to have both OVAL 5.10 and also OVAL 5.11 valid content,
+         temporarily comment out the <notes> construct below till the issue [3] is fixed in OVAL 5.11.1
+         version.
     <notes>
       <note>This will enumerate all files on local partitions</note>
-    </notes>
+    </notes> -->
     <unix:object object_ref="object_file_permissions_ungroupowned" />
   </unix:file_test>
   <unix:file_state comment="Files that are owned by a group."

--- a/RHEL/6/input/checks/rpm_verify_hashes.xml
+++ b/RHEL/6/input/checks/rpm_verify_hashes.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="rpm_verify_hashes" version="1">
+  <definition class="compliance" id="rpm_verify_hashes" version="2">
     <metadata>
       <title>Verify File Hashes with RPM</title>
       <affected family="unix">
@@ -25,6 +25,10 @@
   <linux:rpmverifyfile_object id="object_files_fail_md5_hash" version="1" comment="rpm verify of all files">
     <linux:behaviors nomd5="false"/>
     <linux:name operation="pattern match">.*</linux:name>
+    <linux:epoch operation="pattern match">.*</linux:epoch>
+    <linux:version operation="pattern match">.*</linux:version>
+    <linux:release operation="pattern match">.*</linux:release>
+    <linux:arch operation="pattern match">.*</linux:arch>
     <linux:filepath operation="pattern match">^.*bin/.*$</linux:filepath>
     <filter action="include">state_files_fail_md5_hash</filter>
   </linux:rpmverifyfile_object>

--- a/RHEL/6/input/checks/rpm_verify_permissions.xml
+++ b/RHEL/6/input/checks/rpm_verify_permissions.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="rpm_verify_permissions" version="1">
+  <definition class="compliance" id="rpm_verify_permissions" version="2">
     <metadata>
       <title>Verify File Ownership And Permissions Using RPM</title>
       <affected family="unix">
@@ -28,18 +28,30 @@
   <linux:rpmverifyfile_object id="object_files_fail_user_ownership" version="1" comment="rpm verify of all files">
     <linux:behaviors nomd5="true"/>
     <linux:name operation="pattern match">.*</linux:name>
+    <linux:epoch operation="pattern match">.*</linux:epoch>
+    <linux:version operation="pattern match">.*</linux:version>
+    <linux:release operation="pattern match">.*</linux:release>
+    <linux:arch operation="pattern match">.*</linux:arch>
     <linux:filepath operation="pattern match">.*</linux:filepath>
     <filter action="include">state_files_fail_user_ownership</filter>
   </linux:rpmverifyfile_object>
   <linux:rpmverifyfile_object id="object_files_fail_group_ownership" version="1" comment="rpm verify of all files">
     <linux:behaviors nomd5="true"/>
     <linux:name operation="pattern match">.*</linux:name>
+    <linux:epoch operation="pattern match">.*</linux:epoch>
+    <linux:version operation="pattern match">.*</linux:version>
+    <linux:release operation="pattern match">.*</linux:release>
+    <linux:arch operation="pattern match">.*</linux:arch>
     <linux:filepath operation="pattern match">.*</linux:filepath>
     <filter action="include">state_files_fail_group_ownership</filter>
   </linux:rpmverifyfile_object>
   <linux:rpmverifyfile_object id="object_files_fail_mode" version="1" comment="rpm verify of all files">
     <linux:behaviors nomd5="true"/>
     <linux:name operation="pattern match">.*</linux:name>
+    <linux:epoch operation="pattern match">.*</linux:epoch>
+    <linux:version operation="pattern match">.*</linux:version>
+    <linux:release operation="pattern match">.*</linux:release>
+    <linux:arch operation="pattern match">.*</linux:arch>
     <linux:filepath operation="pattern match">.*</linux:filepath>
     <filter action="include">state_files_fail_mode</filter>
   </linux:rpmverifyfile_object>


### PR DESCRIPTION
The OVAL language versions from 5.10.1 up to current / most recent 5.11 introduced two backward-incompatible changes:
  [1] The 5.10.1 version introduced requirement for ```epoch, version, release,``` and ```arch``` entities of the ```rpmverifyfile_object / rpmverifypackage_object``` objects to have ```MinOccurs=1```:

See:
* http://making-security-measurable.1364806.n2.nabble.com/FOR-REVIEW-OVAL-language-version-5-11-1-Revert-the-rpmverifyfile-object-minOccurs-1-and-rpmverifypacn-tp7586293.html
* https://github.com/OVALProject/Language/issues/238

for further details (or compare:
* https://oval.mitre.org/language/version5.10/ovaldefinition/documentation/linux-definitions-schema.html#rpmverifyfile_object

with 

* https://oval.mitre.org/language/version5.10.1/ovaldefinition/documentation/linux-definitions-schema.html#rpmverifyfile_object

WRT to ```MinOccurs``` attribute value for ```epoch, version, release ```, and ```arch``` entities)

  [2] OVAL 5.11 rc2 moved ```NotesType``` from ```oval-def``` schema to ```oval-common-schema``` based on the following requirements:
* https://github.com/OVALProject/Language/issues/6
* http://making-security-measurable.1364806.n2.nabble.com/New-element-in-VariableType-of-oval-variables-schema-xsd-td7578687.html#a7578714
* https://github.com/OVALProject/Language/commit/c34abb871ee446d9fd9e50a8ccbc8a8e2af5db20

But this change introduced a regression / backward-incompatible change as reported here:
* http://making-security-measurable.1364806.n2.nabble.com/5-11-backwards-incompatibility-issue-Suspect-the-fix-for-issue-6-was-the-culprit-tp7586190.html
* https://github.com/OVALProject/Language/issues/237

This issue (backward-compatibility break) is going to be addressed in upcoming OVAL 5.11.1 version.

Since we:
* need to be able to successfully build SCAP Security Guide content with OVAL 5.11 schema, 
* but also want / need to keep the content valid for / against OVAL 5.10 schema, couple of changes is necessary for the content to successfully build (be valid) on both OVAL versions.

This PR implements those changes.

Testing report:
--

The proposed change has been verified to build && work correctly with OVAL 5.11 schema enabled in the OpenSCAP scanner on Fedora system. It has been also verified to still build (&work) successfully with OVAL 5.10 schema on Red Hat Enterprise Linux 6 system.

Please review.

Thanks, Jan.