### PR TITLE
[Enhancement] [RHEL/7] Add draft / example of Red Hat Enterprise Linux 7 PCI-DSS profile kickstart using Oscap Anaconda Add-on plug-in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,7 @@ install: dist
 	install -m 0644 RHEL/6/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
 	install -m 0644 shared/fixes/bash/templates/remediation_functions $(PREFIX)/$(DATADIR)/scap-security-guide/
 	install -m 0644 RHEL/6/kickstart/*-ks.cfg $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
+	install -m 0644 RHEL/7/kickstart/*-ks.cfg $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
 	install -m 0644 RHEL/6/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide
 	install -m 0644 RHEL/7/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
 	install -m 0644 RHEL/7/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide

--- a/RHEL/7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
+++ b/RHEL/7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
@@ -1,0 +1,150 @@
+# SCAP Security Guide PCI-DSS profile kickstart for Red Hat Enterprise Linux 7 Server
+# Version: 0.0.1
+# Date: 2015-07-07
+#
+# Based on:
+# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Install a fresh new system (optional)
+install
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+url --url=http://192.168.122.1/image
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# encrypted password form for different plaintext password
+rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# --enableshadow	enable shadowed passwords by default
+# --passalgo		hash / crypt algorithm for new passwords
+# See the manual page for authconfig for a complete list of possible options.
+authconfig --enableshadow --passalgo=sha512
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# encrypted password form for different plaintext password
+bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=12288 --grow
+# CCE-26557-9: Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=LogVol02 --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# CCE-26435-8: Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=LogVol01 --vgname=VolGroup --size=1024 --fsoptions="nodev,noexec,nosuid"
+# CCE-26639-5: Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=LogVol03 --vgname=VolGroup --size=2048 --fsoptions="nodev"
+# CCE-26215-4: Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=LogVol04 --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# CCE-26436-6: Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=LogVol05 --vgname=VolGroup --size=512 --fsoptions="nodev"
+logvol swap --name=lv_swap --vgname=VolGroup --size=2016
+
+%addon org_fedora_oscap
+        content-type = scap-security-guide
+        profile = pci-dss
+%end
+
+# Packages selection (%packages section is required)
+#
+# Packages from the following package groups are installed by default when 'Desktop'
+# Anaconda option is selected when installing Red Hat Enterprise Linux 7 Server
+%packages
+@base
+@core
+@desktop-debugging
+@dial-up
+@fonts
+@gnome-desktop
+@guest-agents
+@guest-desktop-agents
+@input-methods
+@internet-browser
+@multimedia
+@print-client
+@x11
+
+# Install selected additional packages (required by PCI-DSS profile)
+# CCE-27024-9: Install AIDE
+aide
+
+# Install openscap-utils so it's possible to perform remediation once the
+# installation is complete
+openscap-utils
+
+# Install libreswan package
+libreswan
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject


### PR DESCRIPTION
This patch adds a draft / example RHEL-7 kickstart file for PCI-DSS profile using the Oscap Anaconda Addon syntax.

Tried using virt-manager && seems to be working fine AFAICT.

Please review.