### PR TITLE
[BugFix] Mark PCI-DSS profiles for Red Hat Enterprise Linux 6 and 7 products as tech-preview for now by prefixing the title with 'Draft' keyword

### DIFF
--- a/RHEL/6/input/profiles/pci-dss.xml
+++ b/RHEL/6/input/profiles/pci-dss.xml
@@ -1,5 +1,5 @@
 <Profile id="pci-dss" xmlns="http://checklists.nist.gov/xccdf/1.1">
-<title>PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 6</title>
+<title>Draft PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 6</title>
 <description>This is a *draft* profile for PCI-DSS v3</description>
 
 <refine-value idref="var_password_pam_unix_remember" selector="4" />

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -1,5 +1,5 @@
 <Profile id="pci-dss" xmlns="http://checklists.nist.gov/xccdf/1.1">
-<title>PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7</title>
+<title>Draft PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7</title>
 <description>This is a *draft* profile for PCI-DSS v3</description>
 
 <refine-value idref="var_password_pam_unix_remember" selector="4" />


### PR DESCRIPTION
<br/>
The current PCI-DSS profiles implementation for Red Hat Enterprise Linux 6 and 7 products is not final version yet (it's a tech preview for now). To mention some missing features, - e.g. there are couple of rules to be ported to RHEL-7 yet, also the PCI-DSS Requirement #1 - #8 IDs need to be added to rule references prior these profiles can be considered final / completed.

Therefore mark them as tech-preview for now by prefixing the respective profile titles with 'Draft' keyword.

Please review.

Thank you, Jan.
