### PR TITLE
[Enhancement] [RHEL/6] [RHEL/7] sshd MAC check and remediation 

### DIFF
--- a/RHEL/6/input/fixes/bash/sshd_use_approved_macs.sh
+++ b/RHEL/6/input/fixes/bash/sshd_use_approved_macs.sh
@@ -1,0 +1,5 @@
+grep -qi ^MACs /etc/ssh/sshd_config && \
+  sed -i "s/MACs.*/MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1/gI" /etc/ssh/sshd_config
+if ! [ $? -eq 0 ]; then
+    echo "MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1" >> /etc/ssh/sshd_config
+fi

--- a/RHEL/6/input/services/ssh.xml
+++ b/RHEL/6/input/services/ssh.xml
@@ -370,6 +370,31 @@ implementation. These are also required for compliance.
 <tested by="DS" on="20121024"/>
 </Rule>
 
+
+<Rule id="sshd_use_approved_macs">
+<title>Use Only Approved MACs</title>
+<description>Limit the MACs to those hash algorithms which are FIPS-approved.
+The following line in <tt>/etc/ssh/sshd_config</tt>
+demonstrates use of FIPS-approved MACs:
+<pre>MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1</pre>
+The man page <tt>sshd_config(5)</tt> contains a list of supported MACs.
+</description>
+<ocil clause="that is not the case">
+Only FIPS-approved MACs should be used.  To verify that only FIPS-approved
+MACs are in use, run the following command:
+<pre>$ sudo grep -i macs /etc/ssh/sshd_config</pre>
+The output should contain only those MACs which are FIPS-approved, namely,
+hmac-sha2-512, hmac-sha2-256, and hmac-sha1 hash functions. 
+</ocil>
+<rationale>
+Approved algorithms should impart some level of confidence in their
+implementation. These are also required for compliance.
+</rationale>
+<oval id="sshd_use_approved_macs" />
+<ref nist="AC-17(2),IA-7,SC-13" disa="68,1453,803,2449,2450" />
+</Rule>
+
+
 <Group id="sshd_strengthen_firewall">
 <title>Strengthen Firewall Configuration if Possible</title>
 <description>If the SSH server is expected to only receive connections from 

--- a/RHEL/7/input/fixes/bash/sshd_use_approved_macs.sh
+++ b/RHEL/7/input/fixes/bash/sshd_use_approved_macs.sh
@@ -1,0 +1,5 @@
+grep -qi ^MACs /etc/ssh/sshd_config && \
+  sed -i "s/MACs.*/MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1/gI" /etc/ssh/sshd_config
+if ! [ $? -eq 0 ]; then
+    echo "MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1" >> /etc/ssh/sshd_config
+fi

--- a/RHEL/7/input/services/ssh.xml
+++ b/RHEL/7/input/services/ssh.xml
@@ -370,6 +370,31 @@ implementation. These are also required for compliance.
 <tested by="DS" on="20121024"/>
 </Rule>
 
+<Rule id="sshd_use_approved_macs">
+<title>Use Only Approved MACs</title>
+<description>Limit the MACs to those hash algorithms which are FIPS-approved.
+The following line in <tt>/etc/ssh/sshd_config</tt>
+demonstrates use of FIPS-approved MACs:
+<pre>MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1</pre>
+The man page <tt>sshd_config(5)</tt> contains a list of supported MACs.
+</description>
+<ocil clause="that is not the case">
+Only FIPS-approved MACs should be used.  To verify that only FIPS-approved
+MACs are in use, run the following command:
+<pre>$ sudo grep -i macs /etc/ssh/sshd_config</pre>
+The output should contain only those MACs which are FIPS-approved, namely,
+hmac-sha2-512, hmac-sha2-256, and hmac-sha1 hash functions.
+<!-- encrypt-then-mac hash functions likely to be added to this list in the future -->
+</ocil>
+<rationale>
+Approved algorithms should impart some level of confidence in their
+implementation. These are also required for compliance.
+</rationale>
+<oval id="sshd_use_approved_macs" />
+<ref nist="AC-17(2),IA-7,SC-13" disa="68,1453,803,2449,2450" ossrg="61,223" />
+</Rule>
+
+
 <Group id="sshd_strengthen_firewall">
 <title>Strengthen Firewall Configuration if Possible</title>
 <description>If the SSH server is expected to only receive connections from 

--- a/shared/oval/sshd_use_approved_macs.xml
+++ b/shared/oval/sshd_use_approved_macs.xml
@@ -1,0 +1,29 @@
+<def-group>
+  <definition class="compliance" id="sshd_use_approved_macs" version="1">
+    <metadata>
+      <title>Use Only FIPS MACs</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+      </affected>
+      <description>Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.</description>
+      <reference source="PCA" ref_id="20150718" ref_url="test_attestation" />
+    </metadata>
+    <criteria comment="SSH is not being used or conditions are met"
+    operator="OR">
+      <extend_definition comment="sshd service is disabled"
+      definition_ref="service_sshd_disabled" />
+      <criterion comment="Check MACs in /etc/ssh/sshd_config"
+      test_ref="test_sshd_use_approved_macs" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="tests the value of MACs setting in the /etc/ssh/sshd_config file"
+  id="test_sshd_use_approved_macs" version="1">
+    <ind:object object_ref="obj_sshd_use_approved_macs" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_sshd_use_approved_macs" version="1">
+    <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*(?i)MACs(?-i)[\s]+hmac-sha2-512,hmac-sha2-256,hmac-sha1[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>


### PR DESCRIPTION
This should satisfy #480. This is a partial port from the RHEL5 MAC check for ssh.

* Added multirhel OVAL check
* Added remediation scripts
* Updated ssh XCCDFs
  * RHEL7 ssh XCCDF has refs for NIST, DISA, and OSSRG
  * RHEL6 ssh XCCDF has references for NIST and DISA

My rationale for the remediation script *not* being shared is due to the EtM algorithms available in RHEL7; I suspect these will be included in the approved list.

Testing:
- Verified check returns properly on RHEL 7 and RHEL 6
- Manually verified remediation on RHEL 7 and RHEL 6