### PR TITLE
[BugFix] Fix Fedora's 'make validate' target when run on RHEL-6 system (system with oscap not supporting OVAL-5.11 yet)

### DIFF
--- a/Fedora/input/checks/oval_5.11/package_firewalld_installed.xml
+++ b/Fedora/input/checks/oval_5.11/package_firewalld_installed.xml
@@ -5,7 +5,7 @@
     <metadata>
       <title>Package firewalld Installed</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>The RPM package firewalld should be installed.</description>
       <reference source="JL" ref_id="RHEL7_20140921" ref_url="test_attestation"/>


### PR DESCRIPTION

The current ```/shared``` version of 'package_firewalld_installed' OVAL check
is included into the final Fedora OVAL everytime (regardless against
which oscap version it's built). But it's required only in case Fedora
OVAL is built with oscap supporting OVAL-5.11 (openscap-1.2.4+), because
this check is dependency just for other firewalld OVAL checks. Therefore
include the ```package_firewalld_installed``` into final Fedora's OVAL only
in case we truly need it (IOW in order to Fedora's ```make validate``` check
wouldn't report a message about un-used OVAL check in the case the Fedora
content is built && validated with oscap <= 1.2.4 version)

This should fix issue reported in: 
&nbsp; &nbsp; [1] https://jenkins.open-scap.org/job/scap-security-guide-pull-requests/76/

Testing report:
-------------------
* RHEL-6 case -- verified the Fedora's ```make validate``` starts passing again once this change is applied,
* Fedora 22 case -- verified the ```service_firewalld_enabled``` check is still working on Fedora once this change is applied.

Please review.

Thank you, Jan.
