### PR TITLE
[BugFix] [shared] Fix false positive in OVAL check for accounts_passwords_pam_faillock_deny rule

### DIFF
--- a/shared/oval/accounts_passwords_pam_faillock_deny.xml
+++ b/shared/oval/accounts_passwords_pam_faillock_deny.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_passwords_pam_faillock_deny" version="3">
+  <definition class="compliance" id="accounts_passwords_pam_faillock_deny" version="4">
     <metadata>
       <title>Lock out account after failed login attempts</title>
       <affected family="unix">
@@ -51,7 +51,7 @@
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so preauth silent in auth section is listed before
          pam_unix.so module in auth section -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+deny=([0-9]+)[\s]*[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*deny=([0-9]+)[\s]*[^\n]*[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -69,7 +69,7 @@
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so in auth section is listed right after pam_unix.so auth row -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]+[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+deny=([0-9]+)[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]+[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*deny=([0-9]+)[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -106,7 +106,7 @@
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so preauth silent in auth section is listed before
          pam_unix.so module in auth section -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+deny=([0-9]+)[\s]*[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*deny=([0-9]+)[\s]*[^\n]*[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -124,7 +124,7 @@
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so in auth section is listed right after pam_unix.so auth row -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]+[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+deny=([0-9]+)[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]+[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*deny=([0-9]+)[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>


### PR DESCRIPTION
The current implementation of OVAL check for ```accounts_passwords_pam_faillock_deny``` rule contains the following bug:
* the regular expression searching for ```deny=``` substring being properly configured in both, ```/etc/pam.d/password-auth```, and ```/etc/pam.d/system-auth``` files is too strict. It requires ```deny=expected_value``` string to be present at the end of ```pam_faillock.so``` row.

But instead of checking if ```deny=expected_value```is present at the end of particular ```pam_faillock.so``` row, we should be checking if ```deny=expected_value``` is at any position (IOW order doesn't matter) in the particular ```pam_faillock.so``` row.

The current OVAL check works fine when just remediation script for ```accounts_passwords_pam_faillock_deny``` rule has been applied (in that case ```deny=expected_value``` will be at the end of particular ```pam_faillock.so``` row).

But it does not work properly (returns false positive) when e.g. also remediation scripts for ```accounts_passwords_pam_faillock_unlock_time``` has been applied (in that case the situation in particular ```pam_faillock.so``` will look as follows):

```
[root@localhost ~]# cat /etc/pam.d/password-auth | grep faillock
auth        required      pam_faillock.so preauth silent deny=6 unlock_time=1800
auth        [default=die] pam_faillock.so authfail deny=6 unlock_time=1800
account     required      pam_faillock.so
```

therefore the current OVAL check for ```accounts_passwords_pam_faillock_deny``` rule will return false even in the case the system in question is configured properly (IOW will return false-positive).

Therefore patch in this PR fixes this issue.

Steps to Reproduce:
----
1) Select ```PCI-DSS``` profile for RHEL-6 or RHEL-7 system when using scap-workbench,
2) Tailor the profile to contain just the following two rules:
```
Set Deny For Failed Password Attempts
Set Lockout Time For Failed Password Attempts
```
3) Scan the un-remediated (RHEL-6 or RHEL-7) system (the actual system release doesn't matter). See like ```fail``` is returned for both rules.
4) Now hit ```Clear`` in scap-workbench. Check-in ```Online-remediation``` checkbox, && hit ```Scan``` again.
5) See how both rules are first ```fail```-ing, then are ```fixed```.
6) Hit ```Clear``` in scap-workbench again, uncheck the ```Online remediation``` checkbox, && hit the ```Scan```button again.

Current result:
---
Rule for ```accounts_passwords_pam_faillock_deny``` is reported as ```fail```ing despite proper configuration being present in both system (```/etc/pam.d/password-auth```, and ```/etc/pam.d/system-auth) files (false-positive).

Expected result:
--
Rule for ```accounts_passwords_pam_faillock_deny``` is reported as ```pass```ing.

Testing report:
--
Have tested the proposed patch on both RHEL-6 && RHEL-7 systems, and AFAICT it seems to be working fine (the aforementioned issue is fixed once this change is applied).

Please review.

Thank you, Jan.

