### PR TITLE
Build HTML guide for every profile in input XCCDF or datastream

### DIFF
--- a/Chromium/Makefile
+++ b/Chromium/Makefile
@@ -11,6 +11,8 @@ ID = ssg
 PROD = chromium
 
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
+# OpenSCAP 1.1.0+ supports generating guides from datastreams
+OPENSCAP_1_1_OR_LATER := $(shell oscap --version | grep -q -E "OpenSCAP command line tool \(oscap\) 1\.[1-9]+[0-9]*\."; echo $$?)
 
 all: shorthand2xccdf tables guide content dist
 
@@ -111,7 +113,12 @@ content-stig: shorthand2xccdf guide checks
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
 
 guide: content
+ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+else
+	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+endif
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml

--- a/Chromium/Makefile
+++ b/Chromium/Makefile
@@ -41,13 +41,6 @@ checks:
 	$(SHARED)/$(TRANS)/combinechecks.py $(CONF) $(PROD) $(IN)/checks > $(OUT)/unlinked-$(PROD)-oval.xml
 	xmllint --format --output $(OUT)/unlinked-$(PROD)-oval.xml $(OUT)/unlinked-$(PROD)-oval.xml
 
-guide: shorthand2xccdf
-#	remove auxiliary Groups which are only for use in tables, and not guide output.
-	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf-guide.xml
-	oscap xccdf generate guide --profile stig-chromium-upstream $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/stig-$(PROD)-upstream-guide.html
-	xsltproc -o $(OUT)/stig-$(PROD)-upstream-guide-custom.html $(TRANS)/xccdf2html.xslt $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml
-
 # example, if needed: for converting XCCDF into shorthand
 #xccdf2shorthand:
 #	xsltproc -o $(XCCDF_OUTPUT_DIR)/rhel5-shorthand.xml $(TRANS)/xccdf2shorthand.xslt $(REFS)/usgcb-rhel5desktop-xccdf.xml
@@ -88,10 +81,13 @@ table-stigs: shorthand2xccdf table-srgmap checks
 tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-srgmap table-stigs
 
-content: shorthand2xccdf guide checks
+content: shorthand2xccdf checks
+#	remove auxiliary Groups which are only for use in tables, and not guide output.
+#	specifying a nonexistent profile, "allrules," to make oscap print all Rules
+	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 #	The relabelids.py script chdirs to ./output, so refer to files from there.
-#	Its second argument controls the IDs, as well as the output filenames.
-#	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
+#	its second argument controls the IDs, as well as the output filenames.
+#	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-ocilrefs-$(PROD)-xccdf.xml $(ID)
@@ -113,6 +109,9 @@ content-stig: shorthand2xccdf guide checks
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml disa-predraft
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-stig-$(PROD)-xccdf.xml disa-predraft
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
+
+guide: content
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
@@ -145,7 +144,7 @@ dist: tables guide content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
 	mkdir -p $(DIST)/guide
-	cp $(OUT)/*-guide.html $(DIST)/guide
+	cp $(OUT)/*-guide-*.html $(DIST)/guide
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -49,7 +49,6 @@ checks:
 content: shorthand2xccdf guide checks
 #   remove auxiliary Groups which are only for use in tables, and not guide output.
 	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -46,15 +46,10 @@ checks:
 	$(SHARED)/$(TRANS)/combinechecks.py $(CONF) $(PROD) $(PROD_CHECKS) > $(OUT)/unlinked-$(PROD)-oval.xml
 	xmllint --format --output $(OUT)/unlinked-$(PROD)-oval.xml $(OUT)/unlinked-$(PROD)-oval.xml
 
-guide: shorthand2xccdf
-#       remove auxiliary Groups which are only for use in tables, and not guide output.
+content: shorthand2xccdf guide checks
+#   remove auxiliary Groups which are only for use in tables, and not guide output.
 	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-#       OpenSCAP-1.1.1 expects exact profile name in order to include also rules into guide
-#       Create guide for common profile
-	oscap xccdf generate guide --profile common $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(ID)-$(PROD)-common-guide.html
-
-content: shorthand2xccdf guide checks
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
@@ -70,6 +65,8 @@ else
 	oscap ds sds-compose $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml $(OUT)/$(ID)-$(PROD)-ds.xml
 endif
 
+guide: content
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
 
 validate-xml:
 ifeq ($(OVAL_5_10), 0)
@@ -99,7 +96,7 @@ dist: guide content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
 	mkdir -p $(DIST)/guide
-	cp $(OUT)/*-guide.html $(DIST)/guide
+	cp $(OUT)/*-guide-*.html $(DIST)/guide
 
 eval-common: content
 	oscap xccdf eval --profile common $(OUT)/$(ID)-$(PROD)-xccdf.xml

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -15,6 +15,8 @@ PROD_CHECKS = $(BUILD)/$(PROD)_checks
 
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
 OVAL_5_10 := $(shell oscap --version | grep -q "OVAL Version: 5.10.*"; echo $$?)
+# OpenSCAP 1.1.0+ supports generating guides from datastreams
+OPENSCAP_1_1_OR_LATER := $(shell oscap --version | grep -q -E "OpenSCAP command line tool \(oscap\) 1\.[1-9]+[0-9]*\."; echo $$?)
 SHELLCHECK_AVAIL := $(shell which shellcheck >& /dev/null; echo $$?)
 
 all: shorthand2xccdf guide content dist
@@ -65,7 +67,12 @@ else
 endif
 
 guide: content
+ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+else
+	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+endif
 
 validate-xml:
 ifeq ($(OVAL_5_10), 0)

--- a/Firefox/Makefile
+++ b/Firefox/Makefile
@@ -11,6 +11,8 @@ ID = ssg
 PROD = firefox
 
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
+# OpenSCAP 1.1.0+ supports generating guides from datastreams
+OPENSCAP_1_1_OR_LATER := $(shell oscap --version | grep -q -E "OpenSCAP command line tool \(oscap\) 1\.[1-9]+[0-9]*\."; echo $$?)
 
 all: shorthand2xccdf tables guide content dist
 
@@ -113,7 +115,12 @@ content-stig: shorthand2xccdf guide checks
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
 
 guide: content
+ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+else
+	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+endif
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml

--- a/Firefox/Makefile
+++ b/Firefox/Makefile
@@ -44,13 +44,6 @@ checks:
 	$(SHARED)/$(TRANS)/combinechecks.py $(CONF) $(PROD) $(IN)/checks > $(OUT)/unlinked-$(PROD)-oval.xml
 	xmllint --format --output $(OUT)/unlinked-$(PROD)-oval.xml $(OUT)/unlinked-$(PROD)-oval.xml
 
-guide: shorthand2xccdf
-#	remove auxiliary Groups which are only for use in tables, and not guide output.
-	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf-guide.xml
-	oscap xccdf generate guide --profile stig-firefox-upstream $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/stig-$(PROD)-upstream-guide.html
-	xsltproc -o $(OUT)/stig-$(PROD)-upstream-guide-custom.html $(TRANS)/xccdf2html.xslt $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml
-
 # example, if needed: for converting XCCDF into shorthand
 #xccdf2shorthand:
 #	xsltproc -o $(XCCDF_OUTPUT_DIR)/rhel5-shorthand.xml $(TRANS)/xccdf2shorthand.xslt $(REFS)/usgcb-rhel5desktop-xccdf.xml
@@ -91,10 +84,12 @@ table-stigs: shorthand2xccdf table-srgmap checks
 tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-srgmap table-stigs
 
-content: shorthand2xccdf guide checks
+content: shorthand2xccdf checks
+#	remove auxiliary Groups which are only for use in tables, and not guide output.
+	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 #	The relabelids.py script chdirs to ./output, so refer to files from there.
-#	Its second argument controls the IDs, as well as the output filenames.
-#	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
+#	its second argument controls the IDs, as well as the output filenames.
+#	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-ocilrefs-$(PROD)-xccdf.xml $(ID)
@@ -116,6 +111,9 @@ content-stig: shorthand2xccdf guide checks
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml disa-predraft
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-stig-$(PROD)-xccdf.xml disa-predraft
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
+
+guide: content
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
@@ -148,7 +146,7 @@ dist: tables guide content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
 	mkdir -p $(DIST)/guide
-	cp $(OUT)/*-guide.html $(DIST)/guide
+	cp $(OUT)/*-guide-*.html $(DIST)/guide
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv

--- a/JRE/Makefile
+++ b/JRE/Makefile
@@ -11,6 +11,8 @@ ID = ssg
 PROD = jre
 
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
+# OpenSCAP 1.1.0+ supports generating guides from datastreams
+OPENSCAP_1_1_OR_LATER := $(shell oscap --version | grep -q -E "OpenSCAP command line tool \(oscap\) 1\.[1-9]+[0-9]*\."; echo $$?)
 
 all: shorthand2xccdf tables guide content dist
 
@@ -113,7 +115,12 @@ content-stig: shorthand2xccdf guide checks
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
 
 guide: content
+ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+else
+	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+endif
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml

--- a/JRE/Makefile
+++ b/JRE/Makefile
@@ -44,13 +44,6 @@ checks:
 	$(SHARED)/$(TRANS)/combinechecks.py $(CONF) $(PROD) $(IN)/checks > $(OUT)/unlinked-$(PROD)-oval.xml
 	xmllint --format --output $(OUT)/unlinked-$(PROD)-oval.xml $(OUT)/unlinked-$(PROD)-oval.xml
 
-guide: shorthand2xccdf
-#	remove auxiliary Groups which are only for use in tables, and not guide output.
-	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf-guide.xml
-	oscap xccdf generate guide --profile stig-java-upstream $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/stig-$(PROD)-upstream-guide.html
-	xsltproc -o $(OUT)/stig-$(PROD)-upstream-guide-custom.html $(TRANS)/xccdf2html.xslt $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml
-
 # example, if needed: for converting XCCDF into shorthand
 #xccdf2shorthand:
 #	xsltproc -o $(XCCDF_OUTPUT_DIR)/rhel5-shorthand.xml $(TRANS)/xccdf2shorthand.xslt $(REFS)/usgcb-rhel5desktop-xccdf.xml
@@ -91,7 +84,9 @@ table-stigs: shorthand2xccdf table-srgmap checks
 tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-srgmap table-stigs
 
-content: shorthand2xccdf guide checks
+content: shorthand2xccdf checks
+#	remove auxiliary Groups which are only for use in tables, and not guide output.
+	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 #	The relabelids.py script chdirs to ./output, so refer to files from there.
 #	Its second argument controls the IDs, as well as the output filenames.
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
@@ -116,6 +111,9 @@ content-stig: shorthand2xccdf guide checks
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml disa-predraft
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-stig-$(PROD)-xccdf.xml disa-predraft
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
+
+guide: content
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
@@ -148,7 +146,7 @@ dist: tables guide content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
 	mkdir -p $(DIST)/guide
-	cp $(OUT)/*-guide.html $(DIST)/guide
+	cp $(OUT)/*-guide-*.html $(DIST)/guide
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ TARBALL = $(RPMBUILD)/SOURCES/$(PKG).tar.gz
 PREFIX=$(DESTDIR)/usr
 DATADIR=share
 MANDIR=man
+DOCDIR=$(DATADIR)/doc
 
 # Define custom canned sequences / macros below
 
@@ -219,14 +220,15 @@ install: dist
 	install -d $(PREFIX)/$(DATADIR)/scap-security-guide
 	install -d $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
 	install -d $(PREFIX)/$(MANDIR)/en/man8/
+	install -d $(PREFIX)/$(DOCDIR)/scap-security-guide
 	install -m 0644 Fedora/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
-	install -m 0644 Fedora/dist/guide/* $(PREFIX)/$(DATADIR)/scap-security-guide/
+	install -m 0644 Fedora/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide
 	install -m 0644 RHEL/6/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
 	install -m 0644 shared/fixes/bash/templates/remediation_functions $(PREFIX)/$(DATADIR)/scap-security-guide/
 	install -m 0644 RHEL/6/kickstart/*-ks.cfg $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
-	install -m 0644 RHEL/6/dist/guide/* $(PREFIX)/$(DATADIR)/scap-security-guide/
+	install -m 0644 RHEL/6/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide
 	install -m 0644 RHEL/7/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
-	install -m 0644 RHEL/7/dist/guide/* $(PREFIX)/$(DATADIR)/scap-security-guide/
+	install -m 0644 RHEL/7/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide
 	install -m 0644 docs/scap-security-guide.8 $(PREFIX)/$(MANDIR)/en/man8/
 
 .PHONY: rhel5 rhel6 rhel7 jre firefox webmin tarball srpm rpm clean all

--- a/OpenStack/Makefile
+++ b/OpenStack/Makefile
@@ -43,18 +43,6 @@ checks:
 	$(SHARED)/$(TRANS)/combinechecks.py $(CONF) $(PROD) $(IN)/checks > $(OUT)/unlinked-$(PROD)-oval.xml
 	xmllint --format --output $(OUT)/unlinked-$(PROD)-oval.xml $(OUT)/unlinked-$(PROD)-oval.xml
 
-guide: shorthand2xccdf
-#	remove auxiliary Groups which are only for use in tables, and not guide output.
-#	specifying a nonexistent profile, "allrules," to make oscap print all Rules
-	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-#	
-#	Begin Guide Creation
-#	NOTE:	If you do not follow the $(profile)-guide.html syntax
-#		you will manually have to include your guide in the
-#		make dist section
-#
-	oscap xccdf generate guide --profile stig-$(PROD)-server $(OUT)/unlinked-$(PROD)-xccdf-guide.xml > $(OUT)/stig-$(PROD)-server-guide.html
-
 # example, if needed: for converting XCCDF into shorthand
 #xccdf2shorthand:
 #	xsltproc -o $(XCCDF_OUTPUT_DIR)/rhel5-shorthand.xml $(TRANS)/xccdf2shorthand.xslt $(REFS)/usgcb-rhel5desktop-xccdf.xml
@@ -120,7 +108,10 @@ alt-titles: shorthand2xccdf
 	$(UTILS)/sync-alt-titles.py -p stig-$(PROD)-server -f $(IN)/auxiliary/alt-titles-stig.xml $(OUT)/unlinked-$(PROD)-xccdf.xml
 	XMLLINT_INDENT="" xmllint --format --output $(IN)/auxiliary/alt-titles-stig.xml $(IN)/auxiliary/alt-titles-stig.xml
 
-content: shorthand2xccdf guide checks
+content: shorthand2xccdf checks
+#	remove auxiliary Groups which are only for use in tables, and not guide output.
+#	specifying a nonexistent profile, "allrules," to make oscap print all Rules
+	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 #	The relabelids.py script chdirs to ./output, so refer to files from there.
 #	Its second argument controls the IDs, as well as the output filenames.
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
@@ -145,6 +136,10 @@ content-stig: shorthand2xccdf guide checks
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml disa-predraft
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-stig-$(PROD)-xccdf.xml disa-predraft
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
+
+guide: content
+	# No profiles available, uncomment this when OpenStack content gets any profiles
+	#$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-server --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
@@ -173,7 +168,7 @@ eval-common:
 # items in dist are expected for distribution in an rpm
 dist: tables guide content
 	mkdir -p $(DIST)/guide $(DIST)/content $(DIST)/policytables
-	cp $(OUT)/*-guide.html $(DIST)/guide
+	cp $(OUT)/*-guide-*.html $(DIST)/guide
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content

--- a/OpenStack/Makefile
+++ b/OpenStack/Makefile
@@ -11,6 +11,8 @@ ID = ssg
 PROD = openstack
 
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
+# OpenSCAP 1.1.0+ supports generating guides from datastreams
+OPENSCAP_1_1_OR_LATER := $(shell oscap --version | grep -q -E "OpenSCAP command line tool \(oscap\) 1\.[1-9]+[0-9]*\."; echo $$?)
 
 all: shorthand2xccdf tables guide checks content dist
 
@@ -139,7 +141,12 @@ content-stig: shorthand2xccdf guide checks
 
 guide: content
 	# No profiles available, uncomment this when OpenStack content gets any profiles
+ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
+	#$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+else
+	#@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
 	#$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+endif
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-server --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml

--- a/OpenStack/Makefile
+++ b/OpenStack/Makefile
@@ -168,7 +168,8 @@ eval-common:
 # items in dist are expected for distribution in an rpm
 dist: tables guide content
 	mkdir -p $(DIST)/guide $(DIST)/content $(DIST)/policytables
-	cp $(OUT)/*-guide-*.html $(DIST)/guide
+	# No profiles available, uncomment this when OpenStack content gets any profiles
+	#cp $(OUT)/*-guide-*.html $(DIST)/guide
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -11,6 +11,8 @@ ID = ssg
 PROD = rhel5
 
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
+# OpenSCAP 1.1.0+ supports generating guides from datastreams
+OPENSCAP_1_1_OR_LATER := $(shell oscap --version | grep -q -E "OpenSCAP command line tool \(oscap\) 1\.[1-9]+[0-9]*\."; echo $$?)
 
 all: shorthand2xccdf tables guide content dist
 
@@ -117,9 +119,16 @@ content-stig: shorthand2xccdf guide checks
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
 
 guide: content
+ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos5-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl5-ds.xml
+else
+	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos5-xccdf.xml
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl5-xccdf.xml
+endif
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-server-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -41,14 +41,6 @@ checks:
 	$(SHARED)/$(TRANS)/combinechecks.py $(CONF) $(PROD) $(IN)/checks > $(OUT)/unlinked-$(PROD)-oval.xml
 	xmllint --format --output $(OUT)/unlinked-$(PROD)-oval.xml $(OUT)/unlinked-$(PROD)-oval.xml
 
-guide: shorthand2xccdf
-#	remove auxiliary Groups which are only for use in tables, and not guide output.
-#	specifying a nonexistent profile, "allrules," to make oscap print all Rules
-	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf-guide.xml
-	oscap xccdf generate guide --profile allrules $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(PROD)-guide.html
-	xsltproc -o $(OUT)/$(PROD)-guide-custom.html $(TRANS)/xccdf2html.xslt $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml
-
 # example, if needed: for converting XCCDF into shorthand
 #xccdf2shorthand:
 #	xsltproc -o $(XCCDF_OUTPUT_DIR)/rhel5-shorthand.xml $(TRANS)/xccdf2shorthand.xslt $(REFS)/usgcb-rhel5desktop-xccdf.xml
@@ -89,7 +81,10 @@ table-stigs: shorthand2xccdf table-srgmap checks
 tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-stigs
 
-content: shorthand2xccdf guide checks
+content: shorthand2xccdf checks
+#	Remove auxiliary Groups which are only for use in tables, and not guide output.
+#	Specifying a nonexistent profile, "allrules," to make oscap print all Rules
+	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 #	The relabelids.py script chdirs to ./output, so refer to files from there.
 #	Its second argument controls the IDs, as well as the output filenames.
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
@@ -121,6 +116,11 @@ content-stig: shorthand2xccdf guide checks
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-stig-$(PROD)-xccdf.xml disa-predraft
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
 
+guide: content
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos5-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl5-xccdf.xml
+
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-server-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
 #	$(TRANS)/xccdf2csv-stig.py $(OUT)/unlinked-stig-$(PROD)-xccdf.xml > $(OUT)/table-stig.csv
@@ -150,7 +150,7 @@ eval-common:
 
 # items in dist are expected for distribution in an rpm
 dist: tables guide content
-	mkdir -p $(DIST)/content
+	mkdir -p $(DIST)/content $(DIST)/guide
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
@@ -160,6 +160,7 @@ dist: tables guide content
 	cp $(OUT)/$(ID)-centos5-ds.xml $(DIST)/content
 	cp $(OUT)/$(ID)-sl5-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-sl5-ds.xml $(DIST)/content
+	cp $(OUT)/*-guide-*.html $(DIST)/guide
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -53,14 +53,6 @@ checks:
 	$(SHARED)/$(TRANS)/combinechecks.py $(CONF) $(PROD) $(PROD_CHECKS) > $(OUT)/unlinked-$(PROD)-oval.xml
 	xmllint --format --output $(OUT)/unlinked-$(PROD)-oval.xml $(OUT)/unlinked-$(PROD)-oval.xml
 
-guide: shorthand2xccdf
-#	remove auxiliary Groups which are only for use in tables, and not guide output.
-#	specifying a nonexistent profile, "allrules," to make oscap print all Rules
-	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf-guide.xml
-	oscap xccdf generate guide --profile allrules $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(PROD)-guide.html
-	xsltproc -o $(OUT)/$(PROD)-guide-custom.html $(TRANS)/xccdf2html.xslt $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml
-
 # example, if needed: for converting XCCDF into shorthand
 #xccdf2shorthand:
 #	xsltproc -o $(XCCDF_OUTPUT_DIR)/rhel5-shorthand.xml $(TRANS)/xccdf2shorthand.xslt $(REFS)/usgcb-rhel5desktop-xccdf.xml
@@ -101,7 +93,10 @@ table-stigs: shorthand2xccdf table-srgmap checks
 tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-srgmap table-stigs
 
-content: shorthand2xccdf guide checks
+content: shorthand2xccdf checks
+#	Remove auxiliary Groups which are only for use in tables, and not guide output.
+#	Specifying a nonexistent profile, "allrules," to make oscap print all Rules
+	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 #	The relabelids.py script chdirs to ./output, so refer to files from there.
 #	Its second argument controls the IDs, as well as the output filenames.
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
@@ -132,6 +127,11 @@ content-stig: shorthand2xccdf guide checks
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml disa-predraft
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-stig-$(PROD)-xccdf.xml disa-predraft
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
+
+guide: content
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos6-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl6-xccdf.xml
 
 submission-stig-check: table-stigs
 	cd $(OUT); ../$(UTILS)/verify-references.py -p stig-$(PROD)-server-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
@@ -173,7 +173,7 @@ dist: tables guide content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
 	mkdir -p $(DIST)/guide
-	cp $(OUT)/*-guide.html $(DIST)/guide
+	cp $(OUT)/*-guide-*.html $(DIST)/guide
 	cp $(OUT)/$(ID)-centos6-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-centos6-ds.xml $(DIST)/content
 	cp $(OUT)/$(ID)-sl6-xccdf.xml $(DIST)/content

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -14,6 +14,8 @@ PROD = rhel6
 PROD_CHECKS = $(BUILD)/$(PROD)_checks
 
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
+# OpenSCAP 1.1.0+ supports generating guides from datastreams
+OPENSCAP_1_1_OR_LATER := $(shell oscap --version | grep -q -E "OpenSCAP command line tool \(oscap\) 1\.[1-9]+[0-9]*\."; echo $$?)
 
 # Don't include the 'test' profile into benchmark by default. Only upon request (e.g. in 'eval-test' target)
 # Value '0' means 'test' will be included. Value '1' means 'test' will NOT be included.
@@ -129,9 +131,16 @@ content-stig: shorthand2xccdf guide checks
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
 
 guide: content
+ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos6-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl6-ds.xml
+else
+	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos6-xccdf.xml
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl6-xccdf.xml
+endif
 
 submission-stig-check: table-stigs
 	cd $(OUT); ../$(UTILS)/verify-references.py -p stig-$(PROD)-server-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -61,15 +61,6 @@ endif
 	$(SHARED)/$(TRANS)/combinechecks.py $(CONF) $(PROD) $(PROD_CHECKS) > $(OUT)/unlinked-$(PROD)-oval.xml
 	xmllint --format --output $(OUT)/unlinked-$(PROD)-oval.xml $(OUT)/unlinked-$(PROD)-oval.xml
 
-guide: shorthand2xccdf
-#	remove auxiliary Groups which are only for use in tables, and not guide output.
-	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf-guide.xml
-#       OpenSCAP-1.1.1 expects exact profile name in order to include also rules into guide
-#       Create guide for RHT-CCP profile
-	oscap xccdf generate guide --profile rht-ccp $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(PROD)-ccp-guide.html
-	xsltproc -o $(OUT)/$(PROD)-ccp-guide-custom.html $(TRANS)/xccdf2html.xslt $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml
-
 # example, if needed: for converting XCCDF into shorthand
 #xccdf2shorthand:
 #	xsltproc -o $(XCCDF_OUTPUT_DIR)/rhel5-shorthand.xml $(TRANS)/xccdf2shorthand.xslt $(REFS)/usgcb-rhel5desktop-xccdf.xml
@@ -108,7 +99,9 @@ table-stigs: shorthand2xccdf table-srgmap checks
 
 tables: table-refs table-idents table-srgmap table-stigs
 
-content: shorthand2xccdf guide checks
+content: shorthand2xccdf checks
+#	Remove auxiliary Groups which are only for use in tables, and not guide output.
+	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 #	The relabelids.py script chdirs to ./output, so refer to files from there.
 #	Its second argument controls the IDs, as well as the output filenames.
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
@@ -139,6 +132,11 @@ content-stig: shorthand2xccdf guide checks
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml disa-predraft
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-stig-$(PROD)-xccdf.xml disa-predraft
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
+
+guide: content
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-xccdf.xml
 
 submission-stig-check: table-stigs
 	cd $(OUT); ../$(UTILS)/verify-references.py -p stig-$(PROD)-server --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
@@ -179,7 +177,7 @@ dist: tables guide content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
 	mkdir -p $(DIST)/guide
-	cp $(OUT)/*-guide.html $(DIST)/guide
+	cp $(OUT)/*-guide-*.html $(DIST)/guide
 	cp $(OUT)/$(ID)-centos7-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-centos7-ds.xml $(DIST)/content
 	cp $(OUT)/$(ID)-sl7-xccdf.xml $(DIST)/content

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -15,6 +15,8 @@ PROD_CHECKS = $(BUILD)/$(PROD)_checks
 
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
 OVAL_5_11 := $(shell oscap --version | grep -q "OVAL Version: 5.11.*"; echo $$?)
+# OpenSCAP 1.1.0+ supports generating guides from datastreams
+OPENSCAP_1_1_OR_LATER := $(shell oscap --version | grep -q -E "OpenSCAP command line tool \(oscap\) 1\.[1-9]+[0-9]*\."; echo $$?)
 
 # Don't include the 'test' profile into benchmark by default. Only upon request (e.g. in 'eval-test' target)
 # Value '0' means 'test' will be included. Value '1' means 'test' will NOT be included.
@@ -134,9 +136,16 @@ content-stig: shorthand2xccdf guide checks
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
 
 guide: content
+ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-ds.xml
+else
+	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-xccdf.xml
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-xccdf.xml
+endif
 
 submission-stig-check: table-stigs
 	cd $(OUT); ../$(UTILS)/verify-references.py -p stig-$(PROD)-server --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml

--- a/RHEVM3/Makefile
+++ b/RHEVM3/Makefile
@@ -11,6 +11,8 @@ ID = ssg
 PROD = rhevm3
 
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
+# OpenSCAP 1.1.0+ supports generating guides from datastreams
+OPENSCAP_1_1_OR_LATER := $(shell oscap --version | grep -q -E "OpenSCAP command line tool \(oscap\) 1\.[1-9]+[0-9]*\."; echo $$?)
 
 all: shorthand2xccdf tables guide checks content dist
 
@@ -138,6 +140,7 @@ content-stig: shorthand2xccdf checks
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
 
 guide: content
+	# TODO: Build datastreams, generate guides from datastreams if possible
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
 
 submission-stig-check: table-stigs

--- a/RHEVM3/Makefile
+++ b/RHEVM3/Makefile
@@ -43,17 +43,6 @@ checks:
 	$(SHARED)/$(TRANS)/combinechecks.py $(CONF) $(PROD) $(IN)/checks > $(OUT)/unlinked-$(PROD)-oval.xml
 	xmllint --format --output $(OUT)/unlinked-$(PROD)-oval.xml $(OUT)/unlinked-$(PROD)-oval.xml
 
-guide: shorthand2xccdf
-#	remove auxiliary Groups which are only for use in tables, and not guide output.
-	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-#	
-#	Begin Guide Creation
-#	NOTE:	If you do not follow the $(profile)-guide.html syntax
-#		you will manually have to include your guide in the
-#		make dist section
-#
-	oscap xccdf generate guide --profile stig-$(PROD)-server $(OUT)/unlinked-$(PROD)-xccdf-guide.xml > $(OUT)/stig-$(PROD)-server-guide.html
-
 # example, if needed: for converting XCCDF into shorthand
 #xccdf2shorthand:
 #	xsltproc -o $(XCCDF_OUTPUT_DIR)/rhel5-shorthand.xml $(TRANS)/xccdf2shorthand.xslt $(REFS)/usgcb-rhel5desktop-xccdf.xml
@@ -119,7 +108,11 @@ alt-titles: shorthand2xccdf
 	$(UTILS)/sync-alt-titles.py -p stig-$(PROD)-server -f $(IN)/auxiliary/alt-titles-stig.xml $(OUT)/unlinked-$(PROD)-xccdf.xml
 	XMLLINT_INDENT="" xmllint --format --output $(IN)/auxiliary/alt-titles-stig.xml $(IN)/auxiliary/alt-titles-stig.xml
 
-content: shorthand2xccdf guide checks
+content: shorthand2xccdf checks
+#	Remove auxiliary Groups which are only for use in tables, and not guide output.
+#	Specifying a nonexistent profile, "allrules," to make oscap print all Rules
+	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
+
 #	The relabelids.py script chdirs to ./output, so refer to files from there.
 #	Its second argument controls the IDs, as well as the output filenames.
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
@@ -130,7 +123,7 @@ content: shorthand2xccdf guide checks
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 
 # not ready until oscap resolve behavior resolved
-content-stig: shorthand2xccdf guide checks
+content-stig: shorthand2xccdf checks
 	xsltproc -stringparam alttitles "../$(IN)/auxiliary/alt-titles-stig.xml" -o $(OUT)/unlinked-$(PROD)-xccdf.xml \
 		$(TRANS)/xccdf-alt-titles.xslt \
 		$(OUT)/unlinked-$(PROD)-xccdf.xml
@@ -143,6 +136,9 @@ content-stig: shorthand2xccdf guide checks
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml disa-predraft
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-stig-$(PROD)-xccdf.xml disa-predraft
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
+
+guide: content
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-server --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
@@ -171,7 +167,7 @@ eval-common:
 # items in dist are expected for distribution in an rpm
 dist: tables guide content
 	mkdir -p $(DIST)/guide $(DIST)/content $(DIST)/policytables
-	cp $(OUT)/*-guide.html $(DIST)/guide
+	cp $(OUT)/*-guide-*.html $(DIST)/guide
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -11,6 +11,8 @@ ID = ssg
 PROD = webmin
 
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
+# OpenSCAP 1.1.0+ supports generating guides from datastreams
+OPENSCAP_1_1_OR_LATER := $(shell oscap --version | grep -q -E "OpenSCAP command line tool \(oscap\) 1\.[1-9]+[0-9]*\."; echo $$?)
 
 all: shorthand2xccdf tables guide content dist
 #all: stats shorthand2xccdf tables guide content dist

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -46,13 +46,6 @@ checks:
 	$(SHARED)/$(TRANS)/combinechecks.py $(CONF) $(PROD) $(IN)/checks > $(OUT)/unlinked-$(PROD)-oval.xml
 	xmllint --format --output $(OUT)/unlinked-$(PROD)-oval.xml $(OUT)/unlinked-$(PROD)-oval.xml
 
-guide: shorthand2xccdf
-#	remove auxiliary Groups which are only for use in tables, and not guide output.
-	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf-guide.xml
-	oscap xccdf generate guide --profile common $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(PROD)-common-guide.html
-	xsltproc -o $(OUT)/$(PROD)-common-guide-custom.html $(TRANS)/xccdf2html.xslt $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml
-
 # example, if needed: for converting XCCDF into shorthand
 #xccdf2shorthand:
 #	xsltproc -o $(XCCDF_OUTPUT_DIR)/rhel5-shorthand.xml $(TRANS)/xccdf2shorthand.xslt $(REFS)/usgcb-rhel5desktop-xccdf.xml
@@ -94,6 +87,9 @@ tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-srgmap table-stigs
 
 content: shorthand2xccdf guide checks
+#	Remove auxiliary Groups which are only for use in tables, and not guide output.
+#	Specifying a nonexistent profile, "allrules," to make oscap print all Rules
+	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 #	The relabelids.py script chdirs to ./output, so refer to files from there.
 #	Its second argument controls the IDs, as well as the output filenames.
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
@@ -113,11 +109,14 @@ content: shorthand2xccdf guide checks
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(OUT)/$(ID)-$(PROD)-ds.xml
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-oval.xml $(OUT)/$(ID)-$(PROD)-ds.xml
 
-content-stig: shorthand2xccdf guide checks
+content-stig: shorthand2xccdf checks
 	xmllint --format --output $(OUT)/unlinked-stig-$(PROD)-xccdf.xml $(OUT)/unlinked-stig-$(PROD)-xccdf.xml
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml disa-predraft
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-stig-$(PROD)-xccdf.xml disa-predraft
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
+
+guide: content
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-server-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
@@ -143,12 +142,13 @@ eval-common:
 
 # items in dist are expected for distribution in an rpm
 dist: tables guide content
-	mkdir -p $(DIST)/content
+	mkdir -p $(DIST)/content $(DIST)/guide
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
+	cp $(OUT)/*-guide-*.html $(DIST)/guide
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -118,7 +118,12 @@ content-stig: shorthand2xccdf checks
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
 
 guide: content
+ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+else
+	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+endif
 
 submission-stig-check: table-stigs
 	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-server-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml

--- a/scap-security-guide.spec.in
+++ b/scap-security-guide.spec.in
@@ -106,10 +106,12 @@ cp -a Chromium/dist/content/ssg-chromium-ds.xml %{buildroot}%{_datadir}/xml/scap
 %lang(en) %{_mandir}/en/man8/scap-security-guide.8.gz
 %if 0%{?rhel}
 %{_datadir}/%{name}/remediation_functions
-%doc Contributors.md README.md BUILD.md RHEL/6/LICENSE RHEL/6/output/rhel6-guide.html RHEL/6/output/table-rhel6-cces.html RHEL/6/output/table-rhel6-nistrefs-common.html RHEL/6/output/table-rhel6-nistrefs.html RHEL/6/output/table-rhel6-srgmap-flat.html RHEL/6/output/table-rhel6-srgmap-flat.xhtml RHEL/6/output/table-rhel6-srgmap.html RHEL/6/output/table-rhel6-stig.html RHEL/6/input/auxiliary/DISCLAIMER JBossEAP5/docs/JBossEAP5_Guide.html
+%doc Contributors.md README.md BUILD.md
+%doc RHEL/6/LICENSE RHEL/6/output/*-guide-*.html RHEL/6/output/table-rhel6-cces.html RHEL/6/output/table-rhel6-nistrefs-common.html RHEL/6/output/table-rhel6-nistrefs.html RHEL/6/output/table-rhel6-srgmap-flat.html RHEL/6/output/table-rhel6-srgmap-flat.xhtml RHEL/6/output/table-rhel6-srgmap.html RHEL/6/output/table-rhel6-stig.html RHEL/6/input/auxiliary/DISCLAIMER
+%doc JBossEAP5/docs/JBossEAP5_Guide.html
 %endif
 %if 0%{?fedora}
-%doc Contributors.md README.md BUILD.md Fedora/LICENSE Fedora/output/ssg-fedora*guide.html
+%doc Contributors.md README.md BUILD.md Fedora/LICENSE Fedora/output/*-guide-*.html
 %endif
 
 %changelog

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -176,7 +176,6 @@ def main():
 
     input_tree = ElementTree.parse(options.input_content)
     benchmarks = get_benchmark_ids_titles_for_input(input_tree)
-    print(benchmarks)
     if len(benchmarks) != 1:
         raise RuntimeError(
             "Expected input file '%s' to contain exactly 1 xccdf:Benchmark. "
@@ -190,7 +189,7 @@ def main():
             "No profiles were found in '%s'." % (options.input_content)
         )
 
-    # TODO: Make the index file nicer, allow switching between profiles, etc...
+    # TODO: Make the index file nicer
 
     index_links = []
     index_initial_src = None

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -162,9 +162,15 @@ def main():
     parser = OptionParser(usage=usage)
     parser.add_option(
         "-i", "--input", dest="input_content",
-        action="store", help="INPUT can be XCCDF or Source DataStream"
+        action="store", help="INPUT can be XCCDF or Source DataStream. XCCDF "
+        "is supported with all OpenSCAP versions. You need OpenSCAP 1.1.0 or "
+        "higher to generate guides from Source DataStream!"
     )
     (options, args) = parser.parse_args()
+
+    if options.input_content is None:
+        parser.print_help()
+        raise RuntimeError("No INPUT file provided, please use --input.")
 
     parent_dir = os.path.dirname(os.path.abspath(options.input_content))
     path_base, _ = os.path.splitext(os.path.basename(options.input_content))

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -212,6 +212,7 @@ def main():
     # TODO: Make the index file nicer
 
     index_links = []
+    index_options = []
     index_initial_src = None
 
     def profile_sort_key(profiles, profile_id):
@@ -242,6 +243,10 @@ def main():
         guide_path = os.path.join(parent_dir, guide_filename)
 
         index_links.append(
+            "<a target=\"guide\" href=\"%s\">%s</a>" %
+            (guide_filename, profile_title)
+        )
+        index_options.append(
             "<option value=\"%s\" data-profile-id=\"%s\">%s</option>" %
             (guide_filename, profile_id, profile_title)
         )
@@ -301,16 +306,22 @@ def main():
     index_source += "\t\t\t}\n"
     index_source += "\t\t</script>\n"
     index_source += "\t</head>\n"
-    index_source += "\t<body>\n"
-    index_source += "\t\tProfile: \n"
-    index_source += "\t\t<select style=\"margin-bottom: 5px\" "
+    index_source += "\t<body onload=\"document.getElementById('js_switcher').style.display = 'block'\">\n"
+    index_source += "\t\t<noscript>\n"
+    index_source += "Profiles: "
+    index_source += ", ".join(index_links) + "\n"
+    index_source += "\t\t</noscript>\n"
+    index_source += "\t\t<div id=\"js_switcher\" style=\"display: none\">\n"
+    index_source += "\t\t\tProfile: \n"
+    index_source += "\t\t\t<select style=\"margin-bottom: 5px\" "
     index_source += "onchange=\"change_profile(this.options[this.selectedIndex]);\""
     index_source += ">\n"
-    index_source += "\n".join(index_links) + "\n"
-    index_source += "\t\t</select>\n"
-    index_source += "\t\t&nbsp;&nbsp;<span id='eval_snippet' style='background: #eee; padding: 3px; border: 1px solid #000'>"
+    index_source += "\n".join(index_options) + "\n"
+    index_source += "\t\t\t</select>\n"
+    index_source += "\t\t\t&nbsp;&nbsp;<span id='eval_snippet' style='background: #eee; padding: 3px; border: 1px solid #000'>"
     index_source += "select a profile to display its guide and a command line snippet needed to use it"
     index_source += "</span>\n"
+    index_source += "\t\t</div>\n"
     index_source += "\t\t<br>\n"
     index_source += \
         "\t\t<iframe src=\"%s\" name=\"guide\" " % (index_initial_src)

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -26,7 +26,7 @@ XCCDF11_NS = "http://checklists.nist.gov/xccdf/1.1"
 XCCDF12_NS = "http://checklists.nist.gov/xccdf/1.2"
 
 # if a profile ID ends with a string listed here we skip it
-PROFILE_ID_BLACKLIST = ["test"]
+PROFILE_ID_BLACKLIST = ["test", "index", "default"]
 # filler XCCDF 1.2 prefix which we will strip to avoid very long filenames
 PROFILE_ID_PREFIX = "xccdf_org.ssgproject.content_profile_"
 
@@ -152,7 +152,8 @@ def generate_guide_for_input_content(input_content, profile_id):
     """
 
     args = [OSCAP_PATH, "xccdf", "generate", "guide"]
-    args.extend(["--profile", profile_id])
+    if profile_id != "":
+        args.extend(["--profile", profile_id])
     args.append(input_content)
 
     ret = subprocess_check_output(args).decode("utf-8")
@@ -197,6 +198,8 @@ def main():
             (options.input_content, len(benchmarks))
         )
     profiles = get_profile_choices_for_input(input_tree, None)
+    # add the default profile
+    profiles[""] = "(default)"
 
     if not profiles:
         raise RuntimeError(
@@ -220,8 +223,13 @@ def main():
         if skip:
             continue
 
+        profile_id_for_path = profile_id
+        if profile_id_for_path == "":
+            profile_id_for_path = "default"
+
         guide_filename = \
-            "%s-guide-%s.html" % (path_base, get_profile_short_id(profile_id))
+            "%s-guide-%s.html" % \
+            (path_base, get_profile_short_id(profile_id_for_path))
         guide_path = os.path.join(parent_dir, guide_filename)
 
         index_links.append("<option value=\"%s\">%s</option>" %

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -199,9 +199,10 @@ def main():
         for blacklisted_id in PROFILE_ID_BLACKLIST:
             if profile_id.endswith(blacklisted_id):
                 skip = True
+                break
 
         if skip:
-            break
+            continue
 
         guide_html = generate_guide_for_input_content(
             options.input_content, profile_id

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -233,9 +233,7 @@ def main():
         if skip:
             continue
 
-        profile_id_for_path = profile_id
-        if profile_id_for_path == "":
-            profile_id_for_path = "default"
+        profile_id_for_path = "default" if not profile_id else profile_id
 
         guide_filename = \
             "%s-guide-%s.html" % \
@@ -264,7 +262,7 @@ def main():
 
                 print(
                     "Generated '%s' for profile ID '%s'." %
-                    (guide_filename, profile_id)
+                    (guide_path, profile_id)
                 )
 
             except Queue.Empty:

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -1,0 +1,185 @@
+#!/usr/bin/python2
+
+"""
+Takes given XCCDF or DataStream and for every profile in it it generates one
+OpenSCAP HTML guide. Also generates an index file that lists all the profiles
+and allows the user to navigate between them.
+
+Author: Martin Preisler <mpreisle@redhat.com>
+"""
+
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    import cElementTree as ElementTree
+
+import os.path
+from optparse import OptionParser
+import subprocess
+
+OSCAP_PATH = "oscap"
+
+XCCDF11_NS = "http://checklists.nist.gov/xccdf/1.1"
+XCCDF12_NS = "http://checklists.nist.gov/xccdf/1.2"
+
+# if a profile ID ends with a string listed here we skip it
+PROFILE_ID_BLACKLIST = ["test"]
+# filler XCCDF 1.2 prefix which we will strip to avoid very long filenames
+PROFILE_ID_PREFIX = "xccdf_org.ssgproject.content_profile_"
+
+
+def get_profile_choices_for_input(input_file, tailoring_file):
+    """Returns a dictionary that maps profile_ids to their respective titles.
+    """
+
+    # Ideally oscap would have a command line to do this, but as of now it
+    # doesn't so we have to implement it ourselves. Importing openscap Python
+    # bindings is nasty and overkill for this.
+
+    ret = {}
+
+    def scrape_profiles(root_element, namespace, dest):
+        for elem in root_element.findall(".//{%s}Profile" % (namespace)):
+            id_ = elem.get("id")
+            if id_ is None:
+                continue
+
+            title = "<unknown>"
+            for element in elem.findall("{%s}title" % (namespace)):
+                title = element.text
+                break
+
+            dest[id_] = title
+
+    input_tree = ElementTree.parse(input_file)
+    input_root = input_tree.getroot()
+
+    scrape_profiles(
+        input_root, XCCDF11_NS, ret
+    )
+    scrape_profiles(
+        input_root, XCCDF12_NS, ret
+    )
+
+    if tailoring_file is not None:
+        tailoring_tree = ElementTree.parse(tailoring_file)
+        tailoring_root = tailoring_tree.getroot()
+
+        scrape_profiles(
+            tailoring_root, XCCDF11_NS, ret
+        )
+        scrape_profiles(
+            tailoring_root, XCCDF12_NS, ret
+        )
+
+    return ret
+
+
+def get_profile_short_id(long_id):
+    """If given profile ID is the XCCDF 1.2 long ID this function shortens it
+    """
+
+    if long_id.startswith(PROFILE_ID_PREFIX):
+        return long_id[len(PROFILE_ID_PREFIX):]
+
+    return long_id
+
+
+def subprocess_check_output(*popenargs, **kwargs):
+    # Backport of subprocess.check_output taken from
+    # https://gist.github.com/edufelipe/1027906
+    #
+    # Originally from Python 2.7 stdlib under PSF, compatible with LGPL2+
+    # Copyright (c) 2003-2005 by Peter Astrand <astrand@lysator.liu.se>
+    # Changes by Eduardo Felipe
+
+    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+    output, unused_err = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        error = subprocess.CalledProcessError(retcode, cmd)
+        error.output = output
+        raise error
+    return output
+
+
+if hasattr(subprocess, "check_output"):
+    # if available we just use the real function
+    subprocess_check_output = subprocess.check_output
+
+
+def generate_guide_for_input_content(input_content, profile_id):
+    """Returns HTML guide for given input_content and profile_id
+    combination. This function assumes only one Benchmark exists
+    in given input_content!
+    """
+
+    args = [OSCAP_PATH, "xccdf", "generate", "guide"]
+    args.extend(["--profile", profile_id])
+    args.append(input_content)
+
+    ret = subprocess_check_output(args).decode("utf-8")
+
+    return ret
+
+
+def main():
+    usage = "usage: %prog [options]"
+    parser = OptionParser(usage=usage)
+    parser.add_option(
+        "-i", "--input", dest="input_content", default=False,
+        action="store", help="INPUT can be XCCDF or Source DataStream"
+    )
+    (options, args) = parser.parse_args()
+
+    parent_dir = os.path.dirname(os.path.abspath(options.input_content))
+    path_base, _ = os.path.splitext(os.path.basename(options.input_content))
+    # avoid -ds and -xccdf suffices in guide filenames
+    if path_base.endswith("-ds"):
+        path_base = path_base[:-3]
+    elif path_base.endswith("-xccdf"):
+        path_base = path_base[:-6]
+
+    profiles = get_profile_choices_for_input(options.input_content, None)
+
+    # TODO: Make the index file nicer, allow switching between profiles, etc...
+    index_source = "<html><body>"
+
+    for profile_id, profile_title in profiles.iteritems():
+        skip = False
+        for blacklisted_id in PROFILE_ID_BLACKLIST:
+            if profile_id.endswith(blacklisted_id):
+                skip = True
+
+        if skip:
+            break
+
+        guide_html = generate_guide_for_input_content(
+            options.input_content, profile_id
+        )
+
+        guide_filename = \
+            "%s-guide-%s.html" % (path_base, get_profile_short_id(profile_id))
+        guide_path = os.path.join(parent_dir, guide_filename)
+        with open(guide_path, "w") as f:
+            f.write(guide_html.encode("utf-8"))
+
+        index_source += "<a href=\"%s\">%s</a><br>" % \
+            (guide_filename, profile_title)
+
+        print(
+            "Generated '%s' for profile ID '%s'." %
+            (guide_filename, profile_id)
+        )
+
+    index_source += "</body></html>"
+
+    index_path = os.path.join(parent_dir, "%s-guide-index.html" % (path_base))
+    with open(index_path, "w") as f:
+        f.write(index_source.encode("utf-8"))
+
+if __name__ == "__main__":
+    main()

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -213,7 +213,17 @@ def main():
     index_links = []
     index_initial_src = None
 
-    for profile_id, profile_title in profiles.iteritems():
+    def profile_sort_key(profiles, profile_id):
+        if profile_id == "":
+            # make sure (default) is last
+            return "zzz(default)"
+
+        # otherwise sort by profile title
+        return profiles[profile_id]
+
+    for profile_id in sorted(profiles.iterkeys(),
+                             key=lambda x: profile_sort_key(profiles, x)):
+        profile_title = profiles[profile_id]
         skip = False
         for blacklisted_id in PROFILE_ID_BLACKLIST:
             if profile_id.endswith(blacklisted_id):


### PR DESCRIPTION
Implemented a script that takes an XCCDF 1.1, 1.2 or source datastream, scrapes all profiles and builds a guide for every profile not in the blacklist. All the guides are placed next to the input file. This solves the issues with `allrules` which is no longer an option with new OpenSCAP versions. It also is the *right thing* IMO because every profile we ship is probably important enough to have a HTML guide.

I am proposing a pull request at this stage to discuss how I should continue. I would like to make this part of the build process and install all the HTML guide when installing the `scap-security-guide` package. The script also generates an index HTML file, right now it just links to all the profile guides but in the future it may have description of the benchmark and allow switching the profiles. This may be a good thing to publish on websites.

Usage example:
```
cd RHEL/6/output
../../../shared/utils/build-all-guides.py -i ssg-rhel6-ds.xml 

Generated 'ssg-rhel6-guide-CSCF-RHEL6-MLS.html' for profile ID 'xccdf_org.ssgproject.content_profile_CSCF-RHEL6-MLS'.
Generated 'ssg-rhel6-guide-usgcb-rhel6-server.html' for profile ID 'xccdf_org.ssgproject.content_profile_usgcb-rhel6-server'.
Generated 'ssg-rhel6-guide-common.html' for profile ID 'xccdf_org.ssgproject.content_profile_common'.
Generated 'ssg-rhel6-guide-pci-dss.html' for profile ID 'xccdf_org.ssgproject.content_profile_pci-dss'.
Generated 'ssg-rhel6-guide-CS2.html' for profile ID 'xccdf_org.ssgproject.content_profile_CS2'.
Generated 'ssg-rhel6-guide-C2S.html' for profile ID 'xccdf_org.ssgproject.content_profile_C2S'.
Generated 'ssg-rhel6-guide-stig-rhel6-server-upstream.html' for profile ID 'xccdf_org.ssgproject.content_profile_stig-rhel6-server-upstream'.
Generated 'ssg-rhel6-guide-server.html' for profile ID 'xccdf_org.ssgproject.content_profile_server'.
Generated 'ssg-rhel6-guide-rht-ccp.html' for profile ID 'xccdf_org.ssgproject.content_profile_rht-ccp'.
```

I should note at this point that building all the guides takes some time. The SSG build system right now is very stupid and builds everything all the time, regardless of whether the input files changed or not. Generating guides every time will slow the build process.

```
time ../../../shared/utils/build-all-guides.py -i ssg-rhel6-ds.xml 

...

real    0m8.802s
user    0m8.619s
sys     0m0.189s
```

I thought about being smart and generating several guides in parallel in the script but in the end I think it's a job of the build system to be smart, not the build scripts. But I will say here that it's possible to bring the times close to 3 seconds on quad core processors with very little work.