### PR TITLE
updating SELinux policy enforcement to reflect dev environments

### DIFF
--- a/RHEL/6/input/system/selinux.xml
+++ b/RHEL/6/input/system/selinux.xml
@@ -115,7 +115,7 @@ Note: During the development or debugging of SELinux modules, it is common to
 temporarily place non-production systems in <tt>permissive</tt> mode. In such 
 temporary cases, SELinux policies should be developed, and once work
 is completed, the system should be reconfigured to
-<tt><sub idref="var_var_selinux_policy_name" /></tt>.
+<tt><sub idref="var_selinux_policy_name" /></tt>.
 </rationale>
 <ident cce="26875-5"  stig="RHEL-06-000023" />
 <oval id="selinux_policytype" value="var_selinux_policy_name"/>

--- a/RHEL/6/input/system/selinux.xml
+++ b/RHEL/6/input/system/selinux.xml
@@ -110,6 +110,12 @@ Check the file <tt>/etc/selinux/config</tt> and ensure the following line appear
 Setting the SELinux policy to <tt>targeted</tt> or a more specialized policy
 ensures the system will confine processes that are likely to be
 targeted for exploitation, such as network or system services.
+
+Note: During the development or debugging of SELinux modules, it is common to 
+temporarily place non-production systems in <tt>permissive</tt> mode. In such 
+temporary cases, SELinux policies should be developed, and once work
+is completed, the system should be reconfigured to
+<tt><sub idref="var_var_selinux_policy_name" /></tt>.
 </rationale>
 <ident cce="26875-5"  stig="RHEL-06-000023" />
 <oval id="selinux_policytype" value="var_selinux_policy_name"/>

--- a/RHEL/7/input/system/selinux.xml
+++ b/RHEL/7/input/system/selinux.xml
@@ -110,6 +110,12 @@ Check the file <tt>/etc/selinux/config</tt> and ensure the following line appear
 Setting the SELinux policy to <tt>targeted</tt> or a more specialized policy
 ensures the system will confine processes that are likely to be
 targeted for exploitation, such as network or system services.
+
+Note: During the development or debugging of SELinux modules, it is common to
+temporarily place non-production systems in <tt>permissive</tt> mode. In such
+temporary cases, SELinux policies should be developed, and once work
+is completed, the system should be reconfigured to
+<tt><sub idref="var_selinux_policy_name" /></tt>.
 </rationale>
 <ident cce="27135-3" />
 <oval id="selinux_policytype" value="var_selinux_policy_name"/>


### PR DESCRIPTION
The current language of the SELinux enforcement check does not reflect developer use cases, where a system may be temporarily configured as ````permissive```` while a SELinux policy is developed. This patch attempts to create initial language to cover such situations.

Thanks to @fcaviggia for raising this issue!