### PR TITLE
[Bugfix] Remove unused RHEL7 platform references in RHEL6 content

### DIFF
--- a/RHEL/6/input/checks/accounts_password_pam_ocredit.xml
+++ b/RHEL/6/input/checks/accounts_password_pam_ocredit.xml
@@ -4,7 +4,6 @@
       <title>Set Password ocredit Requirements</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
       </affected>
       <description>The password ocredit should meet minimum requirements</description>
       <reference source="swells" ref_id="20140926" ref_url="test_attestation" />

--- a/RHEL/6/input/checks/require_singleuser_auth.xml
+++ b/RHEL/6/input/checks/require_singleuser_auth.xml
@@ -4,7 +4,6 @@
       <title>Require Authentication for Single-User Mode</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
       </affected>
       <description>The requirement for a password to boot into single-user mode
       should be configured correctly.</description>

--- a/RHEL/6/input/checks/templates/template_umask
+++ b/RHEL/6/input/checks/templates/template_umask
@@ -7,7 +7,6 @@
       <title>TITLE</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
       </affected>
       <description>DESCRIPTION</description>
     </metadata>


### PR DESCRIPTION
- Removes Red Hat Enterprise Linux 7 from RHEL/6 content that
  is not valid or used by the /shared content