### PR TITLE
[BugFix] [RHEL/7] Various Oscap Anaconda Addon PCI-DSS kickstart fixes

### DIFF
--- a/RHEL/7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
+++ b/RHEL/7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
@@ -1,10 +1,10 @@
 # SCAP Security Guide PCI-DSS profile kickstart for Red Hat Enterprise Linux 7 Server
-# Version: 0.0.1
-# Date: 2015-07-07
+# Version: 0.0.2
+# Date: 2015-08-02
 #
 # Based on:
 # http://fedoraproject.org/wiki/Anaconda/Kickstart
-# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
 # Install a fresh new system (optional)
@@ -17,7 +17,12 @@ install
 # Install from an installation tree on a remote server via FTP or HTTP:
 # --url		the URL to install from
 #
-url --url=http://192.168.122.1/image
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
 #
 # Other possible / supported installation methods:
 # * install from the first CD-ROM/DVD drive on the system:
@@ -114,31 +119,18 @@ logvol swap --name=lv_swap --vgname=VolGroup --size=2016
 %end
 
 # Packages selection (%packages section is required)
-#
-# Packages from the following package groups are installed by default when 'Desktop'
-# Anaconda option is selected when installing Red Hat Enterprise Linux 7 Server
 %packages
-@base
-@core
-@desktop-debugging
-@dial-up
-@fonts
-@gnome-desktop
-@guest-agents
-@guest-desktop-agents
-@input-methods
-@internet-browser
-@multimedia
-@print-client
-@x11
+
+# Require 'Server with GUI' package environment to be installed
+@^Server with GUI
 
 # Install selected additional packages (required by PCI-DSS profile)
 # CCE-27024-9: Install AIDE
 aide
 
-# Install openscap-utils so it's possible to perform remediation once the
+# Install openscap-scanner so it's possible to perform remediation once the
 # installation is complete
-openscap-utils
+openscap-scanner
 
 # Install libreswan package
 libreswan


### PR DESCRIPTION
<br/>
Fix multiple issues in current version of the Oscap Anaconda Add-on formatted kickstart for RHEL-7's PCI-DSS profile:

* Update reference URL to RHEL-7 kickstart syntax guide:
    https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html

* Comment out the 'url' section (mark it just as an example),

* Use '@^Server with GUI' package / comps environment specification
  (instead of listing concrete package groups) as it simplifies the kickstart,  and

* Require 'openscap-scanner' to be installed instead of 'openscap-utils'

Testing report:
--------------
Verified with recent RHEL-7 build it works as expected (after specifying
RHEL-7 image location).

Please review.

Thank you, Jan.