### PR TITLE
CentOS and Scientific Linux CPEs

### DIFF
--- a/RHEL/6/input/checks/platform/rhel6-cpe-dictionary.xml
+++ b/RHEL/6/input/checks/platform/rhel6-cpe-dictionary.xml
@@ -7,4 +7,9 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel6</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:centos:centos:6">
+            <title xml:lang="en-us">CentOS 6</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_centos6</check>
+      </cpe-item>
 </cpe-list>

--- a/RHEL/6/input/checks/platform/rhel6-cpe-dictionary.xml
+++ b/RHEL/6/input/checks/platform/rhel6-cpe-dictionary.xml
@@ -12,4 +12,9 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_centos6</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:scientificlinux:scientificlinux:6">
+            <title xml:lang="en-us">Scientific Linux 6</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_sl6</check>
+      </cpe-item>
 </cpe-list>

--- a/RHEL/7/input/checks/platform/rhel7-cpe-dictionary.xml
+++ b/RHEL/7/input/checks/platform/rhel7-cpe-dictionary.xml
@@ -7,4 +7,9 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel7</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:centos:centos:7">
+            <title xml:lang="en-us">CentOS 7</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_centos7</check>
+      </cpe-item>
 </cpe-list>

--- a/RHEL/7/input/checks/platform/rhel7-cpe-dictionary.xml
+++ b/RHEL/7/input/checks/platform/rhel7-cpe-dictionary.xml
@@ -12,4 +12,9 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_centos7</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:scientificlinux:scientificlinux:7">
+            <title xml:lang="en-us">Scientific Linux 7</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_sl7</check>
+      </cpe-item>
 </cpe-list>

--- a/shared/oval/installed_OS_is_centos6.xml
+++ b/shared/oval/installed_OS_is_centos6.xml
@@ -1,0 +1,42 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_centos6" version="1">
+    <metadata>
+      <title>CentOS 6</title>
+      <affected family="unix">
+        <platform>multi_platform_centos</platform>
+      </affected>
+      <reference ref_id="cpe:/o:centos:centos:6"
+      source="CPE" />
+      <description>The operating system installed on the system is
+      CentOS 6</description>
+      <reference source="MP" ref_id="CENTOS6_20150707" ref_url="test_attestation" />
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_unix_family" />
+      <criterion comment="CentOS6 is installed"
+      test_ref="test_centos" />
+    </criteria>
+  </definition>
+
+  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
+    <ind:object object_ref="obj_unix_family" />
+    <ind:state state_ref="state_unix_family" />
+  </ind:family_test>
+  <ind:family_state id="state_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+  <ind:family_object id="obj_unix_family" version="1" />
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 6" id="test_centos" version="1">
+    <linux:object object_ref="obj_centos" />
+    <linux:state state_ref="state_centos" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_centos" version="1">
+    <linux:version operation="pattern match">^6.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_centos" version="1">
+    <linux:name>centos-release</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/shared/oval/installed_OS_is_centos6.xml
+++ b/shared/oval/installed_OS_is_centos6.xml
@@ -16,7 +16,7 @@
       <criterion comment="Installed operating system is part of the unix family"
       test_ref="test_unix_family" />
       <criterion comment="CentOS6 is installed"
-      test_ref="test_centos" />
+      test_ref="test_centos6" />
     </criteria>
   </definition>
 
@@ -29,14 +29,14 @@
   </ind:family_state>
   <ind:family_object id="obj_unix_family" version="1" />
 
-  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 6" id="test_centos" version="1">
-    <linux:object object_ref="obj_centos" />
-    <linux:state state_ref="state_centos" />
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 6" id="test_centos6" version="1">
+    <linux:object object_ref="obj_centos6" />
+    <linux:state state_ref="state_centos6" />
   </linux:rpminfo_test>
-  <linux:rpminfo_state id="state_centos" version="1">
+  <linux:rpminfo_state id="state_centos6" version="1">
     <linux:version operation="pattern match">^6.*$</linux:version>
   </linux:rpminfo_state>
-  <linux:rpminfo_object id="obj_centos" version="1">
+  <linux:rpminfo_object id="obj_centos6" version="1">
     <linux:name>centos-release</linux:name>
   </linux:rpminfo_object>
 </def-group>

--- a/shared/oval/installed_OS_is_centos6.xml
+++ b/shared/oval/installed_OS_is_centos6.xml
@@ -4,7 +4,7 @@
     <metadata>
       <title>CentOS 6</title>
       <affected family="unix">
-        <platform>multi_platform_centos</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <reference ref_id="cpe:/o:centos:centos:6"
       source="CPE" />

--- a/shared/oval/installed_OS_is_centos7.xml
+++ b/shared/oval/installed_OS_is_centos7.xml
@@ -1,0 +1,42 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_centos7" version="1">
+    <metadata>
+      <title>CentOS 7</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:centos:centos:7"
+      source="CPE" />
+      <description>The operating system installed on the system is
+      CentOS 7</description>
+      <reference source="MP" ref_id="CENTOS7_20150707" ref_url="test_attestation" />
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_unix_family" />
+      <criterion comment="CentOS7 is installed"
+      test_ref="test_centos" />
+    </criteria>
+  </definition>
+
+  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
+    <ind:object object_ref="obj_unix_family" />
+    <ind:state state_ref="state_unix_family" />
+  </ind:family_test>
+  <ind:family_state id="state_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+  <ind:family_object id="obj_unix_family" version="1" />
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="test_centos" version="1">
+    <linux:object object_ref="obj_centos" />
+    <linux:state state_ref="state_centos" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_centos" version="1">
+    <linux:version operation="pattern match">^7.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_centos" version="1">
+    <linux:name>centos-release</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/shared/oval/installed_OS_is_centos7.xml
+++ b/shared/oval/installed_OS_is_centos7.xml
@@ -16,7 +16,7 @@
       <criterion comment="Installed operating system is part of the unix family"
       test_ref="test_unix_family" />
       <criterion comment="CentOS7 is installed"
-      test_ref="test_centos" />
+      test_ref="test_centos7" />
     </criteria>
   </definition>
 
@@ -29,14 +29,14 @@
   </ind:family_state>
   <ind:family_object id="obj_unix_family" version="1" />
 
-  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="test_centos" version="1">
-    <linux:object object_ref="obj_centos" />
-    <linux:state state_ref="state_centos" />
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="test_centos7" version="1">
+    <linux:object object_ref="obj_centos7" />
+    <linux:state state_ref="state_centos7" />
   </linux:rpminfo_test>
-  <linux:rpminfo_state id="state_centos" version="1">
+  <linux:rpminfo_state id="state_centos7" version="1">
     <linux:version operation="pattern match">^7.*$</linux:version>
   </linux:rpminfo_state>
-  <linux:rpminfo_object id="obj_centos" version="1">
+  <linux:rpminfo_object id="obj_centos7" version="1">
     <linux:name>centos-release</linux:name>
   </linux:rpminfo_object>
 </def-group>

--- a/shared/oval/installed_OS_is_sl6.xml
+++ b/shared/oval/installed_OS_is_sl6.xml
@@ -1,0 +1,42 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_sl6" version="1">
+    <metadata>
+      <title>Scientific Linux 6</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:scientificlinux:scientificlinux:6"
+      source="CPE" />
+      <description>The operating system installed on the system is
+      Scientific Linux 6</description>
+      <reference source="MP" ref_id="SL6_20150707" ref_url="test_attestation" />
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_unix_family" />
+      <criterion comment="Scientific Linux 6 is installed"
+      test_ref="test_sl" />
+    </criteria>
+  </definition>
+
+  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
+    <ind:object object_ref="obj_unix_family" />
+    <ind:state state_ref="state_unix_family" />
+  </ind:family_test>
+  <ind:family_state id="state_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+  <ind:family_object id="obj_unix_family" version="1" />
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sl-release is version 6" id="test_sl" version="1">
+    <linux:object object_ref="obj_sl" />
+    <linux:state state_ref="state_sl" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_sl" version="1">
+    <linux:version operation="pattern match">^6.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_sl" version="1">
+    <linux:name>sl-release</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/shared/oval/installed_OS_is_sl6.xml
+++ b/shared/oval/installed_OS_is_sl6.xml
@@ -16,7 +16,7 @@
       <criterion comment="Installed operating system is part of the unix family"
       test_ref="test_unix_family" />
       <criterion comment="Scientific Linux 6 is installed"
-      test_ref="test_sl" />
+      test_ref="test_sl6" />
     </criteria>
   </definition>
 
@@ -29,14 +29,14 @@
   </ind:family_state>
   <ind:family_object id="obj_unix_family" version="1" />
 
-  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sl-release is version 6" id="test_sl" version="1">
-    <linux:object object_ref="obj_sl" />
-    <linux:state state_ref="state_sl" />
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sl-release is version 6" id="test_sl6" version="1">
+    <linux:object object_ref="obj_sl6" />
+    <linux:state state_ref="state_sl6" />
   </linux:rpminfo_test>
-  <linux:rpminfo_state id="state_sl" version="1">
+  <linux:rpminfo_state id="state_sl6" version="1">
     <linux:version operation="pattern match">^6.*$</linux:version>
   </linux:rpminfo_state>
-  <linux:rpminfo_object id="obj_sl" version="1">
+  <linux:rpminfo_object id="obj_sl6" version="1">
     <linux:name>sl-release</linux:name>
   </linux:rpminfo_object>
 </def-group>

--- a/shared/oval/installed_OS_is_sl7.xml
+++ b/shared/oval/installed_OS_is_sl7.xml
@@ -1,0 +1,42 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_sl7" version="1">
+    <metadata>
+      <title>Scientific Linux 7</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:scientificlinux:scientificlinux:6"
+      source="CPE" />
+      <description>The operating system installed on the system is
+      Scientific Linux 7</description>
+      <reference source="MP" ref_id="SL7_20150707" ref_url="test_attestation" />
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_unix_family" />
+      <criterion comment="Scientific Linux 7 is installed"
+      test_ref="test_sl" />
+    </criteria>
+  </definition>
+
+  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
+    <ind:object object_ref="obj_unix_family" />
+    <ind:state state_ref="state_unix_family" />
+  </ind:family_test>
+  <ind:family_state id="state_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+  <ind:family_object id="obj_unix_family" version="1" />
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sl-release is version 7" id="test_sl" version="1">
+    <linux:object object_ref="obj_sl" />
+    <linux:state state_ref="state_sl" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_sl" version="1">
+    <linux:version operation="pattern match">^7.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_sl" version="1">
+    <linux:name>sl-release</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/shared/oval/installed_OS_is_sl7.xml
+++ b/shared/oval/installed_OS_is_sl7.xml
@@ -16,7 +16,7 @@
       <criterion comment="Installed operating system is part of the unix family"
       test_ref="test_unix_family" />
       <criterion comment="Scientific Linux 7 is installed"
-      test_ref="test_sl" />
+      test_ref="test_sl7" />
     </criteria>
   </definition>
 
@@ -29,14 +29,14 @@
   </ind:family_state>
   <ind:family_object id="obj_unix_family" version="1" />
 
-  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sl-release is version 7" id="test_sl" version="1">
-    <linux:object object_ref="obj_sl" />
-    <linux:state state_ref="state_sl" />
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sl-release is version 7" id="test_sl7" version="1">
+    <linux:object object_ref="obj_sl7" />
+    <linux:state state_ref="state_sl7" />
   </linux:rpminfo_test>
-  <linux:rpminfo_state id="state_sl" version="1">
+  <linux:rpminfo_state id="state_sl7" version="1">
     <linux:version operation="pattern match">^7.*$</linux:version>
   </linux:rpminfo_state>
-  <linux:rpminfo_object id="obj_sl" version="1">
+  <linux:rpminfo_object id="obj_sl7" version="1">
     <linux:name>sl-release</linux:name>
   </linux:rpminfo_object>
 </def-group>


### PR DESCRIPTION
These CPE items and OVAL checks are included in OpenSCAP but we should provide them for older versions of OpenSCAP or other SCAP tools that may not include them.