### PR TITLE
[Enhancement][Fedora] Add ShellCheck to Fedora make validate

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,6 +4,10 @@
 
  `# yum -y install git openscap-utils python-lxml`
 
+1a. FEDORA ONLY: Install the ShellCheck package.
+
+ `# dnf -y install ShellCheck`
+
 2. Download the source code 
 
  `$ git clone https://github.com/OpenSCAP/scap-security-guide.git`

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -69,6 +69,7 @@ else
 endif
 
 validate: validate-xml
+	cd $(IN)/fixes/bash; shellcheck -s bash *.sh
 ifeq ($(OVAL_5_10), 0)
 	echo "Skipping validating, use OpenSCAP 1.2.2 or later"
 else

--- a/scap-security-guide.spec.in
+++ b/scap-security-guide.spec.in
@@ -15,6 +15,7 @@ BuildArch:	noarch
 BuildRequires:	libxslt, expat, python, openscap-utils >= 1.0.3, python-lxml
 %if 0%{?fedora}
 BuildRequires:	openscap-utils >= 1.2.2
+BuildRequires:	ShellCheck
 %endif
 Requires:	xml-common, openscap-utils >= 1.0.8
 


### PR DESCRIPTION
- Adds ShellCheck to Fedora `make validate`. ShellCheck is currently
  only available for Fedora.
- Adds ShellCheck BuildRequires for Fedora in .spec file
- Fixes #494