### PR TITLE
Add centos 7 as supported platform

### DIFF
--- a/RHEL/7/input/checks/installed_OS_is_centos7.xml
+++ b/RHEL/7/input/checks/installed_OS_is_centos7.xml
@@ -1,0 +1,1 @@
+../../../../shared/oval/installed_OS_is_centos7.xml

--- a/RHEL/7/input/checks/platform/rhel7-cpe-dictionary.xml
+++ b/RHEL/7/input/checks/platform/rhel7-cpe-dictionary.xml
@@ -7,4 +7,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel7</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:centos:centos:7">
+            <title xml:lang="en-us">Community Enterprise Operating System 7</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_centos7</check>
+      </cpe-item>
 </cpe-list>

--- a/RHEL/7/input/guide.xml
+++ b/RHEL/7/input/guide.xml
@@ -37,6 +37,7 @@ trademarks or trademarks of Red Hat, Inc. in the United States and other
 countries. All other names are registered trademarks or trademarks of their
 respective companies.</rear-matter>
 <platform idref="cpe:/o:redhat:enterprise_linux:7" />
+<platform idref="cpe:/o:centos:centos:7" />
 <platform idref="cpe:/o:redhat:enterprise_linux:7::client" />
 <version>0.9</version>
 </Benchmark>

--- a/config/oval.config
+++ b/config/oval.config
@@ -21,9 +21,10 @@
 # Note: this file uses .ini style formatting
 #
 [Platform]
-multi_platform_oval = multi_platform_fedora, multi_platform_rhel
+multi_platform_oval = multi_platform_fedora, multi_platform_rhel, multi_platform_cent
 multi_platform_fedora = 23,20,21
 multi_platform_rhel = 6,7
+multi_platform_cent = 6,7
 multi_platform_openstack = 
 multi_platform_rhev = 
 

--- a/shared/oval/installed_OS_is_centos7.xml
+++ b/shared/oval/installed_OS_is_centos7.xml
@@ -1,0 +1,56 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_centos7" version="1">
+    <metadata>
+      <title>Community Enterprise Operating System 7</title>
+      <affected family="unix">
+        <platform>Community Enterprise Operating System 7</platform>
+      </affected>
+      <reference ref_id="cpe:/o:centos:centos:7"
+      source="CPE" />
+      <description>The operating system installed on the system is
+      Community Enterprise Operating System 7</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_rhel7_unix_family" />
+      <criteria operator="OR">
+        <criterion comment="Community Enterprise Operating System 7 Workstation is installed"
+        test_ref="test_rhel7_workstation" />
+        <criterion comment="Community Enterprise Operating System 7 Server is installed"
+        test_ref="test_rhel7_server" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_rhel7_unix_family" version="1">
+    <ind:object object_ref="obj_rhel7_unix_family" />
+    <ind:state state_ref="state_rhel7_unix_family" />
+  </ind:family_test>
+  <ind:family_state id="state_rhel7_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+  <ind:family_object id="obj_rhel7_unix_family" version="1" />
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release-workstation is version 7" id="test_rhel7_workstation" version="1">
+    <linux:object object_ref="obj_rhel7_workstation" />
+    <linux:state state_ref="state_rhel7_workstation" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel7_workstation" version="1">
+    <linux:version operation="pattern match">^7.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel7_workstation" version="1">
+    <linux:name>redhat-release-workstation</linux:name>
+  </linux:rpminfo_object>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release-server is version 7" id="test_rhel7_server" version="1">
+    <linux:object object_ref="obj_rhel7_server" />
+    <linux:state state_ref="state_rhel7_server" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel7_server" version="1">
+    <linux:version operation="pattern match">^7.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel7_server" version="1">
+    <linux:name>redhat-release-server</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/shared/oval/installed_OS_is_centos7.xml
+++ b/shared/oval/installed_OS_is_centos7.xml
@@ -15,8 +15,6 @@
       <criterion comment="Installed operating system is part of the unix family"
       test_ref="test_rhel7_unix_family" />
       <criteria operator="OR">
-        <criterion comment="Community Enterprise Operating System 7 Workstation is installed"
-        test_ref="test_rhel7_workstation" />
         <criterion comment="Community Enterprise Operating System 7 Server is installed"
         test_ref="test_rhel7_server" />
       </criteria>
@@ -31,7 +29,7 @@
     <ind:family>unix</ind:family>
   </ind:family_state>
   <ind:family_object id="obj_rhel7_unix_family" version="1" />
-
+  <!--
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release-workstation is version 7" id="test_rhel7_workstation" version="1">
     <linux:object object_ref="obj_rhel7_workstation" />
     <linux:state state_ref="state_rhel7_workstation" />
@@ -42,8 +40,8 @@
   <linux:rpminfo_object id="obj_rhel7_workstation" version="1">
     <linux:name>redhat-release-workstation</linux:name>
   </linux:rpminfo_object>
-
-  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release-server is version 7" id="test_rhel7_server" version="1">
+-->
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="test_rhel7_server" version="1">
     <linux:object object_ref="obj_rhel7_server" />
     <linux:state state_ref="state_rhel7_server" />
   </linux:rpminfo_test>
@@ -51,6 +49,6 @@
     <linux:version operation="pattern match">^7.*$</linux:version>
   </linux:rpminfo_state>
   <linux:rpminfo_object id="obj_rhel7_server" version="1">
-    <linux:name>redhat-release-server</linux:name>
+    <linux:name>centos-release</linux:name>
   </linux:rpminfo_object>
 </def-group>

--- a/shared/oval/installed_OS_is_centos7.xml
+++ b/shared/oval/installed_OS_is_centos7.xml
@@ -13,42 +13,29 @@
     </metadata>
     <criteria>
       <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_rhel7_unix_family" />
-      <criteria operator="OR">
-        <criterion comment="Community Enterprise Operating System 7 Server is installed"
-        test_ref="test_rhel7_server" />
-      </criteria>
+      test_ref="test_cent7_unix_family" />
+      <criterion comment="Community Enterprise Operating System 7 Server is installed"
+        test_ref="test_cent7_server" />
     </criteria>
   </definition>
 
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_rhel7_unix_family" version="1">
-    <ind:object object_ref="obj_rhel7_unix_family" />
-    <ind:state state_ref="state_rhel7_unix_family" />
+  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_cent7_unix_family" version="1">
+    <ind:object object_ref="obj_cent7_unix_family" />
+    <ind:state state_ref="state_cent7_unix_family" />
   </ind:family_test>
-  <ind:family_state id="state_rhel7_unix_family" version="1">
+  <ind:family_state id="state_cent7_unix_family" version="1">
     <ind:family>unix</ind:family>
   </ind:family_state>
-  <ind:family_object id="obj_rhel7_unix_family" version="1" />
-  <!--
-  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release-workstation is version 7" id="test_rhel7_workstation" version="1">
-    <linux:object object_ref="obj_rhel7_workstation" />
-    <linux:state state_ref="state_rhel7_workstation" />
+  <ind:family_object id="obj_cent7_unix_family" version="1" />
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="test_cent7_server" version="1">
+    <linux:object object_ref="obj_cent7_server" />
+    <linux:state state_ref="state_cent7_server" />
   </linux:rpminfo_test>
-  <linux:rpminfo_state id="state_rhel7_workstation" version="1">
+  <linux:rpminfo_state id="state_cent7_server" version="1">
     <linux:version operation="pattern match">^7.*$</linux:version>
   </linux:rpminfo_state>
-  <linux:rpminfo_object id="obj_rhel7_workstation" version="1">
-    <linux:name>redhat-release-workstation</linux:name>
-  </linux:rpminfo_object>
--->
-  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="test_rhel7_server" version="1">
-    <linux:object object_ref="obj_rhel7_server" />
-    <linux:state state_ref="state_rhel7_server" />
-  </linux:rpminfo_test>
-  <linux:rpminfo_state id="state_rhel7_server" version="1">
-    <linux:version operation="pattern match">^7.*$</linux:version>
-  </linux:rpminfo_state>
-  <linux:rpminfo_object id="obj_rhel7_server" version="1">
+  <linux:rpminfo_object id="obj_cent7_server" version="1">
     <linux:name>centos-release</linux:name>
   </linux:rpminfo_object>
 </def-group>

--- a/shared/transforms/combinechecks.py
+++ b/shared/transforms/combinechecks.py
@@ -14,7 +14,7 @@ footer = '</oval_definitions>'
 
 RHEL = 'Red Hat Enterpise Linux'
 FEDORA = 'Fedora'
-
+CENT = 'Community Enterprise Operating System'
 
 def _header(schema_version):
     header = '''<?xml version="1.0" encoding="UTF-8"?>
@@ -64,6 +64,8 @@ def parse_conf_file(conf_file):
 def multi_os(version):
     if re.findall('rhel', version):
         multi_os = RHEL
+    if re.findall('cent', version):
+        multi_os = CENT
     if re.findall('fedora', version):
         multi_os = FEDORA
 


### PR DESCRIPTION
Hi,
As asked in "https://github.com/OpenSCAP/scap-security-guide/issues/374"
Here is a proposal to add centos7 in the rhel7 tree
I don't know if it is the right way to do it, but it seems to work for me...
If there is a better way, feel free to share, i'd love to adapt :)
Regards
Mike