### PR TITLE
[Enhancement] [RHEL/7] Add selected rhel7 remediations

### DIFF
--- a/RHEL/7/input/fixes/bash/auditd_audispd_syslog_plugin_activated.sh
+++ b/RHEL/7/input/fixes/bash/auditd_audispd_syslog_plugin_activated.sh
@@ -1,0 +1,6 @@
+
+grep -q ^active /etc/audisp/plugins.d/syslog.conf && \
+  sed -i "s/active.*/active = yes/g" /etc/audisp/plugins.d/syslog.conf
+if ! [ $? -eq 0 ]; then
+    echo "active = yes" >> /etc/audisp/plugins.d/syslog.conf
+fi

--- a/RHEL/7/input/fixes/bash/auditd_data_retention_space_left_action.sh
+++ b/RHEL/7/input/fixes/bash/auditd_data_retention_space_left_action.sh
@@ -1,0 +1,8 @@
+source ./templates/support.sh
+populate var_auditd_space_left_action
+
+grep -q ^space_left_action /etc/audit/auditd.conf && \
+  sed -i "s/space_left_action.*/space_left_action = $var_auditd_space_left_action/g" /etc/audit/auditd.conf
+if ! [ $? -eq 0 ]; then
+    echo "space_left_action = $var_auditd_space_left_action" >> /etc/audit/auditd.conf
+fi

--- a/RHEL/7/input/fixes/bash/bootloader_audit_argument.sh
+++ b/RHEL/7/input/fixes/bash/bootloader_audit_argument.sh
@@ -1,0 +1,11 @@
+
+# Correct the form of default kernel command line in /etc/default/grub
+grep -q ^GRUB_CMDLINE_LINUX=\".*audit=0.*\" /etc/default/grub && \
+  sed -i "s/audit=[^[:space:]\+]/audit=1/g" /etc/default/grub
+if ! [ $? -eq 0 ]; then
+  sed -i "s/\(GRUB_CMDLINE_LINUX=\)\"\(.*\)\"/\1\"\2 audit=1\"/" /etc/default/grub
+fi
+
+# Correct the form of kernel command line for each installed kernel
+# in the bootloader
+/sbin/grubby --update-kernel=ALL --args="audit=1"


### PR DESCRIPTION
This PR adds RHEL-7 remediation scripts implementation for the following rules:
* ```auditd_data_retention_space_left_action```,
* ```auditd_audispd_syslog_plugin_activated```, and
* ```bootloader_audit_argument```

Testing report:
--
All of the changes have been tested on recent RHEL-7 host and all of them seem to be working fine (AFAICT from testing).

Please review.

Thank you, Jan.