### PR TITLE
[BugFix] [Infrastructure] Fix test_attestation links to be valid URLs (when inspected via link validation tools). Point them to the newly created OpenSCAP/scap-security-guide Contributors wiki page

### DIFF
--- a/Chromium/transforms/constants.xslt
+++ b/Chromium/transforms/constants.xslt
@@ -12,6 +12,7 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/stigs/srgs/Pages/index.aspx</xsl:variable>
+<xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 

--- a/Chromium/transforms/shorthand2xccdf.xslt
+++ b/Chromium/transforms/shorthand2xccdf.xslt
@@ -225,9 +225,8 @@
 
    <xsl:template match="tested">
       <reference>
-        <xsl:attribute name="href">test_attestation</xsl:attribute>
-            <dc:contributor><xsl:value-of select="@by" /></dc:contributor>
-            <dc:date><xsl:value-of select="@on" /></dc:date>
+        <xsl:attribute name="href"><xsl:value-of select="$ssg-contributors-uri" /></xsl:attribute>
+        <xsl:value-of select="concat('Test attestation on ', @on, ' by ', @by)" />
       </reference>
    </xsl:template>
 

--- a/Chromium/transforms/xccdf2table-profileccirefs.xslt
+++ b/Chromium/transforms/xccdf2table-profileccirefs.xslt
@@ -80,7 +80,7 @@
 
 			<td>
 			<!-- print pretty visual indication of testing data -->
-			<xsl:if test="$testinfo and cdf:reference[@href='test_attestation']">
+			<xsl:if test="$testinfo and cdf:reference[@href=$ssg-contributors-uri]">
 				<!-- add green border on left if manual test attestation found -->
 				<xsl:attribute name="style">border-left:solid medium lime</xsl:attribute>
 			</xsl:if>
@@ -96,8 +96,10 @@
 			<!-- print the test attestation info -->
 			<xsl:if test="$testinfo">
 				<!-- in the XCCDF -->
-				<xsl:for-each select="cdf:reference[@href='test_attestation']">
-					<br/><br/><i>Manual check tested on <xsl:value-of select="dc:date"/> by <xsl:value-of select="dc:contributor"/>.</i>
+				<xsl:for-each select="cdf:reference[@href=$ssg-contributors-uri]">
+					<!--    Process the text() of test_attestation reference to drop
+						'Test attestation on' prefix and keep only date and contributor -->
+					<br/><i>Manual check tested on <xsl:value-of select="substring-after(text(), 'Test attestation on ')"/>.</i>
 				</xsl:for-each>
 				<!-- in the associated OVAL -->
 				<xsl:for-each select="$ovalcheck/ovalns:metadata/ovalns:reference[@ref_url='test_attestation']">

--- a/Fedora/transforms/constants.xslt
+++ b/Fedora/transforms/constants.xslt
@@ -12,6 +12,7 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/stigs/srgs/Pages/index.aspx</xsl:variable>
+<xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 

--- a/Fedora/transforms/shorthand2xccdf.xslt
+++ b/Fedora/transforms/shorthand2xccdf.xslt
@@ -228,9 +228,8 @@
 
    <xsl:template match="tested">
       <reference>
-        <xsl:attribute name="href">test_attestation</xsl:attribute>
-            <dc:contributor><xsl:value-of select="@by" /></dc:contributor>
-            <dc:date><xsl:value-of select="@on" /></dc:date>
+        <xsl:attribute name="href"><xsl:value-of select="$ssg-contributors-uri" /></xsl:attribute>
+        <xsl:value-of select="concat('Test attestation on ', @on, ' by ', @by)" />
       </reference>
    </xsl:template>
 

--- a/Firefox/transforms/constants.xslt
+++ b/Firefox/transforms/constants.xslt
@@ -12,6 +12,7 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/cci/index.html</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/srgs</xsl:variable>
+<xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 

--- a/Firefox/transforms/shorthand2xccdf.xslt
+++ b/Firefox/transforms/shorthand2xccdf.xslt
@@ -225,9 +225,8 @@
 
    <xsl:template match="tested">
       <reference>
-        <xsl:attribute name="href">test_attestation</xsl:attribute>
-            <dc:contributor><xsl:value-of select="@by" /></dc:contributor>
-            <dc:date><xsl:value-of select="@on" /></dc:date>
+        <xsl:attribute name="href"><xsl:value-of select="$ssg-contributors-uri" /></xsl:attribute>
+        <xsl:value-of select="concat('Test attestation on ', @on, ' by ', @by)" />
       </reference>
    </xsl:template>
 

--- a/Firefox/transforms/xccdf2table-profileccirefs.xslt
+++ b/Firefox/transforms/xccdf2table-profileccirefs.xslt
@@ -80,7 +80,7 @@
 
 			<td>
 			<!-- print pretty visual indication of testing data -->
-			<xsl:if test="$testinfo and cdf:reference[@href='test_attestation']">
+			<xsl:if test="$testinfo and cdf:reference[@href=$ssg-contributors-uri]">
 				<!-- add green border on left if manual test attestation found -->
 				<xsl:attribute name="style">border-left:solid medium lime</xsl:attribute>
 			</xsl:if>
@@ -96,8 +96,10 @@
 			<!-- print the test attestation info -->
 			<xsl:if test="$testinfo">
 				<!-- in the XCCDF -->
-				<xsl:for-each select="cdf:reference[@href='test_attestation']">
-					<br/><br/><i>Manual check tested on <xsl:value-of select="dc:date"/> by <xsl:value-of select="dc:contributor"/>.</i>
+				<xsl:for-each select="cdf:reference[@href=$ssg-contributors-uri]">
+					<!--    Process the text() of test_attestation reference to drop
+						'Test attestation on' prefix and keep only date and contributor -->
+					<br/><i>Manual check tested on <xsl:value-of select="substring-after(text(), 'Test attestation on ')"/>.</i>
 				</xsl:for-each>
 				<!-- in the associated OVAL -->
 				<xsl:for-each select="$ovalcheck/ovalns:metadata/ovalns:reference[@ref_url='test_attestation']">

--- a/Java/transforms/constants.xslt
+++ b/Java/transforms/constants.xslt
@@ -12,6 +12,7 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/cci/index.html</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/srgs</xsl:variable>
+<xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 

--- a/Java/transforms/shorthand2xccdf.xslt
+++ b/Java/transforms/shorthand2xccdf.xslt
@@ -235,9 +235,8 @@
 
    <xsl:template match="tested">
       <reference>
-        <xsl:attribute name="href">test_attestation</xsl:attribute>
-            <dc:contributor><xsl:value-of select="@by" /></dc:contributor>
-            <dc:date><xsl:value-of select="@on" /></dc:date>
+        <xsl:attribute name="href"><xsl:value-of select="$ssg-contributors-uri" /></xsl:attribute>
+        <xsl:value-of select="concat('Test attestation on ', @on, ' by ', @by)" />
       </reference>
    </xsl:template>
 

--- a/Java/transforms/xccdf2table-profileccirefs.xslt
+++ b/Java/transforms/xccdf2table-profileccirefs.xslt
@@ -80,7 +80,7 @@
 
 			<td>
 			<!-- print pretty visual indication of testing data -->
-			<xsl:if test="$testinfo and cdf:reference[@href='test_attestation']">
+			<xsl:if test="$testinfo and cdf:reference[@href=$ssg-contributors-uri]">
 				<!-- add green border on left if manual test attestation found -->
 				<xsl:attribute name="style">border-left:solid medium lime</xsl:attribute>
 			</xsl:if>
@@ -96,8 +96,10 @@
 			<!-- print the test attestation info -->
 			<xsl:if test="$testinfo">
 				<!-- in the XCCDF -->
-				<xsl:for-each select="cdf:reference[@href='test_attestation']">
-					<br/><br/><i>Manual check tested on <xsl:value-of select="dc:date"/> by <xsl:value-of select="dc:contributor"/>.</i>
+				<xsl:for-each select="cdf:reference[@href=$ssg-contributors-uri]">
+					<!--    Process the text() of test_attestation reference to drop
+						'Test attestation on' prefix and keep only date and contributor -->
+					<br/><i>Manual check tested on <xsl:value-of select="substring-after(text(), 'Test attestation on ')"/>.</i>
 				</xsl:for-each>
 				<!-- in the associated OVAL -->
 				<xsl:for-each select="$ovalcheck/ovalns:metadata/ovalns:reference[@ref_url='test_attestation']">

--- a/OpenStack/transforms/constants.xslt
+++ b/OpenStack/transforms/constants.xslt
@@ -12,6 +12,7 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/stigs/srgs/Pages/index.aspx</xsl:variable>
+<xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 

--- a/OpenStack/transforms/shorthand2xccdf.xslt
+++ b/OpenStack/transforms/shorthand2xccdf.xslt
@@ -217,9 +217,8 @@ exclude-result-prefixes="xccdf xhtml dc">
 
    <xsl:template match="tested">
       <reference>
-        <xsl:attribute name="href">test_attestation</xsl:attribute>
-            <dc:contributor><xsl:value-of select="@by" /></dc:contributor>
-            <dc:date><xsl:value-of select="@on" /></dc:date>
+        <xsl:attribute name="href"><xsl:value-of select="$ssg-contributors-uri" /></xsl:attribute>
+        <xsl:value-of select="concat('Test attestation on ', @on, ' by ', @by)" />
       </reference>
    </xsl:template>
 

--- a/OpenStack/transforms/xccdf2table-profileccirefs.xslt
+++ b/OpenStack/transforms/xccdf2table-profileccirefs.xslt
@@ -142,7 +142,7 @@
 
 			<td>
 			<!-- print pretty visual indication of testing data -->
-			<xsl:if test="$testinfo and cdf:reference[@href='test_attestation']">
+			<xsl:if test="$testinfo and cdf:reference[@href=$ssg-contributors-uri]">
 				<!-- add green border on left if test attestation found -->
 				<xsl:attribute name="style">border-left:solid thick lime</xsl:attribute>
 			</xsl:if>
@@ -152,8 +152,11 @@
 
 			<!-- print the test attestation info -->
 			<xsl:if test="$testinfo">
-				<xsl:for-each select="cdf:reference[@href='test_attestation']">
-					<br/><br/><i>Tested on <xsl:value-of select="dc:date"/> by <xsl:value-of select="dc:contributor"/>.</i>
+				<!-- in the XCCDF -->
+				<xsl:for-each select="cdf:reference[@href=$ssg-contributors-uri]">
+					<!--    Process the text() of test_attestation reference to drop
+						'Test attestation on' prefix and keep only date and contributor -->
+					<br/><i>Manual check tested on <xsl:value-of select="substring-after(text(), 'Test attestation on ')"/>.</i>
 				</xsl:for-each>
 			</xsl:if>
 			</td>

--- a/RHEL/5/transforms/constants.xslt
+++ b/RHEL/5/transforms/constants.xslt
@@ -12,6 +12,7 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/cci/index.html</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/srgs</xsl:variable>
+<xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 

--- a/RHEL/5/transforms/shorthand2xccdf.xslt
+++ b/RHEL/5/transforms/shorthand2xccdf.xslt
@@ -235,9 +235,8 @@
 
    <xsl:template match="tested">
       <reference>
-        <xsl:attribute name="href">test_attestation</xsl:attribute>
-            <dc:contributor><xsl:value-of select="@by" /></dc:contributor>
-            <dc:date><xsl:value-of select="@on" /></dc:date>
+        <xsl:attribute name="href"><xsl:value-of select="$ssg-contributors-uri" /></xsl:attribute>
+        <xsl:value-of select="concat('Test attestation on ', @on, ' by ', @by)" />
       </reference>
    </xsl:template>
 

--- a/RHEL/5/transforms/xccdf2table-profileccirefs.xslt
+++ b/RHEL/5/transforms/xccdf2table-profileccirefs.xslt
@@ -80,7 +80,7 @@
 
 			<td>
 			<!-- print pretty visual indication of testing data -->
-			<xsl:if test="$testinfo and cdf:reference[@href='test_attestation']">
+			<xsl:if test="$testinfo and cdf:reference[@href=$ssg-contributors-uri]">
 				<!-- add green border on left if manual test attestation found -->
 				<xsl:attribute name="style">border-left:solid medium lime</xsl:attribute>
 			</xsl:if>
@@ -96,8 +96,10 @@
 			<!-- print the test attestation info -->
 			<xsl:if test="$testinfo">
 				<!-- in the XCCDF -->
-				<xsl:for-each select="cdf:reference[@href='test_attestation']">
-					<br/><br/><i>Manual check tested on <xsl:value-of select="dc:date"/> by <xsl:value-of select="dc:contributor"/>.</i>
+				<xsl:for-each select="cdf:reference[@href=$ssg-contributors-uri]">
+					<!-- 	Process the text() of test_attestation reference to drop
+						'Test attestation on' prefix and keep only date and contributor -->
+					<br/><i>Manual check tested on <xsl:value-of select="substring-after(text(), 'Test attestation on ')"/>.</i>
 				</xsl:for-each>
 				<!-- in the associated OVAL -->
 				<xsl:for-each select="$ovalcheck/ovalns:metadata/ovalns:reference[@ref_url='test_attestation']">

--- a/RHEL/6/transforms/constants.xslt
+++ b/RHEL/6/transforms/constants.xslt
@@ -12,6 +12,7 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/stigs/srgs/Pages/index.aspx</xsl:variable>
+<xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 

--- a/RHEL/6/transforms/shorthand2xccdf.xslt
+++ b/RHEL/6/transforms/shorthand2xccdf.xslt
@@ -235,9 +235,8 @@
 
    <xsl:template match="tested">
       <reference>
-        <xsl:attribute name="href">test_attestation</xsl:attribute>
-            <dc:contributor><xsl:value-of select="@by" /></dc:contributor>
-            <dc:date><xsl:value-of select="@on" /></dc:date>
+        <xsl:attribute name="href"><xsl:value-of select="$ssg-contributors-uri" /></xsl:attribute>
+        <xsl:value-of select="concat('Test attestation on ', @on, ' by ', @by)" />
       </reference>
    </xsl:template>
 

--- a/RHEL/6/transforms/xccdf2table-profileccirefs.xslt
+++ b/RHEL/6/transforms/xccdf2table-profileccirefs.xslt
@@ -80,7 +80,7 @@
 
 			<td>
 			<!-- print pretty visual indication of testing data -->
-			<xsl:if test="$testinfo and cdf:reference[@href='test_attestation']">
+			<xsl:if test="$testinfo and cdf:reference[@href=$ssg-contributors-uri]">
 				<!-- add green border on left if manual test attestation found -->
 				<xsl:attribute name="style">border-left:solid medium lime</xsl:attribute>
 			</xsl:if>
@@ -96,8 +96,10 @@
 			<!-- print the test attestation info -->
 			<xsl:if test="$testinfo">
 				<!-- in the XCCDF -->
-				<xsl:for-each select="cdf:reference[@href='test_attestation']">
-					<br/><br/><i>Manual check tested on <xsl:value-of select="dc:date"/> by <xsl:value-of select="dc:contributor"/>.</i>
+				<xsl:for-each select="cdf:reference[@href=$ssg-contributors-uri]">
+					<!-- 	Process the text() of test_attestation reference to drop
+						'Test attestation on' prefix and keep only date and contributor -->
+					<br/><i>Manual check tested on <xsl:value-of select="substring-after(text(), 'Test attestation on ')"/>.</i>
 				</xsl:for-each>
 				<!-- in the associated OVAL -->
 				<xsl:for-each select="$ovalcheck/ovalns:metadata/ovalns:reference[@ref_url='test_attestation']">

--- a/RHEL/7/transforms/constants.xslt
+++ b/RHEL/7/transforms/constants.xslt
@@ -12,6 +12,7 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/stigs/srgs/Pages/index.aspx</xsl:variable>
+<xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 

--- a/RHEL/7/transforms/shorthand2xccdf.xslt
+++ b/RHEL/7/transforms/shorthand2xccdf.xslt
@@ -229,9 +229,8 @@
 
    <xsl:template match="tested">
       <reference>
-        <xsl:attribute name="href">test_attestation</xsl:attribute>
-            <dc:contributor><xsl:value-of select="@by" /></dc:contributor>
-            <dc:date><xsl:value-of select="@on" /></dc:date>
+        <xsl:attribute name="href"><xsl:value-of select="$ssg-contributors-uri" /></xsl:attribute>
+        <xsl:value-of select="concat('Test attestation on ', @on, ' by ', @by)" />
       </reference>
    </xsl:template>
 

--- a/RHEL/7/transforms/xccdf2table-profileccirefs.xslt
+++ b/RHEL/7/transforms/xccdf2table-profileccirefs.xslt
@@ -80,7 +80,7 @@
 
 			<td>
 			<!-- print pretty visual indication of testing data -->
-			<xsl:if test="$testinfo and cdf:reference[@href='test_attestation']">
+			<xsl:if test="$testinfo and cdf:reference[@href=$ssg-contributors-uri]">
 				<!-- add green border on left if manual test attestation found -->
 				<xsl:attribute name="style">border-left:solid medium lime</xsl:attribute>
 			</xsl:if>
@@ -96,8 +96,10 @@
 			<!-- print the test attestation info -->
 			<xsl:if test="$testinfo">
 				<!-- in the XCCDF -->
-				<xsl:for-each select="cdf:reference[@href='test_attestation']">
-					<br/><br/><i>Manual check tested on <xsl:value-of select="dc:date"/> by <xsl:value-of select="dc:contributor"/>.</i>
+				<xsl:for-each select="cdf:reference[@href=$ssg-contributors-uri]">
+					<!-- 	Process the text() of test_attestation reference to drop
+						'Test attestation on' prefix and keep only date and contributor -->
+					<br/><i>Manual check tested on <xsl:value-of select="substring-after(text(), 'Test attestation on ')"/>.</i>
 				</xsl:for-each>
 				<!-- in the associated OVAL -->
 				<xsl:for-each select="$ovalcheck/ovalns:metadata/ovalns:reference[@ref_url='test_attestation']">

--- a/RHEVM3/transforms/constants.xslt
+++ b/RHEVM3/transforms/constants.xslt
@@ -12,6 +12,7 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/stigs/srgs/Pages/index.aspx</xsl:variable>
+<xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 

--- a/RHEVM3/transforms/shorthand2xccdf.xslt
+++ b/RHEVM3/transforms/shorthand2xccdf.xslt
@@ -217,9 +217,8 @@ exclude-result-prefixes="xccdf xhtml dc">
 
    <xsl:template match="tested">
       <reference>
-        <xsl:attribute name="href">test_attestation</xsl:attribute>
-            <dc:contributor><xsl:value-of select="@by" /></dc:contributor>
-            <dc:date><xsl:value-of select="@on" /></dc:date>
+        <xsl:attribute name="href"><xsl:value-of select="$ssg-contributors-uri" /></xsl:attribute>
+        <xsl:value-of select="concat('Test attestation on ', @on, ' by ', @by)" />
       </reference>
    </xsl:template>
 

--- a/RHEVM3/transforms/xccdf2table-profileccirefs.xslt
+++ b/RHEVM3/transforms/xccdf2table-profileccirefs.xslt
@@ -142,7 +142,7 @@
 
 			<td>
 			<!-- print pretty visual indication of testing data -->
-			<xsl:if test="$testinfo and cdf:reference[@href='test_attestation']">
+			<xsl:if test="$testinfo and cdf:reference[@href=$ssg-contributors-uri]">
 				<!-- add green border on left if test attestation found -->
 				<xsl:attribute name="style">border-left:solid thick lime</xsl:attribute>
 			</xsl:if>
@@ -152,8 +152,11 @@
 
 			<!-- print the test attestation info -->
 			<xsl:if test="$testinfo">
-				<xsl:for-each select="cdf:reference[@href='test_attestation']">
-					<br/><br/><i>Tested on <xsl:value-of select="dc:date"/> by <xsl:value-of select="dc:contributor"/>.</i>
+				<!-- in the XCCDF -->
+				<xsl:for-each select="cdf:reference[@href=$ssg-contributors-uri]">
+					<!--    Process the text() of test_attestation reference to drop
+						'Test attestation on' prefix and keep only date and contributor -->
+					<br/><i>Manual check tested on <xsl:value-of select="substring-after(text(), 'Test attestation on ')"/>.</i>
 				</xsl:for-each>
 			</xsl:if>
 			</td>

--- a/Webmin/transforms/constants.xslt
+++ b/Webmin/transforms/constants.xslt
@@ -12,6 +12,7 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/cci/index.html</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/srgs</xsl:variable>
+<xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 

--- a/Webmin/transforms/shorthand2xccdf.xslt
+++ b/Webmin/transforms/shorthand2xccdf.xslt
@@ -229,9 +229,8 @@
 
    <xsl:template match="tested">
       <reference>
-        <xsl:attribute name="href">test_attestation</xsl:attribute>
-            <dc:contributor><xsl:value-of select="@by" /></dc:contributor>
-            <dc:date><xsl:value-of select="@on" /></dc:date>
+        <xsl:attribute name="href"><xsl:value-of select="$ssg-contributors-uri" /></xsl:attribute>
+        <xsl:value-of select="concat('Test attestation on ', @on, ' by ', @by)" />
       </reference>
    </xsl:template>
 

--- a/Webmin/transforms/xccdf2table-profileccirefs.xslt
+++ b/Webmin/transforms/xccdf2table-profileccirefs.xslt
@@ -80,7 +80,7 @@
 
 			<td>
 			<!-- print pretty visual indication of testing data -->
-			<xsl:if test="$testinfo and cdf:reference[@href='test_attestation']">
+			<xsl:if test="$testinfo and cdf:reference[@href=$ssg-contributors-uri]">
 				<!-- add green border on left if manual test attestation found -->
 				<xsl:attribute name="style">border-left:solid medium lime</xsl:attribute>
 			</xsl:if>
@@ -96,8 +96,10 @@
 			<!-- print the test attestation info -->
 			<xsl:if test="$testinfo">
 				<!-- in the XCCDF -->
-				<xsl:for-each select="cdf:reference[@href='test_attestation']">
-					<br/><br/><i>Manual check tested on <xsl:value-of select="dc:date"/> by <xsl:value-of select="dc:contributor"/>.</i>
+				<xsl:for-each select="cdf:reference[@href=$ssg-contributors-uri]">
+					<!-- 	Process the text() of test_attestation reference to drop
+						'Test attestation on' prefix and keep only date and contributor -->
+					<br/><i>Manual check tested on <xsl:value-of select="substring-after(text(), 'Test attestation on ')"/>.</i>
 				</xsl:for-each>
 				<!-- in the associated OVAL -->
 				<xsl:for-each select="$ovalcheck/ovalns:metadata/ovalns:reference[@ref_url='test_attestation']">


### PR DESCRIPTION
It has been reported in the downstream bug:
  [1] https://bugzilla.redhat.com/show_bug.cgi?id=1155809

that the ```test_attestation``` links we product in the XCCDF, OVAL, and HTML reports content doesn't produce valid URLs (when inspected with URL validation tools, like e.g. ```linklint```).

Therefore have created new OpenSCAP/scap-security-guide GitHub Contributors wiki page:
  [2] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors

(based on the content of ```Contributors.md``` file present in the SSG's git repository)

and updated the required XSLT transformations across various produced SCAP content products the ```test_attestation``` links to start pointing to this [2] page (which solves the ```linklint``` issue).

Testing report:
--
The proposed change has been tested via ```rpm build``` and via ```make table-stigs`` Makefile targets on the following products:
* RHEL-6,
* RHEL-7,
* Java,
* Firefox

and AFAICT based on the testing it is working fine (the ```test_attestation``` links in produced XCCDF and HTML reports are now pointing to the [2] Contributors page, and there's no difference in the generated ```date``` and ```contributor``` marks in the ```output/table-stig-product-testinfo.html``` page.

Please review.

Thank you, Jan.

__
Note: While the bug [1] requests the very same change (update of ```test_attestation``` links to be valid URLs to be performed also for the produced OVAL content, I first need to test && verify if after similar change the produced OVAL files would be still valid. Therefore will potentially perform similar change for OVAL documents later in some future PR [once it's clear those updated OVALs are still valid]).


