### PR TITLE
[BuildProcessFix] Allow generated OVAL to contain zero variables 

### DIFF
--- a/shared/transforms/combinechecks.py
+++ b/shared/transforms/combinechecks.py
@@ -178,7 +178,8 @@ def main():
     tree.append(tests)
     tree.append(objects)
     tree.append(states)
-    tree.append(variables)
+    if list(variables):
+        tree.append(variables)
 
     ET.dump(tree)
     sys.exit(0)

--- a/shared/transforms/cpe_generate.py
+++ b/shared/transforms/cpe_generate.py
@@ -86,12 +86,13 @@ def main():
     [objects.append(cpe_object) for cpe_object in cpe_objects]
 
     variables = ovaltree.find("./{%s}variables" % oval_ns)
-    cpe_variables = extract_referred_nodes(tests, variables, "var_ref")
-    if cpe_variables:
-        variables.clear()
-        [variables.append(cpe_variable) for cpe_variable in cpe_variables]
-    else:
-        ovaltree.remove(variables)
+    if variables:
+        cpe_variables = extract_referred_nodes(tests, variables, "var_ref")
+        if cpe_variables:
+            variables.clear()
+            [variables.append(cpe_variable) for cpe_variable in cpe_variables]
+        else:
+            ovaltree.remove(variables)
 
     # turn IDs into meaningless numbers
     translator = idtranslate.idtranslator("./output/"+idname+".ini", idname)


### PR DESCRIPTION
Don't include the <variables> element into generated OVAL when there aren't child local / external / environmental variables to be added under it

Fixes issue from https://github.com/OpenSCAP/scap-security-guide/pull/531#issuecomment-98684857