### PR TITLE
[BugFix] [Infrastructure] Fix testcheck.py bug when replacing external variables

### DIFF
--- a/shared/modules/testcheck_module.py
+++ b/shared/modules/testcheck_module.py
@@ -104,7 +104,7 @@ def replace_external_vars(tree):
         node.tag = ovalns + "local_variable"
         literal = ET.Element("literal_component")
         literal.text = os.environ[extvar_id]
-        append(node, literal)
+        node.append(literal)
         # TODO: assignment of external_variable via environment vars, for
         # testing
     return tree


### PR DESCRIPTION
Fixes the following issue (introduced by https://github.com/OpenSCAP/scap-security-guide/commit/b37a13dc4efe1f9b36575c511750db66294190e9):

```
[iankko@host scap-security-guide]$ cd shared/oval/
[iankko@host oval]$ ./testcheck.py account_disable_post_pw_expiration.xml
External_variable with id : var_account_disable_post_pw_expiration
External_variable specified, but no value provided via environment variable
[iankko@host oval]$ export var_account_disable_post_pw_expiration=10
[iankko@host oval]$ ./testcheck.py account_disable_post_pw_expiration.xml
External_variable with id : var_account_disable_post_pw_expiration
Traceback (most recent call last):
  File "./testcheck.py", line 11, in <module>
    testcheck_module.main()
  File "../modules/testcheck_module.py", line 154, in main
    defname = add_oval_elements(body)
  File "../modules/testcheck_module.py", line 58, in add_oval_elements
    tree = replace_external_vars(tree)
  File "../modules/testcheck_module.py", line 107, in replace_external_vars
    append(node, literal)
  File "../modules/testcheck_module.py", line 44, in append
    existing = element.find(".//*[@id='" + newid + "']")
TypeError: cannot concatenate 'str' and 'NoneType' objects
[iankko@host oval]$
```
After this change is applied, the output for same check is as follows:
```
[iankko@host scap-security-guide]$ cd shared/oval/
[iankko@host oval]$ ./testcheck.py account_disable_post_pw_expiration.xml
External_variable with id : var_account_disable_post_pw_expiration
Evaluating with OVAL tempfile : /tmp/account_disable_post_pw_expirationwoxAT0.xml
Writing results to : /tmp/account_disable_post_pw_expirationwoxAT0.xml-results
Definition oval:scap-security-guide.testing:def:100: false
Evaluation done.
```

Please review.

Thank you, Jan.