### PR TITLE
[BugFix] [RHEL/6] [RHEL/7] Don't include the 'test' profile into the benchmark by default, only when requested. Fix couple of other issues in RHEL/6 && RHEL/7 Makefiles

### DIFF
--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -15,14 +15,18 @@ PROD_CHECKS = $(BUILD)/$(PROD)_checks
 
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
 
+# Don't include the 'test' profile into benchmark by default. Only upon request (e.g. in 'eval-test' target)
+# Value '0' means 'test' will be included. Value '1' means 'test' will NOT be included.
+INCLUDE_TEST_PROFILE := $(shell false; echo $$?)
+
 all: shorthand2xccdf tables guide content dist
 
 shorthand-guide:
 ifeq ($(OPENSCAP_SVG), 0)
 	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
-	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
+	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
 else
-	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
+	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
 endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
@@ -130,7 +134,7 @@ content-stig: shorthand2xccdf guide checks
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
 
 submission-stig-check: table-stigs
-	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-server-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
+	cd $(OUT); ../$(UTILS)/verify-references.py -p stig-$(PROD)-server-upstream --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
 #	$(TRANS)/xccdf2csv-stig.py $(OUT)/unlinked-stig-$(PROD)-xccdf.xml > $(OUT)/table-stig.csv
 
 # content-usgcb: coming soon
@@ -148,15 +152,19 @@ validate-xml:
 
 
 validate: validate-xml
-	cd output; ../$(UTILS)/verify-references.py --rules-with-invalid-checks --ovaldefs-unused ssg-$(PROD)-xccdf.xml
+	cd $(OUT); ../$(UTILS)/verify-references.py --rules-with-invalid-checks --ovaldefs-unused ssg-$(PROD)-xccdf.xml
 
 eval-test:
+	# Rebuild the content indicating the 'test' profile should be included
+	make content INCLUDE_TEST_PROFILE=$(shell true; echo $$?)
 	oscap xccdf eval --profile test $(OUT)/$(ID)-$(PROD)-xccdf.xml
 
-eval-common:
-	oscap xccdf eval --profile common --oval-results --results /tmp/results-test.xml $(OUT)/$(ID)-$(PROD)-xccdf.xml
+eval-common: content
+	# Based on oscap(8) OVAL results are always stored into CWD. Therefore
+	# not to pollute CWD -- first change CWD to $(OUT), only then evaluate "common" profile
+	cd $(OUT); oscap xccdf eval --profile common --oval-results --results /tmp/results-test.xml $(ID)-$(PROD)-xccdf.xml
 
-# items in dist are expected for distribution in an rpm
+# Items in dist are expected for distribution in an rpm
 dist: tables guide content
 	mkdir -p $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content

--- a/RHEL/6/input/guide.xslt
+++ b/RHEL/6/input/guide.xslt
@@ -2,13 +2,17 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
 <!-- This transform assembles all fragments into one "shorthand" XCCDF document -->
+<!-- It expects a numeric parameter "withtest" specifying if the 'test' profile should
+     be included ("withtest=0") into the benchmark or not ("withtest=1"). -->
 
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
 
        <!-- adding profiles here -->
-		<xsl:apply-templates select="document('profiles/test.xml')" />
+		<xsl:if test=" number($withtest) = number(0) ">
+			<xsl:apply-templates select="document('profiles/test.xml')" />
+		</xsl:if>
 		<xsl:apply-templates select="document('profiles/CS2.xml')" />
 		<xsl:apply-templates select="document('profiles/common.xml')" />
 		<!-- <xsl:apply-templates select="document('profiles/desktop.xml')" /> -->

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -16,14 +16,18 @@ PROD_CHECKS = $(BUILD)/$(PROD)_checks
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
 OVAL_5_11 := $(shell oscap --version | grep -q "OVAL Version: 5.11.*"; echo $$?)
 
+# Don't include the 'test' profile into benchmark by default. Only upon request (e.g. in 'eval-test' target)
+# Value '0' means 'test' will be included. Value '1' means 'test' will NOT be included.
+INCLUDE_TEST_PROFILE := $(shell false; echo $$?)
+
 all: shorthand2xccdf tables guide content dist
 
 shorthand-guide:
 ifeq ($(OPENSCAP_SVG), 0)
 	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
-	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
+	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
 else
-	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
+	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
 endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
@@ -137,7 +141,7 @@ content-stig: shorthand2xccdf guide checks
 	xmllint --format --output $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml $(OUT)/disa-predraft-stig-$(PROD)-xccdf.xml
 
 submission-stig-check: table-stigs
-	cd output; ../$(UTILS)/verify-references.py -p stig-$(PROD)-server --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
+	cd $(OUT); ../$(UTILS)/verify-references.py -p stig-$(PROD)-server --rules-with-disarefs-outside-profile unlinked-$(PROD)-xccdf-prerefs.xml
 #	$(TRANS)/xccdf2csv-stig.py $(OUT)/unlinked-stig-$(PROD)-xccdf.xml > $(OUT)/table-stig.csv
 
 # content-usgcb: coming soon
@@ -154,15 +158,19 @@ validate-xml:
 	oscap ds sds-validate $(OUT)/$(ID)-sl7-ds.xml
 
 validate: validate-xml
-	cd output; ../$(UTILS)/verify-references.py --rules-with-invalid-checks --ovaldefs-unused ssg-$(PROD)-xccdf.xml
+	cd $(OUT); ../$(UTILS)/verify-references.py --rules-with-invalid-checks --ovaldefs-unused ssg-$(PROD)-xccdf.xml
 
 eval-test:
+	# Rebuild the content indicating the 'test' profile should be included
+	make content INCLUDE_TEST_PROFILE=$(shell true; echo $$?)
 	oscap xccdf eval --profile test $(OUT)/$(ID)-$(PROD)-xccdf.xml
 
-eval-common:
-	oscap xccdf eval --profile common --oval-results --results /tmp/results-test.xml $(OUT)/$(ID)-$(PROD)-xccdf.xml
+eval-common: content
+	# Based on oscap(8) OVAL results are always stored into CWD. Therefore
+	# not to pollute CWD -- first change CWD to $(OUT), only then evaluate "common" profile
+	cd $(OUT); oscap xccdf eval --profile common --oval-results --results /tmp/results-test.xml $(ID)-$(PROD)-xccdf.xml
 
-# items in dist are expected for distribution in an rpm
+# Items in dist are expected for distribution in an rpm
 dist: tables guide content
 	mkdir -p $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content

--- a/RHEL/7/input/guide.xslt
+++ b/RHEL/7/input/guide.xslt
@@ -2,13 +2,17 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
 <!-- This transform assembles all fragments into one "shorthand" XCCDF document -->
+<!-- It expects a numeric parameter "withtest" specifying if the 'test' profile should
+     be included ("withtest=0") into the benchmark or not ("withtest=1"). -->
 
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
 
        <!-- adding profiles here -->
-		<xsl:apply-templates select="document('profiles/test.xml')" />
+		<xsl:if test=" number($withtest) = number(0) ">
+			<xsl:apply-templates select="document('profiles/test.xml')" />
+		</xsl:if>
 		<xsl:apply-templates select="document('profiles/pci-dss.xml')" />
 		<xsl:apply-templates select="document('profiles/rht-ccp.xml')" />
 		<xsl:apply-templates select="document('profiles/common.xml')" />


### PR DESCRIPTION

This change modifies the Makefile's for RHEL/6 and RHEL/7 products
in order to the 'test' profile not to be included into the produced
RHEL-6 and RHEL-7 benchmark by default, since it is profile dedicated
for testing and not intended for production use. Both Makefiles have
been modified to include the 'test' profile only in moment, it's
inclusion was request (for example when evaluating ```eval-test``` target).

This fixes the following downstream bug:
  [1] https://bugzilla.redhat.com/show_bug.cgi?id=1153734

While on the Makefiles, this commit fixes also the following bugs
(in both Makefiles):
* substitute couple of ```cd output;``` calls with ```cd $(OUT);``` equivalents,
* the ```eval-common``` target has been previously missing the ```content```
  prerequisite (so it didn't work when run without first running 'make'
  target for that product),
* also, as written in the ```oscap(8)``` manual page ```oscap``` when run with
  ```--oval-results``` option always places the generated results file into CWD,
  which previously led into polluting CWD with OVAL results file. Therefore
  update the ```eval common``` target to first ```cd``` into ```$(OUT)``` directory,
  and call ```oscap eval``` only then.

Testing report:
---------------
The change has been tested (```make```, ```make eval-test```, ```make eval-common```)
on the following systems:
* RHEL-6,
* RHEL-7, and
* Fedora 21

and it has been verified it works as expected.

Please review.

Thank you, Jan.
