### PR TITLE
Profile titles changed for PCI-DSS and STIG

### DIFF
--- a/RHEL/6/input/profiles/pci-dss.xml
+++ b/RHEL/6/input/profiles/pci-dss.xml
@@ -1,5 +1,5 @@
 <Profile id="pci-dss" xmlns="http://checklists.nist.gov/xccdf/1.1">
-<title>Draft PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 6</title>
+<title>PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 6</title>
 <description>This is a *draft* profile for PCI-DSS v3</description>
 
 <refine-value idref="var_password_pam_unix_remember" selector="4" />

--- a/RHEL/7/input/profiles/pci-dss.xml
+++ b/RHEL/7/input/profiles/pci-dss.xml
@@ -1,5 +1,5 @@
 <Profile id="pci-dss" xmlns="http://checklists.nist.gov/xccdf/1.1">
-<title>Draft PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7</title>
+<title>PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7</title>
 <description>This is a *draft* profile for PCI-DSS v3</description>
 
 <refine-value idref="var_password_pam_unix_remember" selector="4" />

--- a/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-rhel7-server-upstream" extends="common">
-<title override="true">Pre-release Draft STIG for Red Hat Enterprise Linux 7 Server</title>
-<description override="true">This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
+<title override="true">STIG for Red Hat Enterprise Linux 7 Server</title>
+<description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
 
 <!-- STIG refinement values. Note these are set by DISA FSO,
      and should not be manipulated -->


### PR DESCRIPTION
Changed profile titles to be consistent. This improves UX in HTML guides, reports, SCAP Workbench and OSCAP Anaconda Addon.

Added draft info the descriptions.