### PR TITLE
[issue 539] update kernel module XCCDF to use /bin/true instead of /bin/false

### DIFF
--- a/Fedora/transforms/shorthand2xccdf.xslt
+++ b/Fedora/transforms/shorthand2xccdf.xslt
@@ -422,7 +422,7 @@
   <xsl:template match="module-disable-macro">
 To configure the system to prevent the <xhtml:code><xsl:value-of select="@module"/></xhtml:code>
 kernel module from being loaded, add the following line to a file in the directory <xhtml:code>/etc/modprobe.d</xhtml:code>:
-<xhtml:pre xml:space="preserve">install <xsl:value-of select="@module"/> /bin/false</xhtml:pre>
+<xhtml:pre xml:space="preserve">install <xsl:value-of select="@module"/> /bin/true</xhtml:pre>
   </xsl:template>
 
   <xsl:template match="module-disable-check-macro">
@@ -430,7 +430,7 @@ If the system is configured to prevent the loading of the
 <xhtml:code><xsl:value-of select="@module"/></xhtml:code> kernel module,
 it will contain lines inside any file in <xhtml:code>/etc/modprobe.d</xhtml:code> or the deprecated<xhtml:code>/etc/modprobe.conf</xhtml:code>.
 These lines instruct the module loading system to run another program (such as
-<xhtml:code>/bin/false</xhtml:code>) upon a module <xhtml:code>install</xhtml:code> event.
+<xhtml:code>/bin/true</xhtml:code>) upon a module <xhtml:code>install</xhtml:code> event.
 Run the following command to search for such lines in all files in <xhtml:code>/etc/modprobe.d</xhtml:code>
 and the deprecated <xhtml:code>/etc/modprobe.conf</xhtml:code>:
 <xhtml:pre xml:space="preserve">$ grep -r <xsl:value-of select="@module"/> /etc/modprobe.conf /etc/modprobe.d</xhtml:pre>

--- a/RHEL/5/input/fixes/bash/templates/template_kernel_module_disabled
+++ b/RHEL/5/input/fixes/bash/templates/template_kernel_module_disabled
@@ -1,1 +1,1 @@
-echo "install KERNMODULE /bin/false" > /etc/modprobe.d/KERNMODULE.conf
+echo "install KERNMODULE /bin/true" > /etc/modprobe.d/KERNMODULE.conf

--- a/RHEL/5/transforms/shorthand2xccdf.xslt
+++ b/RHEL/5/transforms/shorthand2xccdf.xslt
@@ -440,7 +440,7 @@
   <xsl:template match="module-disable-macro">
 To configure the system to prevent the <xhtml:code><xsl:value-of select="@module"/></xhtml:code>
 kernel module from being loaded, add the following line to a file in the directory <xhtml:code>/etc/modprobe.d</xhtml:code>:
-<xhtml:pre xml:space="preserve">install <xsl:value-of select="@module"/> /bin/false</xhtml:pre>
+<xhtml:pre xml:space="preserve">install <xsl:value-of select="@module"/> /bin/true</xhtml:pre>
   </xsl:template>
 
   <xsl:template match="module-disable-check-macro">
@@ -448,7 +448,7 @@ If the system is configured to prevent the loading of the
 <xhtml:code><xsl:value-of select="@module"/></xhtml:code> kernel module,
 it will contain lines inside any file in <xhtml:code>/etc/modprobe.d</xhtml:code> or the deprecated<xhtml:code>/etc/modprobe.conf</xhtml:code>.
 These lines instruct the module loading system to run another program (such as
-<xhtml:code>/bin/false</xhtml:code>) upon a module <xhtml:code>install</xhtml:code> event.
+<xhtml:code>/bin/true</xhtml:code>) upon a module <xhtml:code>install</xhtml:code> event.
 Run the following command to search for such lines in all files in <xhtml:code>/etc/modprobe.d</xhtml:code>
 and the deprecated <xhtml:code>/etc/modprobe.conf</xhtml:code>:
 <xhtml:pre xml:space="preserve">$ grep -r <xsl:value-of select="@module"/> /etc/modprobe.conf /etc/modprobe.d</xhtml:pre>

--- a/RHEL/6/input/fixes/bash/kernel_module_cramfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_cramfs_disabled.sh
@@ -1,1 +1,1 @@
-echo "install cramfs /bin/false" > /etc/modprobe.d/cramfs.conf
+echo "install cramfs /bin/true" > /etc/modprobe.d/cramfs.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_dccp_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_dccp_disabled.sh
@@ -1,1 +1,1 @@
-echo "install dccp /bin/false" > /etc/modprobe.d/dccp.conf
+echo "install dccp /bin/true" > /etc/modprobe.d/dccp.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_freevxfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_freevxfs_disabled.sh
@@ -1,1 +1,1 @@
-echo "install freevxfs /bin/false" > /etc/modprobe.d/freevxfs.conf
+echo "install freevxfs /bin/true" > /etc/modprobe.d/freevxfs.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_hfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_hfs_disabled.sh
@@ -1,1 +1,1 @@
-echo "install hfs /bin/false" > /etc/modprobe.d/hfs.conf
+echo "install hfs /bin/true" > /etc/modprobe.d/hfs.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_hfsplus_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_hfsplus_disabled.sh
@@ -1,1 +1,1 @@
-echo "install hfsplus /bin/false" > /etc/modprobe.d/hfsplus.conf
+echo "install hfsplus /bin/true" > /etc/modprobe.d/hfsplus.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_jffs2_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_jffs2_disabled.sh
@@ -1,1 +1,1 @@
-echo "install jffs2 /bin/false" > /etc/modprobe.d/jffs2.conf
+echo "install jffs2 /bin/true" > /etc/modprobe.d/jffs2.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_rds_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_rds_disabled.sh
@@ -1,1 +1,1 @@
-echo "install rds /bin/false" > /etc/modprobe.d/rds.conf
+echo "install rds /bin/true" > /etc/modprobe.d/rds.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_sctp_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_sctp_disabled.sh
@@ -1,1 +1,1 @@
-echo "install sctp /bin/false" > /etc/modprobe.d/sctp.conf
+echo "install sctp /bin/true" > /etc/modprobe.d/sctp.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_squashfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_squashfs_disabled.sh
@@ -1,1 +1,1 @@
-echo "install squashfs /bin/false" > /etc/modprobe.d/squashfs.conf
+echo "install squashfs /bin/true" > /etc/modprobe.d/squashfs.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_tipc_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_tipc_disabled.sh
@@ -1,1 +1,1 @@
-echo "install tipc /bin/false" > /etc/modprobe.d/tipc.conf
+echo "install tipc /bin/true" > /etc/modprobe.d/tipc.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_udf_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_udf_disabled.sh
@@ -1,1 +1,1 @@
-echo "install udf /bin/false" > /etc/modprobe.d/udf.conf
+echo "install udf /bin/true" > /etc/modprobe.d/udf.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_usb-storage_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_usb-storage_disabled.sh
@@ -1,1 +1,1 @@
-echo "install usb-storage /bin/false" > /etc/modprobe.d/usb-storage.conf
+echo "install usb-storage /bin/true" > /etc/modprobe.d/usb-storage.conf

--- a/RHEL/6/input/fixes/bash/templates/template_kernel_module_disabled
+++ b/RHEL/6/input/fixes/bash/templates/template_kernel_module_disabled
@@ -1,1 +1,1 @@
-echo "install KERNMODULE /bin/false" > /etc/modprobe.d/KERNMODULE.conf
+echo "install KERNMODULE /bin/true" > /etc/modprobe.d/KERNMODULE.conf

--- a/RHEL/6/transforms/shorthand2xccdf.xslt
+++ b/RHEL/6/transforms/shorthand2xccdf.xslt
@@ -440,7 +440,7 @@
   <xsl:template match="module-disable-macro">
 To configure the system to prevent the <xhtml:code><xsl:value-of select="@module"/></xhtml:code>
 kernel module from being loaded, add the following line to a file in the directory <xhtml:code>/etc/modprobe.d</xhtml:code>:
-<xhtml:pre xml:space="preserve">install <xsl:value-of select="@module"/> /bin/false</xhtml:pre>
+<xhtml:pre xml:space="preserve">install <xsl:value-of select="@module"/> /bin/true</xhtml:pre>
   </xsl:template>
 
   <xsl:template match="module-disable-check-macro">
@@ -448,7 +448,7 @@ If the system is configured to prevent the loading of the
 <xhtml:code><xsl:value-of select="@module"/></xhtml:code> kernel module,
 it will contain lines inside any file in <xhtml:code>/etc/modprobe.d</xhtml:code> or the deprecated<xhtml:code>/etc/modprobe.conf</xhtml:code>.
 These lines instruct the module loading system to run another program (such as
-<xhtml:code>/bin/false</xhtml:code>) upon a module <xhtml:code>install</xhtml:code> event.
+<xhtml:code>/bin/true</xhtml:code>) upon a module <xhtml:code>install</xhtml:code> event.
 Run the following command to search for such lines in all files in <xhtml:code>/etc/modprobe.d</xhtml:code>
 and the deprecated <xhtml:code>/etc/modprobe.conf</xhtml:code>:
 <xhtml:pre xml:space="preserve">$ grep -r <xsl:value-of select="@module"/> /etc/modprobe.conf /etc/modprobe.d</xhtml:pre>

--- a/RHEL/7/input/fixes/bash/kernel_module_dccp_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_dccp_disabled.sh
@@ -1,1 +1,1 @@
-echo "install dccp /bin/false" > /etc/modprobe.d/dccp.conf
+echo "install dccp /bin/true > /etc/modprobe.d/dccp.conf

--- a/RHEL/7/input/fixes/bash/kernel_module_sctp_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_sctp_disabled.sh
@@ -1,1 +1,1 @@
-echo "install sctp /bin/false" > /etc/modprobe.d/sctp.conf
+echo "install sctp /bin/true > /etc/modprobe.d/sctp.conf

--- a/RHEL/7/input/fixes/bash/templates/template_kernel_module_disabled
+++ b/RHEL/7/input/fixes/bash/templates/template_kernel_module_disabled
@@ -1,1 +1,1 @@
-echo "install KERNMODULE /bin/false" > /etc/modprobe.d/KERNMODULE.conf
+echo "install KERNMODULE /bin/true > /etc/modprobe.d/KERNMODULE.conf

--- a/RHEL/7/transforms/shorthand2xccdf.xslt
+++ b/RHEL/7/transforms/shorthand2xccdf.xslt
@@ -438,7 +438,7 @@
   <xsl:template match="module-disable-macro">
 To configure the system to prevent the <xhtml:code><xsl:value-of select="@module"/></xhtml:code>
 kernel module from being loaded, add the following line to a file in the directory <xhtml:code>/etc/modprobe.d</xhtml:code>:
-<xhtml:pre xml:space="preserve">install <xsl:value-of select="@module"/> /bin/false</xhtml:pre>
+<xhtml:pre xml:space="preserve">install <xsl:value-of select="@module"/> /bin/true</xhtml:pre>
   </xsl:template>
 
   <xsl:template match="module-disable-check-macro">
@@ -446,7 +446,7 @@ If the system is configured to prevent the loading of the
 <xhtml:code><xsl:value-of select="@module"/></xhtml:code> kernel module,
 it will contain lines inside any file in <xhtml:code>/etc/modprobe.d</xhtml:code> or the deprecated<xhtml:code>/etc/modprobe.conf</xhtml:code>.
 These lines instruct the module loading system to run another program (such as
-<xhtml:code>/bin/false</xhtml:code>) upon a module <xhtml:code>install</xhtml:code> event.
+<xhtml:code>/bin/true</xhtml:code>) upon a module <xhtml:code>install</xhtml:code> event.
 Run the following command to search for such lines in all files in <xhtml:code>/etc/modprobe.d</xhtml:code>
 and the deprecated <xhtml:code>/etc/modprobe.conf</xhtml:code>:
 <xhtml:pre xml:space="preserve">$ grep -r <xsl:value-of select="@module"/> /etc/modprobe.conf /etc/modprobe.d</xhtml:pre>

--- a/shared/fixes/bash/kernel_module_bluetooth_disabled.sh
+++ b/shared/fixes/bash/kernel_module_bluetooth_disabled.sh
@@ -1,1 +1,1 @@
-echo "install bluetooth /bin/false" > /etc/modprobe.d/bluetooth.conf
+echo "install bluetooth /bin/true > /etc/modprobe.d/bluetooth.conf


### PR DESCRIPTION
/bin/false causes noise in the logs. updating templates to use /bin/true.

OVAL still accepts either.