### PR TITLE
enable-derivatives.py fix for plain XCCDF 1.1

### DIFF
--- a/shared/utils/enable-derivatives.py
+++ b/shared/utils/enable-derivatives.py
@@ -237,6 +237,9 @@ def main():
         root, XCCDF12_NS, benchmarks
     )
 
+    if len(benchmarks) == 0:
+        raise RuntimeError("No Benchmark found!")
+
     for namespace, benchmark in benchmarks:
         if not add_derivative_cpes(benchmark, namespace, mapping):
             raise RuntimeError(

--- a/shared/utils/enable-derivatives.py
+++ b/shared/utils/enable-derivatives.py
@@ -195,7 +195,7 @@ def main():
     parser.add_option("-o", "--output", dest="output", default=False,
                       action="store", help="XML Tree content")
     (options, args) = parser.parse_args()
-     
+
     if options.centos and options.sl:
         print "Cannot enable two derivative OS(s) at the same time"
         parser.print_help()
@@ -221,14 +221,21 @@ def main():
     root = tree.getroot()
 
     benchmarks = []
-    benchmarks.extend([
-        (XCCDF11_NS, elem)
-        for elem in list(root.findall(".//{%s}Benchmark" % (XCCDF11_NS)))
-    ])
-    benchmarks.extend([
-        (XCCDF12_NS, elem)
-        for elem in list(root.findall(".//{%s}Benchmark" % (XCCDF12_NS)))
-    ])
+
+    def scrape_benchmarks(root_element, namespace, dest):
+        dest.extend([
+            (namespace, elem)
+            for elem in list(root.findall(".//{%s}Benchmark" % (namespace)))
+        ])
+        if root_element.tag == "{%s}Benchmark" % (namespace):
+            dest.append((namespace, root_element))
+
+    scrape_benchmarks(
+        root, XCCDF11_NS, benchmarks
+    )
+    scrape_benchmarks(
+        root, XCCDF12_NS, benchmarks
+    )
 
     for namespace, benchmark in benchmarks:
         if not add_derivative_cpes(benchmark, namespace, mapping):

--- a/shared/utils/enable-derivatives.py
+++ b/shared/utils/enable-derivatives.py
@@ -230,12 +230,8 @@ def main():
         if root_element.tag == "{%s}Benchmark" % (namespace):
             dest.append((namespace, root_element))
 
-    scrape_benchmarks(
-        root, XCCDF11_NS, benchmarks
-    )
-    scrape_benchmarks(
-        root, XCCDF12_NS, benchmarks
-    )
+    scrape_benchmarks(root, XCCDF11_NS, benchmarks)
+    scrape_benchmarks(root, XCCDF12_NS, benchmarks)
 
     if len(benchmarks) == 0:
         raise RuntimeError("No Benchmark found!")


### PR DESCRIPTION
Fixing issue reported by Michael Boutillier. The `enable-derivatives.py` script failed to find the Benchmark element if it is also the root element in the XML document.

Verbatim bug report:
```
Hi all,
Thirst thanks a lot for the all the good work done here ;)

I experience  a strange issue after building via make the ssg for
centos6 (0.1.24
release)

When running :

/usr/bin/oscap xccdf eval --profile pci-dss
/usr/share/xml/scap/ssg-centos6-xccdf/ssg-centos6-xccdf.xml

All check are not applicable



Looking at the content of the produced xccdf i notive that the platform tag
was still referencing rhel and not centos cpe


To make the resulting xccdf work on a centos6 I had to change the following
line in ssg-centos6-xccdf.xml:

*<ns0:platform idref="cpe:/o:linux: enterprise_linux:6" />*

by

*<ns0:platform idref="cpe:/o:centos:centos:6" />*


And now the command bellow work as expected

/usr/bin/oscap xccdf eval --profile pci-dss
/usr/share/xml/scap/ssg-centos6-xccdf/ssg-centos6-xccdf.xml





So I took a big breath and I try to run the enable-derivative.py by hand



When I run it with ds or xccdf the result  differs :



*../../shared/utils/enable-derivatives.py --enable-centos -i
output/ssg-rhel6-xccdf.xml  -o /tmp/mike-centos6-xccdf.xml*

*[mike@caprica 6]$ grep platform /tmp/mike-centos6-xccdf.xml |grep cent*

 --> no output





*../../shared/utils/enable-derivatives.py --enable-centos -i
output/ssg-rhel6-ds.xml  -o /tmp/mike-centos6-ds.xml*



*[mike@caprica 6]$ grep platform /tmp/mike-centos6-ds.xml |grep cent*

*  <ns9:platform idref="cpe:/o:centos:centos:6" />*

 --> we have the centos6 as expected





Digging deeper I thought that it is probably related to the following line:


*    benchmarks.extend([*

*        (XCCDF11_NS, elem)*

*        for elem in list(root.findall(".//{%s}Benchmark" % (XCCDF11_NS)))*

*    ])*

*    benchmarks.extend([*

*        (XCCDF12_NS, elem)*

*        for elem in list(root.findall(".//{%s}Benchmark" % (XCCDF12_NS)))*

*    ])                                                             *

For a strange reason the root.findall seems not to work with the xccdf file

I could not find out why this is not working….



XCCDF :

*<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.1
<http://checklists.nist.gov/xccdf/1.1>"
xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance
<http://www.w3.org/2001/XMLSchema-instance>" id="RHEL-6" resolved="1"
xml:lang="en-US">*



DS:

*<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2
<http://checklists.nist.gov/xccdf/1.2>"
id="xccdf_org.ssgproject.content_benchmark_RHEL-6" resolved="1"
xml:lang="en-US">*





To make a silly test I try the following


*  benchmarks.extend([*

*        (XCCDF11_NS, elem)*

*        for elem in
list(root.findall("."))
*

*    ])*



*../../shared/utils/enable-derivatives.py --enable-centos -i
output/ssg-rhel6-xccdf.xml  -o /tmp/mikeeeee*



*[mike@caprica 6]$ grep centos /tmp/mikeeeee*

*  <ns0:notice id="centos_warning"><html:div>*

*  <ns0:platform idref="cpe:/o:centos:centos:6" />*





The result make me think i'm on looking on the right spot, but I could not
find out why.

Somebody got an idea of what is going on? Or am I totaly missing something


Regards

Mike


PS : the same issue seems to affect RHEL7

REPS: i try to build on centos6 and fedora 21 (just in case i had a strange
python dep issue or something) : same result

-- 
Michael Boutillier


-- 
SCAP Security Guide mailing list
scap-security-guide@lists.fedorahosted.org
https://lists.fedorahosted.org/mailman/listinfo/scap-security-guide
https://github.com/OpenSCAP/scap-security-guide/
```