### PR TITLE
[BugFix][Enhancement] Populated empty NIST fields in XCCDFs

### DIFF
--- a/Fedora/input/system/accounts/physical.xml
+++ b/Fedora/input/system/accounts/physical.xml
@@ -34,7 +34,7 @@ or modification of the file.
 Only root should be able to modify important boot parameters.
 </rationale>
 <oval id="file_user_owner_grub2_cfg" />
-<ref nist="" disa="225"/>
+<ref nist="AC-6(7)" disa="225"/>
 </Rule>
 
 <Rule id="file_group_owner_grub2_cfg" severity="medium">
@@ -50,7 +50,7 @@ The <tt>root</tt> group is a highly-privileged group. Furthermore, the group-own
 file should not have any access privileges anyway.
 </rationale>
 <oval id="file_group_owner_grub2_cfg" />
-<ref nist="" disa="225"/>
+<ref nist="AC-6(7)" disa="225"/>
 </Rule>
 
 <Rule id="file_permissions_grub2_cfg" severity="medium">
@@ -70,7 +70,7 @@ Proper permissions ensure that only the root user can modify important boot
 parameters.
 </rationale>
 <oval id="file_permissions_grub2_cfg" />
-<ref nist="" disa="225"/>
+<ref nist="AC-6(7)" disa="225"/>
 </Rule>
 
 <Rule id="bootloader_password" severity="medium">

--- a/Fedora/input/system/accounts/restrictions/root_logins.xml
+++ b/Fedora/input/system/accounts/restrictions/root_logins.xml
@@ -155,7 +155,7 @@ section on the root account. Doing so might cause the system to
 become inaccessible.
 </warning>
 <oval id="no_shelllogin_for_systemaccounts" />
-<ref nist="" disa="178" />
+<ref nist="AC-2,CM-6(b)" disa="178" />
 </Rule>
 
 <Rule id="no_uidzero_except_root" severity="medium">

--- a/Fedora/input/system/accounts/session.xml
+++ b/Fedora/input/system/accounts/session.xml
@@ -88,7 +88,7 @@ Including these entries increases the risk that root could
 execute code from an untrusted location.
 </rationale>
 <!-- <oval id="root_path_no_dot" /> -->
-<ref nist=""/>
+<ref nist="CM-6(b)" disa="366"/>
 </Rule>
 
 <Rule id="root_path_no_groupother_writable">
@@ -110,7 +110,7 @@ execute code provided by unprivileged users,
 and potentially malicious code.
 </rationale>
 <oval id="accounts_root_path_dirs_no_write" />
-<ref nist=""/>
+<ref nist="CM-6(b)" disa="366"/>
 </Rule>
 </Group>
 
@@ -144,7 +144,7 @@ to one another's home directories, this can be provided using
 groups or ACLs.
 </rationale>
 <oval id="file_permissions_home_dirs" />
-<ref nist=""/>
+<ref nist="AC-6(7)" disa="225"/>
 </Rule>
 
 <Group id="user_umask">
@@ -222,7 +222,7 @@ umask 077
 umask 077</pre>
 </ocil>
 <!-- <oval id="accounts_umask_etc_bashrc" value="var_accounts_user_umask"/> -->
-<ref nist="" disa="366"/>
+<ref nist="SA-8" disa="366"/>
 </Rule>
 
 <Rule id="accounts_umask_cshrc">
@@ -244,7 +244,7 @@ All output must show the value of <tt>umask</tt> set to 077, as shown in the bel
 umask 077</pre>
 </ocil>
 <!-- <oval id="accounts_umask_etc_csh_cshrc" value="var_accounts_user_umask"/> -->
-<ref nist="" disa="366"/>
+<ref nist="SA-8" disa="366"/>
 </Rule>
 
 <Rule id="accounts_umask_etc_profile">
@@ -266,7 +266,7 @@ All output must show the value of <tt>umask</tt> set to 077, as shown in the bel
 umask 077</pre>
 </ocil>
 <!-- <oval id="accounts_umask_etc_profile" value="var_accounts_user_umask" /> -->
-<ref nist="" disa="366"/>
+<ref nist="SA-8" disa="366"/>
 </Rule>
 
 <Rule id="accounts_umask_login_defs">
@@ -288,7 +288,7 @@ All output must show the value of <tt>umask</tt> set to 077, as shown in the bel
 umask 077</pre>
 </ocil>
 <!-- <oval id="accounts_umask_etc_login_defs" value="var_accounts_user_umask" /> -->
-<ref nist="" disa="366"/>
+<ref nist="SA-8" disa="366"/>
 </Rule>
 
 </Group>

--- a/Fedora/input/system/network/ipv6.xml
+++ b/Fedora/input/system/network/ipv6.xml
@@ -160,7 +160,7 @@ from the network otherwise. The example address here is an IPv6 address
 reserved for documentation purposes, as defined by RFC3849.
 </description>
 <!--oval id="network_ipv6_static_address" /-->
-<ref nist="" />
+<ref disa="366" />
 </Rule>
 
 <Rule id="network_ipv6_privacy_extensions">
@@ -176,7 +176,7 @@ IP address to not trivially reveal its hardware address, this setting should be
 applied.
 </description>
 <!--oval id="network_ipv6_privacy_extensions" /-->
-<ref nist="" />
+<ref disa="366" />
 </Rule>
 
 <Rule id="network_ipv6_default_gateway">
@@ -189,7 +189,7 @@ Router addresses should be manually set and not accepted via any
 auto-configuration or router advertisement.
 </description>
 <!--oval id="network_ipv6_default_gateway" /-->
-<ref nist="" />
+<ref disa="366" />
 </Rule>
 
 <Group id="network_ipv6_limit_requests">

--- a/Fedora/input/system/permissions/execution.xml
+++ b/Fedora/input/system/permissions/execution.xml
@@ -146,7 +146,7 @@ heap higher than this address, the hardware prevents execution in that
 address range. This is enabled by default on the latest Red Hat and Fedora 
 systems if supported by the hardware.</rationale>
 <oval id="sysctl_kernel_exec_shield" />
-<ref nist="" />
+<ref nist="SC-39" disa="2530" />
 </Rule>
 
 <Rule id="sysctl_kernel_randomize_va_space" severity="medium">
@@ -160,7 +160,7 @@ makes it more difficult for an attacker to know the location of existing code
 in order to re-purpose it using return oriented programming (ROP) techniques.
 </rationale>
 <!--oval id="sysctl_kernel_randomize_va_space" /-->
-<ref nist="" />
+<ref nist="SC-30(2)" />
 </Rule>
 </Group>
 
@@ -197,7 +197,7 @@ installed on older systems that do not support the XD or NX bit, as
 this may prevent them from booting.</warning>
 <rationale>On 32-bit systems that support the XD or NX bit, the vendor-supplied
 PAE kernel is required to enable either Execute Disable (XD) or No Execute (NX) support.</rationale>
-<ref nist="" />
+<ref nist="CM-6(b)" />
 </Rule>
 
 <Rule id="bios_enable_execution_restrictions">
@@ -208,7 +208,7 @@ under a Security section. Look for Execute Disable (XD) on Intel-based systems a
 on AMD-based systems.</description>
 <rationale>Computers with the ability to prevent this type of code execution frequently put an option in the BIOS that will
 allow users to turn the feature on or off at will.</rationale>
-<ref nist="" />
+<ref nist="CM-6(b)" />
 </Rule>
 
 </Group> <!--<Group id="enable_nx"> -->

--- a/RHEL/5/input/system/accounts/restrictions/account_expiration.xml
+++ b/RHEL/5/input/system/accounts/restrictions/account_expiration.xml
@@ -60,7 +60,7 @@ who may have compromised their credentials.
 </rationale>
 <ident stig="GEN006660" />
 <oval id="accounts_disable_post_pw_expiration" value="var_account_disable_post_pw_expiration"/>
-<ref nist="" disa="17" />
+<ref nist="AC-2(3)" disa="17" />
 </Rule>
 
 <Rule id="accounts_unique_name">

--- a/RHEL/6/input/services/dhcp.xml
+++ b/RHEL/6/input/services/dhcp.xml
@@ -170,7 +170,7 @@ daemon messages to a dedicated log file is part of the syslog configuration
 outlined in the Logging and Auditing section</rationale>
 <ident cce="26898-7" />
 <oval id="dhcp_server_configure_logging" />
-<ref nist="" />
+<ref nist="AU-12" />
 </Rule>
 
 </Group> <!-- <Group id="dhcp_server_configuration"> -->

--- a/RHEL/6/input/system/accounts/physical.xml
+++ b/RHEL/6/input/system/accounts/physical.xml
@@ -35,7 +35,7 @@ Only root should be able to modify important boot parameters.
 </rationale>
 <ident cce="26995-1"  stig="RHEL-06-000065" />
 <oval id="file_user_owner_grub_conf" />
-<ref nist="" disa="225"/>
+<ref nist="AC-6(7)" disa="225"/>
 <tested by="DS" on="20121026"/>
 </Rule>
 
@@ -53,7 +53,7 @@ file should not have any access privileges anyway.
 </rationale>
 <ident cce="27022-3"  stig="RHEL-06-000066" />
 <oval id="file_group_owner_grub_conf" />
-<ref nist="" disa="225"/>
+<ref nist="AC-6(7)" disa="225"/>
 <tested by="DS" on="20121026"/>
 </Rule>
 
@@ -75,7 +75,7 @@ parameters.
 </rationale>
 <ident cce="26949-8"  stig="RHEL-06-000067" />
 <oval id="file_permissions_grub_conf" />
-<ref nist="" disa="225"/>
+<ref nist="AC-6(7)" disa="225"/>
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/6/input/system/accounts/session.xml
+++ b/RHEL/6/input/system/accounts/session.xml
@@ -90,7 +90,7 @@ execute code from an untrusted location.
 </rationale>
 <ident cce="26826-8" />
 <oval id="root_path_no_dot" />
-<ref nist=""/>
+<ref nist="CM-6(b)" disa="366"/>
 </Rule>
 
 <Rule id="root_path_no_groupother_writable">
@@ -113,7 +113,7 @@ and potentially malicious code.
 </rationale>
 <ident cce="26768-2" />
 <oval id="accounts_root_path_dirs_no_write" />
-<ref nist=""/>
+<ref nist="CM-6(b)" disa="366"/>
 </Rule>
 </Group>
 
@@ -148,7 +148,7 @@ groups or ACLs.
 </rationale>
 <ident cce="26981-1" />
 <oval id="file_permissions_home_dirs" />
-<ref nist="AC-6"/>
+<ref nist="AC-6(7)"/>
 </Rule>
 
 <Group id="user_umask">

--- a/RHEL/6/input/system/logging.xml
+++ b/RHEL/6/input/system/logging.xml
@@ -122,7 +122,7 @@ configuration, user authentication, and other such information. Log files should
 protected from unauthorized access.</rationale>
 <ident cce="26812-8"  stig="RHEL-06-000133" />
 <oval id="rsyslog_files_ownership" />
-<ref nist="AC-6" disa="1314"/>
+<ref nist="AC-6,SI-11" disa="1314"/>
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -151,7 +151,7 @@ configuration, user authentication, and other such information. Log files should
 protected from unauthorized access.</rationale>
 <ident cce="26821-9"  stig="RHEL-06-000134" />
 <oval id="rsyslog_files_groupownership" />
-<ref nist="AC-6" disa="1314"/>
+<ref nist="AC-6,SI-11" disa="1314"/>
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -186,7 +186,7 @@ users could change the logged data, eliminating their forensic value.
 </rationale>
 <ident cce="27190-8"  stig="RHEL-06-000135" />
 <oval id="rsyslog_files_permissions" />
-<ref nist="" disa="1314"/>
+<ref nist="SI-11" disa="1314"/>
 <tested by="DS" on="20121024"/>
 </Rule>
 </Group>

--- a/RHEL/6/input/system/network/ipv6.xml
+++ b/RHEL/6/input/system/network/ipv6.xml
@@ -168,7 +168,7 @@ reserved for documentation purposes, as defined by RFC3849.
 </description>
 <ident cce="27233-6" />
 <oval id="network_ipv6_static_address" />
-<ref nist="" />
+<ref nist="CM-6(b)" />
 </Rule>
 
 <Rule id="network_ipv6_privacy_extensions">
@@ -185,7 +185,7 @@ applied.
 </description>
 <ident cce="27154-4" />
 <oval id="network_ipv6_privacy_extensions" />
-<ref nist="" />
+<ref nist="CM-6(b)" />
 </Rule>
 
 <Rule id="network_ipv6_default_gateway">
@@ -199,7 +199,7 @@ auto-configuration or router advertisement.
 </description>
 <ident cce="27234-4" />
 <oval id="network_ipv6_default_gateway" />
-<ref nist="" />
+<ref nist="CM-6(b)" />
 </Rule>
 
 <Group id="network_ipv6_limit_requests">

--- a/RHEL/6/input/system/permissions/execution.xml
+++ b/RHEL/6/input/system/permissions/execution.xml
@@ -131,7 +131,7 @@ heap higher than this address, the hardware prevents execution in that
 address range.</rationale>
 <ident cce="27007-4"  stig="RHEL-06-000079" />
 <oval id="sysctl_kernel_exec_shield" />
-<ref nist="" />
+<ref nist="SC-39" disa="2530" />
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -147,7 +147,7 @@ in order to re-purpose it using return oriented programming (ROP) techniques.
 </rationale>
 <ident cce="26999-3"  stig="RHEL-06-000078" />
 <oval id="sysctl_kernel_randomize_va_space" />
-<ref nist="" />
+<ref nist="SC-30(2)" />
 <tested by="DS" on="20121024"/>
 </Rule>
 </Group>
@@ -185,7 +185,7 @@ this may prevent them from booting.</warning>
 <rationale>On 32-bit systems that support the XD or NX bit, the vendor-supplied
 PAE kernel is required to enable either Execute Disable (XD) or No Execute (NX) support.</rationale>
 <ident cce="27010-8" />
-<ref nist="" />
+<ref nist="CM-6(b)" />
 </Rule>
 
 <Rule id="bios_enable_execution_restrictions">
@@ -196,7 +196,7 @@ under a Security section. Look for Execute Disable (XD) on Intel-based systems a
 on AMD-based systems.</description>
 <rationale>Computers with the ability to prevent this type of code execution frequently put an option in the BIOS that will
 allow users to turn the feature on or off at will.</rationale>
-<ref nist="" />
+<ref nist="CM-6(b)" />
 <ident cce="27163-5" />
 </Rule>
 

--- a/RHEL/6/input/system/permissions/files.xml
+++ b/RHEL/6/input/system/permissions/files.xml
@@ -411,7 +411,7 @@ unprivileged users to elevate privileges. The presence of these files should be
 strictly controlled on the system.</rationale>
 <ident cce="26769-0" />
 <oval id="file_permissions_unauthorized_sgid" />
-<ref nist=""/>
+<ref nist="AC-6(1)"/>
 </Rule>
 
 <Rule id="file_permissions_unauthorized_suid">

--- a/RHEL/6/input/system/software/disk_partitioning.xml
+++ b/RHEL/6/input/system/software/disk_partitioning.xml
@@ -39,7 +39,7 @@ restrictive mount options, which can help protect programs which use it.
 </rationale>
 <ident cce="26435-8" stig="RHEL-06-000001" />
 <oval id="partition_for_tmp" />
-<ref nist="" disa="1208"/>
+<ref nist="SC-32" disa="1208"/>
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -59,7 +59,7 @@ world-writable directories installed by other software packages.
 </rationale>
 <ident cce="26639-5" stig="RHEL-06-000002" />
 <oval id="partition_for_var" />
-<ref nist="" disa="1208"/>
+<ref nist="SC-32" disa="1208"/>
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -78,7 +78,7 @@ and other files in <tt>/var/</tt>.
 </rationale>
 <ident cce="26215-4"  stig="RHEL-06-000003" />
 <oval id="partition_for_var_log" />
-<ref nist="AU-9" disa="1208"/>
+<ref nist="AU-9,SC-32" disa="1208"/>
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -100,7 +100,7 @@ of space.
 </rationale>
 <ident cce="26436-6"  stig="RHEL-06-000004" />
 <oval id="partition_for_var_log_audit" />
-<ref nist="AU-4,AU-9" disa="137,138,1208"/>
+<ref nist="AU-4,AU-9,SC-32" disa="137,138,1208"/>
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -121,7 +121,7 @@ users cannot trivially fill partitions used for log or audit data storage.
 </rationale>
 <ident cce="26557-9"  stig="RHEL-06-000007" />
 <oval id="partition_for_home" />
-<ref nist="" disa="1208"/>
+<ref nist="SC-32" disa="1208"/>
 <tested by="MM" on="20120928"/>
 </Rule>
 

--- a/RHEL/7/input/services/dhcp.xml
+++ b/RHEL/7/input/services/dhcp.xml
@@ -170,7 +170,7 @@ daemon messages to a dedicated log file is part of the syslog configuration
 outlined in the Logging and Auditing section</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <!--<oval id="dhcp_server_configure_logging" /> -->
-<ref nist="" />
+<ref nist="AU-12" />
 </Rule>
 
 </Group> <!-- <Group id="dhcp_server_configuration"> -->

--- a/RHEL/7/input/system/accounts/physical.xml
+++ b/RHEL/7/input/system/accounts/physical.xml
@@ -35,7 +35,7 @@ Only root should be able to modify important boot parameters.
 </rationale>
 <ident cce="26860-7" />
 <oval id="file_user_owner_grub2_cfg" />
-<ref nist="" disa=""/>
+<ref nist="AC-6(7)" disa="225"/>
 <tested by="DS" on="20121026"/>
 </Rule>
 
@@ -53,7 +53,7 @@ file should not have any access privileges anyway.
 </rationale>
 <ident cce="26812-8" />
 <oval id="file_group_owner_grub2_cfg" />
-<ref nist="" disa=""/>
+<ref nist="AC-6(7)" disa="225"/>
 <tested by="DS" on="20121026"/>
 </Rule>
 
@@ -74,7 +74,7 @@ parameters.
 </rationale>
 <ident cce="27054-6" />
 <oval id="file_permissions_grub2_cfg" />
-<ref nist="" disa=""/>
+<ref nist="AC-6(7)" disa="225"/>
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/system/accounts/session.xml
+++ b/RHEL/7/input/system/accounts/session.xml
@@ -90,7 +90,7 @@ execute code from an untrusted location.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="root_path_no_dot" />
-<ref nist=""/>
+<ref nist="CM-6(b)" disa="366"/>
 </Rule>
 
 <Rule id="root_path_no_groupother_writable">
@@ -113,7 +113,7 @@ and potentially malicious code.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="accounts_root_path_dirs_no_write" />
-<ref nist=""/>
+<ref nist="CM-6(b)" disa="366"/>
 </Rule>
 </Group>
 
@@ -148,7 +148,7 @@ groups or ACLs.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="file_permissions_home_dirs" />
-<ref nist="AC-6"/>
+<ref nist="AC-6(7)" disa="225"/>
 </Rule>
 
 <Group id="user_umask">

--- a/RHEL/7/input/system/logging.xml
+++ b/RHEL/7/input/system/logging.xml
@@ -122,7 +122,7 @@ configuration, user authentication, and other such information. Log files should
 protected from unauthorized access.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="rsyslog_files_ownership" />
-<ref nist="AC-6" disa="1314"/>
+<ref nist="AC-6,SI-11" disa="1314"/>
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -151,7 +151,7 @@ configuration, user authentication, and other such information. Log files should
 protected from unauthorized access.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="rsyslog_files_groupownership" />
-<ref nist="AC-6" disa="1314"/>
+<ref nist="AC-6,SI-11" disa="1314"/>
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -184,7 +184,7 @@ users could change the logged data, eliminating their forensic value.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="rsyslog_files_permissions" />
-<ref nist="" disa="1314"/>
+<ref nist="SI-11" disa="1314"/>
 <tested by="DS" on="20121024"/>
 </Rule>
 </Group>

--- a/RHEL/7/input/system/network/ipv6.xml
+++ b/RHEL/7/input/system/network/ipv6.xml
@@ -167,7 +167,7 @@ reserved for documentation purposes, as defined by RFC3849.
 </description>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="network_ipv6_static_address" />
-<ref nist="" />
+<ref disa="366" />
 </Rule>
 
 <Rule id="network_ipv6_privacy_extensions">
@@ -184,7 +184,7 @@ applied.
 </description>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="network_ipv6_privacy_extensions" />
-<ref nist="" />
+<ref disa="366" />
 </Rule>
 
 <Rule id="network_ipv6_default_gateway">
@@ -198,7 +198,7 @@ auto-configuration or router advertisement.
 </description>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="network_ipv6_default_gateway" />
-<ref nist="" />
+<ref disa="366" />
 </Rule>
 
 <Group id="network_ipv6_limit_requests">

--- a/RHEL/7/input/system/permissions/execution.xml
+++ b/RHEL/7/input/system/permissions/execution.xml
@@ -151,7 +151,7 @@ address range. This is enabled by default on the latest Red Hat and Fedora
 systems if supported by the hardware.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="sysctl_kernel_exec_shield" />
-<ref nist="" />
+<ref nist="SC-39" disa="2530" />
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -167,7 +167,7 @@ in order to re-purpose it using return oriented programming (ROP) techniques.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="sysctl_kernel_randomize_va_space" />
-<ref nist="" />
+<ref nist="SC-30(2)" />
 <tested by="DS" on="20121024"/>
 </Rule>
 </Group>
@@ -206,7 +206,7 @@ this may prevent them from booting.</warning>
 <rationale>On 32-bit systems that support the XD or NX bit, the vendor-supplied
 PAE kernel is required to enable either Execute Disable (XD) or No Execute (NX) support.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
-<ref nist="" />
+<ref nist="CM-6(b)" />
 </Rule>
 
 <Rule id="bios_enable_execution_restrictions">
@@ -217,7 +217,7 @@ under a Security section. Look for Execute Disable (XD) on Intel-based systems a
 on AMD-based systems.</description>
 <rationale>Computers with the ability to prevent this type of code execution frequently put an option in the BIOS that will
 allow users to turn the feature on or off at will.</rationale>
-<ref nist="" />
+<ref nist="CM-6(b)" />
 <ident cce="RHEL7-CCE-TBD" />
 </Rule>
 
@@ -230,6 +230,7 @@ allow users to turn the feature on or off at will.</rationale>
 <rationale>Unprivileged access to the kernel syslog can expose sensitive kernel 
 address information.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
+<ref nist="SI-11" disa="1314" />
 <oval id="sysctl_kernel_dmesg_restrict" />
 </Rule> 
   

--- a/RHEL/7/input/system/permissions/files.xml
+++ b/RHEL/7/input/system/permissions/files.xml
@@ -411,7 +411,7 @@ unprivileged users to elevate privileges. The presence of these files should be
 strictly controlled on the system.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="file_permissions_unauthorized_sgid" />
-<ref nist=""/>
+<ref nist="AC-6(1)"/>
 </Rule>
 
 <Rule id="file_permissions_unauthorized_suid">

--- a/RHEL/7/input/system/software/disk_partitioning.xml
+++ b/RHEL/7/input/system/software/disk_partitioning.xml
@@ -39,7 +39,7 @@ restrictive mount options, which can help protect programs which use it.
 </rationale>
 <ident cce="27173-4" />
 <oval id="partition_for_tmp" />
-<ref nist="" disa=""/>
+<ref nist="SC-32" />
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -59,7 +59,7 @@ world-writable directories installed by other software packages.
 </rationale>
 <ident cce="26404-4" />
 <oval id="partition_for_var" />
-<ref nist="" disa=""/>
+<ref nist="SC-32" />
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -78,7 +78,7 @@ and other files in <tt>/var/</tt>.
 </rationale>
 <ident cce="26967-0" />
 <oval id="partition_for_var_log" />
-<ref nist="AU-9" disa=""/>
+<ref nist="AU-9,SC-32" disa=""/>
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -100,7 +100,7 @@ of space.
 </rationale>
 <ident cce="26971-2" />
 <oval id="partition_for_var_log_audit" />
-<ref nist="AU-4,AU-9" disa=""/>
+<ref nist="AU-4,AU-9,SC-32" disa=""/>
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -121,7 +121,7 @@ users cannot trivially fill partitions used for log or audit data storage.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="partition_for_home" />
-<ref nist="" disa="1208"/>
+<ref nist="SC-32" disa="1208"/>
 <tested by="MM" on="20120928"/>
 </Rule>
 


### PR DESCRIPTION
This updates the 'nist=""' fields in the Fedora, RHEL5, RHEL6, and RHEL7 XCCDF files.

Fields were determined by the following references:
 * NIST SP800-53A rev.4
 * RHEL7 STIG Requirements XLSX
 * DISA RedHat 6 STIG V1R8
 * DISA RedHat 5 STIG V1R11
 * DISA GPOS SRG V1R2
 * DoD CIO RMFKS

This should also satisfy #626 

Tested and built successfully on: RHEL6
