### PR TITLE
Use "Override" inherititance processing model

### DIFF
--- a/RHEL/6/input/profiles/stig-rhel6-server-upstream.xml
+++ b/RHEL/6/input/profiles/stig-rhel6-server-upstream.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-rhel6-server-upstream" extends="common">
-<title>Upstream STIG for RHEL 6 Server</title>
-<description>This profile is developed under the DoD consensus model and DISA FSO Vendor STIG process,
+<title override="true">Upstream STIG for RHEL 6 Server</title>
+<description override="true">This profile is developed under the DoD consensus model and DISA FSO Vendor STIG process,
 serving as the upstream development environment for the Red Hat Enterprise Linux 6 Server STIG.
 
 As a result of the upstream/downstream relationship between the SCAP Security Guide project 

--- a/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-rhel7-server-upstream" extends="common">
-<title>Pre-release Draft STIG for RHEL 7 Server</title>
-<description>This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
+<title override="true">Pre-release Draft STIG for RHEL 7 Server</title>
+<description override="true">This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
 
 <!-- STIG refinement values. Note these are set by DISA FSO,
      and should not be manipulated -->


### PR DESCRIPTION
This addresses confusing titles and descriptions when using "extends"
feature. Example of confusing title was

     Common Profile for General-Purpose SystemsPre-release Draft STIG
     for RHEL 7 Server

From now, only the latter title/description will be shown.

Learn more about Inheritance procssing models in Table 33 from
NIST-IR-7275r4.

Note: I have changed only STIG profiles to use @override, other profiles
that use @extends feature may have use some title/description
rewording.