### PR TITLE
adding remember=4 in support of PCI requirements

### DIFF
--- a/RHEL/6/input/system/accounts/pam.xml
+++ b/RHEL/6/input/system/accounts/pam.xml
@@ -50,6 +50,7 @@ keep the user from alternating between the same password too
 frequently.</description>
 <value selector="">5</value>
 <value selector="0">0</value>
+<value selector="4">4</value>
 <value selector="5">5</value>
 <value selector="10">10</value>
 <value selector="24">24</value>


### PR DESCRIPTION
PCI requires that 4 passwords be remembered. Updating remember variable to allow this selection in XCCDF profile.