### PR TITLE
[BugFix] [RHEL/7] [Fedora] [OpenStack] [RHEVM3] Update "nist800-53uri" XSLT constant to point to new NIST.SP.800-53r4.pdf location

### DIFF
--- a/Fedora/transforms/constants.xslt
+++ b/Fedora/transforms/constants.xslt
@@ -7,7 +7,7 @@
 <xsl:variable name="cceuri">http://cce.mitre.org</xsl:variable>
 
 <!-- abbreviated as references in the XCCDF-->
-<xsl:variable name="nist800-53uri">http://csrc.nist.gov/publications/nistpubs/800-53-Rev3/sp800-53-rev3-final.pdf</xsl:variable>
+<xsl:variable name="nist800-53uri">http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf</xsl:variable>
 <xsl:variable name="cnss1253uri">http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf</xsl:variable>
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>

--- a/OpenStack/transforms/constants.xslt
+++ b/OpenStack/transforms/constants.xslt
@@ -7,7 +7,7 @@
 <xsl:variable name="cceuri">http://cce.mitre.org</xsl:variable>
 
 <!-- abbreviated as references in the XCCDF-->
-<xsl:variable name="nist800-53uri">http://csrc.nist.gov/publications/nistpubs/800-53-Rev3/sp800-53-rev3-final.pdf</xsl:variable>
+<xsl:variable name="nist800-53uri">http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf</xsl:variable>
 <xsl:variable name="cnss1253uri">http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf</xsl:variable>
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>

--- a/RHEL/7/transforms/constants.xslt
+++ b/RHEL/7/transforms/constants.xslt
@@ -7,7 +7,7 @@
 <xsl:variable name="cceuri">http://cce.mitre.org</xsl:variable>
 
 <!-- abbreviated as references in the XCCDF-->
-<xsl:variable name="nist800-53uri">http://csrc.nist.gov/publications/nistpubs/800-53-Rev3/sp800-53-rev3-final.pdf</xsl:variable>
+<xsl:variable name="nist800-53uri">http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf</xsl:variable>
 <xsl:variable name="cnss1253uri">http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf</xsl:variable>
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>

--- a/RHEL/7/transforms/xccdf2html.xslt
+++ b/RHEL/7/transforms/xccdf2html.xslt
@@ -556,7 +556,7 @@
                     <xsl:when test='./@href = "http://iase.disa.mil/stigs/cci/Pages/index.aspx"'>
                       <a href="{@href}">DISA CCI-<xsl:value-of select="text()"/></a>
                     </xsl:when>
-                    <xsl:when test='./@href = "http://csrc.nist.gov/publications/nistpubs/800-53-Rev3/sp800-53-rev3-final.pdf"'>
+                    <xsl:when test='./@href = "http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf"'>
                       <a href="{@href}">NIST <xsl:value-of select="text()"/></a>
                     </xsl:when>
                     <xsl:otherwise>
@@ -664,7 +664,7 @@
                     <xsl:when test='./@href = "http://iase.disa.mil/stigs/cci/Pages/index.aspx"'>
                       <a href="{@href}">DISA CCI-<xsl:value-of select="text()"/></a>
                     </xsl:when>
-                    <xsl:when test='./@href = "http://csrc.nist.gov/publications/nistpubs/800-53-Rev3/sp800-53-rev3-final.pdf"'>
+                    <xsl:when test='./@href = "http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf"'>
                       <a href="{@href}">NIST <xsl:value-of select="text()"/></a>
                     </xsl:when>
                     <xsl:otherwise>

--- a/RHEVM3/transforms/constants.xslt
+++ b/RHEVM3/transforms/constants.xslt
@@ -7,7 +7,7 @@
 <xsl:variable name="cceuri">http://cce.mitre.org</xsl:variable>
 
 <!-- abbreviated as references in the XCCDF-->
-<xsl:variable name="nist800-53uri">http://csrc.nist.gov/publications/nistpubs/800-53-Rev3/sp800-53-rev3-final.pdf</xsl:variable>
+<xsl:variable name="nist800-53uri">http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf</xsl:variable>
 <xsl:variable name="cnss1253uri">http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf</xsl:variable>
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>


### PR DESCRIPTION
The NIST SP 800-53 special publication location has changed from:
&nbsp; &nbsp;  [1] http://csrc.nist.gov/publications/nistpubs/800-53-Rev3/sp800-53-rev3-final.pdf
to:
&nbsp; &nbsp;  [2] http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf

therefore update ```nist800-53uri``` value at those places, where the link wasn't updated yet.

This partly [*] fixes downstream:
  [2] https://bugzilla.redhat.com/show_bug.cgi?id=1155808

Please review.

Thank you, Jan.

__
[*] partly because the rest of the links have been corrected between the issue report
    and today already.