### PR TITLE
[BugFix] [RHEL/7] [Fedora] Drop mention about pam_passwdqc module from RHEL-7's XCCDF. Finish 'pam_cracklib' to 'pam_pwquality' switch for RHEL-7 and Fedora content

### DIFF
--- a/Fedora/input/system/accounts/pam.xml
+++ b/Fedora/input/system/accounts/pam.xml
@@ -105,9 +105,9 @@ stringent password strength requirements. It is provided
 in an RPM of the same name and can be configured by setting the configuration
 settings in <tt>/etc/passwdqc.conf</tt>.
 <br /><br />
-The man pages <tt>pam_cracklib(8)</tt> and <tt>pam_passwdqc(8)</tt>
-provide information on the capabilities and configuration of
-each.</description>
+The man pages <tt>pam_pwquality(8)</tt>, <tt>pam_cracklib(8)</tt>, and
+<tt>pam_passwdqc(8)</tt> provide information on the capabilities and
+configuration of each.</description>
 
 <Group id="password_quality_pwquality">
 <title>Set Password Quality Requirements with pam_pwquality</title>
@@ -438,12 +438,13 @@ Note that passwords which are changed on compromised systems will still be compr
 
 <Rule id="accounts_password_pam_minclass">
 <title>Set Password Strength Minimum Different Categories</title>
-<description>The pam_cracklib module's <tt>minclass</tt> parameter controls requirements for
-usage of different character classes, or types, of character that must exist in a password
-before it is considered valid. For example, setting this value to three (3) requires that
-any password must have characters from at least three different categories in order to be
-approved. The default value is zero (0), meaning there are no required classes. There are
-four categories available:
+<description>The pam_pwquality module's <tt>minclass</tt> parameter controls
+requirements for usage of different character classes, or types, of character
+that must exist in a password before it is considered valid. For example,
+setting this value to three (3) requires that any password must have characters
+from at least three different categories in order to be approved. The default
+value is zero (0), meaning there are no required classes. There are four
+categories available:
 <pre>
 * Upper-case characters
 * Lower-case characters

--- a/Fedora/input/system/accounts/restrictions/password_expiration.xml
+++ b/Fedora/input/system/accounts/restrictions/password_expiration.xml
@@ -86,7 +86,7 @@ Nowadays recommended values, considered as secure by various organizations
 focused on topic of computer security, range from <tt>12 (FISMA)</tt> up to
 <tt>14 (DoD)</tt> characters for password length requirements.
 If a program consults <tt>/etc/login.defs</tt> and also another PAM module
-(such as <tt>pam_cracklib</tt>) during a password change operation,
+(such as <tt>pam_pwquality</tt>) during a password change operation,
 then the most restrictive must be satisfied. See PAM section
 for more information about enforcing password quality requirements.
 </description>

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_maxrepeat.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_maxrepeat.sh
@@ -1,0 +1,8 @@
+source ./templates/support.sh
+populate var_password_pam_maxrepeat
+
+if egrep -q ^maxrepeat[[:space:]]*=[[:space:]]*[[:digit:]]+ /etc/security/pwquality.conf; then
+	sed -i "s/^\(maxrepeat *= *\).*/\1$var_password_pam_maxrepeat/" /etc/security/pwquality.conf
+else
+	sed -i "/\(maxrepeat *= *\).*/a maxrepeat = $var_password_pam_maxrepeat" /etc/security/pwquality.conf
+fi

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_minclass.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_minclass.sh
@@ -1,0 +1,8 @@
+source ./templates/support.sh
+populate var_password_pam_minclass
+
+if egrep -q ^minclass[[:space:]]*=[[:space:]]*[[:digit:]]+ /etc/security/pwquality.conf; then
+	sed -i "s/^\(minclass *= *\).*/\1$var_password_pam_minclass/" /etc/security/pwquality.conf
+else
+	sed -i "/\(minclass *= *\).*/a minclass = $var_password_pam_minclass" /etc/security/pwquality.conf
+fi

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_minlen.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_minlen.sh
@@ -1,7 +1,7 @@
 source ./templates/support.sh
 populate var_password_pam_minlen
 
-if egrep -q ^minlen[[:space:]]*=[[:space:]]*[-]?[[:digit:]]+ /etc/security/pwquality.conf; then
+if egrep -q ^minlen[[:space:]]*=[[:space:]]*[[:digit:]]+ /etc/security/pwquality.conf; then
 	sed -i "s/^\(minlen *= *\).*/\1$var_password_pam_minlen/" /etc/security/pwquality.conf
 else
 	sed -i "/\(minlen *= *\).*/a minlen = $var_password_pam_minlen" /etc/security/pwquality.conf

--- a/RHEL/7/input/fixes/bash/password_require_minimum_class.sh
+++ b/RHEL/7/input/fixes/bash/password_require_minimum_class.sh
@@ -1,6 +1,0 @@
-grep -q minclass /etc/pam.d/system-auth
-if [ $? = "0" ]; then
-    sed --follow-symlinks -i "/pam_pwquality.so/s/minclass=[0-4]/minclass=3/" /etc/pam.d/system-auth
-else
-    sed --follow-symlinks -i "/pam_pwquality.so/s/pam_pwquality.so /pam_pwquality.so minclass=3 /" /etc/pam.d/system-auth
-fi

--- a/RHEL/7/input/fixes/bash/password_require_minimum_class.sh
+++ b/RHEL/7/input/fixes/bash/password_require_minimum_class.sh
@@ -1,6 +1,6 @@
 grep -q minclass /etc/pam.d/system-auth
 if [ $? = "0" ]; then
-    sed --follow-symlinks -i "/pam_cracklib.so/s/minclass=[0-4]/minclass=3/" /etc/pam.d/system-auth
+    sed --follow-symlinks -i "/pam_pwquality.so/s/minclass=[0-4]/minclass=3/" /etc/pam.d/system-auth
 else
-    sed --follow-symlinks -i "/pam_cracklib.so/s/pam_cracklib.so /pam_cracklib.so minclass=3 /" /etc/pam.d/system-auth
+    sed --follow-symlinks -i "/pam_pwquality.so/s/pam_pwquality.so /pam_pwquality.so minclass=3 /" /etc/pam.d/system-auth
 fi

--- a/RHEL/7/input/system/accounts/pam.xml
+++ b/RHEL/7/input/system/accounts/pam.xml
@@ -102,12 +102,7 @@ are not the previous password reversed, and are not simply a change
 of case from the previous password. It can also require passwords to
 be in certain character classes.
 <br /><br />
-The <tt>pam_passwdqc</tt> PAM module also provides the ability to enforce
-stringent password strength requirements. It is provided
-in an RPM of the same name and can be configured by setting the configuration
-settings in <tt>/etc/passwdqc.conf</tt>.
-<br /><br />
-The man pages <tt>pam_cracklib(8)</tt> and <tt>pam_passwdqc(8)</tt>
+The man pages <tt>pam_pwquality(8)</tt> and <tt>pam_cracklib(8)</tt>
 provide information on the capabilities and configuration of
 each.</description>
 
@@ -459,12 +454,13 @@ Note that passwords which are changed on compromised systems will still be compr
 
 <Rule id="accounts_password_pam_minclass">
 <title>Set Password Strength Minimum Different Categories</title>
-<description>The pam_cracklib module's <tt>minclass</tt> parameter controls requirements for
-usage of different character classes, or types, of character that must exist in a password
-before it is considered valid. For example, setting this value to three (3) requires that
-any password must have characters from at least three different categories in order to be
-approved. The default value is zero (0), meaning there are no required classes. There are
-four categories available:
+<description>The pam_pwquality module's <tt>minclass</tt> parameter controls
+requirements for usage of different character classes, or types, of character
+that must exist in a password before it is considered valid. For example,
+setting this value to three (3) requires that any password must have characters
+from at least three different categories in order to be approved. The default
+value is zero (0), meaning there are no required classes. There are four
+categories available:
 <pre>
 * Upper-case characters
 * Lower-case characters

--- a/shared/oval/accounts_password_pam_dcredit.xml
+++ b/shared/oval/accounts_password_pam_dcredit.xml
@@ -34,6 +34,6 @@
     <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_password_pam_dcredit" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for pam_cracklib dcredit" datatype="int" id="var_password_pam_dcredit" version="1" />
+  <external_variable comment="External variable for pam_pwquality dcredit" datatype="int" id="var_password_pam_dcredit" version="1" />
 
 </def-group>

--- a/shared/oval/accounts_password_pam_difok.xml
+++ b/shared/oval/accounts_password_pam_difok.xml
@@ -34,6 +34,6 @@
     <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_password_pam_difok" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for pam_cracklib difok" datatype="int" id="var_password_pam_difok" version="1" />
+  <external_variable comment="External variable for pam_pwquality difok" datatype="int" id="var_password_pam_difok" version="1" />
 
 </def-group>

--- a/shared/oval/accounts_password_pam_lcredit.xml
+++ b/shared/oval/accounts_password_pam_lcredit.xml
@@ -34,6 +34,6 @@
     <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_password_pam_lcredit" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for pam_cracklib lcredit" datatype="int" id="var_password_pam_lcredit" version="1" />
+  <external_variable comment="External variable for pam_pwquality lcredit" datatype="int" id="var_password_pam_lcredit" version="1" />
 
 </def-group>

--- a/shared/oval/accounts_password_pam_maxrepeat.xml
+++ b/shared/oval/accounts_password_pam_maxrepeat.xml
@@ -34,5 +34,5 @@
     <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_password_pam_maxrepeat" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for pam_cracklib maxrepeat" datatype="int" id="var_password_pam_maxrepeat" version="1" />
+  <external_variable comment="External variable for pam_pwquality maxrepeat" datatype="int" id="var_password_pam_maxrepeat" version="1" />
 </def-group>

--- a/shared/oval/accounts_password_pam_minclass.xml
+++ b/shared/oval/accounts_password_pam_minclass.xml
@@ -37,7 +37,7 @@
     var_ref="var_password_pam_minclass" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for pam_cracklib minclass"
+  <external_variable comment="External variable for pam_pwquality minclass"
   datatype="int" id="var_password_pam_minclass" version="1" />
 
 </def-group>

--- a/shared/oval/accounts_password_pam_minlen.xml
+++ b/shared/oval/accounts_password_pam_minlen.xml
@@ -34,6 +34,6 @@
     <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_password_pam_minlen" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for pam_cracklib minlen" datatype="int" id="var_password_pam_minlen" version="1" />
+  <external_variable comment="External variable for pam_pwquality minlen" datatype="int" id="var_password_pam_minlen" version="1" />
 
 </def-group>

--- a/shared/oval/accounts_password_pam_ocredit.xml
+++ b/shared/oval/accounts_password_pam_ocredit.xml
@@ -34,6 +34,6 @@
     <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_password_pam_ocredit" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for pam_cracklib ocredit" datatype="int" id="var_password_pam_ocredit" version="1" />
+  <external_variable comment="External variable for pam_pwquality ocredit" datatype="int" id="var_password_pam_ocredit" version="1" />
 
 </def-group>

--- a/shared/oval/accounts_password_pam_retry.xml
+++ b/shared/oval/accounts_password_pam_retry.xml
@@ -54,5 +54,5 @@
     <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_password_pam_retry" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for pam_cracklib retry" datatype="int" id="var_password_pam_retry" version="1" />
+  <external_variable comment="External variable for pam_pwquality retry" datatype="int" id="var_password_pam_retry" version="1" />
 </def-group>

--- a/shared/oval/accounts_password_pam_ucredit.xml
+++ b/shared/oval/accounts_password_pam_ucredit.xml
@@ -34,6 +34,6 @@
     <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_password_pam_ucredit" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for pam_cracklib ucredit" datatype="int" id="var_password_pam_ucredit" version="1" />
+  <external_variable comment="External variable for pam_pwquality ucredit" datatype="int" id="var_password_pam_ucredit" version="1" />
 
 </def-group>


### PR DESCRIPTION
This patch is doing the following two things:
* drops mentions about ```pam_passwdqc``` module for RHEL-7's XCCDF content (since ```pam_passwdqc``` module isn't available for RHEL-7, neither directly, nor in EPEL-7),
* finishes ```pam_cracklib``` to ```pam_pwquality``` PAM module naming replacement (couple of occurrences have been corrected via previous fixes already. This patch just finishes / corrects those occurrences previously omitted / overlooked).

These changes partly [*] fix the following downstream bug:
  [1] https://bugzilla.redhat.com/show_bug.cgi?id=1178967


Testing report:
--
The proposed changes have been tested on all three (RHEL-6, RHEL-7, and Fedora 20) products && AFAICT from testing they are working fine (```make validate``` still passes on RHEL-6 and Fedora, the content builds && works fine for all three products).

Please review.

Thank you, Jan.

__
[*] Partly because there have been more patches in the past already
    replacing 'pam_cracklib' occurrences with 'pam_pwquality' for RHEL-7
    and Fedora. This patch is just fixing what's got omitted before.

