### PR TITLE
[BugFix] [Enhancement] [RHEL/7] [Fedora] Various auditd.conf related OVAL checks fixes

### DIFF
--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -49,6 +49,7 @@
 
   <refine-value idref="var_auditd_num_logs" selector="5"/>
   <select idref="auditd_data_retention_num_logs" selected="true"/>
+  <select idref="auditd_data_retention_max_log_file" selected="true"/>
 
   <select idref="audit_rules_time_adjtimex" selected="true"/>
   <select idref="audit_rules_time_settimeofday" selected="true"/>

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -54,6 +54,7 @@
   <select idref="auditd_data_retention_space_left_action" selected="true"/>
   <select idref="auditd_data_retention_admin_space_left_action" selected="true"/>
   <select idref="auditd_data_retention_action_mail_acct" selected="true"/>
+  <select idref="file_ownership_var_log_audit" selected="true"/>
 
   <select idref="audit_rules_time_adjtimex" selected="true"/>
   <select idref="audit_rules_time_settimeofday" selected="true"/>

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -52,6 +52,7 @@
   <select idref="auditd_data_retention_max_log_file" selected="true"/>
   <select idref="auditd_data_retention_max_log_file_action" selected="true"/>
   <select idref="auditd_data_retention_space_left_action" selected="true"/>
+  <select idref="auditd_data_retention_admin_space_left_action" selected="true"/>
 
   <select idref="audit_rules_time_adjtimex" selected="true"/>
   <select idref="audit_rules_time_settimeofday" selected="true"/>

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -47,6 +47,9 @@
 
 <!-- Audit section rules -->
 
+  <refine-value idref="var_auditd_num_logs" selector="5"/>
+  <select idref="auditd_data_retention_num_logs" selected="true"/>
+
   <select idref="audit_rules_time_adjtimex" selected="true"/>
   <select idref="audit_rules_time_settimeofday" selected="true"/>
   <select idref="audit_rules_time_stime" selected="true"/>

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -50,6 +50,7 @@
   <refine-value idref="var_auditd_num_logs" selector="5"/>
   <select idref="auditd_data_retention_num_logs" selected="true"/>
   <select idref="auditd_data_retention_max_log_file" selected="true"/>
+  <select idref="auditd_data_retention_max_log_file_action" selected="true"/>
 
   <select idref="audit_rules_time_adjtimex" selected="true"/>
   <select idref="audit_rules_time_settimeofday" selected="true"/>

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -51,6 +51,7 @@
   <select idref="auditd_data_retention_num_logs" selected="true"/>
   <select idref="auditd_data_retention_max_log_file" selected="true"/>
   <select idref="auditd_data_retention_max_log_file_action" selected="true"/>
+  <select idref="auditd_data_retention_space_left_action" selected="true"/>
 
   <select idref="audit_rules_time_adjtimex" selected="true"/>
   <select idref="audit_rules_time_settimeofday" selected="true"/>

--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -53,6 +53,7 @@
   <select idref="auditd_data_retention_max_log_file_action" selected="true"/>
   <select idref="auditd_data_retention_space_left_action" selected="true"/>
   <select idref="auditd_data_retention_admin_space_left_action" selected="true"/>
+  <select idref="auditd_data_retention_action_mail_acct" selected="true"/>
 
   <select idref="audit_rules_time_adjtimex" selected="true"/>
   <select idref="audit_rules_time_settimeofday" selected="true"/>

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -283,7 +283,7 @@ log file size and the number of logs retained.</rationale>
 <ref nist="AU-1(b),AU-11,IR-5" />
 </Rule>
 
-<Rule id="configure_auditd_max_log_file_action" severity="medium">
+<Rule id="auditd_data_retention_max_log_file_action" severity="medium">
 <title>Configure auditd max_log_file_action Upon Reaching Maximum Log Size</title>
 <description> The default action to take when the logs reach their maximum size
 is to rotate the log files, discarding the oldest one. To configure the action taken

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -393,7 +393,7 @@ or halt when disk space has run low:
 audit records. If a separate partition or logical volume of adequate size
 is used, running low on space for audit records should never occur.
 </rationale>
-<!-- <oval id="auditd_data_retention_admin_space_left_action" value="var_auditd_admin_space_left_action" /> -->
+<oval id="auditd_data_retention_admin_space_left_action" value="var_auditd_admin_space_left_action" />
 <ref nist="AU-1(b),AU-4,AU-5(b),IR-5" disa="140,1343" />
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -313,7 +313,7 @@ minimizes the chances of the system unexpectedly running out of disk space by
 being overwhelmed with log data. However, for systems that must never discard
 log data, or which use external processes to transfer it and reclaim space,
 <tt>keep_logs</tt> can be employed.</rationale>
-<!-- <oval id="auditd_data_retention_max_log_file_action" value="var_auditd_max_log_file_action" /> -->
+<oval id="auditd_data_retention_max_log_file_action" value="var_auditd_max_log_file_action" />
 <ref nist="AU-1(b),AU-4,AU-11,IR-5" />
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -279,7 +279,7 @@ determine how much data the system will retain in each audit log file:
 <rationale>The total storage for audit log files must be large enough to retain
 log information over the period required. This is a function of the maximum
 log file size and the number of logs retained.</rationale>
-<!-- <oval id="auditd_data_retention_max_log_file" value="var_auditd_max_log_file" />  -->
+<oval id="auditd_data_retention_max_log_file" value="var_auditd_max_log_file" />
 <ref nist="AU-1(b),AU-11,IR-5" />
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -776,7 +776,7 @@ If users can write to audit logs, audit trails can be modified or destroyed.
 </ocil>
 <rationale>Failure to give ownership of the audit log files to root allows the designated
 owner, and unauthorized users, potential access to sensitive information.</rationale>
-<!-- <oval id="file_ownership_var_log_audit" /> -->
+<oval id="file_ownership_var_log_audit" />
 <ref nist="AC-6,AU-1(b),AU-9,IR-5" disa="166" />
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -260,7 +260,7 @@ file size and the number of logs retained.</rationale>
 <ref nist="AU-1(b),AU-11,IR-5" />
 </Rule>
 
-<Rule id="configure_auditd_max_log_file" severity="medium">
+<Rule id="auditd_data_retention_max_log_file" severity="medium">
 <title>Configure auditd Max Log File Size</title>
 <description>Determine the amount of audit data (in megabytes)
 which should be retained in each log file. Edit the file

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -364,7 +364,7 @@ Acceptable values are <tt>email</tt>, <tt>suspend</tt>, <tt>single</tt>, and <tt
 </ocil>
 <rationale>Notifying administrators of an impending disk space problem may
 allow them to take corrective action prior to any disruption.</rationale>
-<!-- <oval id="auditd_data_retention_space_left_action" value="var_auditd_space_left_action"/> -->
+<oval id="auditd_data_retention_space_left_action" value="var_auditd_space_left_action"/>
 <ref nist="AU-1(b),AU-4,AU-5(b),IR-5" disa="140,143" />
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -238,7 +238,7 @@ normally.</i>
 <value selector="sync">sync</value>
 </Value>
 
-<Rule id="configure_auditd_num_logs" severity="medium">
+<Rule id="auditd_data_retention_num_logs" severity="medium">
 <title>Configure auditd Number of Logs Retained</title>
 <description>Determine how many log files
 <tt>auditd</tt> should retain when it rotates logs.

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -256,7 +256,7 @@ determine how many logs the system is configured to retain after rotation:
 <rationale>The total storage for audit log files must be large enough to retain
 log information over the period required. This is a function of the maximum log
 file size and the number of logs retained.</rationale>
-<!-- <oval id="auditd_data_retention_num_logs" value="var_auditd_num_logs" />  -->
+<oval id="auditd_data_retention_num_logs" value="var_auditd_num_logs" />
 <ref nist="AU-1(b),AU-11,IR-5" />
 </Rule>
 

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -766,7 +766,7 @@ If users can write to audit logs, audit trails can be modified or destroyed.
 <ref nist="AC-6,AU-1(b),AU-9,IR-5" disa="" />
 </Rule>
 
-<Rule id="audit_logs_rootowner">
+<Rule id="file_ownership_var_log_audit">
 <title>System Audit Logs Must Be Owned By Root</title>
 <description>
 <fileowner-desc-macro file="/var/log" owner="root"/>

--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -413,7 +413,7 @@ account when it needs to notify an administrator:
 </ocil>
 <rationale>Email sent to the root account is typically aliased to the
 administrators of the system, who can take appropriate action.</rationale>
-<!-- <oval id="auditd_data_retention_action_mail_acct" value="var_auditd_action_mail_acct" /> -->
+<oval id="auditd_data_retention_action_mail_acct" value="var_auditd_action_mail_acct" />
 <ref nist="AU-1(b),AU-4,AU-5(a),IR-5" disa="139,144" />
 </Rule>
 

--- a/OpenStack/input/profiles/stig-rhevm3.xml
+++ b/OpenStack/input/profiles/stig-rhevm3.xml
@@ -110,7 +110,7 @@
 <select idref="enable_auditd_bootloader" selected="true"/>
 
 <select idref="auditd_data_retention_num_logs" selected="true"/>
-<select idref="configure_auditd_max_log_file" selected="true"/>
+<select idref="auditd_data_retention_max_log_file" selected="true"/>
 <select idref="configure_auditd_max_log_file_action" selected="true"/>
 <select idref="configure_auditd_admin_space_left_action" selected="true"/>
 

--- a/OpenStack/input/profiles/stig-rhevm3.xml
+++ b/OpenStack/input/profiles/stig-rhevm3.xml
@@ -109,7 +109,7 @@
 <select idref="enable_auditd_service" selected="true"/>
 <select idref="enable_auditd_bootloader" selected="true"/>
 
-<select idref="configure_auditd_num_logs" selected="true"/>
+<select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="configure_auditd_max_log_file" selected="true"/>
 <select idref="configure_auditd_max_log_file_action" selected="true"/>
 <select idref="configure_auditd_admin_space_left_action" selected="true"/>

--- a/OpenStack/input/profiles/stig-rhevm3.xml
+++ b/OpenStack/input/profiles/stig-rhevm3.xml
@@ -111,7 +111,7 @@
 
 <select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="auditd_data_retention_max_log_file" selected="true"/>
-<select idref="configure_auditd_max_log_file_action" selected="true"/>
+<select idref="auditd_data_retention_max_log_file_action" selected="true"/>
 <select idref="configure_auditd_admin_space_left_action" selected="true"/>
 
 <!-- <select idref="audit_time_rules" selected="true"/> -->

--- a/RHEL/6/input/auxiliary/stig_overlay.xml
+++ b/RHEL/6/input/auxiliary/stig_overlay.xml
@@ -1071,7 +1071,7 @@
 		<VMSinfo VKey="38498" SVKey="50299" VRelease="1" />
 		<title>Audit log files must have mode 0640 or less permissive.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="audit_logs_rootowner" ownerid="RHEL-06-000384" disa="162" severity="medium">
+	<overlay owner="disastig" ruleid="file_ownership_var_log_audit" ownerid="RHEL-06-000384" disa="162" severity="medium">
 		<VMSinfo VKey="38495" SVKey="50296" VRelease="1" />
 		<title>Audit log files must be owned by root.</title>
 	</overlay>

--- a/RHEL/6/input/auxiliary/stig_overlay.xml
+++ b/RHEL/6/input/auxiliary/stig_overlay.xml
@@ -449,7 +449,7 @@
 	<overlay owner="disastig" ruleid="bootloader_audit_argument" ownerid="RHEL-06-000157" disa="1464" severity="low">
 		<title>Auditing must be enabled at boot by setting a kernel parameter.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="configure_auditd_num_logs" ownerid="RHEL-06-000159" disa="366" severity="medium">
+	<overlay owner="disastig" ruleid="auditd_data_retention_num_logs" ownerid="RHEL-06-000159" disa="366" severity="medium">
 		<VMSinfo VKey="38636" SVKey="50437" VRelease="1" />
 		<title>The system must retain enough rotated audit logs to cover the required log retention period.</title>
 	</overlay>

--- a/RHEL/6/input/auxiliary/stig_overlay.xml
+++ b/RHEL/6/input/auxiliary/stig_overlay.xml
@@ -457,7 +457,7 @@
 		<VMSinfo VKey="38633" SVKey="50434" VRelease="1" />
 		<title>The system must set a maximum audit log file size.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="configure_auditd_max_log_file_action" ownerid="RHEL-06-000161" disa="366" severity="medium">
+	<overlay owner="disastig" ruleid="auditd_data_retention_max_log_file_action" ownerid="RHEL-06-000161" disa="366" severity="medium">
 		<VMSinfo VKey="38634" SVKey="50435" VRelease="1" />
 		<title>The system must rotate audit log files that reach the maximum file size.</title>
 	</overlay>

--- a/RHEL/6/input/auxiliary/stig_overlay.xml
+++ b/RHEL/6/input/auxiliary/stig_overlay.xml
@@ -453,7 +453,7 @@
 		<VMSinfo VKey="38636" SVKey="50437" VRelease="1" />
 		<title>The system must retain enough rotated audit logs to cover the required log retention period.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="configure_auditd_max_log_file" ownerid="RHEL-06-000160" disa="366" severity="medium">
+	<overlay owner="disastig" ruleid="auditd_data_retention_max_log_file" ownerid="RHEL-06-000160" disa="366" severity="medium">
 		<VMSinfo VKey="38633" SVKey="50434" VRelease="1" />
 		<title>The system must set a maximum audit log file size.</title>
 	</overlay>

--- a/RHEL/6/input/profiles/C2S.xml
+++ b/RHEL/6/input/profiles/C2S.xml
@@ -406,7 +406,7 @@ baseline.
 <select idref="auditd_data_retention_admin_space_left_action" selected="true" />
 
 <!-- CIS 5.2.1.3 Keep All Auditing Information (Scored) -->
-<select idref="configure_auditd_max_log_file_action" selected="true" />
+<select idref="auditd_data_retention_max_log_file_action" selected="true" />
 
 <!-- CIS 5.2.2 Enable auditd Service (Scored) -->
 <select idref="service_auditd_enabled" selected="true"/>

--- a/RHEL/6/input/profiles/C2S.xml
+++ b/RHEL/6/input/profiles/C2S.xml
@@ -398,7 +398,7 @@ baseline.
 <!-- CIS 5.2 Configure System Accounting (auditd) -->
 <!-- CIS 5.2.1 Configure Data Retention -->
 <!-- CIS 5.2.1.1 Configure Audit Log Storage Size (Not Scored) -->
-<select idref="configure_auditd_max_log_file" selected="true"/>
+<select idref="auditd_data_retention_max_log_file" selected="true"/>
 
 <!-- CIS 5.2.1.2 Disable System on Audit Log Full (Not Scored) -->
 <select idref="auditd_data_retention_space_left_action" selected="true" />

--- a/RHEL/6/input/profiles/CS2.xml
+++ b/RHEL/6/input/profiles/CS2.xml
@@ -137,7 +137,7 @@
 <select idref="audit_rules_kernel_module_loading" selected="true"/>
 <select idref="audit_rules_immutable" selected="true" />
 <select idref="file_permissions_var_log_audit" selected="true"/>
-<select idref="audit_logs_rootowner" selected="true" />
+<select idref="file_ownership_var_log_audit" selected="true" />
 <select idref="audit_rules_login_events" selected="true" />
 <select idref="audit_rules_session_events" selected="true" />
 <select idref="audit_rules_unsuccessful_file_modification" selected="true"/>

--- a/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
+++ b/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
@@ -55,7 +55,7 @@ for production deployment.</description>
 <select idref="auditd_data_retention_action_mail_acct" selected="true" />
 <select idref="auditd_data_retention_admin_space_left_action" selected="true" />
 <select idref="configure_auditd_audispd" selected="true" />
-<select idref="configure_auditd_max_log_file" selected="true" />
+<select idref="auditd_data_retention_max_log_file" selected="true" />
 <select idref="configure_auditd_max_log_file_action" selected="true" />
 <select idref="auditd_data_retention_num_logs" selected="true" />
 <select idref="auditd_data_retention_space_left_action" selected="true" />

--- a/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
+++ b/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
@@ -56,7 +56,7 @@ for production deployment.</description>
 <select idref="auditd_data_retention_admin_space_left_action" selected="true" />
 <select idref="configure_auditd_audispd" selected="true" />
 <select idref="auditd_data_retention_max_log_file" selected="true" />
-<select idref="configure_auditd_max_log_file_action" selected="true" />
+<select idref="auditd_data_retention_max_log_file_action" selected="true" />
 <select idref="auditd_data_retention_num_logs" selected="true" />
 <select idref="auditd_data_retention_space_left_action" selected="true" />
 <select idref="cups_disable_browsing" selected="false" />

--- a/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
+++ b/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
@@ -23,7 +23,7 @@ for production deployment.</description>
 <select idref="audit_rules_file_deletion_events" selected="false" />
 <select idref="audit_rules_kernel_module_loading" selected="true" />
 <select idref="file_permissions_var_log_audit" selected="true" />
-<select idref="audit_logs_rootowner" selected="true" />
+<select idref="file_ownership_var_log_audit" selected="true" />
 <select idref="audit_rules_mac_modification" selected="true" />
 <select idref="audit_rules_login_events" selected="true" />
 <select idref="audit_rules_session_events" selected="true" />

--- a/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
+++ b/RHEL/6/input/profiles/CSCF-RHEL6-MLS.xml
@@ -57,7 +57,7 @@ for production deployment.</description>
 <select idref="configure_auditd_audispd" selected="true" />
 <select idref="configure_auditd_max_log_file" selected="true" />
 <select idref="configure_auditd_max_log_file_action" selected="true" />
-<select idref="configure_auditd_num_logs" selected="true" />
+<select idref="auditd_data_retention_num_logs" selected="true" />
 <select idref="auditd_data_retention_space_left_action" selected="true" />
 <select idref="cups_disable_browsing" selected="false" />
 <select idref="cups_disable_printserver" selected="true" />

--- a/RHEL/6/input/profiles/common.xml
+++ b/RHEL/6/input/profiles/common.xml
@@ -112,7 +112,7 @@
 
 <select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="auditd_data_retention_max_log_file" selected="true"/>
-<select idref="configure_auditd_max_log_file_action" selected="true"/>
+<select idref="auditd_data_retention_max_log_file_action" selected="true"/>
 <select idref="auditd_data_retention_admin_space_left_action" selected="true"/>
 
 <!-- <select idref="audit_time_rules" selected="true"/> -->

--- a/RHEL/6/input/profiles/common.xml
+++ b/RHEL/6/input/profiles/common.xml
@@ -111,7 +111,7 @@
 <select idref="bootloader_audit_argument" selected="true"/>
 
 <select idref="auditd_data_retention_num_logs" selected="true"/>
-<select idref="configure_auditd_max_log_file" selected="true"/>
+<select idref="auditd_data_retention_max_log_file" selected="true"/>
 <select idref="configure_auditd_max_log_file_action" selected="true"/>
 <select idref="auditd_data_retention_admin_space_left_action" selected="true"/>
 

--- a/RHEL/6/input/profiles/common.xml
+++ b/RHEL/6/input/profiles/common.xml
@@ -110,7 +110,7 @@
 <select idref="service_auditd_enabled" selected="true"/>
 <select idref="bootloader_audit_argument" selected="true"/>
 
-<select idref="configure_auditd_num_logs" selected="true"/>
+<select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="configure_auditd_max_log_file" selected="true"/>
 <select idref="configure_auditd_max_log_file_action" selected="true"/>
 <select idref="auditd_data_retention_admin_space_left_action" selected="true"/>

--- a/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
+++ b/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
@@ -191,7 +191,7 @@
 
 <!--	AU-1(b) -->
 <select idref="auditd_data_retention_num_logs" selected="true" />
-<select idref="configure_auditd_max_log_file" selected="true" />
+<select idref="auditd_data_retention_max_log_file" selected="true" />
 <select idref="configure_auditd_max_log_file_action" selected="true" />
 <select idref="auditd_data_retention_space_left_action" selected="true" />
 <refine-value idref="var_auditd_admin_space_left_action" selector="halt" />

--- a/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
+++ b/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
@@ -65,7 +65,7 @@
 <select idref="userowner_rsyslog_files" selected="true" />
 <select idref="groupowner_rsyslog_files" selected="true" />
 <select idref="file_permissions_var_log_audit" selected="true" />
-<select idref="audit_logs_rootowner" selected="true" />
+<select idref="file_ownership_var_log_audit" selected="true" />
 <select idref="audit_rules_immutable" selected="true" />
 <select idref="accounts_no_uid_except_zero" selected="true" />
 <select idref="rpm_verify_permissions" selected="true" />
@@ -211,7 +211,7 @@
 <select idref="package_rsyslog_installed" selected="true" />
 <select idref="rsyslog_accept_remote_messages_none" selected="true" />
 <select idref="ensure_logrotate_activated" selected="true" />
-<select idref="audit_logs_rootowner" selected="true" />
+<select idref="file_ownership_var_log_audit" selected="true" />
 <select idref="partition_for_var_log" selected="true" />
 
 <!--	CM-3 -->

--- a/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
+++ b/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
@@ -190,7 +190,7 @@
 <select idref="service_autofs_disabled" selected="true" />
 
 <!--	AU-1(b) -->
-<select idref="configure_auditd_num_logs" selected="true" />
+<select idref="auditd_data_retention_num_logs" selected="true" />
 <select idref="configure_auditd_max_log_file" selected="true" />
 <select idref="configure_auditd_max_log_file_action" selected="true" />
 <select idref="auditd_data_retention_space_left_action" selected="true" />

--- a/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
+++ b/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
@@ -192,7 +192,7 @@
 <!--	AU-1(b) -->
 <select idref="auditd_data_retention_num_logs" selected="true" />
 <select idref="auditd_data_retention_max_log_file" selected="true" />
-<select idref="configure_auditd_max_log_file_action" selected="true" />
+<select idref="auditd_data_retention_max_log_file_action" selected="true" />
 <select idref="auditd_data_retention_space_left_action" selected="true" />
 <refine-value idref="var_auditd_admin_space_left_action" selector="halt" />
 <select idref="auditd_data_retention_admin_space_left_action" selected="true" />

--- a/RHEL/6/input/profiles/nist-CL-IL-AL.xml
+++ b/RHEL/6/input/profiles/nist-CL-IL-AL.xml
@@ -265,7 +265,7 @@ assurance."</description>
 <!-- AU-1(b) -->
 <select idref="auditd_data_retention_num_logs" selected="true" />
 <select idref="auditd_data_retention_max_log_file" selected="true" />
-<select idref="configure_auditd_max_log_file_action" selected="true" />
+<select idref="auditd_data_retention_max_log_file_action" selected="true" />
 <select idref="auditd_data_retention_space_left_action" selected="true" />
 <select idref="auditd_data_retention_admin_space_left_action" selected="true" />
 <select idref="auditd_data_retention_action_mail_acct" selected="true" />

--- a/RHEL/6/input/profiles/nist-CL-IL-AL.xml
+++ b/RHEL/6/input/profiles/nist-CL-IL-AL.xml
@@ -264,7 +264,7 @@ assurance."</description>
 
 <!-- AU-1(b) -->
 <select idref="auditd_data_retention_num_logs" selected="true" />
-<select idref="configure_auditd_max_log_file" selected="true" />
+<select idref="auditd_data_retention_max_log_file" selected="true" />
 <select idref="configure_auditd_max_log_file_action" selected="true" />
 <select idref="auditd_data_retention_space_left_action" selected="true" />
 <select idref="auditd_data_retention_admin_space_left_action" selected="true" />

--- a/RHEL/6/input/profiles/nist-CL-IL-AL.xml
+++ b/RHEL/6/input/profiles/nist-CL-IL-AL.xml
@@ -131,7 +131,7 @@ assurance."</description>
 <select idref="service_oddjobd_disabled" selected="true" />
 <select idref="rpm_verify_permissions" selected="true" />
 <select idref="file_permissions_var_log_audit" selected="true" />
-<select idref="audit_logs_rootowner" selected="true" />
+<select idref="file_ownership_var_log_audit" selected="true" />
 <select idref="userowner_shadow_file" selected="true" />
 <select idref="groupowner_shadow_file" selected="true" />
 <select idref="file_permissions_etc_shadow" selected="true" />

--- a/RHEL/6/input/profiles/nist-CL-IL-AL.xml
+++ b/RHEL/6/input/profiles/nist-CL-IL-AL.xml
@@ -263,7 +263,7 @@ assurance."</description>
 <select idref="gconf_gnome_disable_automount" selected="true" />
 
 <!-- AU-1(b) -->
-<select idref="configure_auditd_num_logs" selected="true" />
+<select idref="auditd_data_retention_num_logs" selected="true" />
 <select idref="configure_auditd_max_log_file" selected="true" />
 <select idref="configure_auditd_max_log_file_action" selected="true" />
 <select idref="auditd_data_retention_space_left_action" selected="true" />

--- a/RHEL/6/input/profiles/pci-dss.xml
+++ b/RHEL/6/input/profiles/pci-dss.xml
@@ -28,7 +28,7 @@
 <select idref="audit_rules_usergroup_modification" selected="true"/>
 <select idref="audit_rules_networkconfig_modification" selected="true"/>
 <select idref="file_permissions_var_log_audit" selected="true"/>
-<select idref="audit_logs_rootowner" selected="true"/>
+<select idref="file_ownership_var_log_audit" selected="true"/>
 <select idref="audit_rules_mac_modification" selected="true"/>
 <select idref="audit_rules_dac_modification_chmod" selected="true"/>
 <select idref="audit_rules_dac_modification_chown" selected="true"/>

--- a/RHEL/6/input/profiles/pci-dss.xml
+++ b/RHEL/6/input/profiles/pci-dss.xml
@@ -13,7 +13,7 @@
 
 <select idref="service_auditd_enabled" selected="true"/>
 <select idref="bootloader_audit_argument" selected="true"/>
-<select idref="configure_auditd_num_logs" selected="true"/>
+<select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="configure_auditd_max_log_file" selected="true"/>
 <select idref="configure_auditd_max_log_file_action" selected="true"/>
 <select idref="auditd_data_retention_space_left_action" selected="true"/>

--- a/RHEL/6/input/profiles/pci-dss.xml
+++ b/RHEL/6/input/profiles/pci-dss.xml
@@ -15,7 +15,7 @@
 <select idref="bootloader_audit_argument" selected="true"/>
 <select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="auditd_data_retention_max_log_file" selected="true"/>
-<select idref="configure_auditd_max_log_file_action" selected="true"/>
+<select idref="auditd_data_retention_max_log_file_action" selected="true"/>
 <select idref="auditd_data_retention_space_left_action" selected="true"/>
 <select idref="auditd_data_retention_admin_space_left_action" selected="true"/>
 <select idref="auditd_data_retention_action_mail_acct" selected="true"/>

--- a/RHEL/6/input/profiles/pci-dss.xml
+++ b/RHEL/6/input/profiles/pci-dss.xml
@@ -14,7 +14,7 @@
 <select idref="service_auditd_enabled" selected="true"/>
 <select idref="bootloader_audit_argument" selected="true"/>
 <select idref="auditd_data_retention_num_logs" selected="true"/>
-<select idref="configure_auditd_max_log_file" selected="true"/>
+<select idref="auditd_data_retention_max_log_file" selected="true"/>
 <select idref="configure_auditd_max_log_file_action" selected="true"/>
 <select idref="auditd_data_retention_space_left_action" selected="true"/>
 <select idref="auditd_data_retention_admin_space_left_action" selected="true"/>

--- a/RHEL/6/input/profiles/test.xml
+++ b/RHEL/6/input/profiles/test.xml
@@ -29,7 +29,7 @@
 
 
 
-<select idref="configure_auditd_num_logs" selected="true"/>
+<select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="configure_auditd_max_log_file" selected="true"/>
 <select idref="auditd_data_retention_action_mail_acct" selected="true"/>
 <select idref="auditd_data_retention_space_left_action" selected="true"/>

--- a/RHEL/6/input/profiles/test.xml
+++ b/RHEL/6/input/profiles/test.xml
@@ -34,7 +34,7 @@
 <select idref="auditd_data_retention_action_mail_acct" selected="true"/>
 <select idref="auditd_data_retention_space_left_action" selected="true"/>
 <select idref="auditd_data_retention_admin_space_left_action" selected="true"/>
-<select idref="configure_auditd_max_log_file_action" selected="true"/>
+<select idref="auditd_data_retention_max_log_file_action" selected="true"/>
 
 <refine-value idref="var_auditd_num_logs" selector="5"/>
 <refine-value idref="var_auditd_max_log_file" selector="6"/>

--- a/RHEL/6/input/profiles/test.xml
+++ b/RHEL/6/input/profiles/test.xml
@@ -30,7 +30,7 @@
 
 
 <select idref="auditd_data_retention_num_logs" selected="true"/>
-<select idref="configure_auditd_max_log_file" selected="true"/>
+<select idref="auditd_data_retention_max_log_file" selected="true"/>
 <select idref="auditd_data_retention_action_mail_acct" selected="true"/>
 <select idref="auditd_data_retention_space_left_action" selected="true"/>
 <select idref="auditd_data_retention_admin_space_left_action" selected="true"/>

--- a/RHEL/6/input/system/auditing.xml
+++ b/RHEL/6/input/system/auditing.xml
@@ -237,7 +237,7 @@ normally.</i>
 <value selector="sync">sync</value>
 </Value>
 
-<Rule id="configure_auditd_num_logs" severity="medium">
+<Rule id="auditd_data_retention_num_logs" severity="medium">
 <title>Configure auditd Number of Logs Retained</title>
 <description>Determine how many log files
 <tt>auditd</tt> should retain when it rotates logs.

--- a/RHEL/6/input/system/auditing.xml
+++ b/RHEL/6/input/system/auditing.xml
@@ -286,7 +286,7 @@ log file size and the number of logs retained.</rationale>
 <tested by="DS" on="20121024"/>
 </Rule>
 
-<Rule id="configure_auditd_max_log_file_action" severity="medium">
+<Rule id="auditd_data_retention_max_log_file_action" severity="medium">
 <title>Configure auditd max_log_file_action Upon Reaching Maximum Log Size</title>
 <description> The default action to take when the logs reach their maximum size
 is to rotate the log files, discarding the oldest one. To configure the action taken

--- a/RHEL/6/input/system/auditing.xml
+++ b/RHEL/6/input/system/auditing.xml
@@ -732,7 +732,7 @@ If users can write to audit logs, audit trails can be modified or destroyed.
 <tested by="DS" on="20121024"/>
 </Rule> 
 
-<Rule id="audit_logs_rootowner">
+<Rule id="file_ownership_var_log_audit">
 <title>System Audit Logs Must Be Owned By Root</title>
 <description>
 <fileowner-desc-macro file="/var/log" owner="root"/>

--- a/RHEL/6/input/system/auditing.xml
+++ b/RHEL/6/input/system/auditing.xml
@@ -261,7 +261,7 @@ file size and the number of logs retained.</rationale>
 <tested by="DS" on="20121024"/>
 </Rule>
 
-<Rule id="configure_auditd_max_log_file" severity="medium">
+<Rule id="auditd_data_retention_max_log_file" severity="medium">
 <title>Configure auditd Max Log File Size</title>
 <description>Determine the amount of audit data (in megabytes)
 which should be retained in each log file. Edit the file

--- a/RHEL/7/input/auxiliary/stig_overlay.xml
+++ b/RHEL/7/input/auxiliary/stig_overlay.xml
@@ -1057,7 +1057,7 @@
 		<VMSinfo VKey="38498" SVKey="50299" VRelease="1" />
 		<title>Audit log files must have mode 0640 or less permissive.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="audit_logs_rootowner" ownerid="RHEL-06-000384" disa="162" severity="medium">
+	<overlay owner="disastig" ruleid="file_ownership_var_log_audit" ownerid="RHEL-06-000384" disa="162" severity="medium">
 		<VMSinfo VKey="38495" SVKey="50296" VRelease="1" />
 		<title>Audit log files must be owned by root.</title>
 	</overlay>

--- a/RHEL/7/input/auxiliary/stig_overlay.xml
+++ b/RHEL/7/input/auxiliary/stig_overlay.xml
@@ -445,7 +445,7 @@
 		<VMSinfo VKey="38633" SVKey="50434" VRelease="1" />
 		<title>The system must set a maximum audit log file size.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="configure_auditd_max_log_file_action" ownerid="RHEL-06-000161" disa="366" severity="medium">
+	<overlay owner="disastig" ruleid="auditd_data_retention_max_log_file_action" ownerid="RHEL-06-000161" disa="366" severity="medium">
 		<VMSinfo VKey="38634" SVKey="50435" VRelease="1" />
 		<title>The system must rotate audit log files that reach the maximum file size.</title>
 	</overlay>

--- a/RHEL/7/input/auxiliary/stig_overlay.xml
+++ b/RHEL/7/input/auxiliary/stig_overlay.xml
@@ -441,7 +441,7 @@
 		<VMSinfo VKey="38636" SVKey="50437" VRelease="1" />
 		<title>The system must retain enough rotated audit logs to cover the required log retention period.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="configure_auditd_max_log_file" ownerid="RHEL-06-000160" disa="366" severity="medium">
+	<overlay owner="disastig" ruleid="auditd_data_retention_max_log_file" ownerid="RHEL-06-000160" disa="366" severity="medium">
 		<VMSinfo VKey="38633" SVKey="50434" VRelease="1" />
 		<title>The system must set a maximum audit log file size.</title>
 	</overlay>

--- a/RHEL/7/input/auxiliary/stig_overlay.xml
+++ b/RHEL/7/input/auxiliary/stig_overlay.xml
@@ -437,7 +437,7 @@
 	<overlay owner="disastig" ruleid="bootloader_audit_argument" ownerid="RHEL-06-000157" disa="1464" severity="low">
 		<title>Auditing must be enabled at boot by setting a kernel parameter.</title>
 	</overlay>
-	<overlay owner="disastig" ruleid="configure_auditd_num_logs" ownerid="RHEL-06-000159" disa="366" severity="medium">
+	<overlay owner="disastig" ruleid="auditd_data_retention_num_logs" ownerid="RHEL-06-000159" disa="366" severity="medium">
 		<VMSinfo VKey="38636" SVKey="50437" VRelease="1" />
 		<title>The system must retain enough rotated audit logs to cover the required log retention period.</title>
 	</overlay>

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -15,8 +15,7 @@
 <select idref="service_auditd_enabled" selected="true"/>
 <!-- <select idref="bootloader_audit_argument" selected="true"/> reason: needs to be ported to RHEL-7 -->
 <select idref="auditd_data_retention_num_logs" selected="true"/>
-<!-- <select idref="auditd_data_retention_max_log_file" selected="true"/> 
-     reason: "auditd_data_retention_max_log_file" needs to be ported to RHEL-7 -->
+<select idref="auditd_data_retention_max_log_file" selected="true"/>
 <!-- <select idref="configure_auditd_max_log_file_action" selected="true"/> 
      reason: "auditd_data_retention_max_log_file_action" needs to be ported to RHEL-7 -->
 <!-- <select idref="auditd_data_retention_space_left_action" selected="true"/> reason: needs to be ported to RHEL-7 -->

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -15,7 +15,7 @@
 <select idref="service_auditd_enabled" selected="true"/>
 <!-- <select idref="bootloader_audit_argument" selected="true"/> reason: needs to be ported to RHEL-7 -->
 <select idref="auditd_data_retention_num_logs" selected="true"/>
-<!-- <select idref="configure_auditd_max_log_file" selected="true"/> 
+<!-- <select idref="auditd_data_retention_max_log_file" selected="true"/> 
      reason: "auditd_data_retention_max_log_file" needs to be ported to RHEL-7 -->
 <!-- <select idref="configure_auditd_max_log_file_action" selected="true"/> 
      reason: "auditd_data_retention_max_log_file_action" needs to be ported to RHEL-7 -->

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -16,8 +16,7 @@
 <!-- <select idref="bootloader_audit_argument" selected="true"/> reason: needs to be ported to RHEL-7 -->
 <select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="auditd_data_retention_max_log_file" selected="true"/>
-<!-- <select idref="auditd_data_retention_max_log_file_action" selected="true"/> 
-     reason: "auditd_data_retention_max_log_file_action" needs to be ported to RHEL-7 -->
+<select idref="auditd_data_retention_max_log_file_action" selected="true"/>
 <!-- <select idref="auditd_data_retention_space_left_action" selected="true"/> reason: needs to be ported to RHEL-7 -->
 <!-- <select idref="auditd_data_retention_admin_space_left_action" selected="true"/> reason: needs to be ported to RHEL-7 -->
 <!-- <select idref="auditd_data_retention_action_mail_acct" selected="true"/> reason: needs to be ported to RHEL-7 -->

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -13,7 +13,7 @@
 
 <select idref="service_auditd_enabled" selected="true"/>
 <!-- <select idref="bootloader_audit_argument" selected="true"/> reason: needs to be ported to RHEL-7 -->
-<!-- <select idref="configure_auditd_num_logs" selected="true"/>
+<!-- <select idref="auditd_data_retention_num_logs" selected="true"/>
      reson: "auditd_data_retention_num_logs" needs to be ported to RHEL-7 -->
 <!-- <select idref="configure_auditd_max_log_file" selected="true"/> 
      reason: "auditd_data_retention_max_log_file" needs to be ported to RHEL-7 -->

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -10,11 +10,11 @@
 <refine-value idref="var_password_pam_minlen" selector="7" />
 <refine-value idref="var_password_pam_minclass" selector="2" />
 <refine-value idref="var_accounts_maximum_age_login_defs" selector="90" />
+<refine-value idref="var_auditd_num_logs" selector="5"/>
 
 <select idref="service_auditd_enabled" selected="true"/>
 <!-- <select idref="bootloader_audit_argument" selected="true"/> reason: needs to be ported to RHEL-7 -->
-<!-- <select idref="auditd_data_retention_num_logs" selected="true"/>
-     reson: "auditd_data_retention_num_logs" needs to be ported to RHEL-7 -->
+<select idref="auditd_data_retention_num_logs" selected="true"/>
 <!-- <select idref="configure_auditd_max_log_file" selected="true"/> 
      reason: "auditd_data_retention_max_log_file" needs to be ported to RHEL-7 -->
 <!-- <select idref="configure_auditd_max_log_file_action" selected="true"/> 

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -29,7 +29,7 @@
 <select idref="audit_rules_usergroup_modification" selected="true"/>
 <select idref="audit_rules_networkconfig_modification" selected="true"/>
 <select idref="file_permissions_var_log_audit" selected="true"/>
-<!-- <select idref="file_ownership_var_log_audit" selected="true"/> reason: "file_ownership_var_log_audit" needs to be ported to RHEL-7 -->
+<select idref="file_ownership_var_log_audit" selected="true"/>
 <select idref="audit_rules_mac_modification" selected="true"/>
 <select idref="audit_rules_dac_modification_chmod" selected="true"/>
 <select idref="audit_rules_dac_modification_chown" selected="true"/>

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -29,7 +29,7 @@
 <select idref="audit_rules_usergroup_modification" selected="true"/>
 <select idref="audit_rules_networkconfig_modification" selected="true"/>
 <select idref="file_permissions_var_log_audit" selected="true"/>
-<!-- <select idref="audit_logs_rootowner" selected="true"/> reason: "file_ownership_var_log_audit" needs to be ported to RHEL-7 -->
+<!-- <select idref="file_ownership_var_log_audit" selected="true"/> reason: "file_ownership_var_log_audit" needs to be ported to RHEL-7 -->
 <select idref="audit_rules_mac_modification" selected="true"/>
 <select idref="audit_rules_dac_modification_chmod" selected="true"/>
 <select idref="audit_rules_dac_modification_chown" selected="true"/>

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -18,7 +18,7 @@
 <select idref="auditd_data_retention_max_log_file" selected="true"/>
 <select idref="auditd_data_retention_max_log_file_action" selected="true"/>
 <select idref="auditd_data_retention_space_left_action" selected="true"/>
-<!-- <select idref="auditd_data_retention_admin_space_left_action" selected="true"/> reason: needs to be ported to RHEL-7 -->
+<select idref="auditd_data_retention_admin_space_left_action" selected="true"/>
 <!-- <select idref="auditd_data_retention_action_mail_acct" selected="true"/> reason: needs to be ported to RHEL-7 -->
 <!-- <select idref="configure_auditd_audispd" selected="true"/> reason: needs to be implemented for both RHEL-6 && RHEL-7 -->
 <select idref="audit_rules_time_adjtimex" selected="true"/>

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -19,7 +19,7 @@
 <select idref="auditd_data_retention_max_log_file_action" selected="true"/>
 <select idref="auditd_data_retention_space_left_action" selected="true"/>
 <select idref="auditd_data_retention_admin_space_left_action" selected="true"/>
-<!-- <select idref="auditd_data_retention_action_mail_acct" selected="true"/> reason: needs to be ported to RHEL-7 -->
+<select idref="auditd_data_retention_action_mail_acct" selected="true"/>
 <!-- <select idref="configure_auditd_audispd" selected="true"/> reason: needs to be implemented for both RHEL-6 && RHEL-7 -->
 <select idref="audit_rules_time_adjtimex" selected="true"/>
 <select idref="audit_rules_time_settimeofday" selected="true"/>

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -16,7 +16,7 @@
 <!-- <select idref="bootloader_audit_argument" selected="true"/> reason: needs to be ported to RHEL-7 -->
 <select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="auditd_data_retention_max_log_file" selected="true"/>
-<!-- <select idref="configure_auditd_max_log_file_action" selected="true"/> 
+<!-- <select idref="auditd_data_retention_max_log_file_action" selected="true"/> 
      reason: "auditd_data_retention_max_log_file_action" needs to be ported to RHEL-7 -->
 <!-- <select idref="auditd_data_retention_space_left_action" selected="true"/> reason: needs to be ported to RHEL-7 -->
 <!-- <select idref="auditd_data_retention_admin_space_left_action" selected="true"/> reason: needs to be ported to RHEL-7 -->

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -17,7 +17,7 @@
 <select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="auditd_data_retention_max_log_file" selected="true"/>
 <select idref="auditd_data_retention_max_log_file_action" selected="true"/>
-<!-- <select idref="auditd_data_retention_space_left_action" selected="true"/> reason: needs to be ported to RHEL-7 -->
+<select idref="auditd_data_retention_space_left_action" selected="true"/>
 <!-- <select idref="auditd_data_retention_admin_space_left_action" selected="true"/> reason: needs to be ported to RHEL-7 -->
 <!-- <select idref="auditd_data_retention_action_mail_acct" selected="true"/> reason: needs to be ported to RHEL-7 -->
 <!-- <select idref="configure_auditd_audispd" selected="true"/> reason: needs to be implemented for both RHEL-6 && RHEL-7 -->

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -282,7 +282,7 @@ file size and the number of logs retained.</rationale>
 <tested by="DS" on="20121024"/>
 </Rule>
 
-<Rule id="configure_auditd_max_log_file" severity="medium">
+<Rule id="auditd_data_retention_max_log_file" severity="medium">
 <title>Configure auditd Max Log File Size</title>
 <description>Determine the amount of audit data (in megabytes)
 which should be retained in each log file. Edit the file

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -812,7 +812,7 @@ If users can write to audit logs, audit trails can be modified or destroyed.
 <tested by="DS" on="20121024"/>
 </Rule>
 
-<Rule id="audit_logs_rootowner">
+<Rule id="file_ownership_var_log_audit">
 <title>System Audit Logs Must Be Owned By Root</title>
 <description>
 <fileowner-desc-macro file="/var/log" owner="root"/>

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -307,7 +307,7 @@ log file size and the number of logs retained.</rationale>
 <tested by="DS" on="20121024"/>
 </Rule>
 
-<Rule id="configure_auditd_max_log_file_action" severity="medium">
+<Rule id="auditd_data_retention_max_log_file_action" severity="medium">
 <title>Configure auditd max_log_file_action Upon Reaching Maximum Log Size</title>
 <description> The default action to take when the logs reach their maximum size
 is to rotate the log files, discarding the oldest one. To configure the action taken

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -258,7 +258,7 @@ normally.</i>
 <value selector="sync">sync</value>
 </Value>
 
-<Rule id="configure_auditd_num_logs" severity="medium">
+<Rule id="auditd_data_retention_num_logs" severity="medium">
 <title>Configure auditd Number of Logs Retained</title>
 <description>Determine how many log files
 <tt>auditd</tt> should retain when it rotates logs.

--- a/RHEVM3/input/profiles/stig-rhevm3.xml
+++ b/RHEVM3/input/profiles/stig-rhevm3.xml
@@ -110,7 +110,7 @@
 <select idref="enable_auditd_bootloader" selected="true"/>
 
 <select idref="auditd_data_retention_num_logs" selected="true"/>
-<select idref="configure_auditd_max_log_file" selected="true"/>
+<select idref="auditd_data_retention_max_log_file" selected="true"/>
 <select idref="configure_auditd_max_log_file_action" selected="true"/>
 <select idref="configure_auditd_admin_space_left_action" selected="true"/>
 

--- a/RHEVM3/input/profiles/stig-rhevm3.xml
+++ b/RHEVM3/input/profiles/stig-rhevm3.xml
@@ -109,7 +109,7 @@
 <select idref="enable_auditd_service" selected="true"/>
 <select idref="enable_auditd_bootloader" selected="true"/>
 
-<select idref="configure_auditd_num_logs" selected="true"/>
+<select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="configure_auditd_max_log_file" selected="true"/>
 <select idref="configure_auditd_max_log_file_action" selected="true"/>
 <select idref="configure_auditd_admin_space_left_action" selected="true"/>

--- a/RHEVM3/input/profiles/stig-rhevm3.xml
+++ b/RHEVM3/input/profiles/stig-rhevm3.xml
@@ -111,7 +111,7 @@
 
 <select idref="auditd_data_retention_num_logs" selected="true"/>
 <select idref="auditd_data_retention_max_log_file" selected="true"/>
-<select idref="configure_auditd_max_log_file_action" selected="true"/>
+<select idref="auditd_data_retention_max_log_file_action" selected="true"/>
 <select idref="configure_auditd_admin_space_left_action" selected="true"/>
 
 <!-- <select idref="audit_time_rules" selected="true"/> -->

--- a/shared/oval/auditd_data_retention_action_mail_acct.xml
+++ b/shared/oval/auditd_data_retention_action_mail_acct.xml
@@ -1,11 +1,14 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_action_mail_acct" version="1">
+  <definition class="compliance" id="auditd_data_retention_action_mail_acct" version="2">
     <metadata>
       <title>Auditd Email Account to Notify Upon Action</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>action_mail_acct setting in /etc/audit/auditd.conf is set to a certain account</description>
+      <reference source="JL" ref_id="RHEL6_20150813" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150813" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA22_20150813" ref_url="test_attestation" />
     </metadata>
     <criteria>
         <criterion comment="action_mail_acct setting in auditd.conf" test_ref="test_auditd_data_retention_action_mail_acct" />

--- a/shared/oval/auditd_data_retention_admin_space_left_action.xml
+++ b/shared/oval/auditd_data_retention_admin_space_left_action.xml
@@ -1,12 +1,14 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_admin_space_left_action" version="1">
+  <definition class="compliance" id="auditd_data_retention_admin_space_left_action" version="2">
     <metadata>
       <title>Auditd Action to Take When Disk is Low on Space</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>admin_space_left_action setting in /etc/audit/auditd.conf is set to a certain action</description>
-      <reference source="JL" ref_id="20140312" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL6_20140312" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150813" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA22_20150813" ref_url="test_attestation" />
     </metadata>
 
     <criteria>
@@ -33,6 +35,5 @@
   </ind:textfilecontent54_state>
 
   <external_variable comment="audit admin_space_left_action setting" datatype="string" id="var_auditd_admin_space_left_action" version="1" />
-
 
 </def-group>

--- a/shared/oval/auditd_data_retention_max_log_file.xml
+++ b/shared/oval/auditd_data_retention_max_log_file.xml
@@ -1,11 +1,14 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_max_log_file" version="1">
+  <definition class="compliance" id="auditd_data_retention_max_log_file" version="2">
     <metadata>
       <title>Auditd Maximum Log File Size</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>max_log_file setting in /etc/audit/auditd.conf is set to at least a certain value</description>
+      <reference source="JL" ref_id="RHEL6_20150813" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150813" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA22_20150813" ref_url="test_attestation" />
     </metadata>
 
     <criteria>
@@ -32,6 +35,5 @@
   </ind:textfilecontent54_state>
 
   <external_variable comment="audit max_log_file settting" datatype="int" id="var_auditd_max_log_file" version="1" />
-
 
 </def-group>

--- a/shared/oval/auditd_data_retention_max_log_file_action.xml
+++ b/shared/oval/auditd_data_retention_max_log_file_action.xml
@@ -1,11 +1,14 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_max_log_file_action" version="1">
+  <definition class="compliance" id="auditd_data_retention_max_log_file_action" version="2">
     <metadata>
       <title>Auditd Action to Take When Maximum Log Size Reached</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>max_log_file_action setting in /etc/audit/auditd.conf is set to a certain action</description>
+      <reference source="JL" ref_id="RHEL6_20150813" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150813" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA22_20150813" ref_url="test_attestation" />
     </metadata>
 
     <criteria>
@@ -32,6 +35,5 @@
   </ind:textfilecontent54_state>
 
   <external_variable comment="audit max_log_file_action setting" datatype="string" id="var_auditd_max_log_file_action" version="1" />
-
 
 </def-group>

--- a/shared/oval/auditd_data_retention_num_logs.xml
+++ b/shared/oval/auditd_data_retention_num_logs.xml
@@ -1,11 +1,14 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_num_logs" version="1">
+  <definition class="compliance" id="auditd_data_retention_num_logs" version="2">
     <metadata>
       <title>Auditd Maximum Number of Logs to Retain</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>num_logs setting in /etc/audit/auditd.conf is set to at least a certain value</description>
+      <reference source="JL" ref_id="RHEL6_20150812" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150812" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA22_20150812" ref_url="test_attestation" />
     </metadata>
 
     <criteria>

--- a/shared/oval/auditd_data_retention_space_left_action.xml
+++ b/shared/oval/auditd_data_retention_space_left_action.xml
@@ -1,11 +1,14 @@
 <def-group>
-  <definition class="compliance" id="auditd_data_retention_space_left_action" version="2">
+  <definition class="compliance" id="auditd_data_retention_space_left_action" version="3">
     <metadata>
       <title>Auditd Action to Take When Disk Starting to Run Low on Space</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>space_left_action setting in /etc/audit/auditd.conf is set to a certain action</description>
+      <reference source="JL" ref_id="RHEL6_20150813" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150813" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA22_20150813" ref_url="test_attestation" />
     </metadata>
 
     <criteria>
@@ -32,6 +35,5 @@
   </ind:textfilecontent54_state>
 
   <external_variable comment="audit space_left_action setting" datatype="string" id="var_auditd_space_left_action" version="2" />
-
 
 </def-group>

--- a/shared/oval/file_ownership_var_log_audit.xml
+++ b/shared/oval/file_ownership_var_log_audit.xml
@@ -1,11 +1,14 @@
 <def-group>
-  <definition class="compliance" id="file_ownership_var_log_audit" version="1">
+  <definition class="compliance" id="file_ownership_var_log_audit" version="2">
     <metadata>
       <title>Verify /var/log/audit Ownership</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>Checks that all /var/log/audit files and directories are owned by the root user and group.</description>
+      <reference source="JL" ref_id="RHEL6_20150814" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150814" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA22_20150814" ref_url="test_attestation" />
     </metadata>
     <criteria operator="AND">
       <criterion test_ref="test_ownership_var_log_audit_files" />


### PR DESCRIPTION
This PR adds new ```RHEL/7``` and ```Fedora``` products OVAL checks for the following rules:
* ```auditd_data_retention_num_logs```,
* ```auditd_data_retention_max_log_file```,
* ```auditd_data_retention_max_log_file_action```,
* ```auditd_data_retention_space_left_action```,
* ```auditd_data_retention_admin_space_left_action```,
* ```auditd_data_retention_action_mail_acct```, and finally
* ```file_ownership_var_log_audit``` (though this rule isn't related with ```auditd.conf``` it's about checking ownership of ```/var/log/audit/audit.log``` audit log file && therefore has been updated within this PR too).

Together with adding these new enhancements, it also unifies XCCDF ID with OVAL ID (preferring the OVAL one) for rules, where it would be necessary. The unification for each of such cases is performed both in the XCCDF prose and also in the profile references (all profiles referencing that rule), and also in the auxiliary XSLT transformation for that product.

The changes are split into commits based on action that was performed in that moment (either ID unification, or adding new OVAL check enhancement).

Testing report:
------------------
All of the proposed changes have been tested on the following systems:
* RHEL-6.7 host,
* RHEL-7.1 host,
* Fedora 22 host

and all of them have been identified as working properly / as expected (=> added ```test_attestations``` references into those OVALs together with date stamp && product id, when the testing was performed).

Please review.

Thank you, Jan.
