### PR TITLE
[BugFix] [Infrastructure] Fix 'test_attestation' links in the produced OVAL documents "ssg-$(PROD)-oval.xml" to be valid URLs pointing to GH SSG Contributors wiki page

### DIFF
--- a/Chromium/Makefile
+++ b/Chromium/Makefile
@@ -90,13 +90,15 @@ tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-srgmap table-stigs
 
 content: shorthand2xccdf guide checks
-#	the relabelids.py script chdirs to ./output, so refer to files from there.
-#	its second argument controls the IDs, as well as the output filenames.
-#	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
+#	The relabelids.py script chdirs to ./output, so refer to files from there.
+#	Its second argument controls the IDs, as well as the output filenames.
+#	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-ocilrefs-$(PROD)-xccdf.xml $(ID)
-# 	Once things are relabelled, create a datastream
+#	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
+	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
+#	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
 	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \

--- a/Chromium/transforms/oval-fix-test-attestation-urls.xslt
+++ b/Chromium/transforms/oval-fix-test-attestation-urls.xslt
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="yes"/>
+
+
+
+  <!-- This transform takes an OVAL document as input and expands
+       'test_attestation' value in the 'ref_url' <reference> attribute
+       to proper GitHub SCAP Security Guide Contributors URL:
+         [1] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors
+
+       The valid URLs in the OVAL document's "ref_url" attribute are
+       required in order to the OVAL HTML report to contain valid links,
+       when inspected via toolks like e.g. "linklint".
+
+       This fixes Red Hat downstream bug for OVAL files produced by
+       SCAP Security Guide:
+         [2] https://bugzilla.redhat.com/show_bug.cgi?id=1155809
+
+       DO NOT REMOVE THIS TRANSFORMATION! -->
+
+
+
+  <xsl:include href="constants.xslt"/>
+
+  <!-- First copy the input OVAL into the output OVAL -->
+  <xsl:template match="@*|node()" priority="-2">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Then update 'test_attestation' URL's in "ref_url" attribute
+       of the <reference> element to be a valid URL pointing to [1] -->
+  <xsl:template match="@ref_url">
+    <xsl:attribute name="ref_url">
+      <xsl:if test=". = 'test_attestation'">
+        <xsl:value-of select="$ssg-contributors-uri" />
+      </xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -56,7 +56,9 @@ guide: shorthand2xccdf
 
 content: shorthand2xccdf guide checks
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
-#       Once things are relabelled, create a datastream
+#	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
+	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
+#	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
 	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \

--- a/Fedora/transforms/oval-fix-test-attestation-urls.xslt
+++ b/Fedora/transforms/oval-fix-test-attestation-urls.xslt
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="yes"/>
+
+
+
+  <!-- This transform takes an OVAL document as input and expands
+       'test_attestation' value in the 'ref_url' <reference> attribute
+       to proper GitHub SCAP Security Guide Contributors URL:
+         [1] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors
+
+       The valid URLs in the OVAL document's "ref_url" attribute are
+       required in order to the OVAL HTML report to contain valid links,
+       when inspected via toolks like e.g. "linklint".
+
+       This fixes Red Hat downstream bug for OVAL files produced by
+       SCAP Security Guide:
+         [2] https://bugzilla.redhat.com/show_bug.cgi?id=1155809
+
+       DO NOT REMOVE THIS TRANSFORMATION! -->
+
+
+
+  <xsl:include href="constants.xslt"/>
+
+  <!-- First copy the input OVAL into the output OVAL -->
+  <xsl:template match="@*|node()" priority="-2">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Then update 'test_attestation' URL's in "ref_url" attribute
+       of the <reference> element to be a valid URL pointing to [1] -->
+  <xsl:template match="@ref_url">
+    <xsl:attribute name="ref_url">
+      <xsl:if test=". = 'test_attestation'">
+        <xsl:value-of select="$ssg-contributors-uri" />
+      </xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/Firefox/Makefile
+++ b/Firefox/Makefile
@@ -93,13 +93,15 @@ tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-srgmap table-stigs
 
 content: shorthand2xccdf guide checks
-#	the relabelids.py script chdirs to ./output, so refer to files from there.
-#	its second argument controls the IDs, as well as the output filenames.
-#	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
+#	The relabelids.py script chdirs to ./output, so refer to files from there.
+#	Its second argument controls the IDs, as well as the output filenames.
+#	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-ocilrefs-$(PROD)-xccdf.xml $(ID)
-# 	Once things are relabelled, create a datastream
+#	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
+	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
+#	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
 	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \

--- a/Firefox/transforms/oval-fix-test-attestation-urls.xslt
+++ b/Firefox/transforms/oval-fix-test-attestation-urls.xslt
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="yes"/>
+
+
+
+  <!-- This transform takes an OVAL document as input and expands
+       'test_attestation' value in the 'ref_url' <reference> attribute
+       to proper GitHub SCAP Security Guide Contributors URL:
+         [1] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors
+
+       The valid URLs in the OVAL document's "ref_url" attribute are
+       required in order to the OVAL HTML report to contain valid links,
+       when inspected via toolks like e.g. "linklint".
+
+       This fixes Red Hat downstream bug for OVAL files produced by
+       SCAP Security Guide:
+         [2] https://bugzilla.redhat.com/show_bug.cgi?id=1155809
+
+       DO NOT REMOVE THIS TRANSFORMATION! -->
+
+
+
+  <xsl:include href="constants.xslt"/>
+
+  <!-- First copy the input OVAL into the output OVAL -->
+  <xsl:template match="@*|node()" priority="-2">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Then update 'test_attestation' URL's in "ref_url" attribute
+       of the <reference> element to be a valid URL pointing to [1] -->
+  <xsl:template match="@ref_url">
+    <xsl:attribute name="ref_url">
+      <xsl:if test=". = 'test_attestation'">
+        <xsl:value-of select="$ssg-contributors-uri" />
+      </xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/Java/Makefile
+++ b/Java/Makefile
@@ -93,13 +93,15 @@ tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-srgmap table-stigs
 
 content: shorthand2xccdf guide checks
-#	the relabelids.py script chdirs to ./output, so refer to files from there.
-#	its second argument controls the IDs, as well as the output filenames.
-#	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
+#	The relabelids.py script chdirs to ./output, so refer to files from there.
+#	Its second argument controls the IDs, as well as the output filenames.
+#	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-ocilrefs-$(PROD)-xccdf.xml $(ID)
-# 	Once things are relabelled, create a datastream
+#	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
+	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
+#	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
 	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \

--- a/Java/transforms/oval-fix-test-attestation-urls.xslt
+++ b/Java/transforms/oval-fix-test-attestation-urls.xslt
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="yes"/>
+
+
+
+  <!-- This transform takes an OVAL document as input and expands
+       'test_attestation' value in the 'ref_url' <reference> attribute
+       to proper GitHub SCAP Security Guide Contributors URL:
+         [1] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors
+
+       The valid URLs in the OVAL document's "ref_url" attribute are
+       required in order to the OVAL HTML report to contain valid links,
+       when inspected via toolks like e.g. "linklint".
+
+       This fixes Red Hat downstream bug for OVAL files produced by
+       SCAP Security Guide:
+         [2] https://bugzilla.redhat.com/show_bug.cgi?id=1155809
+
+       DO NOT REMOVE THIS TRANSFORMATION! -->
+
+
+
+  <xsl:include href="constants.xslt"/>
+
+  <!-- First copy the input OVAL into the output OVAL -->
+  <xsl:template match="@*|node()" priority="-2">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Then update 'test_attestation' URL's in "ref_url" attribute
+       of the <reference> element to be a valid URL pointing to [1] -->
+  <xsl:template match="@ref_url">
+    <xsl:attribute name="ref_url">
+      <xsl:if test=". = 'test_attestation'">
+        <xsl:value-of select="$ssg-contributors-uri" />
+      </xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/OpenStack/Makefile
+++ b/OpenStack/Makefile
@@ -121,12 +121,15 @@ alt-titles: shorthand2xccdf
 	XMLLINT_INDENT="" xmllint --format --output $(IN)/auxiliary/alt-titles-stig.xml $(IN)/auxiliary/alt-titles-stig.xml
 
 content: shorthand2xccdf guide checks
-#	the relabelids.py script chdirs to ./output, so refer to files from there.
-#	its second argument controls the IDs, as well as the output filenames.
-#	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
+#	The relabelids.py script chdirs to ./output, so refer to files from there.
+#	Its second argument controls the IDs, as well as the output filenames.
+#	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-ocilrefs-$(PROD)-xccdf.xml $(ID)
+#	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
+	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
+
 
 # not ready until oscap resolve behavior resolved
 content-stig: shorthand2xccdf guide checks

--- a/OpenStack/transforms/oval-fix-test-attestation-urls.xslt
+++ b/OpenStack/transforms/oval-fix-test-attestation-urls.xslt
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="yes"/>
+
+
+
+  <!-- This transform takes an OVAL document as input and expands
+       'test_attestation' value in the 'ref_url' <reference> attribute
+       to proper GitHub SCAP Security Guide Contributors URL:
+         [1] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors
+
+       The valid URLs in the OVAL document's "ref_url" attribute are
+       required in order to the OVAL HTML report to contain valid links,
+       when inspected via toolks like e.g. "linklint".
+
+       This fixes Red Hat downstream bug for OVAL files produced by
+       SCAP Security Guide:
+         [2] https://bugzilla.redhat.com/show_bug.cgi?id=1155809
+
+       DO NOT REMOVE THIS TRANSFORMATION! -->
+
+
+
+  <xsl:include href="constants.xslt"/>
+
+  <!-- First copy the input OVAL into the output OVAL -->
+  <xsl:template match="@*|node()" priority="-2">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Then update 'test_attestation' URL's in "ref_url" attribute
+       of the <reference> element to be a valid URL pointing to [1] -->
+  <xsl:template match="@ref_url">
+    <xsl:attribute name="ref_url">
+      <xsl:if test=". = 'test_attestation'">
+        <xsl:value-of select="$ssg-contributors-uri" />
+      </xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -90,13 +90,15 @@ tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-stigs
 
 content: shorthand2xccdf guide checks
-#	the relabelids.py script chdirs to ./output, so refer to files from there.
-#	its second argument controls the IDs, as well as the output filenames.
-#	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
+#	The relabelids.py script chdirs to ./output, so refer to files from there.
+#	Its second argument controls the IDs, as well as the output filenames.
+#	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-ocilrefs-$(PROD)-xccdf.xml $(ID)
-# 	Once things are relabelled, create a datastream
+#	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
+	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
+#	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
 	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
@@ -106,10 +108,10 @@ content: shorthand2xccdf guide checks
 #	Add in CPE and OVAL content to datastream
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(OUT)/$(ID)-$(PROD)-ds.xml
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-oval.xml $(OUT)/$(ID)-$(PROD)-ds.xml
-#   Make CentOS variants of XCCDF and Source DataStream
+#	Make CentOS variants of XCCDF and Source DataStream
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-centos -i $(OUT)/$(ID)-$(PROD)-xccdf.xml -o $(OUT)/$(ID)-centos5-xccdf.xml
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-centos -i $(OUT)/$(ID)-$(PROD)-ds.xml -o $(OUT)/$(ID)-centos5-ds.xml
-#   Make Scientific Linux variants of XCCDF and Source DataStream
+#	Make Scientific Linux variants of XCCDF and Source DataStream
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-sl -i $(OUT)/$(ID)-$(PROD)-xccdf.xml -o $(OUT)/$(ID)-sl5-xccdf.xml
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-sl -i $(OUT)/$(ID)-$(PROD)-ds.xml -o $(OUT)/$(ID)-sl5-ds.xml
 

--- a/RHEL/5/transforms/oval-fix-test-attestation-urls.xslt
+++ b/RHEL/5/transforms/oval-fix-test-attestation-urls.xslt
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="yes"/>
+
+
+
+  <!-- This transform takes an OVAL document as input and expands
+       'test_attestation' value in the 'ref_url' <reference> attribute
+       to proper GitHub SCAP Security Guide Contributors URL:
+         [1] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors
+
+       The valid URLs in the OVAL document's "ref_url" attribute are
+       required in order to the OVAL HTML report to contain valid links,
+       when inspected via toolks like e.g. "linklint".
+
+       This fixes Red Hat downstream bug for OVAL files produced by
+       SCAP Security Guide:
+         [2] https://bugzilla.redhat.com/show_bug.cgi?id=1155809
+
+       DO NOT REMOVE THIS TRANSFORMATION! -->
+
+
+
+  <xsl:include href="constants.xslt"/>
+
+  <!-- First copy the input OVAL into the output OVAL -->
+  <xsl:template match="@*|node()" priority="-2">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Then update 'test_attestation' URL's in "ref_url" attribute
+       of the <reference> element to be a valid URL pointing to [1] -->
+  <xsl:template match="@ref_url">
+    <xsl:attribute name="ref_url">
+      <xsl:if test=". = 'test_attestation'">
+        <xsl:value-of select="$ssg-contributors-uri" />
+      </xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -98,13 +98,15 @@ tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-srgmap table-stigs
 
 content: shorthand2xccdf guide checks
-#	the relabelids.py script chdirs to ./output, so refer to files from there.
-#	its second argument controls the IDs, as well as the output filenames.
-#	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
+#	The relabelids.py script chdirs to ./output, so refer to files from there.
+#	Its second argument controls the IDs, as well as the output filenames.
+#	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-ocilrefs-$(PROD)-xccdf.xml $(ID)
-# 	Once things are relabelled, create a datastream
+#	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
+	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
+#	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
 	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
@@ -114,10 +116,10 @@ content: shorthand2xccdf guide checks
 #	Add in CPE and OVAL content to datastream
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(OUT)/$(ID)-$(PROD)-ds.xml
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-oval.xml $(OUT)/$(ID)-$(PROD)-ds.xml
-#   Make CentOS variants of XCCDF and Source DataStream
+#	Make CentOS variants of XCCDF and Source DataStream
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-centos -i $(OUT)/$(ID)-$(PROD)-xccdf.xml -o $(OUT)/$(ID)-centos6-xccdf.xml
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-centos -i $(OUT)/$(ID)-$(PROD)-ds.xml -o $(OUT)/$(ID)-centos6-ds.xml
-#   Make Scientific Linux variants of XCCDF and Source DataStream
+#	Make Scientific Linux variants of XCCDF and Source DataStream
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-sl -i $(OUT)/$(ID)-$(PROD)-xccdf.xml -o $(OUT)/$(ID)-sl6-xccdf.xml
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-sl -i $(OUT)/$(ID)-$(PROD)-ds.xml -o $(OUT)/$(ID)-sl6-ds.xml
 

--- a/RHEL/6/transforms/oval-fix-test-attestation-urls.xslt
+++ b/RHEL/6/transforms/oval-fix-test-attestation-urls.xslt
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="yes"/>
+
+
+
+  <!-- This transform takes an OVAL document as input and expands
+       'test_attestation' value in the 'ref_url' <reference> attribute
+       to proper GitHub SCAP Security Guide Contributors URL:
+         [1] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors
+
+       The valid URLs in the OVAL document's "ref_url" attribute are
+       required in order to the OVAL HTML report to contain valid links,
+       when inspected via toolks like e.g. "linklint".
+
+       This fixes Red Hat downstream bug for OVAL files produced by
+       SCAP Security Guide:
+         [2] https://bugzilla.redhat.com/show_bug.cgi?id=1155809
+
+       DO NOT REMOVE THIS TRANSFORMATION! -->
+
+
+
+  <xsl:include href="constants.xslt"/>
+
+  <!-- First copy the input OVAL into the output OVAL -->
+  <xsl:template match="@*|node()" priority="-2">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Then update 'test_attestation' URL's in "ref_url" attribute
+       of the <reference> element to be a valid URL pointing to [1] -->
+  <xsl:template match="@ref_url">
+    <xsl:attribute name="ref_url">
+      <xsl:if test=". = 'test_attestation'">
+        <xsl:value-of select="$ssg-contributors-uri" />
+      </xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -105,26 +105,28 @@ table-stigs: shorthand2xccdf table-srgmap checks
 tables: table-refs table-idents table-srgmap table-stigs
 
 content: shorthand2xccdf guide checks
-#	the relabelids.py script chdirs to ./output, so refer to files from there.
-#	its second argument controls the IDs, as well as the output filenames.
-#	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
+#	The relabelids.py script chdirs to ./output, so refer to files from there.
+#	Its second argument controls the IDs, as well as the output filenames.
+#	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-ocilrefs-$(PROD)-xccdf.xml $(ID)
-#       Once things are relabelled, create a datastream
+#	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
+	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
+#	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
 	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	oscap ds sds-compose $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml $(OUT)/$(ID)-$(PROD)-ds.xml
-#       Add in CPE and OVAL content to datastream
+#	Add in CPE and OVAL content to datastream
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(OUT)/$(ID)-$(PROD)-ds.xml
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-oval.xml $(OUT)/$(ID)-$(PROD)-ds.xml
-#   Make CentOS variants of XCCDF and Source DataStream
+#	Make CentOS variants of XCCDF and Source DataStream
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-centos -i $(OUT)/$(ID)-$(PROD)-xccdf.xml -o $(OUT)/$(ID)-centos7-xccdf.xml
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-centos -i $(OUT)/$(ID)-$(PROD)-ds.xml -o $(OUT)/$(ID)-centos7-ds.xml
-#   Make Scientific Linux variants of XCCDF and Source DataStream
+#	Make Scientific Linux variants of XCCDF and Source DataStream
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-sl -i $(OUT)/$(ID)-$(PROD)-xccdf.xml -o $(OUT)/$(ID)-sl7-xccdf.xml
 	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-sl -i $(OUT)/$(ID)-$(PROD)-ds.xml -o $(OUT)/$(ID)-sl7-ds.xml
 

--- a/RHEL/7/transforms/oval-fix-test-attestation-urls.xslt
+++ b/RHEL/7/transforms/oval-fix-test-attestation-urls.xslt
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="yes"/>
+
+
+
+  <!-- This transform takes an OVAL document as input and expands
+       'test_attestation' value in the 'ref_url' <reference> attribute
+       to proper GitHub SCAP Security Guide Contributors URL:
+         [1] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors
+
+       The valid URLs in the OVAL document's "ref_url" attribute are
+       required in order to the OVAL HTML report to contain valid links,
+       when inspected via toolks like e.g. "linklint".
+
+       This fixes Red Hat downstream bug for OVAL files produced by
+       SCAP Security Guide:
+         [2] https://bugzilla.redhat.com/show_bug.cgi?id=1155809
+
+       DO NOT REMOVE THIS TRANSFORMATION! -->
+
+
+
+  <xsl:include href="constants.xslt"/>
+
+  <!-- First copy the input OVAL into the output OVAL -->
+  <xsl:template match="@*|node()" priority="-2">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Then update 'test_attestation' URL's in "ref_url" attribute
+       of the <reference> element to be a valid URL pointing to [1] -->
+  <xsl:template match="@ref_url">
+    <xsl:attribute name="ref_url">
+      <xsl:if test=". = 'test_attestation'">
+        <xsl:value-of select="$ssg-contributors-uri" />
+      </xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/RHEVM3/Makefile
+++ b/RHEVM3/Makefile
@@ -121,12 +121,14 @@ alt-titles: shorthand2xccdf
 	XMLLINT_INDENT="" xmllint --format --output $(IN)/auxiliary/alt-titles-stig.xml $(IN)/auxiliary/alt-titles-stig.xml
 
 content: shorthand2xccdf guide checks
-#	the relabelids.py script chdirs to ./output, so refer to files from there.
-#	its second argument controls the IDs, as well as the output filenames.
-#	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
+#	The relabelids.py script chdirs to ./output, so refer to files from there.
+#	Its second argument controls the IDs, as well as the output filenames.
+#	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-ocilrefs-$(PROD)-xccdf.xml $(ID)
+#	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
+	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 
 # not ready until oscap resolve behavior resolved
 content-stig: shorthand2xccdf guide checks

--- a/RHEVM3/transforms/oval-fix-test-attestation-urls.xslt
+++ b/RHEVM3/transforms/oval-fix-test-attestation-urls.xslt
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="yes"/>
+
+
+
+  <!-- This transform takes an OVAL document as input and expands
+       'test_attestation' value in the 'ref_url' <reference> attribute
+       to proper GitHub SCAP Security Guide Contributors URL:
+         [1] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors
+
+       The valid URLs in the OVAL document's "ref_url" attribute are
+       required in order to the OVAL HTML report to contain valid links,
+       when inspected via toolks like e.g. "linklint".
+
+       This fixes Red Hat downstream bug for OVAL files produced by
+       SCAP Security Guide:
+         [2] https://bugzilla.redhat.com/show_bug.cgi?id=1155809
+
+       DO NOT REMOVE THIS TRANSFORMATION! -->
+
+
+
+  <xsl:include href="constants.xslt"/>
+
+  <!-- First copy the input OVAL into the output OVAL -->
+  <xsl:template match="@*|node()" priority="-2">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Then update 'test_attestation' URL's in "ref_url" attribute
+       of the <reference> element to be a valid URL pointing to [1] -->
+  <xsl:template match="@ref_url">
+    <xsl:attribute name="ref_url">
+      <xsl:if test=". = 'test_attestation'">
+        <xsl:value-of select="$ssg-contributors-uri" />
+      </xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -95,13 +95,15 @@ tables: table-refs table-idents table-stigs
 #tables: table-refs table-idents table-srgmap table-stigs
 
 content: shorthand2xccdf guide checks
-#	the relabelids.py script chdirs to ./output, so refer to files from there.
-#	its second argument controls the IDs, as well as the output filenames.
-#	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
+#	The relabelids.py script chdirs to ./output, so refer to files from there.
+#	Its second argument controls the IDs, as well as the output filenames.
+#	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-ocilrefs-$(PROD)-xccdf.xml $(ID)
-# 	Once things are relabelled, create a datastream
+#	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
+	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
+#	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
 	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \

--- a/Webmin/transforms/oval-fix-test-attestation-urls.xslt
+++ b/Webmin/transforms/oval-fix-test-attestation-urls.xslt
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="yes"/>
+
+
+
+  <!-- This transform takes an OVAL document as input and expands
+       'test_attestation' value in the 'ref_url' <reference> attribute
+       to proper GitHub SCAP Security Guide Contributors URL:
+         [1] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors
+
+       The valid URLs in the OVAL document's "ref_url" attribute are
+       required in order to the OVAL HTML report to contain valid links,
+       when inspected via toolks like e.g. "linklint".
+
+       This fixes Red Hat downstream bug for OVAL files produced by
+       SCAP Security Guide:
+         [2] https://bugzilla.redhat.com/show_bug.cgi?id=1155809
+
+       DO NOT REMOVE THIS TRANSFORMATION! -->
+
+
+
+  <xsl:include href="constants.xslt"/>
+
+  <!-- First copy the input OVAL into the output OVAL -->
+  <xsl:template match="@*|node()" priority="-2">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Then update 'test_attestation' URL's in "ref_url" attribute
+       of the <reference> element to be a valid URL pointing to [1] -->
+  <xsl:template match="@ref_url">
+    <xsl:attribute name="ref_url">
+      <xsl:if test=". = 'test_attestation'">
+        <xsl:value-of select="$ssg-contributors-uri" />
+      </xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
It has been reported via downstream bug:
  [1] https://bugzilla.redhat.com/show_bug.cgi?id=1155809

that the 'test_attestation' links we produce in XCCDF and OVAL documents
are not valid links when inspected via tools like e.g. "linklint".

The XCCDF part has been already corrected via PR:
  [2] https://github.com/OpenSCAP/scap-security-guide/pull/580

This commit is fixing the very same issue but for the OVAL "ssg-$(PROD)-oval.xml"
documents generated for the different products yet.

The original problem as reported in [1] can be for the OVAL documents reproduced
e.g. as follows (it assumes the [linklint](http://www.linklint.org/) executable is accessible on the system in question via the ```$LINKLINT``` variable):
```
# oscap oval eval --results oval_results.xml --report oval_report.html /usr/share/xml/scap/ssg/content/ssg-rhel7-oval.xml
# $LINKLINT -error -net oval_report.html
```
Current result on unfixed ```test_attestation``` links:
```
# /root/Downloads/linklint-2.3.5/linklint-2.3.5 -error -net oval_report.html 

Checking links locally in /tmp/test
that match: /oval_report.html
1 seed: /oval_report.html

Seed:    /oval_report.html
checking /oval_report.html

Processing ...
#------------------------------------------------------------
# ERROR   1 missing other file
#------------------------------------------------------------
/test_attestation

found   1 directory with files
found   1 html file
found   1 named anchor
ERROR   1 missing other file

Linklint found 1 file in 1 directory and checked 1 html file.
There was 1 missing file. 1 file had broken links.
1 error, no warnings.
```
Note: It's visible in the above output ```linklint``` was unable to found link to ```/test_attestation```

Result on fixed OVAL ```test_attestation``` links (result on the same scenario when this patch is applied):
```
# /root/Downloads/linklint-2.3.5/linklint-2.3.5 -error -net oval_report.html 

Checking links locally in /root
that match: /oval_report.html
1 seed: /oval_report.html

Seed:    /oval_report.html
checking /oval_report.html

Processing ...

found   1 directory with files
found   1 html file
found   1 https link
found   1 named anchor

Linklint found 1 file in 1 directory and checked 1 html file.
There were no missing files. No files had broken links.
No errors, no warnings.
```
Note: In this case it's visble that ```linklint``` reported zero files have broken links. Also the working links can be verified manually by opening ```oval_report.html``` file in the browser and following some of the links e.g. ```RHEL7_20150605``` for the ```service_abrtd_disabled``` rule that visiting them will point the user to the Contributors page:
  [3] https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors

Please review.

Thank you, Jan.

P.S.: Note:
--
The newly added ```oval-fix-test-attestation-urls.xslt``` XSLT transformation fixing the links have been intentionally placed under the ```transforms/``` location on per-product basis (copy of the very same file multiple times for each affected product). I have tried to place it into the ```shared/``` directory, but since it depends on / requires also ```constants.xslt``` XSLT change, would need to move ```constants.xlst``` to ```shared/``` directory too. But this is not possible to do right now, because yet other product specific XSLT transformations, like e.g. ```shorthand2xccdf.xslt``` also depends on ```constants.xslt```-- require it to be present in the product specific ```/transforms``` directory. Therefore to be able to move the new ```oval-fix-test-attestation-urls.xslt```  XSLT tranformation into ```shared/``` directory, I would need to move all of the existing various XSLT transformations into ```shared/``` directory. While by itself it is not unfeasible, but requires more time that I have currently got (0.1.23 release is very close), for now I have decided to put a separate product copy of ```oval-fix-test-attestation-urls.xslt``` into each product, and will merge the existing XSLT transformations later (can't dedicate time to it right now).
