### PR TITLE
[Bugfix][Fedora] Add user/group auditing modifiction check to XCCDF

### DIFF
--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -646,7 +646,7 @@ each file specified (and with <tt>perm=wa</tt> for each).
 will alert the system administrator(s) to any modifications. Any
 unexpected users, groups, or modifications should be investigated for
 legitimacy.</rationale>
-<!-- <oval id="audit_rules_usergroup_modification" /> -->
+<oval id="audit_rules_usergroup_modification" />
 <ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,1403,1404,1405,1684,1683,1685,1686"/>
 </Rule>
 


### PR DESCRIPTION
- Add OVAL tag to XCCDF for auditing user/group changes which was
  causing `make validate` to fail.