### PR TITLE
[BugFix] [Fedora] Fix failing 'make validate' for Fedora product when Fedora content is built & validated on RHEL-6 system

### DIFF
--- a/Fedora/input/checks/oval_5.11/package_cronie_installed.xml
+++ b/Fedora/input/checks/oval_5.11/package_cronie_installed.xml
@@ -4,7 +4,7 @@
     <metadata>
       <title>Package cronie Installed</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>The RPM package cronie should be installed.</description>
       <reference source="galford" ref_id="20150923" ref_url="test_attestation"/>


### PR DESCRIPTION

Currently ```package_cronie_installed``` OVAL check is reported as
not being referenced in Fedora content when Fedora content is
build on RHEL-6. This is because 'package_cronie_installed'
OVAL is used only by ```service_crond_enabled``` OVAL-5.11 Fedora
OVAL check (but this check is not built on RHEL-6, since OVAL-5.11
is not supported there yet). Therefore ```package_cronie_installed```
OVAL should be located in Fedora/input/checks/oval-5.11 directory
(to be included into final OVAL document only in case we are building
with oscap supporting OVAL-5.11, and not in all case).

Testing report:
--------------
Verified on RHEL-6 that once this change is applied, Fedora's 'make validate'
starts passing again.
