### PR TITLE
[BugFix] [RHEL/6] [RHEL/7] [Fedora] audit_rules_login_events rule XCCDF and OVAL fixes

### DIFF
--- a/Fedora/input/system/auditing.xml
+++ b/Fedora/input/system/auditing.xml
@@ -1269,14 +1269,16 @@ and root. If the <tt>auditd</tt> daemon is configured to use the
 default), add the following lines to <tt>/etc/audit/audit.rules</tt> file in
 order to watch for attempted manual edits of files involved in storing logon
 events:
-<pre>-w /var/log/faillog -p wa -k logins
+<pre>-w /var/log/tallylog -p wa -k logins
+-w /var/run/faillock/ -p wa -k logins
 -w /var/log/lastlog -p wa -k logins</pre>
 If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
 program to read audit rules during daemon startup, add the following lines to a
 file with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>
 in order to watch for attempted manual edits of files involved in storing logon
 events:
-<pre>-w /var/log/faillog -p wa -k logins
+<pre>-w /var/log/tallylog -p wa -k logins
+-w /var/run/faillock/ -p wa -k logins
 -w /var/log/lastlog -p wa -k logins</pre>
 </description>
 <rationale>Manual editing of these files may indicate nefarious activity, such

--- a/RHEL/6/input/checks/audit_rules_login_events.xml
+++ b/RHEL/6/input/checks/audit_rules_login_events.xml
@@ -1,23 +1,33 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_login_events" version="1">
+  <definition class="compliance" id="audit_rules_login_events" version="2">
     <metadata>
       <title>Record Attempts to Alter Login and Logout Events</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
       <description>Audit rules should be configured to log successful and unsuccessful login and logout events.</description>
+      <reference source="JL" ref_id="RHEL6_20150926" ref_url="test_attestation" />
     </metadata>
     <criteria operator="AND">
-      <criterion comment="faillog" test_ref="test_audit_rules_login_events_faillog" />
+      <criterion comment="tallylog" test_ref="test_audit_rules_login_events_tallylog" />
+      <criterion comment="faillock" test_ref="test_audit_rules_login_events_faillock" />
       <criterion comment="lastlog" test_ref="test_audit_rules_login_events_lastlog" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" comment="faillog" id="test_audit_rules_login_events_faillog" version="1">
-    <ind:object object_ref="object_audit_rules_login_events_faillog" />
+  <ind:textfilecontent54_test check="all" comment="tallylog" id="test_audit_rules_login_events_tallylog" version="1">
+    <ind:object object_ref="object_audit_rules_login_events_tallylog" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_audit_rules_login_events_faillog" version="1">
+  <ind:textfilecontent54_object id="object_audit_rules_login_events_tallylog" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w\s+/var/log/faillog\s+\-p\s+wa\s+\-k\s+[-\w]+\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w\s+/var/log/tallylog\s+\-p\s+wa\s+\-k\s+[-\w]+\s*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_test check="all" comment="faillock" id="test_audit_rules_login_events_faillock" version="1">
+    <ind:object object_ref="object_audit_rules_login_events_faillock" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_login_events_faillock" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w\s+/var/run/faillock/\s+\-p\s+wa\s+\-k\s+[-\w]+\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" comment="lastlog" id="test_audit_rules_login_events_lastlog" version="1">

--- a/RHEL/6/input/system/auditing.xml
+++ b/RHEL/6/input/system/auditing.xml
@@ -1136,12 +1136,13 @@ calls with others as identifying earlier in this guide is more efficient.
 
 <Rule id="audit_rules_login_events">
 <title>Record Attempts to Alter Login and Logout Events</title>
-<description> 
+<description>
 The audit system already collects login info for all users and root. To watch for attempted manual edits of
 files involved in storing login events, add the following to <tt>/etc/audit/audit.rules</tt>:
-<pre>-w /var/log/faillog -p wa -k logins 
+<pre>-w /var/log/tallylog -p wa -k logins
+-w /var/run/faillock/ -p wa -k logins
 -w /var/log/lastlog -p wa -k logins</pre>
-</description> 
+</description>
 <rationale>Manual editing of these files may indicate nefarious activity, such
 as an attacker attempting to remove evidence of an intrusion.</rationale>
 <ident cce="26691-6" />

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -1345,13 +1345,15 @@ and root. If the <tt>auditd</tt> daemon is configured to use the
 default), add the following lines to a file with suffix <tt>.rules</tt> in the
 directory <tt>/etc/audit/rules.d</tt> in order to watch for attempted manual
 edits of files involved in storing logon events:
-<pre>-w /var/log/faillog -p wa -k logins
+<pre>-w /var/log/tallylog -p wa -k logins
+-w /var/run/faillock/ -p wa -k logins
 -w /var/log/lastlog -p wa -k logins</pre>
 If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
 utility to read audit rules during daemon startup, add the following lines to
 <tt>/etc/audit/audit.rules</tt> file in order to watch for unattempted manual
 edits of files involved in storing logon events:
-<pre>-w /var/log/faillog -p wa -k logins
+<pre>-w /var/log/tallylog -p wa -k logins
+-w /var/run/faillock/ -p wa -k logins
 -w /var/log/lastlog -p wa -k logins</pre>
 </description>
 <rationale>Manual editing of these files may indicate nefarious activity, such

--- a/shared/oval/audit_rules_login_events.xml
+++ b/shared/oval/audit_rules_login_events.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_login_events" version="1">
+  <definition class="compliance" id="audit_rules_login_events" version="2">
     <metadata>
       <title>Record Attempts to Alter Login and Logout Events</title>
       <affected family="unix">
@@ -7,8 +7,8 @@
         <platform>multi_platform_fedora</platform>
       </affected>
       <description>Audit rules should be configured to log successful and unsuccessful login and logout events.</description>
-      <reference source="JL" ref_id="RHEL7_20150518" ref_url="test_attestation" />
-      <reference source="JL" ref_id="FEDORA20_20150518" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20150926" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA22_20150926" ref_url="test_attestation" />
     </metadata>
 
     <criteria operator="OR">
@@ -16,14 +16,16 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <criterion comment="audit augenrules" test_ref="test_arle_augenrules" />
-        <criterion comment="audit augenrules faillog" test_ref="test_arle_faillog_augenrules" />
+        <criterion comment="audit augenrules tallylog" test_ref="test_arle_tallylog_augenrules" />
+        <criterion comment="audit augenrules faillock" test_ref="test_arle_faillock_augenrules" />
         <criterion comment="audit augenrules lastlog" test_ref="test_arle_lastlog_augenrules" />
       </criteria>
 
       <!-- Test the auditctl case -->
       <criteria operator="AND">
         <criterion comment="audit auditctl" test_ref="test_arle_auditctl" />
-        <criterion comment="audit auditctl faillog" test_ref="test_arle_faillog_auditctl" />
+        <criterion comment="audit auditctl tallylog" test_ref="test_arle_tallylog_auditctl" />
+        <criterion comment="audit auditctl faillock" test_ref="test_arle_faillock_auditctl" />
         <criterion comment="audit auditctl lastlog" test_ref="test_arle_lastlog_auditctl" />
       </criteria>
 
@@ -40,12 +42,21 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules faillog" id="test_arle_faillog_augenrules" version="1">
-    <ind:object object_ref="object_arle_faillog_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules tallylog" id="test_arle_tallylog_augenrules" version="1">
+    <ind:object object_ref="object_arle_tallylog_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arle_faillog_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_arle_tallylog_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w\s+/var/log/faillog\s+\-p\s+wa\s+\-k\s+[-\w]+\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w\s+/var/log/tallylog\s+\-p\s+wa\s+\-k\s+[-\w]+\s*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules faillock" id="test_arle_faillock_augenrules" version="1">
+    <ind:object object_ref="object_arle_faillock_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arle_faillock_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w\s+/var/run/faillock/\s+\-p\s+wa\s+\-k\s+[-\w]+\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -68,12 +79,21 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl faillog" id="test_arle_faillog_auditctl" version="1">
-    <ind:object object_ref="object_arle_faillog_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl tallylog" id="test_arle_tallylog_auditctl" version="1">
+    <ind:object object_ref="object_arle_tallylog_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arle_faillog_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_arle_tallylog_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w\s+/var/log/faillog\s+\-p\s+wa\s+\-k\s+[-\w]+\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w\s+/var/log/tallylog\s+\-p\s+wa\s+\-k\s+[-\w]+\s*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl faillock" id="test_arle_faillock_auditctl" version="1">
+    <ind:object object_ref="object_arle_faillock_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arle_faillock_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w\s+/var/run/faillock/\s+\-p\s+wa\s+\-k\s+[-\w]+\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
This changeset fixes the issue:
  https://github.com/OpenSCAP/scap-security-guide/issues/607

namely:
* patch https://github.com/OpenSCAP/scap-security-guide/commit/a8e6b1fa70cc0cd94c58eb37f909dcd788d8d0bd -- updates XCCDF description for this rule for RHEL-6, RHEL-7, and Fedora products not to require audit watch object for ```/var/log/faillog``` location, but instead of that require presence of audit watch object for the following two locations:
  * ```/var/log/tallylog```, and
  * ```/var/run/faillock/```

```/var/log/faillog``` is not shipped by pam starting from RHEL-6 any more (see downstream bug:
  https://bugzilla.redhat.com/show_bug.cgi?id=675168 for details). Instead of that the aforementioned two locations are required to be audited instead,

* patch https://github.com/OpenSCAP/scap-security-guide/commit/00c6d8fa16bd1d878ba767ffda0be7e124915e84  -- updates the existing ```RHEL/6``` OVAL check not to require ```/var/log/faillog```, but instead of that to require those two new locations, and

* finally patch https://github.com/OpenSCAP/scap-security-guide/commit/44104c7f3fec7fddff4939a6b375b4a4c05eeb15 -- updates the existing ```RHEL/7``` and ```Fedora``` OVAL check to do the same (not to require ```/var/log/faillog```, but instead of that require ```/var/log/tallylog``` and ```/var/run/faillock``` to be audited).

Testing report:
-------------------
The proposed change has been tested on the following systems:
* RHEL-6, 
* RHEL-7, and
* Fedora 22

and AFAICT from testing it is working well on all three of the systems from the above list.

Please review.

Thank you, Jan.