### PR TITLE
[Enhancement] [BugFix] Port two more audit rules to RHEL-7 && Fedora

### DIFF
--- a/Fedora/input/checks/audit_rules_mac_modification.xml
+++ b/Fedora/input/checks/audit_rules_mac_modification.xml
@@ -1,0 +1,1 @@
+../../../shared/oval/audit_rules_mac_modification.xml

--- a/Fedora/input/checks/audit_rules_networkconfig_modification.xml
+++ b/Fedora/input/checks/audit_rules_networkconfig_modification.xml
@@ -1,0 +1,1 @@
+../../../shared/oval/audit_rules_networkconfig_modification.xml

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -46,6 +46,8 @@
 
 <!-- Audit section rules -->
 
+  <select idref="audit_rules_mac_modification" selected="true"/>
+
   <!-- Audit DAC modifications -->
   <select idref="audit_rules_dac_modification_chmod" selected="true"/>
   <select idref="audit_rules_dac_modification_chown" selected="true"/>

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -46,6 +46,7 @@
 
 <!-- Audit section rules -->
 
+  <select idref="audit_rules_networkconfig_modification" selected="true"/>
   <select idref="audit_rules_mac_modification" selected="true"/>
 
   <!-- Audit DAC modifications -->

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -652,8 +652,20 @@ legitimacy.</rationale>
 
 <Rule id="audit_rules_networkconfig_modification">
 <title>Record Events that Modify the System's Network Environment</title>
-<description>Add the following to <tt>/etc/audit/audit.rules</tt>, setting
-ARCH to either b32 or b64 as appropriate for your system:
+<description>If the <tt>auditd</tt> daemon is configured to use the
+<tt>auditctl</tt> utility to read audit rules during daemon startup (the
+default), add the following lines to <tt>/etc/audit/audit.rules</tt> file,
+setting ARCH to either b32 or b64 as appropriate for your system:
+<pre># audit_rules_networkconfig_modification
+-a always,exit -F arch=ARCH -S sethostname -S setdomainname -k audit_rules_networkconfig_modification
+-w /etc/issue -p wa -k audit_rules_networkconfig_modification
+-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification
+-w /etc/hosts -p wa -k audit_rules_networkconfig_modification
+-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
+program to read audit rules during daemon startup, add the following lines to a
+file with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>,
+setting ARCH to either b32 or b64 as appropriate for your system:
 <pre># audit_rules_networkconfig_modification
 -a always,exit -F arch=ARCH -S sethostname -S setdomainname -k audit_rules_networkconfig_modification
 -w /etc/issue -p wa -k audit_rules_networkconfig_modification

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -671,7 +671,7 @@ each file specified (and <tt>perm=wa</tt> should be indicated for each).
 <rationale>The network environment should not be modified by anything other
 than administrator action. Any change to network parameters should be
 audited.</rationale>
-<!-- <oval id="audit_rules_networkconfig_modification" /> -->
+<oval id="audit_rules_networkconfig_modification" />
 <ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -709,7 +709,13 @@ owner, and unauthorized users, potential access to sensitive information.</ratio
 
 <Rule id="audit_rules_mac_modification">
 <title>Record Events that Modify the System's Mandatory Access Controls</title>
-<description>Add the following to <tt>/etc/audit/audit.rules</tt>:
+<description>If the <tt>auditd</tt> daemon is configured to use the
+<tt>auditctl</tt> utility to read audit rules during daemon startup (the
+default), add the following line to <tt>/etc/audit/audit.rules</tt> file:
+<pre>-w /etc/selinux/ -p wa -k MAC-policy</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
+program to read audit rules during daemon startup, add the following line to a
+file with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 <pre>-w /etc/selinux/ -p wa -k MAC-policy</pre>
 </description>
 <ocil clause="the system is not configured to audit attempts to change the MAC policy">

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -723,7 +723,7 @@ configuration, a line should be returned (including
 <rationale>The system's mandatory access policy (SELinux) should not be
 arbitrarily changed by anything other than administrator action. All changes to
 MAC policy should be audited.</rationale>
-<!-- <oval id="audit_rules_mac_modification" /> -->
+<oval id="audit_rules_mac_modification" />
 <ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" />
 </Rule>
 

--- a/RHEL/7/input/checks/audit_rules_mac_modification.xml
+++ b/RHEL/7/input/checks/audit_rules_mac_modification.xml
@@ -1,0 +1,1 @@
+../../../../shared/oval/audit_rules_mac_modification.xml

--- a/RHEL/7/input/checks/audit_rules_networkconfig_modification.xml
+++ b/RHEL/7/input/checks/audit_rules_networkconfig_modification.xml
@@ -1,0 +1,1 @@
+../../../../shared/oval/audit_rules_networkconfig_modification.xml

--- a/RHEL/7/input/profiles/common.xml
+++ b/RHEL/7/input/profiles/common.xml
@@ -4,6 +4,8 @@
 <select idref="partition_for_var_log" selected="true"/>
 <select idref="partition_for_var_log_audit" selected="true"/>
 
+<select idref="audit_rules_mac_modification" selected="true"/>
+
 <!-- Audit DAC modifications -->
 <select idref="audit_rules_dac_modification_chmod" selected="true"/>
 <select idref="audit_rules_dac_modification_chown" selected="true"/>

--- a/RHEL/7/input/profiles/common.xml
+++ b/RHEL/7/input/profiles/common.xml
@@ -4,6 +4,7 @@
 <select idref="partition_for_var_log" selected="true"/>
 <select idref="partition_for_var_log_audit" selected="true"/>
 
+<select idref="audit_rules_networkconfig_modification" selected="true"/>
 <select idref="audit_rules_mac_modification" selected="true"/>
 
 <!-- Audit DAC modifications -->

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -674,8 +674,21 @@ legitimacy.</rationale>
 
 <Rule id="audit_rules_networkconfig_modification">
 <title>Record Events that Modify the System's Network Environment</title>
-<description>Add the following to <tt>/etc/audit/audit.rules</tt>, setting
-ARCH to either b32 or b64 as appropriate for your system:
+<description>If the <tt>auditd</tt> daemon is configured to use the
+<tt>augenrules</tt> program to read audit rules during daemon startup (the
+default), add the following lines to a file with suffix <tt>.rules</tt> in the
+directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32 or b64 as
+appropriate for your system:
+<pre># audit_rules_networkconfig_modification
+-a always,exit -F arch=ARCH -S sethostname -S setdomainname -k audit_rules_networkconfig_modification
+-w /etc/issue -p wa -k audit_rules_networkconfig_modification
+-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification
+-w /etc/hosts -p wa -k audit_rules_networkconfig_modification
+-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+utility to read audit rules during daemon startup, add the following lines to
+<tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 or b64 as
+appropriate for your system:
 <pre># audit_rules_networkconfig_modification
 -a always,exit -F arch=ARCH -S sethostname -S setdomainname -k audit_rules_networkconfig_modification
 -w /etc/issue -p wa -k audit_rules_networkconfig_modification

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -736,7 +736,14 @@ owner, and unauthorized users, potential access to sensitive information.</ratio
 
 <Rule id="audit_rules_mac_modification">
 <title>Record Events that Modify the System's Mandatory Access Controls</title>
-<description>Add the following to <tt>/etc/audit/audit.rules</tt>:
+<description>If the <tt>auditd</tt> daemon is configured to use the
+<tt>augenrules</tt> program to read audit rules during daemon startup (the
+default), add the following line to a file with suffix <tt>.rules</tt> in the
+directory <tt>/etc/audit/rules.d</tt>:
+<pre>-w /etc/selinux/ -p wa -k MAC-policy</pre>
+If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+utility to read audit rules during daemon startup, add the following line to
+<tt>/etc/audit/audit.rules</tt> file:
 <pre>-w /etc/selinux/ -p wa -k MAC-policy</pre>
 </description>
 <ocil clause="the system is not configured to audit attempts to change the MAC policy">

--- a/shared/oval/audit_rules_mac_modification.xml
+++ b/shared/oval/audit_rules_mac_modification.xml
@@ -1,0 +1,69 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_mac_modification" version="1">
+    <metadata>
+      <title>Record Events that Modify the System's Mandatory Access Controls</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>Audit rules that detect changes to the system's mandatory access controls (SELinux) are enabled.</description>
+      <reference source="JL" ref_id="RHEL7_20150424" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150424" ref_url="test_attestation" />
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <criterion comment="audit augenrules" test_ref="test_armm_augenrules" />
+        <criterion comment="audit selinux changes augenrules" test_ref="test_armm_selinux_watch_augenrules" />
+      </criteria>
+
+      <!-- Test the auditctl case -->
+      <criteria operator="AND">
+        <criterion comment="audit auditctl" test_ref="test_armm_auditctl" />
+        <criterion comment="audit selinux changes auditctl" test_ref="test_armm_selinux_watch_auditctl" />
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <!-- Test the augenrules case -->
+  <ind:textfilecontent54_test check="all" comment="audit augenrules" id="test_armm_augenrules" version="1">
+    <ind:object object_ref="object_armm_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_armm_augenrules" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/augenrules.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit selinux changes augenrules" id="test_armm_selinux_watch_augenrules" version="1">
+    <ind:object object_ref="object_armm_selinux_watch_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_armm_selinux_watch_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/selinux/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+\-k[\s]+[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Test the auditctl case -->
+  <ind:textfilecontent54_test check="all" comment="audit auditctl" id="test_armm_auditctl" version="1">
+    <ind:object object_ref="object_armm_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_armm_auditctl" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/auditctl.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit selinux changes auditctl" id="test_armm_selinux_watch_auditctl" version="1">
+    <ind:object object_ref="object_armm_selinux_watch_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_armm_selinux_watch_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/selinux/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+\-k[\s]+[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/shared/oval/audit_rules_networkconfig_modification.xml
+++ b/shared/oval/audit_rules_networkconfig_modification.xml
@@ -1,0 +1,150 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_networkconfig_modification" version="1">
+    <metadata>
+      <title>Record Events that Modify the System's Network Environment</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>The network environment should not be modified by anything other than
+      administrator action. Any change to network parameters should be audited.</description>
+      <reference source="JL" ref_id="RHEL7_20150424" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150424" ref_url="test_attestation" />
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <criterion comment="audit augenrules" test_ref="test_arnm_augenrules" />
+        <criterion comment="audit network syscalls augenrules" test_ref="test_arnm_syscall_augenrules" />
+        <criterion comment="audit /etc/issue augenrules" test_ref="test_arnm_etc_issue_augenrules" />
+        <criterion comment="audit /etc/issue.net augenrules" test_ref="test_arnm_etc_issue_net_augenrules" />
+        <criterion comment="audit /etc/hosts augenrules" test_ref="test_arnm_etc_hosts_augenrules" />
+        <criterion comment="audit /etc/sysconfig/network augenrules" test_ref="test_arnm_etc_sysconfig_network_augenrules" />
+      </criteria>
+
+      <!-- Test the auditctl case -->
+      <criteria operator="AND">
+        <criterion comment="audit auditctl" test_ref="test_arnm_auditctl" />
+        <criterion comment="audit network syscalls auditctl" test_ref="test_arnm_syscall_auditctl" />
+        <criterion comment="audit /etc/issue auditctl" test_ref="test_arnm_etc_issue_auditctl" />
+        <criterion comment="audit /etc/issue.net auditctl" test_ref="test_arnm_etc_issue_net_auditctl" />
+        <criterion comment="audit /etc/hosts auditctl" test_ref="test_arnm_etc_hosts_auditctl" />
+        <criterion comment="audit /etc/sysconfig/network auditctl" test_ref="test_arnm_etc_sysconfig_network_auditctl" />
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <!-- Test the augenrules case -->
+  <ind:textfilecontent54_test check="all" comment="audit augenrules" id="test_arnm_augenrules" version="1">
+    <ind:object object_ref="object_arnm_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_augenrules" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/augenrules.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit network syscalls augenrules" id="test_arnm_syscall_augenrules" version="1">
+    <ind:object object_ref="object_arnm_syscall_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_syscall_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-a\s+always,exit\s+(\-F\s+arch=(b64|b32)\s+)?\-S\s+sethostname\s+\-S\s+setdomainname\s+\-k\s+[-\w]+\s*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/issue augenrules" id="test_arnm_etc_issue_augenrules" version="1">
+    <ind:object object_ref="object_arnm_etc_issue_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_issue_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+\-k[\s]+[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/issue.net augenrules" id="test_arnm_etc_issue_net_augenrules" version="1">
+    <ind:object object_ref="object_arnm_etc_issue_net_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_issue_net_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue\.net[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+\-k[\s]+[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/hosts augenrules" id="test_arnm_etc_hosts_augenrules" version="1">
+    <ind:object object_ref="object_arnm_etc_hosts_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_hosts_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/hosts[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+\-k[\s]+[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/sysconfig/network augenrules" id="test_arnm_etc_sysconfig_network_augenrules" version="1">
+    <ind:object object_ref="object_arnm_etc_sysconfig_network_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_sysconfig_network_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/sysconfig/network[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+\-k[\s]+[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Test the auditctl case -->
+  <ind:textfilecontent54_test check="all" comment="audit auditctl" id="test_arnm_auditctl" version="1">
+    <ind:object object_ref="object_arnm_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_auditctl" version="1">
+    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/auditctl.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit network syscalls auditctl" id="test_arnm_syscall_auditctl" version="1">
+    <ind:object object_ref="object_arnm_syscall_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_syscall_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-a\s+always,exit\s+(\-F\s+arch=(b64|b32)\s+)?\-S\s+sethostname\s+\-S\s+setdomainname\s+\-k\s+[-\w]+\s*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/issue auditctl" id="test_arnm_etc_issue_auditctl" version="1">
+    <ind:object object_ref="object_arnm_etc_issue_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_issue_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+\-k[\s]+[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/issue.net auditctl" id="test_arnm_etc_issue_net_auditctl" version="1">
+    <ind:object object_ref="object_arnm_etc_issue_net_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_issue_net_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue\.net[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+\-k[\s]+[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/hosts auditctl" id="test_arnm_etc_hosts_auditctl" version="1">
+    <ind:object object_ref="object_arnm_etc_hosts_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_hosts_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/hosts[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+\-k[\s]+[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/sysconfig/network auditctl" id="test_arnm_etc_sysconfig_network_auditctl" version="1">
+    <ind:object object_ref="object_arnm_etc_sysconfig_network_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_sysconfig_network_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/sysconfig/network[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+\-k[\s]+[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>


### PR DESCRIPTION
This patchset ports the following two audit rules:
* ```audit_rules_mac_modification```
* ```audit_rules_networkconfig_modification```

to RHEL-7 and Fedora operating systems.

The change for each rule is performed in two steps:
* first commit of the pair updates the OVAL check (it to work properly on RHEL/7 & Fedora),
* the second commit of the pair updates the XCCDF prose for particular rule

Testing report:
-------------------
All four changes have been tested on RHEL-7 and Fedora 20 systems. OVAL check ports for both rules work properly (AFAICT). The same for guides updates (have built guide for both products manually & verified the prose is updated / contains the expected form).

Please review.

Thank you, Jan.