### PR TITLE
[Enhancement] [RHEL/7] New remediation for 'audit_rules_time_clock_settime' rule

### DIFF
--- a/RHEL/7/input/fixes/bash/audit_rules_time_clock_settime.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_time_clock_settime.sh
@@ -1,0 +1,17 @@
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+# First perform the remediation of the syscall rule
+# Retrieve hardware architecture of the underlying system
+[ $(getconf LONG_BIT) = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
+
+for ARCH in "${RULE_ARCHS[@]}"
+do
+	PATTERN="-a always,exit -F arch=$ARCH -S .* -k .*"
+	GROUP="clock_settime"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S clock_settime -k audit_time_rules"
+	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+done


### PR DESCRIPTION
<br/>
Testing report:
---------------
Verified it works fine on RHEL-7 system in both case (```augenrules``` / ```auditctl``` tool
used to load audit rules). Also verified it works fine in the two scenarios:
* audit.rules file contains no rule at all for ```clock_settime``` system call,
* audit.rules file contains partial audit rule definition (e.g. only 32-bit version
  on 64-bit system) for ```clock_settime``` system call.

Please review.

Thank you, Jan.
