### PR TITLE
[Enhancement] [BugFix] Port yet more audit rules to RHEL-7 && Fedora

### DIFF
--- a/Fedora/input/checks/audit_rules_dac_modification_chmod.xml
+++ b/Fedora/input/checks/audit_rules_dac_modification_chmod.xml
@@ -1,0 +1,1 @@
+../../../shared/oval/audit_rules_dac_modification_chmod.xml

--- a/Fedora/input/checks/audit_rules_dac_modification_chown.xml
+++ b/Fedora/input/checks/audit_rules_dac_modification_chown.xml
@@ -1,0 +1,1 @@
+../../../shared/oval/audit_rules_dac_modification_chown.xml

--- a/Fedora/input/checks/audit_rules_dac_modification_fchmod.xml
+++ b/Fedora/input/checks/audit_rules_dac_modification_fchmod.xml
@@ -1,0 +1,1 @@
+../../../shared/oval/audit_rules_dac_modification_fchmod.xml

--- a/Fedora/input/checks/audit_rules_dac_modification_fchmodat.xml
+++ b/Fedora/input/checks/audit_rules_dac_modification_fchmodat.xml
@@ -1,0 +1,1 @@
+../../../shared/oval/audit_rules_dac_modification_fchmodat.xml

--- a/Fedora/input/checks/audit_rules_privileged_commands.xml
+++ b/Fedora/input/checks/audit_rules_privileged_commands.xml
@@ -1,0 +1,1 @@
+../../../shared/oval/audit_rules_privileged_commands.xml

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -47,6 +47,7 @@
 <!-- Audit section rules -->
 
   <!-- Audit DAC modifications -->
+  <select idref="audit_rules_dac_modification_fchmod" selected="true"/>
   <select idref="audit_rules_dac_modification_fchmodat" selected="true"/>
   <select idref="audit_rules_dac_modification_fchown" selected="true"/>
   <select idref="audit_rules_dac_modification_fchownat" selected="true"/>

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -47,6 +47,7 @@
 <!-- Audit section rules -->
 
   <!-- Audit DAC modifications -->
+  <select idref="audit_rules_dac_modification_chown" selected="true"/>
   <select idref="audit_rules_dac_modification_fchmod" selected="true"/>
   <select idref="audit_rules_dac_modification_fchmodat" selected="true"/>
   <select idref="audit_rules_dac_modification_fchown" selected="true"/>

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -58,6 +58,7 @@
   <select idref="audit_rules_dac_modification_setxattr" selected="true"/>
 
   <select idref="audit_rules_unsuccessful_file_modification" selected="true"/>
+  <select idref="audit_rules_privileged_commands" selected="true"/>
   <select idref="audit_rules_media_export" selected="true"/>
   <select idref="audit_rules_file_deletion_events" selected="true"/>
   <select idref="audit_rules_sysadmin_actions" selected="true"/>

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -47,6 +47,7 @@
 <!-- Audit section rules -->
 
   <!-- Audit DAC modifications -->
+  <select idref="audit_rules_dac_modification_fchmodat" selected="true"/>
   <select idref="audit_rules_dac_modification_fchown" selected="true"/>
   <select idref="audit_rules_dac_modification_fchownat" selected="true"/>
   <select idref="audit_rules_dac_modification_fremovexattr" selected="true"/>

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -47,6 +47,7 @@
 <!-- Audit section rules -->
 
   <!-- Audit DAC modifications -->
+  <select idref="audit_rules_dac_modification_chmod" selected="true"/>
   <select idref="audit_rules_dac_modification_chown" selected="true"/>
   <select idref="audit_rules_dac_modification_fchmod" selected="true"/>
   <select idref="audit_rules_dac_modification_fchmodat" selected="true"/>

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -822,7 +822,7 @@ number of ways while still achieving the desired effect.  Here the system calls
 have been placed independent of other system calls.  Grouping these system
 calls with others as identifying earlier in this guide is more efficient.
 </warning>
-<!-- <oval id="audit_rules_dac_modification_fchmod" /> -->
+<oval id="audit_rules_dac_modification_fchmod" />
 <ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -753,11 +753,18 @@ abuse among both authorized and unauthorized users.</rationale>
 
 <Rule id="audit_rules_dac_modification_chmod">
 <title>Record Events that Modify the System's Discretionary Access Controls - chmod</title>
-<description>At a minimum the audit system should collect file
-permission changes for all users and root. Add the following to
-<tt>/etc/audit/audit.rules</tt>:
+<description>At a minimum the audit system should collect file permission
+changes for all users and root. If the <tt>auditd</tt> daemon is configured to
+use the <tt>auditctl</tt> utility to read audit rules during daemon startup
+(the default), add the following line to <tt>/etc/audit/audit.rules</tt> file:
 <pre>-a always,exit -F arch=b32 -S chmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
-If the system is 64 bit then also add the following:
+If the system is 64 bit then also add the following line:
+<pre>-a always,exit -F arch=b64 -S chmod  -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
+program to read audit rules during daemon startup, add the following line to a
+file with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+<pre>-a always,exit -F arch=b32 -S chmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the system is 64 bit then also add the following line:
 <pre>-a always,exit -F arch=b64 -S chmod  -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
 </description>
 <rationale>The changing of file permissions could indicate that a user is attempting to

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -797,7 +797,7 @@ number of ways while still achieving the desired effect.  Here the system calls
 have been placed independent of other system calls.  Grouping these system 
 calls with others as identifying earlier in this guide is more efficient.
 </warning>
-<!-- <oval id="audit_rules_dac_modification_chown" /> -->
+<oval id="audit_rules_dac_modification_chown" />
 <ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -1233,7 +1233,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
-<!-- <oval id="audit_rules_privileged_commands" /> -->
+<oval id="audit_rules_privileged_commands" />
 <ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-2(4),AU-12(a),AU-12(c),IR-5" disa="40" />
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -828,11 +828,18 @@ calls with others as identifying earlier in this guide is more efficient.
 
 <Rule id="audit_rules_dac_modification_fchmodat">
 <title>Record Events that Modify the System's Discretionary Access Controls - fchmodat</title>
-<description>At a minimum the audit system should collect file
-permission changes for all users and root. Add the following to
-<tt>/etc/audit/audit.rules</tt>:
+<description>At a minimum the audit system should collect file permission
+changes for all users and root. If the <tt>auditd</tt> daemon is configured to
+use the <tt>auditctl</tt> utility to read audit rules during daemon startup
+(the default), add the following line to <tt>/etc/audit/audit.rules</tt> file:
 <pre>-a always,exit -F arch=b32 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
-If the system is 64 bit then also add the following:
+If the system is 64 bit then also add the following line:
+<pre>-a always,exit -F arch=b64 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
+program to read audit rules during daemon startup, add the following line to a
+file with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+<pre>-a always,exit -F arch=b32 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the system is 64 bit then also add the following line:
 <pre>-a always,exit -F arch=b64 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
 </description>
 <ocil>

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -778,11 +778,18 @@ calls with others as identifying earlier in this guide is more efficient.
 
 <Rule id="audit_rules_dac_modification_chown">
 <title>Record Events that Modify the System's Discretionary Access Controls - chown</title>
-<description>At a minimum the audit system should collect file
-permission changes for all users and root. Add the following to
-<tt>/etc/audit/audit.rules</tt>:
+<description>At a minimum the audit system should collect file permission
+changes for all users and root. If the <tt>auditd</tt> daemon is configured to
+use the <tt>auditctl</tt> utility to read audit rules during daemon startup
+(the default), add the following line to <tt>/etc/audit/audit.rules</tt> file:
 <pre>-a always,exit -F arch=b32 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
-If the system is 64 bit then also add the following:
+If the system is 64 bit then also add the following line:
+<pre>-a always,exit -F arch=b64 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
+program to read audit rules during daemon startup, add the following line to a
+file with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+<pre>-a always,exit -F arch=b32 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the system is 64 bit then also add the following line:
 <pre>-a always,exit -F arch=b64 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
 </description>
 <ocil>

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -847,7 +847,7 @@ number of ways while still achieving the desired effect.  Here the system calls
 have been placed independent of other system calls.  Grouping these system
 calls with others as identifying earlier in this guide is more efficient.
 </warning>
-<!-- <oval id="audit_rules_dac_modification_fchmodat" /> -->
+<oval id="audit_rules_dac_modification_fchmodat" />
 <ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -803,11 +803,18 @@ calls with others as identifying earlier in this guide is more efficient.
 
 <Rule id="audit_rules_dac_modification_fchmod">
 <title>Record Events that Modify the System's Discretionary Access Controls - fchmod</title>
-<description>At a minimum the audit system should collect file
-permission changes for all users and root. Add the following to
-<tt>/etc/audit/audit.rules</tt>:
+<description>At a minimum the audit system should collect file permission
+changes for all users and root. If the <tt>auditd</tt> daemon is configured to
+use the <tt>auditctl</tt> utility to read audit rules during daemon startup
+(the default), add the following line to <tt>/etc/audit/audit.rules</tt> file:
 <pre>-a always,exit -F arch=b32 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
-If the system is 64 bit then also add the following:
+If the system is 64 bit then also add the following line:
+<pre>-a always,exit -F arch=b64 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
+program to read audit rules during daemon startup, add the following line to a
+file with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+<pre>-a always,exit -F arch=b32 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the system is 64 bit then also add the following line:
 <pre>-a always,exit -F arch=b64 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
 </description>
 <ocil>

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -772,7 +772,7 @@ number of ways while still achieving the desired effect.  Here the system calls
 have been placed independent of other system calls.  Grouping these system
 calls with others as identifying earlier in this guide is more efficient.
 </warning>
-<!-- <oval id="audit_rules_dac_modification_chmod" /> -->
+<oval id="audit_rules_dac_modification_chmod" />
 <ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -1206,15 +1206,23 @@ these events could serve as evidence of potential system compromise.</rationale>
 
 <Rule id="audit_rules_privileged_commands">
 <title>Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands</title>
-<description>At a minimum the audit system should collect the
-execution of privileged commands for all users and root.
-To find the relevant setuid / setgid programs, run the following command
-for each local partition <i>PART</i>:
+<description>At a minimum the audit system should collect the execution of
+privileged commands for all users and root. To find the relevant setuid /
+setgid programs, run the following command for each local partition
+<i>PART</i>:
 <pre>$ sudo find <i>PART</i> -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null</pre>
-Then, for each setuid / setgid program on the system, add a line of the
-following form to <tt>/etc/audit/audit.rules</tt>, where
-<i>SETUID_PROG_PATH</i> is the full path to each setuid / setgid program
-in the list:
+If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+utility to read audit rules during daemon startup (the default), add a line of
+the following form to <tt>/etc/audit/audit.rules</tt> for each setuid / setgid
+program on the system, replacing the <i>SETUID_PROG_PATH</i> part with the full
+path of that setuid / setgid program in the list:
+<pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
+program to read audit rules during daemon startup, add a line of the following
+form to a file with suffix <tt>.rules</tt> in the directory
+<tt>/etc/audit/rules.d</tt> for each setuid / setgid program on the system,
+replacing the <i>SETUID_PROG_PATH</i> part with the full path of that setuid /
+setgid program in the list:
 <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged</pre>
 </description>
 <ocil clause="it is not the case">

--- a/RHEL/7/input/checks/audit_rules_dac_modification_chmod.xml
+++ b/RHEL/7/input/checks/audit_rules_dac_modification_chmod.xml
@@ -1,0 +1,1 @@
+../../../../shared/oval/audit_rules_dac_modification_chmod.xml

--- a/RHEL/7/input/checks/audit_rules_dac_modification_chown.xml
+++ b/RHEL/7/input/checks/audit_rules_dac_modification_chown.xml
@@ -1,0 +1,1 @@
+../../../../shared/oval/audit_rules_dac_modification_chown.xml

--- a/RHEL/7/input/checks/audit_rules_dac_modification_fchmod.xml
+++ b/RHEL/7/input/checks/audit_rules_dac_modification_fchmod.xml
@@ -1,0 +1,1 @@
+../../../../shared/oval/audit_rules_dac_modification_fchmod.xml

--- a/RHEL/7/input/checks/audit_rules_dac_modification_fchmodat.xml
+++ b/RHEL/7/input/checks/audit_rules_dac_modification_fchmodat.xml
@@ -1,0 +1,1 @@
+../../../../shared/oval/audit_rules_dac_modification_fchmodat.xml

--- a/RHEL/7/input/checks/audit_rules_privileged_commands.xml
+++ b/RHEL/7/input/checks/audit_rules_privileged_commands.xml
@@ -1,0 +1,1 @@
+../../../../shared/oval/audit_rules_privileged_commands.xml

--- a/RHEL/7/input/profiles/common.xml
+++ b/RHEL/7/input/profiles/common.xml
@@ -5,6 +5,7 @@
 <select idref="partition_for_var_log_audit" selected="true"/>
 
 <!-- Audit DAC modifications -->
+<select idref="audit_rules_dac_modification_fchmodat" selected="true"/>
 <select idref="audit_rules_dac_modification_fchown" selected="true"/>
 <select idref="audit_rules_dac_modification_fchownat" selected="true"/>
 <select idref="audit_rules_dac_modification_fremovexattr" selected="true"/>

--- a/RHEL/7/input/profiles/common.xml
+++ b/RHEL/7/input/profiles/common.xml
@@ -16,6 +16,7 @@
 <select idref="audit_rules_dac_modification_setxattr" selected="true"/>
 
 <select idref="audit_rules_unsuccessful_file_modification" selected="true"/>
+<select idref="audit_rules_privileged_commands" selected="true"/>
 <select idref="audit_rules_media_export" selected="true"/>
 <select idref="audit_rules_file_deletion_events" selected="true"/>
 <select idref="audit_rules_sysadmin_actions" selected="true"/>

--- a/RHEL/7/input/profiles/common.xml
+++ b/RHEL/7/input/profiles/common.xml
@@ -5,6 +5,7 @@
 <select idref="partition_for_var_log_audit" selected="true"/>
 
 <!-- Audit DAC modifications -->
+<select idref="audit_rules_dac_modification_chown" selected="true"/>
 <select idref="audit_rules_dac_modification_fchmod" selected="true"/>
 <select idref="audit_rules_dac_modification_fchmodat" selected="true"/>
 <select idref="audit_rules_dac_modification_fchown" selected="true"/>

--- a/RHEL/7/input/profiles/common.xml
+++ b/RHEL/7/input/profiles/common.xml
@@ -5,6 +5,7 @@
 <select idref="partition_for_var_log_audit" selected="true"/>
 
 <!-- Audit DAC modifications -->
+<select idref="audit_rules_dac_modification_chmod" selected="true"/>
 <select idref="audit_rules_dac_modification_chown" selected="true"/>
 <select idref="audit_rules_dac_modification_fchmod" selected="true"/>
 <select idref="audit_rules_dac_modification_fchmodat" selected="true"/>

--- a/RHEL/7/input/profiles/common.xml
+++ b/RHEL/7/input/profiles/common.xml
@@ -5,6 +5,7 @@
 <select idref="partition_for_var_log_audit" selected="true"/>
 
 <!-- Audit DAC modifications -->
+<select idref="audit_rules_dac_modification_fchmod" selected="true"/>
 <select idref="audit_rules_dac_modification_fchmodat" selected="true"/>
 <select idref="audit_rules_dac_modification_fchown" selected="true"/>
 <select idref="audit_rules_dac_modification_fchownat" selected="true"/>

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -1260,15 +1260,23 @@ these events could serve as evidence of potential system compromise.</rationale>
 
 <Rule id="audit_rules_privileged_commands">
 <title>Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands</title>
-<description>At a minimum the audit system should collect the
-execution of privileged commands for all users and root.
-To find the relevant setuid / setgid programs, run the following command
-for each local partition <i>PART</i>:
+<description>At a minimum the audit system should collect the execution of
+privileged commands for all users and root. To find the relevant setuid /
+setgid programs, run the following command for each local partition
+<i>PART</i>:
 <pre>$ sudo find <i>PART</i> -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null</pre>
-Then, for each setuid / setgid program on the system, add a line of the
-following form to <tt>/etc/audit/audit.rules</tt>, where
-<i>SETUID_PROG_PATH</i> is the full path to each setuid / setgid program
-in the list:
+If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
+program to read audit rules during daemon startup (the default), add a line of
+the following form to a file with suffix <tt>.rules</tt> in the directory
+<tt>/etc/audit/rules.d</tt> for each setuid / setgid program on the system,
+replacing the <i>SETUID_PROG_PATH</i> part with the full path of that setuid /
+setgid program in the list:
+<pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+utility to read audit rules during daemon startup, add a line of the following
+form to <tt>/etc/audit/audit.rules</tt> for each setuid / setgid program on the
+system, replacing the <i>SETUID_PROG_PATH</i> part with the full path of that
+setuid / setgid program in the list:
 <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged</pre>
 </description>
 <ocil clause="it is not the case">

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -859,11 +859,19 @@ calls with others as identifying earlier in this guide is more efficient.
 
 <Rule id="audit_rules_dac_modification_fchmodat">
 <title>Record Events that Modify the System's Discretionary Access Controls - fchmodat</title>
-<description>At a minimum the audit system should collect file
-permission changes for all users and root. Add the following to
-<tt>/etc/audit/audit.rules</tt>:
+<description>At a minimum the audit system should collect file permission
+changes for all users and root. If the <tt>auditd</tt> daemon is configured to
+use the <tt>augenrules</tt> program to read audit rules during daemon startup
+(the default), add the following line to a file with suffix <tt>.rules</tt> in
+the directory <tt>/etc/audit/rules.d</tt>:
 <pre>-a always,exit -F arch=b32 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
-If the system is 64 bit then also add the following:
+If the system is 64 bit then also add the following line:
+<pre>-a always,exit -F arch=b64 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+utility to read audit rules during daemon startup, add the following line to
+<tt>/etc/audit/audit.rules</tt> file:
+<pre>-a always,exit -F arch=b32 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the system is 64 bit then also add the following line:
 <pre>-a always,exit -F arch=b64 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
 </description>
 <ocil>

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -807,11 +807,19 @@ calls with others as identifying earlier in this guide is more efficient.
 
 <Rule id="audit_rules_dac_modification_chown">
 <title>Record Events that Modify the System's Discretionary Access Controls - chown</title>
-<description>At a minimum the audit system should collect file
-permission changes for all users and root. Add the following to
-<tt>/etc/audit/audit.rules</tt>:
+<description>At a minimum the audit system should collect file permission
+changes for all users and root. If the <tt>auditd</tt> daemon is configured to
+use the <tt>augenrules</tt> program to read audit rules during daemon startup
+(the default), add the following line to a file with suffix <tt>.rules</tt> in
+the directory <tt>/etc/audit/rules.d</tt>:
 <pre>-a always,exit -F arch=b32 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
-If the system is 64 bit then also add the following:
+If the system is 64 bit then also add the following line:
+<pre>-a always,exit -F arch=b64 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+utility to read audit rules during daemon startup, add the following line to
+<tt>/etc/audit/audit.rules</tt> file:
+<pre>-a always,exit -F arch=b32 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the system is 64 bit then also add the following line:
 <pre>-a always,exit -F arch=b64 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
 </description>
 <ocil>

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -833,11 +833,19 @@ calls with others as identifying earlier in this guide is more efficient.
 
 <Rule id="audit_rules_dac_modification_fchmod">
 <title>Record Events that Modify the System's Discretionary Access Controls - fchmod</title>
-<description>At a minimum the audit system should collect file
-permission changes for all users and root. Add the following to
-<tt>/etc/audit/audit.rules</tt>:
+<description>At a minimum the audit system should collect file permission
+changes for all users and root. If the <tt>auditd</tt> daemon is configured to
+use the <tt>augenrules</tt> program to read audit rules during daemon startup
+(the default), add the following line to a file with suffix <tt>.rules</tt> in
+the directory <tt>/etc/audit/rules.d</tt>:
 <pre>-a always,exit -F arch=b32 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
-If the system is 64 bit then also add the following:
+If the system is 64 bit then also add the following line:
+<pre>-a always,exit -F arch=b64 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+utility to read audit rules during daemon startup, add the following line to
+<tt>/etc/audit/audit.rules</tt> file:
+<pre>-a always,exit -F arch=b32 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the system is 64 bit then also add the following line:
 <pre>-a always,exit -F arch=b64 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
 </description>
 <ocil>

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -781,11 +781,19 @@ abuse among both authorized and unauthorized users.</rationale>
 
 <Rule id="audit_rules_dac_modification_chmod">
 <title>Record Events that Modify the System's Discretionary Access Controls - chmod</title>
-<description>At a minimum the audit system should collect file
-permission changes for all users and root. Add the following to
-<tt>/etc/audit/audit.rules</tt>:
+<description>At a minimum the audit system should collect file permission
+changes for all users and root. If the <tt>auditd</tt> daemon is configured to
+use the <tt>augenrules</tt> program to read audit rules during daemon startup
+(the default), add the following line to a file with suffix <tt>.rules</tt> in
+the directory <tt>/etc/audit/rules.d</tt>:
 <pre>-a always,exit -F arch=b32 -S chmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
-If the system is 64 bit then also add the following:
+If the system is 64 bit then also add the following line:
+<pre>-a always,exit -F arch=b64 -S chmod  -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+utility to read audit rules during daemon startup, add the following line to
+<tt>/etc/audit/audit.rules</tt> file:
+<pre>-a always,exit -F arch=b32 -S chmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
+If the system is 64 bit then also add the following line:
 <pre>-a always,exit -F arch=b64 -S chmod  -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod</pre>
 </description>
 <rationale>The changing of file permissions could indicate that a user is attempting to

--- a/shared/oval/audit_rules_dac_modification_chmod.xml
+++ b/shared/oval/audit_rules_dac_modification_chmod.xml
@@ -1,0 +1,99 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_dac_modification_chmod" version="1">
+    <metadata>
+      <title>Audit Discretionary Access Control Modification Events - chmod</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>The changing of file permissions and attributes should be audited.</description>
+      <reference source="JL" ref_id="RHEL7_20150421" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150421" ref_url="test_attestation" />
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <criterion comment="audit augenrules" test_ref="test_ardm_chmod_augenrules" />
+        <criterion comment="audit augenrules 32-bit chmod" test_ref="test_32bit_ardm_chmod_augenrules" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of chmod audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_x86_64" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of chmod audit DAC rule -->
+          <criterion comment="audit augenrules 64-bit chmod" test_ref="test_64bit_ardm_chmod_augenrules" />
+        </criteria>
+      </criteria>
+
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <criterion comment="audit auditctl" test_ref="test_ardm_chmod_auditctl" />
+        <criterion comment="audit auditctl 32-bit chmod" test_ref="test_32bit_ardm_chmod_auditctl" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of chmod audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_x86_64" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of chmod audit DAC rule -->
+          <criterion comment="audit auditctl 64-bit chmod" test_ref="test_64bit_ardm_chmod_auditctl" />
+        </criteria>
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <!-- Test the augenrules case -->
+  <ind:textfilecontent54_test check="all" comment="audit augenrules" id="test_ardm_chmod_augenrules" version="1">
+    <ind:object object_ref="object_ardm_chmod_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_ardm_chmod_augenrules" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/augenrules.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit chmod" id="test_32bit_ardm_chmod_augenrules" version="1">
+    <ind:object object_ref="object_32bit_ardm_chmod_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_chmod_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*-S[\s]+chmod[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit chmod" id="test_64bit_ardm_chmod_augenrules" version="1">
+    <ind:object object_ref="object_64bit_ardm_chmod_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_chmod_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*-S[\s]+chmod[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Test the auditctl case -->
+  <ind:textfilecontent54_test check="all" comment="audit auditctl" id="test_ardm_chmod_auditctl" version="1">
+    <ind:object object_ref="object_ardm_chmod_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_ardm_chmod_auditctl" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/auditctl.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit chmod" id="test_32bit_ardm_chmod_auditctl" version="1">
+    <ind:object object_ref="object_32bit_ardm_chmod_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_chmod_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*-S[\s]+chmod[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit chmod" id="test_64bit_ardm_chmod_auditctl" version="1">
+    <ind:object object_ref="object_64bit_ardm_chmod_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_chmod_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*-S[\s]+chmod[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/shared/oval/audit_rules_dac_modification_chown.xml
+++ b/shared/oval/audit_rules_dac_modification_chown.xml
@@ -1,0 +1,99 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_dac_modification_chown" version="1">
+    <metadata>
+      <title>Audit Discretionary Access Control Modification Events - chown</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>The changing of file permissions and attributes should be audited.</description>
+      <reference source="JL" ref_id="RHEL7_20150421" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150421" ref_url="test_attestation" />
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <criterion comment="audit augenrules" test_ref="test_ardm_chown_augenrules" />
+        <criterion comment="audit augenrules 32-bit chown" test_ref="test_32bit_ardm_chown_augenrules" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of chown audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_x86_64" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of chown audit DAC rule -->
+          <criterion comment="audit augenrules 64-bit chown" test_ref="test_64bit_ardm_chown_augenrules" />
+        </criteria>
+      </criteria>
+
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <criterion comment="audit auditctl" test_ref="test_ardm_chown_auditctl" />
+        <criterion comment="audit auditctl 32-bit chown" test_ref="test_32bit_ardm_chown_auditctl" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of chown audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_x86_64" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of chown audit DAC rule -->
+          <criterion comment="audit auditctl 64-bit chown" test_ref="test_64bit_ardm_chown_auditctl" />
+        </criteria>
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <!-- Test the augenrules case -->
+  <ind:textfilecontent54_test check="all" comment="audit augenrules" id="test_ardm_chown_augenrules" version="1">
+    <ind:object object_ref="object_ardm_chown_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_ardm_chown_augenrules" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/augenrules.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit chown" id="test_32bit_ardm_chown_augenrules" version="1">
+    <ind:object object_ref="object_32bit_ardm_chown_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_chown_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*-S[\s]+chown[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit chown" id="test_64bit_ardm_chown_augenrules" version="1">
+    <ind:object object_ref="object_64bit_ardm_chown_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_chown_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*-S[\s]+chown[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Test the auditctl case -->
+  <ind:textfilecontent54_test check="all" comment="audit auditctl" id="test_ardm_chown_auditctl" version="1">
+    <ind:object object_ref="object_ardm_chown_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_ardm_chown_auditctl" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/auditctl.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit chown" id="test_32bit_ardm_chown_auditctl" version="1">
+    <ind:object object_ref="object_32bit_ardm_chown_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_chown_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*-S[\s]+chown[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit chown" id="test_64bit_ardm_chown_auditctl" version="1">
+    <ind:object object_ref="object_64bit_ardm_chown_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_chown_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*-S[\s]+chown[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/shared/oval/audit_rules_dac_modification_fchmod.xml
+++ b/shared/oval/audit_rules_dac_modification_fchmod.xml
@@ -1,0 +1,99 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_dac_modification_fchmod" version="1">
+    <metadata>
+      <title>Audit Discretionary Access Control Modification Events - fchmod</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>The changing of file permissions and attributes should be audited.</description>
+      <reference source="JL" ref_id="RHEL7_20150421" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150421" ref_url="test_attestation" />
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <criterion comment="audit augenrules" test_ref="test_ardm_fchmod_augenrules" />
+        <criterion comment="audit augenrules 32-bit fchmod" test_ref="test_32bit_ardm_fchmod_augenrules" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of fchmod audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_x86_64" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of fchmod audit DAC rule -->
+          <criterion comment="audit augenrules 64-bit fchmod" test_ref="test_64bit_ardm_fchmod_augenrules" />
+        </criteria>
+      </criteria>
+
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <criterion comment="audit auditctl" test_ref="test_ardm_fchmod_auditctl" />
+        <criterion comment="audit auditctl 32-bit fchmod" test_ref="test_32bit_ardm_fchmod_auditctl" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of fchmod audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_x86_64" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of fchmod audit DAC rule -->
+          <criterion comment="audit auditctl 64-bit fchmod" test_ref="test_64bit_ardm_fchmod_auditctl" />
+        </criteria>
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <!-- Test the augenrules case -->
+  <ind:textfilecontent54_test check="all" comment="audit augenrules" id="test_ardm_fchmod_augenrules" version="1">
+    <ind:object object_ref="object_ardm_fchmod_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_ardm_fchmod_augenrules" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/augenrules.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit fchmod" id="test_32bit_ardm_fchmod_augenrules" version="1">
+    <ind:object object_ref="object_32bit_ardm_fchmod_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_fchmod_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*-S[\s]+fchmod[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit fchmod" id="test_64bit_ardm_fchmod_augenrules" version="1">
+    <ind:object object_ref="object_64bit_ardm_fchmod_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_fchmod_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*-S[\s]+fchmod[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Test the auditctl case -->
+  <ind:textfilecontent54_test check="all" comment="audit auditctl" id="test_ardm_fchmod_auditctl" version="1">
+    <ind:object object_ref="object_ardm_fchmod_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_ardm_fchmod_auditctl" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/auditctl.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit fchmod" id="test_32bit_ardm_fchmod_auditctl" version="1">
+    <ind:object object_ref="object_32bit_ardm_fchmod_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_fchmod_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*-S[\s]+fchmod[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit fchmod" id="test_64bit_ardm_fchmod_auditctl" version="1">
+    <ind:object object_ref="object_64bit_ardm_fchmod_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_fchmod_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*-S[\s]+fchmod[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/shared/oval/audit_rules_dac_modification_fchmodat.xml
+++ b/shared/oval/audit_rules_dac_modification_fchmodat.xml
@@ -1,0 +1,99 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_dac_modification_fchmodat" version="1">
+    <metadata>
+      <title>Audit Discretionary Access Control Modification Events - fchmodat</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>The changing of file permissions and attributes should be audited.</description>
+      <reference source="JL" ref_id="RHEL7_20150420" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150420" ref_url="test_attestation" />
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <criterion comment="audit augenrules" test_ref="test_ardm_fchmodat_augenrules" />
+        <criterion comment="audit augenrules 32-bit fchmodat" test_ref="test_32bit_ardm_fchmodat_augenrules" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of fchmodat audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_x86_64" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of fchmodat audit DAC rule -->
+          <criterion comment="audit augenrules 64-bit fchmodat" test_ref="test_64bit_ardm_fchmodat_augenrules" />
+        </criteria>
+      </criteria>
+
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <criterion comment="audit auditctl" test_ref="test_ardm_fchmodat_auditctl" />
+        <criterion comment="audit auditctl 32-bit fchmodat" test_ref="test_32bit_ardm_fchmodat_auditctl" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of fchmodat audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_x86_64" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of fchmodat audit DAC rule -->
+          <criterion comment="audit auditctl 64-bit fchmodat" test_ref="test_64bit_ardm_fchmodat_auditctl" />
+        </criteria>
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <!-- Test the augenrules case -->
+  <ind:textfilecontent54_test check="all" comment="audit augenrules" id="test_ardm_fchmodat_augenrules" version="1">
+    <ind:object object_ref="object_ardm_fchmodat_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_ardm_fchmodat_augenrules" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/augenrules.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit fchmodat" id="test_32bit_ardm_fchmodat_augenrules" version="1">
+    <ind:object object_ref="object_32bit_ardm_fchmodat_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_fchmodat_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*-S[\s]+fchmodat[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit fchmodat" id="test_64bit_ardm_fchmodat_augenrules" version="1">
+    <ind:object object_ref="object_64bit_ardm_fchmodat_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_fchmodat_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*-S[\s]+fchmodat[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Test the auditctl case -->
+  <ind:textfilecontent54_test check="all" comment="audit auditctl" id="test_ardm_fchmodat_auditctl" version="1">
+    <ind:object object_ref="object_ardm_fchmodat_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_ardm_fchmodat_auditctl" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/auditctl.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit fchmodat" id="test_32bit_ardm_fchmodat_auditctl" version="1">
+    <ind:object object_ref="object_32bit_ardm_fchmodat_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_fchmodat_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*-S[\s]+fchmodat[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit fchmodat" id="test_64bit_ardm_fchmodat_auditctl" version="1">
+    <ind:object object_ref="object_64bit_ardm_fchmodat_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_fchmodat_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*-S[\s]+fchmodat[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*-k[\s]+[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/shared/oval/audit_rules_privileged_commands.xml
+++ b/shared/oval/audit_rules_privileged_commands.xml
@@ -1,0 +1,146 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_privileged_commands" version="1">
+    <metadata>
+      <title>Ensure auditd Collects Information on the Use of Privileged Commands</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>Audit rules about the information on the use of privileged commands are enabled.</description>
+      <reference source="JL" ref_id="RHEL7_20150420" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150420" ref_url="test_attestation" />
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <criterion comment="audit augenrules" test_ref="test_arpc_augenrules" />
+        <criterion comment="audit augenrules suid sgid" test_ref="test_arpc_suid_sgid_augenrules" />
+        <criterion comment="audit augenrules binaries count matches rules count" test_ref="test_arpc_bin_count_equals_rules_count_augenrules" />
+      </criteria>
+
+      <!-- Test the auditctl case -->
+      <criteria operator="AND">
+        <criterion comment="audit auditctl" test_ref="test_arpc_auditctl" />
+        <criterion comment="audit auditctl suid sgid" test_ref="test_arpc_suid_sgid_auditctl" />
+        <criterion comment="audit auditctl binaries count matches rules count" test_ref="test_arpc_bin_count_equals_rules_count_auditctl" />
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <!-- First define OVAL entities that can be reused across tests below -->
+  <unix:file_object id="object_system_privileged_commands" comment="system files with setuid or setgid permission set" version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" max_depth="-1" />
+    <unix:path operation="equals">/</unix:path>
+    <!-- [a-z]+ regex below is a workaround for OpenSCAP https://fedorahosted.org/openscap/ticket/457 bug -->
+    <unix:filename operation="pattern match">[a-z]+</unix:filename>
+    <filter action="include">state_setuid_or_setgid_set</filter>
+    <filter action="exclude">state_dev_proc_sys_dirs</filter>
+  </unix:file_object>
+
+  <unix:file_state id="state_setuid_or_setgid_set" version="1" operator="OR">
+    <unix:suid datatype="boolean">true</unix:suid>
+    <unix:sgid datatype="boolean">true</unix:sgid>
+  </unix:file_state>
+
+  <unix:file_state id="state_dev_proc_sys_dirs" version="1">
+    <unix:filepath operation="pattern match">^\/(dev|proc|sys)\/.*$</unix:filepath>
+  </unix:file_state>
+
+  <local_variable id="variable_full_form_of_audit_rule" comment="full form of audit rules for privileged commands" datatype="string" version="1">
+    <concat>
+      <literal_component>-a always,exit -F path=</literal_component>
+      <object_component object_ref="object_system_privileged_commands" item_field="filepath" />
+      <literal_component> -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged</literal_component>
+    </concat>
+  </local_variable>
+
+  <local_variable id="variable_count_of_suid_sgid_binaries_on_system" comment="count of suid / sgid binaries actually present on the system" datatype="int" version="1">
+    <count>
+      <object_component object_ref="object_system_privileged_commands" item_field="filepath" />
+    </count>
+  </local_variable>
+
+  <ind:variable_object id="object_count_of_suid_sgid_binaries_on_system" version="1">
+    <ind:var_ref>variable_count_of_suid_sgid_binaries_on_system</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:textfilecontent54_state id="state_proper_audit_rule_but_for_unprivileged_command" version="1">
+    <ind:subexpression operation="not equal" datatype="string" var_ref="variable_full_form_of_audit_rule" var_check="all" />
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_audit_rules_privileged_commands" version="1">
+    <ind:subexpression operation="pattern match" datatype="string" var_ref="variable_full_form_of_audit_rule" var_check="at least one"/>
+  </ind:textfilecontent54_state>
+
+  <!-- Test the augenrules case -->
+  <ind:textfilecontent54_test check="all" comment="audit augenrules" id="test_arpc_augenrules" version="1">
+    <ind:object object_ref="object_arpc_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arpc_augenrules" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/augenrules.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="audit augenrules suid sgid" id="test_arpc_suid_sgid_augenrules" version="1">
+    <ind:object object_ref="object_arpc_suid_sgid_augenrules" />
+    <ind:state state_ref="state_audit_rules_privileged_commands" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arpc_suid_sgid_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*(-a always,exit -F path=[^\n]+ -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged)[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+    <filter action="exclude">state_proper_audit_rule_but_for_unprivileged_command</filter>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="variable_count_of_privileged_commands_having_audit_definition_augenrules" comment="count of suid / sgid binaries having full audit rule definition in some of /etc/audit/rules.d/*.rules files" datatype="int" version="1">
+    <count>
+      <object_component object_ref="object_arpc_suid_sgid_augenrules" item_field="subexpression" />
+    </count>
+  </local_variable>
+  <ind:variable_state id="state_count_of_privileged_commands_having_audit_definition_augenrules" version="1">
+    <ind:value operation="equals" datatype="int" var_ref="variable_count_of_privileged_commands_having_audit_definition_augenrules" var_check="at least one" />
+  </ind:variable_state>
+  <ind:variable_test check="all" check_existence="all_exist" id="test_arpc_bin_count_equals_rules_count_augenrules" comment="audit augenrules binaries count matches rules count" version="1">
+    <ind:object object_ref="object_count_of_suid_sgid_binaries_on_system" />
+    <ind:state state_ref="state_count_of_privileged_commands_having_audit_definition_augenrules" />
+  </ind:variable_test>
+
+  <!-- Test the auditctl case -->
+  <ind:textfilecontent54_test check="all" comment="audit auditctl" id="test_arpc_auditctl" version="1">
+    <ind:object object_ref="object_arpc_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arpc_auditctl" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/auditctl.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="audit auditctl suid sgid" id="test_arpc_suid_sgid_auditctl" version="1">
+    <ind:object object_ref="object_arpc_suid_sgid_auditctl" />
+    <ind:state state_ref="state_audit_rules_privileged_commands" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arpc_suid_sgid_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*(-a always,exit -F path=[^\n]+ -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged)[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+    <filter action="exclude">state_proper_audit_rule_but_for_unprivileged_command</filter>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="variable_count_of_privileged_commands_having_audit_definition_auditctl" comment="count of suid / sgid binaries having full audit rule definition in /etc/audit/audit.rules file" datatype="int" version="1">
+    <count>
+      <object_component object_ref="object_arpc_suid_sgid_auditctl" item_field="subexpression" />
+    </count>
+  </local_variable>
+  <ind:variable_state id="state_count_of_privileged_commands_having_audit_definition_auditctl" version="1">
+    <ind:value operation="equals" datatype="int" var_ref="variable_count_of_privileged_commands_having_audit_definition_auditctl" var_check="at least one" />
+  </ind:variable_state>
+  <ind:variable_test check="all" check_existence="all_exist" id="test_arpc_bin_count_equals_rules_count_auditctl" comment="audit auditctl binaries count matches rules count" version="1">
+    <ind:object object_ref="object_count_of_suid_sgid_binaries_on_system" />
+    <ind:state state_ref="state_count_of_privileged_commands_having_audit_definition_auditctl" />
+  </ind:variable_test>
+
+</def-group>


### PR DESCRIPTION
This patchset ports the following five existing RHEL-6 audit rules to RHEL-7 && Fedora products:
* ```audit_rules_privileged_commands```
* ```audit_rules_dac_modification_fchmodat```
* ```audit_rules_dac_modification_fchmod```
* ```audit_rules_dac_modification_chown```
* ```audit_rules_dac_modification_chmod```

Each rule port is split into two commits:
* the first commit ports the corresponding OVAL check to ```/shared``` directory & makes links to RHEL/7 && Fedora products,
* the second commit from the pair updates the corresponding XCCDF rule description (in both RHEL/7 && Fedora) products to reflect the fact there are two locations, where the setting can be applied.

The port ```audit_rules_privileged_commands``` fixes the following issues:
* https://github.com/OpenSCAP/scap-security-guide/issues/134
* https://github.com/OpenSCAP/scap-security-guide/issues/5
and possibly also:
* https://github.com/OpenSCAP/scap-security-guide/issues/82

Testing report:
------------------
All changes have been tested on both products (RHEL/7 && Fedora) - both the OVAL changes && the XCCDF text changes and AFAICT from testing all of them work fine.

Please review.

Thank you, Jan.