### PR TITLE
[BugFix] [RHEL/6] Override title and description for each currently existing profile extending some another RHEL-6 SCAP profile

### DIFF
--- a/RHEL/6/input/profiles/desktop.xml
+++ b/RHEL/6/input/profiles/desktop.xml
@@ -1,6 +1,6 @@
 <Profile id="desktop" extends="common">
-<title>Desktop Baseline</title>
-<description>This profile is for a desktop installation of RHEL 6.</description>
+<title override="true">Desktop Baseline</title>
+<description override="true">This profile is for a desktop installation of RHEL 6.</description>
 <select idref="gconf_gdm_enable_warning_gui_banner" selected="true"/>
 <select idref="gconf_gdm_set_login_banner_text" selected="true"/>
 <select idref="gconf_gnome_screensaver_idle_delay" selected="true"/>

--- a/RHEL/6/input/profiles/ftp.xml
+++ b/RHEL/6/input/profiles/ftp.xml
@@ -1,8 +1,8 @@
 <Profile id="ftp" extends="server" xmlns="http://checklists.nist.gov/xccdf/1.1" >
 <!-- Once the OVAL is put in/tested an extended ref to the server profile should be added -->
 <!--<Profile id="ftp" extends="server" xmlns="http://checklists.nist.gov/xccdf/1.1" > -->
-<title>ftp</title>
-<description>This profile is for FTP servers.</description>
+<title override="true">ftp</title>
+<description override="true">This profile is for FTP servers.</description>
 <select idref="package_vsftpd_installed" selected="true"/>
 <select idref="ftp_log_transactions" selected="true"/>
 <select idref="ftp_present_banner" selected="true"/>

--- a/RHEL/6/input/profiles/nist-CL-IL-AL.xml
+++ b/RHEL/6/input/profiles/nist-CL-IL-AL.xml
@@ -1,6 +1,6 @@
 <Profile id="nist-cl-il-al" extends="common">
-<title>CNSSI 1253 Low/Low/Low</title>
-<description>This profile follows the Committee on National Security Systems Instruction
+<title override="true">CNSSI 1253 Low/Low/Low</title>
+<description override="true">This profile follows the Committee on National Security Systems Instruction
 (CNSSI) No. 1253, "Security Categorization and Control Selection for National Security
 Systems" on security controls to meet low confidentiality, low integrity, and low
 assurance."</description>

--- a/RHEL/6/input/profiles/server.xml
+++ b/RHEL/6/input/profiles/server.xml
@@ -1,6 +1,6 @@
 <Profile id="server" extends="common">
-<title>Server Baseline</title>
-<description>This profile is for RHEL 6 acting as a server.</description>
+<title override="true">Server Baseline</title>
+<description override="true">This profile is for Red Hat Enterprise Linux 6 acting as a server.</description>
 <select idref="deactivate_wireless_interfaces" selected="true"/>
 <select idref="disable_xwindows_with_runlevel" selected="true"/>
 <select idref="packagegroup_xwindows_remove" selected="true"/>


### PR DESCRIPTION

Fixes downstream bug:
  https://bugzilla.redhat.com/show_bug.cgi?id=1246529

Testing report:
--
The change has been tested on RHEL-6.7 system && works as expected (e.g. the title && description of the ```Server``` profile once this change is applied isn't concatenation of strings from ```Common``` and ```Server``` profiles).

Please review.

Thank you, Jan.