### PR TITLE
Fix to allow hyphens in hostnames and mountpoints and ipv6 addresses

### DIFF
--- a/RHEL/5/input/checks/mount_option_nodev_removable_filesystems.xml
+++ b/RHEL/5/input/checks/mount_option_nodev_removable_filesystems.xml
@@ -23,7 +23,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_nfs_nodev_etc_fstab" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*[\.\w]+:[/\w]+\s+[/\w]+\s+nfs[4]?\s+(.*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+(.*)$</ind:pattern>
     <!-- the "not equal" operation essentially means all instances of the regexp -->
     <ind:instance datatype="int" operation="not equal">0</ind:instance>
   </ind:textfilecontent54_object>
@@ -36,7 +36,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_no_nfs_defined_etc_fstab_nodev" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*[\.\w]+:[/\w]+\s+[/\w]+\s+nfs[4]?\s+.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+.*$</ind:pattern>
     <!-- the "not equal" operation below essentially means all instances of the regexp -->
     <ind:instance datatype="int" operation="not equal">0</ind:instance>
   </ind:textfilecontent54_object>

--- a/RHEL/5/input/checks/mount_option_nosuid_removable_filesystems.xml
+++ b/RHEL/5/input/checks/mount_option_nosuid_removable_filesystems.xml
@@ -23,7 +23,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_nfs_nosuid_etc_fstab" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*[\.\w]+:[/\w]+\s+[/\w]+\s+nfs[4]?\s+(.*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+(.*)$</ind:pattern>
     <!-- the "not equal" operation essentially means all instances of the regexp -->
     <ind:instance datatype="int" operation="not equal">0</ind:instance>
   </ind:textfilecontent54_object>
@@ -36,7 +36,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_no_nfs_defined_etc_fstab_nosuid" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*[\.\w]+:[/\w]+\s+[/\w]+\s+nfs[4]?\s+.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+.*$</ind:pattern>
     <!-- the "not equal" operation below essentially means all instances of the regexp -->
     <ind:instance datatype="int" operation="not equal">0</ind:instance>
   </ind:textfilecontent54_object>

--- a/RHEL/6/input/checks/mount_option_nodev_remote_filesystems.xml
+++ b/RHEL/6/input/checks/mount_option_nodev_remote_filesystems.xml
@@ -21,7 +21,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_nfs_nodev_etc_fstab" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*[\.\w]+:[/\w]+\s+[/\w]+\s+nfs[4]?\s+(.*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+(.*)$</ind:pattern>
     <!-- the "not equal" operation essentially means all instances of the regexp -->
     <ind:instance datatype="int" operation="not equal">0</ind:instance>
   </ind:textfilecontent54_object>
@@ -34,7 +34,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_no_nfs_defined_etc_fstab_nodev" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*[\.\w]+:[/\w]+\s+[/\w]+\s+nfs[4]?\s+.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+.*$</ind:pattern>
     <!-- the "not equal" operation below essentially means all instances of the regexp -->
     <ind:instance datatype="int" operation="not equal">0</ind:instance>
   </ind:textfilecontent54_object>

--- a/RHEL/6/input/checks/mount_option_nosuid_remote_filesystems.xml
+++ b/RHEL/6/input/checks/mount_option_nosuid_remote_filesystems.xml
@@ -21,7 +21,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_nfs_nosuid_etc_fstab" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*[\.\w]+:[/\w]+\s+[/\w]+\s+nfs[4]?\s+(.*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+(.*)$</ind:pattern>
     <!-- the "not equal" operation essentially means all instances of the regexp -->
     <ind:instance datatype="int" operation="not equal">0</ind:instance>
   </ind:textfilecontent54_object>
@@ -34,7 +34,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_no_nfs_defined_etc_fstab_nosuid" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*[\.\w]+:[/\w]+\s+[/\w]+\s+nfs[4]?\s+.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+.*$</ind:pattern>
     <!-- the "not equal" operation below essentially means all instances of the regexp -->
     <ind:instance datatype="int" operation="not equal">0</ind:instance>
   </ind:textfilecontent54_object>


### PR DESCRIPTION
While thinking about it I also noticed its only checking fstab, shouldn't it check /etc/fstab and /proc/mounts ? Also I only fixed hyphens but a mountpoint could have more valid characters - not sure what nfs would allow in theory :D

Greetings
Klaas