### PR TITLE
[BugFix] [Enhancement] Fix 'display_login_attempts' rule for RHEL-7 and Fedora

### DIFF
--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -28,6 +28,7 @@
     <!-- <select idref="root_path_default" selected="true"/> -->
     <!-- Verify Proper Storage and Existence of Password Hashes section rules -->
     <select idref="no_empty_passwords" selected="true"/>
+    <select idref="display_login_attempts" selected="true"/>
     <select idref="no_hashes_outside_shadow" selected="true"/>
     <!-- <select idref="gid_passwd_group_same" selected="true"/> -->
     <select idref="no_netrc_files" selected="true"/>

--- a/Fedora/input/system/accounts/pam.xml
+++ b/Fedora/input/system/accounts/pam.xml
@@ -58,13 +58,16 @@ frequently.</description>
 <Rule id="display_login_attempts">
 <title>Set Last Logon/Access Notification</title>
 <description>To configure the system to notify users of last logon/access
-using <tt>pam_lastlog</tt>, add the following line immediately after <tt>session  required  pam_limits.so</tt>:
-<pre>session       required     pam_lastlog.so showfailed</pre>
+using <tt>pam_lastlog</tt>, add or correct the <tt>pam_lastlog</tt> settings in
+<tt>/etc/pam.d/postlogin</tt> to read as follows:
+<pre>session     [success=1 default=ignore] pam_succeed_if.so service !~ gdm* service !~ su* quiet
+session     [default=1]   pam_lastlog.so nowtmp showfailed
+session     optional      pam_lastlog.so silent noupdate showfailed</pre>
 </description>
 <ocil clause="that is not the case">
 To ensure that last logon/access notification is configured correctly, run
 the following command:
-<pre>$ grep pam_lastlog.so /etc/pam.d/system-auth</pre>
+<pre>$ grep pam_lastlog.so /etc/pam.d/postlogin</pre>
 The output should show output <tt>showfailed</tt>.
 </ocil>
 <rationale>

--- a/Fedora/input/system/accounts/pam.xml
+++ b/Fedora/input/system/accounts/pam.xml
@@ -77,7 +77,7 @@ of unsuccessful attempts that were made to login to their account
 allows the user to determine if any unauthorized activity has occurred
 and gives them an opportunity to notify administrators.
 </rationale>
-<!--oval id="display_login_attempts" /-->
+<oval id="display_login_attempts" />
 <ref disa="53" />
 </Rule>
 

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -73,7 +73,7 @@
 <!-- <select idref="gid_passwd_group_same" selected="true"/> reason: needs to be implemented for both RHEL-6 & RHEL-7 -->
 <select idref="accounts_password_all_shadowed" selected="true"/>
 <select idref="no_empty_passwords" selected="true"/>
-<!-- <select idref="display_login_attempts" selected="true"/> reason: needs to be ported to RHEL-7 -->
+<select idref="display_login_attempts" selected="true"/>
 <select idref="account_disable_post_pw_expiration" selected="true"/>
 <select idref="accounts_passwords_pam_faillock_deny" selected="true"/>
 <select idref="accounts_passwords_pam_faillock_unlock_time" selected="true"/>

--- a/RHEL/7/input/system/accounts/pam.xml
+++ b/RHEL/7/input/system/accounts/pam.xml
@@ -59,13 +59,16 @@ frequently.</description>
 <Rule id="display_login_attempts">
 <title>Set Last Logon/Access Notification</title>
 <description>To configure the system to notify users of last logon/access
-using <tt>pam_lastlog</tt>, add the following line immediately after <tt>session  required  pam_limits.so</tt>:
-<pre>session       required     pam_lastlog.so showfailed</pre>
+using <tt>pam_lastlog</tt>, add or correct the <tt>pam_lastlog</tt> settings in
+<tt>/etc/pam.d/postlogin</tt> to read as follows:
+<pre>session     [success=1 default=ignore] pam_succeed_if.so service !~ gdm* service !~ su* quiet
+session     [default=1]   pam_lastlog.so nowtmp showfailed
+session     optional      pam_lastlog.so silent noupdate showfailed</pre>
 </description>
 <ocil clause="that is not the case">
 To ensure that last logon/access notification is configured correctly, run
 the following command:
-<pre>$ grep pam_lastlog.so /etc/pam.d/system-auth</pre>
+<pre>$ grep pam_lastlog.so /etc/pam.d/postlogin</pre>
 The output should show output <tt>showfailed</tt>.
 </ocil>
 <rationale>

--- a/shared/oval/display_login_attempts.xml
+++ b/shared/oval/display_login_attempts.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="display_login_attempts" version="1">
+    <metadata>
+      <title>Set Last Login/Access Notification</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>Configure the system to notify users of last login/access using pam_lastlog.</description>
+      <reference source="JL" ref_id="RHEL7_20150611" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA20_20150611" ref_url="test_attestation" />
+    </metadata>
+    <criteria>
+      <criterion comment="Conditions for pam_lastlog are satisfied" test_ref="test_display_login_attempts" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="Check the pam_lastlog configuration of /etc/pam.d/postlogin" id="test_display_login_attempts" version="1">
+    <ind:object object_ref="obj_display_login_attempts" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_display_login_attempts" version="1">
+    <!-- Read whole /etc/pam.d/postlogin as single line so we can verify form
+         of both pam_lastlog.so rows and their order -->
+    <ind:behaviors singleline="true" />
+    <ind:filepath>/etc/pam.d/postlogin</ind:filepath>
+    <ind:pattern operation="pattern match">[\n][\s]*session[\s]+\[default=1\][\s]+pam_lastlog.so[\s\w\d\=]+showfailed[\s\w\d\=]*\n[\s]*session[\s]+optional[\s]+pam_lastlog.so[\s\w\d\=]+showfailed[\s\w\d\=]*[\n]</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>


### PR DESCRIPTION
This patchset is doing the following:
* patch https://github.com/OpenSCAP/scap-security-guide/commit/276d4b923a989d98680d364a56fbc901a1c21778 updates the ```RHEL/7``` and ```Fedora``` XCCDF prose for ```display_login_attempts``` rule it to recommend proper ```pam_lastlog.so``` module setting (it has been verified with Tomas Mraz, PAM package maintainer that on RHEL-7 and Fedora systems the proper ```pam_lastlog.so``` PAM module setting should happen in ```/etc/pam.d/postlogin``` configuration file, and not, like currently recommended in ```/etc/pam.d/system-auth``` file. The ```/etc/pam.d/system-auth``` recommendation is still correct for the case of ```RHEL/6``` system though, therefore the corresponding ```RHEL/6``` XCCDF object for this rule hasn't been modified),

This change fixes ```pam_lastlog.so``` issue (leading to invalid PAM configuration) as reported in:
&nbsp; &nbsp; [1] https://lists.fedorahosted.org/pipermail/scap-security-guide/2015-June/006449.html

* patch https://github.com/OpenSCAP/scap-security-guide/commit/28c5758bb5e7a89f669fbf46260d0f80c77c0950 adds ```/shared``` version of OVAL checks for ```RHEL/7``` and ```Fedora``` products for this rule (```display_login_attempts```). Also switches using of that rule on for Fedora's ```common``` profile and RHEL-7's ```PCI-DSS``` profile.

Testing report:
--
The proposed OVAL check has been manually tested on both products (RHEL-7 && Fedora 20), and seems to be working fine (AFAICT), therefore also added ```test_attestation```s for these two systems.

Please review.

Thank you, Jan.
