### PR TITLE
More scap-security-guide.spec.in fixes

### DIFF
--- a/scap-security-guide.spec.in
+++ b/scap-security-guide.spec.in
@@ -69,9 +69,10 @@ cp -a Fedora/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content
 cp -a Chromium/dist/content/ssg-chromium-ds.xml %{buildroot}%{_datadir}/xml/scap/ssg/content
 #cp -a Webmin/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content
 
-# We only want datastreams on Fedora, lets get rid of plain XCCDF and OVAL files
+# We only want datastreams on Fedora, lets get rid of plain XCCDF, OVAL and CPE dict files
 rm %{buildroot}%{_datadir}/xml/scap/ssg/content/*-xccdf.xml
 rm %{buildroot}%{_datadir}/xml/scap/ssg/content/*-oval.xml
+rm %{buildroot}%{_datadir}/xml/scap/ssg/content/*-cpe-dictionary.xml
 %endif
 
 # Add in oscap-scan files

--- a/scap-security-guide.spec.in
+++ b/scap-security-guide.spec.in
@@ -57,7 +57,6 @@ mkdir -p %{buildroot}%{_datadir}/xml/scap/ssg/content
 #cp -a RHEL/5/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content/
 cp -a RHEL/6/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content/
 cp -a RHEL/7/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content/
-cp -a JBossEAP5/eap5-* %{buildroot}%{_datadir}/xml/scap/ssg/content/
 cp -a JRE/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content/
 cp -a Firefox/dist/content/* %{buildroot}%{_datadir}/xml/scap/ssg/content/
 
@@ -74,6 +73,9 @@ rm %{buildroot}%{_datadir}/xml/scap/ssg/content/*-xccdf.xml
 rm %{buildroot}%{_datadir}/xml/scap/ssg/content/*-oval.xml
 rm %{buildroot}%{_datadir}/xml/scap/ssg/content/*-cpe-dictionary.xml
 %endif
+
+# We do this after the filtering on Fedora because we don't ship JBossEAP5 datastreams
+cp -a JBossEAP5/eap5-* %{buildroot}%{_datadir}/xml/scap/ssg/content/
 
 # Add in oscap-scan files
 #mkdir -p %{buildroot}%{_sysconfdir}/sysconfig/


### PR DESCRIPTION
- filter out CPE dicts on Fedora
- make sure we don't filter out JBossEAP5 even on Fedora because we don't ship any datastreams, XCCDF+OVAL is the only way to get that content

PS: Sorry about the branch name, it's wrong but it's pushed now.