### PR TITLE
[Enhancement] Enable application content in Fedora

### DIFF
--- a/Firefox/Makefile
+++ b/Firefox/Makefile
@@ -14,8 +14,8 @@ OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
 
 all: shorthand2xccdf tables guide content dist
 
-stats:
-	$(SHARED)/$(TRANS)/stats.sh
+#stats:
+#	$(SHARED)/$(TRANS)/stats.sh
 
 shorthand-guide:
 ifeq ($(OPENSCAP_SVG), 0)
@@ -145,6 +145,8 @@ dist: tables guide content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
+	mkdir -p $(DIST)/guide
+	cp $(OUT)/*-guide.html $(DIST)/guide
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,12 @@ webmin:
 chromium:
 	cd Chromium/ && $(MAKE)
 
-validate: fedora rhel6 rhel7 openstack rhevm3 chromium
+validate: fedora rhel6 rhel7 openstack rhevm3 chromium firefox java
 	cd Fedora/ && $(MAKE) validate
 	cd RHEL/6/ && $(MAKE) validate
 	cd Chromium/ && $(MAKE) validate
+	cd Firefox/ && $(MAKE) validate
+	cd Java/ && $(MAKE) validate
 	# Enable below when content validates correctly
 	#cd RHEL/7/ && $(MAKE) validate
 	#cd OpenStack && $(MAKE) validate
@@ -119,6 +121,7 @@ tarball: rpmroot
 	(cd $(RPMBUILD)/$(PKG)/RHEL/6/ && $(MAKE) clean)
 	(cd $(RPMBUILD)/$(PKG)/RHEL/7/ && $(MAKE) clean)
 	(cd $(RPMBUILD)/$(PKG)/Fedora/ && $(MAKE) clean)
+	(cd $(RPMBUILD)/$(PKG)/Chromium/ && $(MAKE) clean)
 	(cd $(RPMBUILD)/$(PKG)/Java/ && $(MAKE) clean)
 	(cd $(RPMBUILD)/$(PKG)/Firefox/ && $(MAKE) clean)
 	(cd $(RPMBUILD)/$(PKG)/Webmin/ && $(MAKE) clean)
@@ -199,6 +202,7 @@ clean:
 	cd Java && $(MAKE) clean
 	cd Firefox && $(MAKE) clean
 	cd Webmin && $(MAKE) clean
+	cd Chromium && $(MAKE) clean
 	rm -f scap-security-guide.spec
 
 install: dist

--- a/scap-security-guide.spec.in
+++ b/scap-security-guide.spec.in
@@ -73,10 +73,16 @@ cp -a JBossEAP5/eap5-* %{buildroot}%{_datadir}/xml/scap/ssg/content/
 # Add in RHEL-6 functions library for remediations
 cp -a RHEL/6/input/fixes/bash/templates/functions %{buildroot}%{_datadir}/%{name}/functions
 %endif
-%if 0%{?fedora}
 
+%if 0%{?fedora}
 # Add in core Fedora content (SCAP XCCDF and OVAL)
 cp -a Fedora/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content
+
+# Add in datastream form of RHEL-5 benchmark
+#cp -a RHEL/6/dist/content/ssg-rhel5-ds.xml %{buildroot}%{_datadir}/xml/scap/ssg/rhel5
+# Add in datastream form of RHEL benchmark(s)
+cp -a RHEL/6/dist/content/ssg-rhel6-ds.xml %{buildroot}%{_datadir}/xml/scap/ssg/content
+cp -a RHEL/7/dist/content/ssg-rhel7-ds.xml %{buildroot}%{_datadir}/xml/scap/ssg/content
 
 # Add in application content (SCAP XCCDF and OVAL)
 cp -a Java/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content

--- a/scap-security-guide.spec.in
+++ b/scap-security-guide.spec.in
@@ -40,6 +40,9 @@ package to verify that the system conforms to provided guidelines.
 %build
 %if 0%{?fedora}
 (cd Fedora && make dist)
+(cd Java && make dist)
+(cd Firefox && make dist)
+(cd Chromium && make dist)
 %endif
 #(cd RHEL/5 && make dist)
 (cd RHEL/6 && make dist)
@@ -49,13 +52,13 @@ package to verify that the system conforms to provided guidelines.
 #(cd Webmin && make dist)
 
 %install
+mkdir -p %{buildroot}%{_datadir}/xml/scap/ssg/content
 mkdir -p %{buildroot}%{_mandir}/en/man8/
 
 # Add in manpage
 cp -a docs/scap-security-guide.8 %{buildroot}%{_mandir}/en/man8/scap-security-guide.8
 
 %if 0%{?rhel}
-mkdir -p %{buildroot}%{_datadir}/xml/scap/ssg/content
 mkdir -p %{buildroot}%{_datadir}/%{name}
 
 # Add in core content (SCAP)
@@ -71,25 +74,17 @@ cp -a JBossEAP5/eap5-* %{buildroot}%{_datadir}/xml/scap/ssg/content/
 cp -a RHEL/6/input/fixes/bash/templates/functions %{buildroot}%{_datadir}/%{name}/functions
 %endif
 %if 0%{?fedora}
-#mkdir -p %{buildroot}%{_datadir}/xml/scap/ssg/{fedora,java,rhel{5,6,7},firefox,webmin}
-mkdir -p %{buildroot}%{_datadir}/xml/scap/ssg/{fedora,rhel{6,7}}
-mkdir -p %{buildroot}%{_mandir}/en/man8/
 
 # Add in core Fedora content (SCAP XCCDF and OVAL)
-cp -a Fedora/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/fedora
+cp -a Fedora/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content
 
-# Add in datastream form of RHEL-5 benchmark
-#cp -a RHEL/6/dist/content/ssg-rhel5-ds.xml %{buildroot}%{_datadir}/xml/scap/ssg/rhel5
-# Add in datastream form of RHEL-6 benchmark
-cp -a RHEL/6/dist/content/ssg-rhel6-ds.xml %{buildroot}%{_datadir}/xml/scap/ssg/rhel6
-# Add in datastream form of RHEL-7 benchmark
-cp -a RHEL/7/dist/content/ssg-rhel7-ds.xml %{buildroot}%{_datadir}/xml/scap/ssg/rhel7
-# Add in datastream form of Java benchmark
-#cp -a Java/dist/content/ssg-java-ds.xml %{buildroot}%{_datadir}/xml/scap/ssg/java
-# Add in datastream form of Firefox benchmark
-#cp -a Firefox/dist/content/ssg-firefox-ds.xml %{buildroot}%{_datadir}/xml/scap/ssg/firefox
+# Add in application content (SCAP XCCDF and OVAL)
+cp -a Java/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content
+cp -a Firefox/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content
+cp -a Chromium/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content
+
 # Add in datastream form of Webmin benchmark
-#cp -a Webmin/dist/content/ssg-webmin-ds.xml %{buildroot}%{_datadir}/xml/scap/ssg/webmin
+#cp -a Webmin/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content
 %endif
 
 # Add in oscap-scan files


### PR DESCRIPTION
- Add Firefox, Java, and Chromium OVAL/XCCDF in Fedora RPM builds
- Standardize Makefiles for Firefox, Java, and Chromium content