### PR TITLE
Ensure that the Banner config appears on a line by itself

### DIFF
--- a/RHEL/7/input/fixes/bash/sshd_enable_warning_banner.sh
+++ b/RHEL/7/input/fixes/bash/sshd_enable_warning_banner.sh
@@ -1,5 +1,6 @@
 grep -qi ^Banner /etc/ssh/sshd_config && \
   sed -i "s/Banner.*/Banner \/etc\/issue/gI" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then
+    echo "" >> /etc/ssh/sshd_config
     echo "Banner /etc/issue" >> /etc/ssh/sshd_config
 fi


### PR DESCRIPTION
When I ran the fix (remediation) file on a fresh RHEL7.1 install on AWS EC2, the final line of /etc/ssh/sshd_config was:

    #	ForceCommand cvs serverBanner /etc/issue
