### PR TITLE
[bugfix] pam_faillock OVAL checks should use preauth instead of authsucc

### DIFF
--- a/RHEL/6/input/checks/accounts_passwords_pam_faillock_interval.xml
+++ b/RHEL/6/input/checks/accounts_passwords_pam_faillock_interval.xml
@@ -9,14 +9,14 @@
       <reference source="swells" ref_id="20131025" ref_url="test_attestation" />
     </metadata>
     <criteria>
-      <criterion comment="authsucc default is set to 900" test_ref="test_accounts_passwords_pam_faillock_fail_interval_system-auth" />
+      <criterion comment="preauth default is set to 900" test_ref="test_accounts_passwords_pam_faillock_fail_interval_system-auth" />
       <criterion comment="authfail default is set to 900" test_ref="test_accounts_passwords_pam_faillock_authfail_fail_interval_system-auth" />
       <criterion comment="authfail default is set to 900" test_ref="test_accounts_passwords_pam_faillock_fail_interval_password-auth" />
-      <criterion comment="authsucc default is set to 900" test_ref="test_accounts_passwords_pam_faillock_authsucc_fail_interval_password-auth" />
+      <criterion comment="preauth default is set to 900" test_ref="test_accounts_passwords_pam_faillock_preauth_fail_interval_password-auth" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check maximum authsucc fail_interval allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_fail_interval_system-auth" version="2">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check maximum preauth fail_interval allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_fail_interval_system-auth" version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_fail_interval_system-auth" />
     <ind:state state_ref="state_accounts_passwords_pam_faillock_fail_interval_system-auth" />
   </ind:textfilecontent54_test>
@@ -31,15 +31,15 @@
     <ind:state state_ref="state_accounts_passwords_pam_faillock_fail_interval_password-auth" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check maximum authsucc fail_interval allowed in /etc/pam.d/password-auth" id="test_accounts_passwords_pam_faillock_authsucc_fail_interval_password-auth" version="2">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_authsucc_fail_interval_password-auth" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check maximum preauth fail_interval allowed in /etc/pam.d/password-auth" id="test_accounts_passwords_pam_faillock_preauth_fail_interval_password-auth" version="2">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_preauth_fail_interval_password-auth" />
     <ind:state state_ref="state_accounts_passwords_pam_faillock_fail_interval_password-auth" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_fail_interval_system-auth" version="2">
     <ind:path>/etc/pam.d</ind:path>
     <ind:filename>system-auth</ind:filename>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+authsucc.*fail_interval=([0-9]*).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -57,10 +57,10 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_authsucc_fail_interval_password-auth" version="2">
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_preauth_fail_interval_password-auth" version="2">
     <ind:path>/etc/pam.d</ind:path>
     <ind:filename>password-auth</ind:filename>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+authsucc.*fail_interval=([0-9]*).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/RHEL/6/input/checks/accounts_passwords_pam_faillock_unlock_time.xml
+++ b/RHEL/6/input/checks/accounts_passwords_pam_faillock_unlock_time.xml
@@ -8,14 +8,14 @@
       <description>The number of allowed failed logins should be set correctly.</description>
     </metadata>
     <criteria>
-      <criterion comment="authsucc default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_unlock_time_system-auth" />
+      <criterion comment="preauth default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_unlock_time_system-auth" />
       <criterion comment="authfail default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_authfail_unlock_time_system-auth" />
       <criterion comment="authfail default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_unlock_time_password-auth" />
-      <criterion comment="authsucc default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_authsucc_unlock_time_password-auth" />
+      <criterion comment="preauth default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check authsucc maximum failed login attempts allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_unlock_time_system-auth" version="2">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check preauth maximum failed login attempts allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_unlock_time_system-auth" version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_system-auth" />
     <ind:state state_ref="state_accounts_passwords_pam_faillock_unlock_time_system-auth" />
   </ind:textfilecontent54_test>
@@ -30,15 +30,15 @@
     <ind:state state_ref="state_accounts_passwords_pam_faillock_unlock_time_password-auth" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check authsucc maximum failed login attempts allowed in /etc/pam.d/password-auth" id="test_accounts_passwords_pam_faillock_authsucc_unlock_time_password-auth" version="2">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_authsucc_unlock_time_password-auth" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check preauth maximum failed login attempts allowed in /etc/pam.d/password-auth" id="test_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" version="2">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" />
     <ind:state state_ref="state_accounts_passwords_pam_faillock_unlock_time_password-auth" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_unlock_time_system-auth" version="2">
     <ind:path>/etc/pam.d</ind:path>
     <ind:filename>system-auth</ind:filename>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+authsucc.*unlock_time=([0-9]*).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+preauth.*unlock_time=([0-9]*).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -56,10 +56,10 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_authsucc_unlock_time_password-auth" version="2">
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" version="2">
     <ind:path>/etc/pam.d</ind:path>
     <ind:filename>password-auth</ind:filename>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+authsucc.*unlock_time=([0-9]*).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+preauth.*unlock_time=([0-9]*).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
- authsucc is no longer used in checks. Use preauth instead.
- Fixes all pam_faillock OVAL