### PR TITLE
Break down RHEL7's firewalld description into multiple lines

### DIFF
--- a/RHEL/7/input/system/network/firewalld.xml
+++ b/RHEL/7/input/system/network/firewalld.xml
@@ -83,7 +83,12 @@ The following listing displays the result of this command on common Red Hat
 Enterprise Linux 7 Server system:
 <pre>
 # firewall-cmd --get-service
-amanda-client bacula bacula-client dhcp dhcpv6 dhcpv6-client dns ftp high-availability http https imaps ipp ipp-client ipsec kerberos kpasswd ldap ldaps libvirt libvirt-tls mdns mountd ms-wbt mysql nfs ntp openvpn pmcd pmproxy pmwebapi pmwebapis pop3s postgresql proxy-dhcp radius rpc-bind samba samba-client smtp ssh telnet tftp tftp-client transmission-client vnc-server wbem-https
+amanda-client bacula bacula-client dhcp dhcpv6 dhcpv6-client dns ftp
+high-availability http https imaps ipp ipp-client ipsec kerberos kpasswd
+ldap ldaps libvirt libvirt-tls mdns mountd ms-wbt mysql nfs ntp openvpn
+pmcd pmproxy pmwebapi pmwebapis pop3s postgresql proxy-dhcp radius rpc-bind
+samba samba-client smtp ssh telnet tftp tftp-client transmission-client
+vnc-server wbem-https
 </pre>
 Finally to view the network zones that will be active after the next firewalld
 service reload, enter the following command as root:


### PR DESCRIPTION
This avoids issues with the HTML guide where the pre-formatted lines are
long and made the guide wide in the browser.

Wide guide (before fix):
![broken_wide_guide](https://cloud.githubusercontent.com/assets/753153/8989070/2753d886-36ea-11e5-8564-69c7396101d3.png)

Fixed guide (after fix):
![fixed_wide_guide](https://cloud.githubusercontent.com/assets/753153/8989072/2d886622-36ea-11e5-8871-ba3407f5c4a7.png)

I thought about fixing this in the HTML report and guide by making the descriptions not overflow but offer scrollbars instead but the UX is still terrible. Scrolling such a wide description is no fun.

