### PR TITLE
[Enhancement] [RHEL/6] [RHEL/7] auditd flush check and remediation

### DIFF
--- a/RHEL/6/input/fixes/bash/auditd_data_retention_flush.sh
+++ b/RHEL/6/input/fixes/bash/auditd_data_retention_flush.sh
@@ -1,17 +1,1 @@
-source ./templates/support.sh
-populate var_auditd_flush
-
-# if flush is present, flush param edited to var_auditd_flush
-# else flush param is defined by var_auditd_flush
-#
-# the freq param is disabled if var_auditd_flush isn't incremental
-
-grep -q ^flush /etc/audit/auditd.conf && \
-  sed -i 's/^flush.*/flush = '"$var_auditd_flush"'/g' /etc/audit/auditd.conf
-if ! [ $? -eq 0 ]; then
-  echo "flush = $var_auditd_flush" >> /etc/audit/auditd.conf
-fi
-
-if ! [ "$var_auditd_flush" == "incremental" ]; then
-  sed -i 's/^freq/##freq/g' /etc/audit/auditd.conf
-fi
+../../../../../shared/fixes/bash/auditd_data_retention_flush.sh

--- a/RHEL/6/input/fixes/bash/auditd_data_retention_flush.sh
+++ b/RHEL/6/input/fixes/bash/auditd_data_retention_flush.sh
@@ -1,0 +1,17 @@
+source ./templates/support.sh
+populate var_auditd_flush
+
+# if flush is present, flush param edited to var_auditd_flush
+# else flush param is defined by var_auditd_flush
+#
+# the freq param is disabled if var_auditd_flush isn't incremental
+
+grep -q ^flush /etc/audit/auditd.conf && \
+  sed -i 's/^flush.*/flush = '"$var_auditd_flush"'/g' /etc/audit/auditd.conf
+if ! [ $? -eq 0 ]; then
+  echo "flush = $var_auditd_flush" >> /etc/audit/auditd.conf
+fi
+
+if ! [ "$var_auditd_flush" == "incremental" ]; then
+  sed -i 's/^freq/##freq/g' /etc/audit/auditd.conf
+fi

--- a/RHEL/6/input/system/auditing.xml
+++ b/RHEL/6/input/system/auditing.xml
@@ -227,6 +227,16 @@ normally.</i>
 <value selector="admin">admin</value>
 </Value>
 
+<Value id="var_auditd_flush" type="string" >
+<title>Auditd priority for flushing data to disk</title>
+<description>The setting for flush in /etc/audit/auditd.conf</description>
+<value selector="">data</value>
+<value selector="none">none</value>
+<value selector="incremental">incremental</value>
+<value selector="data">data</value>
+<value selector="sync">sync</value>
+</Value>
+
 <Rule id="configure_auditd_num_logs" severity="medium">
 <title>Configure auditd Number of Logs Retained</title>
 <description>Determine how many log files
@@ -415,6 +425,32 @@ administrators of the system, who can take appropriate action.</rationale>
 <ident cce="27241-9"  stig="RHEL-06-000313" />
 <oval id="auditd_data_retention_action_mail_acct" value="var_auditd_action_mail_acct" />
 <ref nist="AU-1(b),AU-4,AU-5(a),IR-5" disa="139,144" />
+</Rule>
+
+<Rule id="auditd_data_retention_flush">
+<title>Configure auditd flush priority</title>
+<description>The <tt>auditd</tt> service can be configured to 
+synchronously write audit event data to disk. Add or correct the following 
+line in <tt>/etc/audit/auditd.conf</tt> to ensure that audit event data is 
+fully synchronized with the log files on the disk:
+<pre>flush = <sub idref="var_auditd_flush" /></pre>
+</description>
+<ocil clause="auditd is not configured to synchronously write audit 
+event data to disk">
+Inspect <tt>/etc/audit/auditd.conf</tt> and locate the following line to
+determine if the system is configured to synchronize audit event data 
+with the log files on the disk:
+<tt>$ sudo grep flush /etc/audit/auditd.conf</tt>
+<pre>flush = DATA</pre>
+Acceptable values are <tt>DATA</tt>, and <tt>SYNC</tt>. The setting is 
+case-insensitive.
+</ocil>
+<rationale>Audit data should be synchronously written to disk to ensure 
+log integrity. These parameters assure that all audit event data is fully 
+synchronized with the log files on the disk.</rationale>
+<!-- <ident cce=""  stig="" /> -->
+<oval id="auditd_data_retention_flush" value="var_auditd_flush" />
+<ref nist="AU-9,AU-12(1)" disa="1576" />
 </Rule>
 
 <Rule id="configure_auditd_audispd" severity="low">

--- a/RHEL/7/input/fixes/bash/auditd_data_retention_flush.sh
+++ b/RHEL/7/input/fixes/bash/auditd_data_retention_flush.sh
@@ -1,17 +1,1 @@
-source ./templates/support.sh
-populate var_auditd_flush
-
-# if flush is present, flush param edited to var_auditd_flush
-# else flush param is defined by var_auditd_flush
-#
-# the freq param is disabled if var_auditd_flush isn't incremental
-
-grep -q ^flush /etc/audit/auditd.conf && \
-  sed -i 's/^flush.*/flush = '"$var_auditd_flush"'/g' /etc/audit/auditd.conf
-if ! [ $? -eq 0 ]; then
-  echo "flush = $var_auditd_flush" >> /etc/audit/auditd.conf
-fi
-
-if ! [ "$var_auditd_flush" == "incremental" ]; then
-  sed -i 's/^freq/##freq/g' /etc/audit/auditd.conf
-fi
+../../../../../shared/fixes/bash/auditd_data_retention_flush.sh

--- a/RHEL/7/input/fixes/bash/auditd_data_retention_flush.sh
+++ b/RHEL/7/input/fixes/bash/auditd_data_retention_flush.sh
@@ -1,0 +1,17 @@
+source ./templates/support.sh
+populate var_auditd_flush
+
+# if flush is present, flush param edited to var_auditd_flush
+# else flush param is defined by var_auditd_flush
+#
+# the freq param is disabled if var_auditd_flush isn't incremental
+
+grep -q ^flush /etc/audit/auditd.conf && \
+  sed -i 's/^flush.*/flush = '"$var_auditd_flush"'/g' /etc/audit/auditd.conf
+if ! [ $? -eq 0 ]; then
+  echo "flush = $var_auditd_flush" >> /etc/audit/auditd.conf
+fi
+
+if ! [ "$var_auditd_flush" == "incremental" ]; then
+  sed -i 's/^freq/##freq/g' /etc/audit/auditd.conf
+fi

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -248,6 +248,16 @@ normally.</i>
 <value selector="admin">admin</value>
 </Value>
 
+<Value id="var_auditd_flush" type="string" >
+<title>Auditd priority for flushing data to disk</title>
+<description>The setting for flush in /etc/audit/auditd.conf</description>
+<value selector="">data</value>
+<value selector="none">none</value>
+<value selector="incremental">incremental</value>
+<value selector="data">data</value>
+<value selector="sync">sync</value>
+</Value>
+
 <Rule id="configure_auditd_num_logs" severity="medium">
 <title>Configure auditd Number of Logs Retained</title>
 <description>Determine how many log files
@@ -436,6 +446,32 @@ administrators of the system, who can take appropriate action.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="auditd_data_retention_action_mail_acct" value="var_auditd_action_mail_acct" />
 <ref nist="AU-1(b),AU-4,AU-5(a),IR-5" disa="139,144" />
+</Rule>
+
+<Rule id="auditd_data_retention_flush">
+<title>Configure auditd flush priority</title>
+<description>The <tt>auditd</tt> service can be configured to
+synchronously write audit event data to disk. Add or correct the following
+line in <tt>/etc/audit/auditd.conf</tt> to ensure that audit event data is
+fully synchronized with the log files on the disk:
+<pre>flush = <sub idref="var_auditd_flush" /></pre>
+</description>
+<ocil clause="auditd is not configured to synchronously write audit 
+event data to disk">
+Inspect <tt>/etc/audit/auditd.conf</tt> and locate the following line to
+determine if the system is configured to synchronize audit event data
+with the log files on the disk:
+<tt>$ sudo grep flush /etc/audit/auditd.conf</tt>
+<pre>flush = DATA</pre>
+Acceptable values are <tt>DATA</tt>, and <tt>SYNC</tt>. The setting is
+case-insensitive.
+</ocil>
+<rationale>Audit data should be synchronously written to disk to ensure
+log integrity. These parameters assure that all audit event data is fully
+synchronized with the log files on the disk.</rationale>
+<!-- <ident cce="" -->
+<oval id="auditd_data_retention_flush" value="var_auditd_flush" />
+<ref nist="AU-9,AU-12(1)" disa="1576" />
 </Rule>
 
 <Rule id="configure_auditd_audispd" severity="medium">

--- a/shared/fixes/bash/auditd_data_retention_flush.sh
+++ b/shared/fixes/bash/auditd_data_retention_flush.sh
@@ -1,0 +1,29 @@
+source ./templates/support.sh
+populate var_auditd_flush
+
+AUDITCONFIG=/etc/audit/auditd.conf
+
+# if flush is present, flush param edited to var_auditd_flush
+# else flush param is defined by var_auditd_flush
+#
+# the freq param is only used value 'incremental' and will be
+# commented out if flush != incremental
+#
+# if flush == incremental && freq param is not defined, it 
+# will be defined as the package-default value of 20
+
+grep -q ^flush $AUDITCONFIG && \
+  sed -i 's/^flush.*/flush = '"$var_auditd_flush"'/g' $AUDITCONFIG
+if ! [ $? -eq 0 ]; then
+  echo "flush = $var_auditd_flush" >> $AUDITCONFIG
+fi
+
+if ! [ "$var_auditd_flush" == "incremental" ]; then
+  sed -i 's/^freq/##freq/g' $AUDITCONFIG
+elif [ "$var_auditd_flush" == "incremental" ]; then
+  grep -q freq $AUDITCONFIG && \
+    sed -i 's/^#\+freq/freq/g' $AUDITCONFIG
+  if ! [ $? -eq 0 ]; then
+    echo "freq = 20" >> $AUDITCONFIG
+  fi
+fi

--- a/shared/oval/auditd_data_retention_flush.xml
+++ b/shared/oval/auditd_data_retention_flush.xml
@@ -1,0 +1,40 @@
+<def-group>
+  <definition class="compliance" id="auditd_data_retention_flush" version="1">
+    <metadata>
+      <title>Auditd priority for flushing data to disk</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+      </affected>
+      <description>The setting for flush in /etc/audit/auditd.conf</description>
+      <reference source="PCA" ref_id="20150718" ref_url="test_attestation" />
+    </metadata>
+
+    <criteria>
+        <criterion comment="flush setting in auditd.conf" test_ref="test_auditd_data_retention_flush" />
+    </criteria>
+
+  </definition>
+
+  <ind:textfilecontent54_test check="all" 
+  comment="test the value of flush parameter in /etc/audit/auditd.conf" 
+  id="test_auditd_data_retention_flush" version="1">
+    <ind:object object_ref="object_auditd_data_retention_flush" />
+    <ind:state state_ref="state_auditd_data_retention_flush" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_auditd_data_retention_flush" version="1">
+    <ind:filepath>/etc/audit/auditd.conf</ind:filepath>
+    <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
+    <!-- Require at least one space before and after the equal sign -->
+    <ind:pattern operation="pattern match">^[ ]*flush[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_auditd_data_retention_flush" version="1">
+    <ind:subexpression operation="case insensitive equals" var_ref="var_auditd_flush" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="audit flush setting" datatype="string" id="var_auditd_flush" version="1" />
+
+
+</def-group>


### PR DESCRIPTION
This should satisfy #387.

090e41e:
* Added multirhel OVAL check
* ~~Added remediation scripts~~
* Updated auditing XCCDFs
  * XCCDF has refs for NIST and DISA

1aab7ea:
 * Incorporated the recommendations by @redhatrises 
  * remediation script is now shared
  * fixed script logic to revert "freq" parameter if flush == incremental
 * Re-tested and re-verified on RHEL6, CentOS 6, CentOS 7

This was not added to any of the profiles.

Testing:
- Verified check returns properly on RHEL6, CentOS 6, CentOS 7
- Manually verified remediation on RHEL6, CentOS 6, CentOS 7