### PR TITLE
The java-dist has been already renamed to jre-dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ MANDIR=man
 # Define Makefile targets below
 
 all: fedora rhel5 rhel6 rhel7 openstack rhevm3 webmin firefox chromium rpm zipfile
-dist: chromium-dist firefox-dist fedora-dist java-dist rhel6-dist rhel7-dist
+dist: chromium-dist firefox-dist fedora-dist jre-dist rhel6-dist rhel7-dist
 
 fedora:
 	cd Fedora/ && $(MAKE)


### PR DESCRIPTION
Related to 98b34993aee6005fb0cfaa33e231b9485ec04a70.

Addressing broken `make dist`
make: *** No rule to make target 'java-dist', needed by 'dist'.  Stop.