### PR TITLE
Install all the guides to a sub-dir.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,16 +220,16 @@ install: dist
 	install -d $(PREFIX)/$(DATADIR)/scap-security-guide
 	install -d $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
 	install -d $(PREFIX)/$(MANDIR)/en/man8/
-	install -d $(PREFIX)/$(DOCDIR)/scap-security-guide
+	install -d $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
 	install -m 0644 Fedora/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
-	install -m 0644 Fedora/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide
+	install -m 0644 Fedora/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
 	install -m 0644 RHEL/6/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
 	install -m 0644 shared/fixes/bash/templates/remediation_functions $(PREFIX)/$(DATADIR)/scap-security-guide/
 	install -m 0644 RHEL/6/kickstart/*-ks.cfg $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
 	install -m 0644 RHEL/7/kickstart/*-ks.cfg $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
-	install -m 0644 RHEL/6/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide
+	install -m 0644 RHEL/6/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
 	install -m 0644 RHEL/7/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
-	install -m 0644 RHEL/7/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide
+	install -m 0644 RHEL/7/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
 	install -m 0644 docs/scap-security-guide.8 $(PREFIX)/$(MANDIR)/en/man8/
 
 .PHONY: rhel5 rhel6 rhel7 jre firefox webmin tarball srpm rpm clean all


### PR DESCRIPTION
There is too much of them in that directory already.

I would like to have DISCLAIMER and LICENSE and perhaps README.md in the /usr/share/doc/scap-security-guide. Now it would be lost in the many guides.

Also -doc sub-package should be easier after that (as we should keep LICENSE and DISCLAIMER in the base pkg).