### PR TITLE
[bugfix][RHEL6/7] Update audit log permission content

### DIFF
--- a/RHEL/6/input/system/auditing.xml
+++ b/RHEL/6/input/system/auditing.xml
@@ -677,15 +677,16 @@ audited.</rationale>
 </Rule>
 
 <Rule id="file_permissions_var_log_audit">
-<title>System Audit Logs Must Have Mode 0640 or Less Permissive</title>
+<title>System Audit Logs Must Have Mode 0600 or Less Permissive</title>
 <description>
 Change the mode of the audit log files with the following command:
-<pre>$ sudo chmod 0640 <i>audit_file</i></pre>
+<pre>$ sudo chmod 0600 <i>audit.log</i>
+$ sudo chmod 0400 <i>audit.log.*</i></pre>
 </description>
 <ocil clause="any are more permissive">
 Run the following command to check the mode of the system audit logs:
 <pre>$ sudo ls -l /var/log/audit</pre>
-Audit logs must be mode 0640 or less permissive.
+Audit logs must be mode 0600 or less permissive.
 </ocil>
 <rationale>
 If users can write to audit logs, audit trails can be modified or destroyed.

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -757,15 +757,16 @@ audited.</rationale>
 </Rule>
 
 <Rule id="file_permissions_var_log_audit">
-<title>System Audit Logs Must Have Mode 0640 or Less Permissive</title>
+<title>System Audit Logs Must Have Mode 0600 or Less Permissive</title>
 <description>
 Change the mode of the audit log files with the following command:
-<pre>$ sudo chmod 0640 <i>audit_file</i></pre>
+<pre>$ sudo chmod 0600 <i>audit.log</i>
+$ sudo chmod 0400 <i>audit.log.*</i></pre>
 </description>
 <ocil clause="any are more permissive">
 Run the following command to check the mode of the system audit logs:
 <pre>$ sudo ls -l /var/log/audit</pre>
-Audit logs must be mode 0640 or less permissive.
+Audit logs must be mode 0600 or less permissive.
 </ocil>
 <rationale>
 If users can write to audit logs, audit trails can be modified or destroyed.

--- a/shared/fixes/bash/file_permissions_var_log_audit.sh
+++ b/shared/fixes/bash/file_permissions_var_log_audit.sh
@@ -1,2 +1,4 @@
-chmod -R 640 /var/log/audit/*
+chmod 600 /var/log/audit/audit.log
+chmod 400 /var/log/audit/audit.log.*
 chmod 640 /etc/audit/audit.rules
+chmod 640 /etc/audit/auditd.conf

--- a/shared/oval/file_permissions_var_log_audit.xml
+++ b/shared/oval/file_permissions_var_log_audit.xml
@@ -7,30 +7,57 @@
       </affected>
       <description>Checks for correct permissions for all log files in /var/log/audit.</description>
     </metadata>
-    <criteria>
-      <criterion test_ref="test_file_permissions_var_log_audit" negate="true" />
+    <criteria operator="AND">
+      <criterion test_ref="test_file_permissions_var_log_audit_writeable" negate="true" />
+      <criterion test_ref="test_file_permissions_var_log_audit_rotated" negate="true" />
     </criteria>
   </definition>
-  <unix:file_test check="all" check_existence="at_least_one_exists" comment="/var/log/audit files mode 0640" id="test_file_permissions_var_log_audit" version="1">
-    <unix:object object_ref="object_var_log_audit_files" />
-    <unix:state state_ref="state_not_mode_0640" />
+  <unix:file_test check="all" check_existence="at_least_one_exists" comment="/var/log/audit files mode 0640" id="test_file_permissions_var_log_audit_rotated" version="1">
+    <unix:object object_ref="object_var_log_audit_files_rotated" />
+    <unix:state state_ref="state_not_mode_0400" />
   </unix:file_test>
-  <unix:file_object comment="/var/log/audit files" id="object_var_log_audit_files" version="1">
+  <unix:file_object comment="/var/log/audit/audit.log.* files" id="object_var_log_audit_files_rotated" version="1">
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
     <unix:path operation="equals">/var/log/audit</unix:path>
-    <unix:filename operation="pattern match">^.*$</unix:filename>
-    <filter action="include">state_not_mode_0640</filter>
+    <unix:filename operation="pattern match">^audit\.log\..*$</unix:filename>
+    <filter action="include">state_not_mode_0400</filter>
   </unix:file_object>
-  <unix:file_state id="state_not_mode_0640" version="1" operator="OR">
+  <unix:file_state id="state_not_mode_0400" version="1" operator="OR">
     <!-- if any one of these is true then mode is NOT 0640 (hence the OR operator) -->
     <unix:suid datatype="boolean">true</unix:suid>
     <unix:sgid datatype="boolean">true</unix:sgid>
     <unix:sticky datatype="boolean">true</unix:sticky>
+    <unix:uwrite datatype="boolean">true</unix:uwrite>
     <unix:uexec datatype="boolean">true</unix:uexec>
+    <unix:gread datatype="boolean">true</unix:gread>
     <unix:gwrite datatype="boolean">true</unix:gwrite>
     <unix:gexec datatype="boolean">true</unix:gexec>
     <unix:oread datatype="boolean">true</unix:oread>
     <unix:owrite datatype="boolean">true</unix:owrite>
     <unix:oexec datatype="boolean">true</unix:oexec>
   </unix:file_state>
+
+  <unix:file_test check="all" check_existence="at_least_one_exists" comment="/var/log/audit files mode 0640" id="test_file_permissions_var_log_audit_writeable" version="1">
+    <unix:object object_ref="object_var_log_audit_files_writeable" />
+    <unix:state state_ref="state_not_mode_0600" />
+  </unix:file_test>
+  <unix:file_object comment="/var/log/audit/audit.log file" id="object_var_log_audit_files_writeable" version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
+    <unix:filepath operation="equals">/var/log/audit/audit\.log</unix:filepath>
+    <filter action="include">state_not_mode_0600</filter>
+  </unix:file_object>
+  <unix:file_state id="state_not_mode_0600" version="1" operator="OR">
+    <!-- if any one of these is true then mode is NOT 0640 (hence the OR operator) -->
+    <unix:suid datatype="boolean">true</unix:suid>
+    <unix:sgid datatype="boolean">true</unix:sgid>
+    <unix:sticky datatype="boolean">true</unix:sticky>
+    <unix:uexec datatype="boolean">true</unix:uexec>
+    <unix:gread datatype="boolean">true</unix:gread>
+    <unix:gwrite datatype="boolean">true</unix:gwrite>
+    <unix:gexec datatype="boolean">true</unix:gexec>
+    <unix:oread datatype="boolean">true</unix:oread>
+    <unix:owrite datatype="boolean">true</unix:owrite>
+    <unix:oexec datatype="boolean">true</unix:oexec>
+  </unix:file_state>
+
 </def-group>


### PR DESCRIPTION
- By default, the auditing daemon writes to a log with 0600 permissions and rotates logs to
  0400 permissions which is more restrictive than the XCCDF, OVAL, and bash remediation scripts
  check and remediate.
- Fixes #482