### PR TITLE
CentOS support

### DIFF
--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -148,6 +148,8 @@ dist: tables guide content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
+	cp $(OUT)/$(ID)-centos5-xccdf.xml $(DIST)/content
+	cp $(OUT)/$(ID)-centos5-ds.xml $(DIST)/content
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -106,6 +106,9 @@ content: shorthand2xccdf guide checks
 #	Add in CPE and OVAL content to datastream
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(OUT)/$(ID)-$(PROD)-ds.xml
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-oval.xml $(OUT)/$(ID)-$(PROD)-ds.xml
+#   Make CentOS variants of XCCDF and Source DataStream
+	$(SHARED)/$(UTILS)/enable-centos.py $(OUT)/$(ID)-$(PROD)-xccdf.xml $(OUT)/$(ID)-centos5-xccdf.xml
+	$(SHARED)/$(UTILS)/enable-centos.py $(OUT)/$(ID)-$(PROD)-ds.xml $(OUT)/$(ID)-centos5-ds.xml
 
 content-stig: shorthand2xccdf guide checks
 	xmllint --format --output $(OUT)/unlinked-stig-$(PROD)-xccdf.xml $(OUT)/unlinked-stig-$(PROD)-xccdf.xml
@@ -125,6 +128,8 @@ validate-xml:
 	oscap cpe validate-xml $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml
 	oscap oval validate-xml --schematron $(OUT)/$(ID)-$(PROD)-cpe-oval.xml
 	oscap ds sds-validate $(OUT)/$(ID)-$(PROD)-ds.xml
+	oscap xccdf validate-xml $(OUT)/$(ID)-centos5-xccdf.xml
+	oscap ds sds-validate $(OUT)/$(ID)-centos5-ds.xml
 
 validate: validate-xml
 	cd output; ../$(UTILS)/verify-references.py --rules-with-invalid-checks --ovaldefs-unused ssg-$(PROD)-xccdf.xml

--- a/RHEL/5/input/guide.xml
+++ b/RHEL/5/input/guide.xml
@@ -38,7 +38,5 @@ countries. All other names are registered trademarks or trademarks of their
 respective companies.</rear-matter>
 <platform idref="cpe:/o:redhat:enterprise_linux:4" />
 <platform idref="cpe:/o:redhat:enterprise_linux:5" />
-<platform idref="cpe:/o:centos:centos:4" />
-<platform idref="cpe:/o:centos:centos:5" />
 <version>0.9</version>
 </Benchmark>

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -150,6 +150,8 @@ dist: tables guide content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
 	mkdir -p $(DIST)/guide
 	cp $(OUT)/*-guide.html $(DIST)/guide
+	cp $(OUT)/$(ID)-centos6-xccdf.xml $(DIST)/content
+	cp $(OUT)/$(ID)-centos6-ds.xml $(DIST)/content
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -106,6 +106,9 @@ content: shorthand2xccdf guide checks
 #	Add in CPE and OVAL content to datastream
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(OUT)/$(ID)-$(PROD)-ds.xml
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-oval.xml $(OUT)/$(ID)-$(PROD)-ds.xml
+#   Make CentOS variants of XCCDF and Source DataStream
+	$(SHARED)/$(UTILS)/enable-centos.py $(OUT)/$(ID)-$(PROD)-xccdf.xml $(OUT)/$(ID)-centos6-xccdf.xml
+	$(SHARED)/$(UTILS)/enable-centos.py $(OUT)/$(ID)-$(PROD)-ds.xml $(OUT)/$(ID)-centos6-ds.xml
 
 content-stig: shorthand2xccdf guide checks
 	xmllint --format --output $(OUT)/unlinked-stig-$(PROD)-xccdf.xml $(OUT)/unlinked-stig-$(PROD)-xccdf.xml
@@ -125,6 +128,8 @@ validate-xml:
 	oscap cpe validate-xml $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml
 	oscap oval validate-xml --schematron $(OUT)/$(ID)-$(PROD)-cpe-oval.xml
 	oscap ds sds-validate $(OUT)/$(ID)-$(PROD)-ds.xml
+	oscap xccdf validate-xml $(OUT)/$(ID)-centos6-xccdf.xml
+	oscap ds sds-validate $(OUT)/$(ID)-centos6-ds.xml
 
 validate: validate-xml
 	cd output; ../$(UTILS)/verify-references.py --rules-with-invalid-checks --ovaldefs-unused ssg-$(PROD)-xccdf.xml

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -105,6 +105,9 @@ content: shorthand2xccdf guide checks
 #       Add in CPE and OVAL content to datastream
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(OUT)/$(ID)-$(PROD)-ds.xml
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-oval.xml $(OUT)/$(ID)-$(PROD)-ds.xml
+#   Make CentOS variants of XCCDF and Source DataStream
+	$(SHARED)/$(UTILS)/enable-centos.py $(OUT)/$(ID)-$(PROD)-xccdf.xml $(OUT)/$(ID)-centos7-xccdf.xml
+	$(SHARED)/$(UTILS)/enable-centos.py $(OUT)/$(ID)-$(PROD)-ds.xml $(OUT)/$(ID)-centos7-ds.xml
 
 content-stig: shorthand2xccdf guide checks
 	xmllint --format --output $(OUT)/unlinked-stig-$(PROD)-xccdf.xml $(OUT)/unlinked-stig-$(PROD)-xccdf.xml 
@@ -124,6 +127,8 @@ validate-xml:
 	oscap cpe validate-xml $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml
 	oscap oval validate-xml --schematron $(OUT)/$(ID)-$(PROD)-cpe-oval.xml
 	oscap ds sds-validate $(OUT)/$(ID)-$(PROD)-ds.xml
+	oscap xccdf validate-xml $(OUT)/$(ID)-centos7-xccdf.xml
+	oscap ds sds-validate $(OUT)/$(ID)-centos7-ds.xml
 
 validate: validate-xml
 	cd output; ../$(UTILS)/verify-references.py --rules-with-invalid-checks --ovaldefs-unused ssg-$(PROD)-xccdf.xml

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -149,6 +149,8 @@ dist: tables guide content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
 	mkdir -p $(DIST)/guide
 	cp $(OUT)/*-guide.html $(DIST)/guide
+	cp $(OUT)/$(ID)-centos7-xccdf.xml $(DIST)/content
+	cp $(OUT)/$(ID)-centos7-ds.xml $(DIST)/content
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv

--- a/shared/utils/enable-centos.py
+++ b/shared/utils/enable-centos.py
@@ -36,11 +36,12 @@ CENTOS_NOTICE = \
     "<ul>\n" \
     "<li><i>CentOS</i> is not an exact copy of " \
     "<i>Red Hat Enterprise Linux</i>. There may be configuration differences " \
-    "that produce both false positives and false negatives. If this occurs " \
+    "that produce false positives and/or false negatives. If this occurs " \
     "please file a bug report.</li>\n" \
     "\n" \
     "<li><i>CentOS</i> has its own build system, compiler options, patchsets, " \
-    "and is a community-led operating system, <i>CentOS</i> does not inherit " \
+    "and is a community supported, non-commercial operating system. " \
+    "<i>CentOS</i> does not inherit " \
     "certifications or evaluations from <i>Red Hat Enterprise Linux</i>. As " \
     "such, some configuration rules (such as those requiring " \
     "<i>FIPS 140-2</i> encryption) will continue to fail on <i>CentOS</i>.</li>\n" \

--- a/shared/utils/enable-centos.py
+++ b/shared/utils/enable-centos.py
@@ -96,17 +96,21 @@ def add_centos_notice(benchmark, namespace):
     """Adds CentOS notice as the first notice to given benchmark.
     """
 
+    index = -1
     prev_element = None
     existing_notices = list(benchmark.iterfind("{%s}notice" % (namespace)))
     if len(existing_notices) > 0:
         prev_element = existing_notices[0]
+        # insert before the first notice
+        index = list(benchmark).index(prev_element)
     else:
         existing_descriptions = list(
             benchmark.iterfind("{%s}description" % (namespace))
         )
         prev_element = existing_descriptions[-1]
+        # insert after the last description
+        index = list(benchmark).index(prev_element) + 1
 
-    index = list(benchmark).index(prev_element)
     if index == -1:
         raise RuntimeError(
             "Can't find existing notices or description in benchmark '%s'." %

--- a/shared/utils/enable-centos.py
+++ b/shared/utils/enable-centos.py
@@ -29,10 +29,9 @@ CENTOS_NOTICE = \
     "<p>This benchmark is a direct port of a <i>SCAP Security Guide </i> " \
     "benchmark developed for <i>Red Hat Enterprise Linux</i>. It has been " \
     "modified through an automated process to remove specific dependencies " \
-    "on <i>Red Hat Enterprise Linux</i> and to function with <i>CentOS</i> " \
-    "&#8212; <i>Community Enterprise Operating System</i>. The result is a " \
-    "generally useful <i>SCAP Security Guide</i> benchmark with the following " \
-    "caveats:</p>\n" \
+    "on <i>Red Hat Enterprise Linux</i> and to function with <i>CentOS</i>. " \
+    "The result is a generally useful <i>SCAP Security Guide</i> benchmark " \
+    "with the following caveats:</p>\n" \
     "<ul>\n" \
     "<li><i>CentOS</i> is not an exact copy of " \
     "<i>Red Hat Enterprise Linux</i>. There may be configuration differences " \

--- a/shared/utils/enable-centos.py
+++ b/shared/utils/enable-centos.py
@@ -1,0 +1,166 @@
+#!/usr/bin/python2
+
+"""
+Takes given XCCDF or DataStream and adds CentOS CPE name next to RHEL CPE names.
+Can automatically recognize RHEL5, 6, 7 CPEs and adds the CentOS ones next to
+those accordingly.
+
+Apart from adding the CPEs it adds a notice informing the user that the content
+has been enabled for CentOS and what are the implications.
+
+Author: Martin Preisler <mpreisle@redhat.com>
+"""
+
+from xml.etree import cElementTree as ElementTree
+import sys
+
+XCCDF11_NS = "http://checklists.nist.gov/xccdf/1.1"
+XCCDF12_NS = "http://checklists.nist.gov/xccdf/1.2"
+
+RHEL_CENTOS_CPE_MAPPING = {
+    "cpe:/o:redhat:enterprise_linux:4": "cpe:/o:centos:centos:4",
+    "cpe:/o:redhat:enterprise_linux:5": "cpe:/o:centos:centos:5",
+    "cpe:/o:redhat:enterprise_linux:6": "cpe:/o:centos:centos:6",
+    "cpe:/o:redhat:enterprise_linux:7": "cpe:/o:centos:centos:7",
+}
+
+CENTOS_NOTICE = \
+    "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n" \
+    "<p>This benchmark is a direct port of a <i>SCAP Security Guide </i> " \
+    "benchmark developed for <i>Red Hat Enterprise Linux</i>. It has been " \
+    "modified through an automated process to remove specific dependencies " \
+    "on <i>Red Hat Enterprise Linux</i> and to function with <i>CentOS</i> " \
+    "&#8212; <i>Community Enterprise Operating System</i>. The result is a " \
+    "generally useful <i>SCAP Security Guide</i> benchmark with the following " \
+    "caveats:</p>\n" \
+    "<ul>\n" \
+    "<li><i>CentOS</i> is not an exact copy of " \
+    "<i>Red Hat Enterprise Linux</i>. There may be configuration differences " \
+    "that produce both false positives and false negatives. If this occurs " \
+    "please file a bug report.</li>\n" \
+    "\n" \
+    "<li><i>CentOS</i> has its own build system, compiler options, patchsets, " \
+    "and is a community-led operating system, <i>CentOS</i> does not inherit " \
+    "certifications or evaluations from <i>Red Hat Enterprise Linux</i>. As " \
+    "such, some configuration rules (such as those requiring " \
+    "<i>FIPS 140-2</i> encryption) will continue to fail on <i>CentOS</i>.</li>\n" \
+    "</ul>\n" \
+    "\n" \
+    "<p>Members of the <i>CentOS</i> community are invited to participate in " \
+    "<a href=\"http://open-scap.org\">OpenSCAP</a> and " \
+    "<a href=\"https://github.com/OpenSCAP/scap-security-guide\">" \
+    "SCAP Security Guide</a> development. Bug reports and patches " \
+    "can be sent to GitHub: " \
+    "<a href=\"https://github.com/OpenSCAP/scap-security-guide\">" \
+    "https://github.com/OpenSCAP/scap-security-guide</a>. " \
+    "The mailing list is at " \
+    "<a href=\"https://fedorahosted.org/mailman/listinfo/scap-security-guide\">" \
+    "https://fedorahosted.org/mailman/listinfo/scap-security-guide</a>" \
+    ".</p>" \
+    "</div>"
+
+CENTOS_NOTICE_ELEMENT = ElementTree.fromstring(CENTOS_NOTICE)
+
+
+def add_centos_cpes(elem, namespace):
+    """Adds CentOS CPEs next to RHEL ones, checks XCCDF elements of given
+    namespace.
+    """
+
+    affected = False
+
+    for child in list(elem):
+        affected = affected or add_centos_cpes(child, namespace)
+
+    # precompute this so that we can affect the tree while iterating
+    children = list(elem.iterfind("{%s}platform" % (namespace)))
+
+    for child in children:
+        idref = child.get("idref")
+        if idref in RHEL_CENTOS_CPE_MAPPING:
+            new_platform = ElementTree.Element("{%s}platform" % (namespace))
+            new_platform.set("idref", RHEL_CENTOS_CPE_MAPPING[idref])
+            # this is done for the newline and indentation
+            new_platform.tail = child.tail
+
+            index = list(elem).index(child)
+            # insert it right after the respective RHEL CPE
+            elem.insert(index + 1, new_platform)
+
+            affected = True
+
+    return affected
+
+
+def add_centos_notice(benchmark, namespace):
+    """Adds CentOS notice as the first notice to given benchmark.
+    """
+
+    prev_element = None
+    existing_notices = list(benchmark.iterfind("{%s}notice" % (namespace)))
+    if len(existing_notices) > 0:
+        prev_element = existing_notices[0]
+    else:
+        existing_descriptions = list(
+            benchmark.iterfind("{%s}description" % (namespace))
+        )
+        prev_element = existing_descriptions[-1]
+
+    index = list(benchmark).index(prev_element)
+    if index == -1:
+        raise RuntimeError(
+            "Can't find existing notices or description in benchmark '%s'." %
+            (benchmark)
+        )
+
+    elem = ElementTree.Element("{%s}notice" % (namespace))
+    elem.set("id", "centos_warning")
+    elem.append(CENTOS_NOTICE_ELEMENT)
+    # this is done for the newline and indentation
+    elem.tail = prev_element.tail
+    benchmark.insert(index, elem)
+
+    return True
+
+
+def main():
+    # the first arg is the script name
+    if len(sys.argv) != 1 + 2:
+        print("Usage: enable-centos.py INPUT OUTPUT")
+        print("")
+        print("INPUT can be XCCDF or Source DataStream.")
+
+        sys.exit(1)
+
+    input_ = sys.argv[1]
+    output = sys.argv[2]
+
+    tree = ElementTree.ElementTree()
+    tree.parse(input_)
+
+    benchmarks = []
+    benchmarks.extend([
+        (XCCDF11_NS, elem)
+        for elem in list(tree.iter("{%s}Benchmark" % (XCCDF11_NS)))
+    ])
+    benchmarks.extend([
+        (XCCDF12_NS, elem)
+        for elem in list(tree.iter("{%s}Benchmark" % (XCCDF12_NS)))
+    ])
+
+    for namespace, benchmark in benchmarks:
+        if not add_centos_cpes(benchmark, namespace):
+            raise RuntimeError(
+                "Could not add CentOS CPEs to Benchmark '%s'." % (benchmark)
+            )
+
+        if not add_centos_notice(benchmark, namespace):
+            raise RuntimeError(
+                "Managed to add CentOS CPEs but failed to add the notice to "
+                "affected XCCDF Benchmark '%s'." % (benchmark)
+            )
+
+    tree.write(output)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds ssg-centos variants next to ssg-rhel XCCDFs and datastreams. These new files have CentOS CPEs and work out of the box on CentOS machines. They contain an informative notice about the change. You can see the notice on the following screenshot of HTML guide generated from the CentOS datastream:

![centos_notice](https://cloud.githubusercontent.com/assets/753153/7835580/696d4ae2-047a-11e5-9a9e-1ec80a8affa0.png)

How the files are generated:
1) the build process creates XCCDF, OVAL and datastream files
2) the enable-centos.py script is run on XCCDF and datastream to produce their CentOS variants
3) these new files are copied to dist as part of `make dist`

I would like to thank Russell Doty, Jan Lieskovsky, Simon Lukasik and Shawn Wells for their feedback and contributions to this feature.

Feedback welcome!