### PR TITLE
Use SSG version in XCCDF benchmark <version> element

### DIFF
--- a/Chromium/Makefile
+++ b/Chromium/Makefile
@@ -1,3 +1,5 @@
+include ../VERSION
+
 IN = input
 OUT = output
 TRANS = transforms
@@ -26,7 +28,7 @@ endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide
-	xsltproc -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
+	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml
 	$(SHARED)/$(UTILS)/unselect-empty-xccdf-groups.py --input $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml --output $(OUT)/unlinked-$(PROD)-xccdf.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-xccdf.xml $(OUT)/unlinked-$(PROD)-xccdf.xml

--- a/Chromium/transforms/shorthand2xccdf.xslt
+++ b/Chromium/transforms/shorthand2xccdf.xslt
@@ -14,6 +14,8 @@
 
 <xsl:include href="constants.xslt"/>
 
+<xsl:param name="ssg_version">unknown</xsl:param>
+
 <xsl:variable name="ovalfile">unlinked-chromium-oval.xml</xsl:variable>
 <xsl:variable name="defaultseverity" select="'low'" />
 

--- a/Chromium/transforms/shorthand2xccdf.xslt
+++ b/Chromium/transforms/shorthand2xccdf.xslt
@@ -36,6 +36,11 @@
     </xsl:attribute>
   </xsl:template>
 
+  <!-- insert SSG version -->
+  <xsl:template match="Benchmark/version">
+    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -1,3 +1,5 @@
+include ../VERSION
+
 IN = input
 OUT = output
 BUILD = build
@@ -31,7 +33,7 @@ endif
 	xmllint --format --output $(OUT)/$(ID)-$(PROD)-shorthand.xml $(OUT)/$(ID)-$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide
-	xsltproc -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(ID)-$(PROD)-shorthand.xml
+	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(ID)-$(PROD)-shorthand.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml
 	$(SHARED)/$(UTILS)/unselect-empty-xccdf-groups.py --input $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml --output $(OUT)/unlinked-$(PROD)-xccdf.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-xccdf.xml $(OUT)/unlinked-$(PROD)-xccdf.xml

--- a/Fedora/transforms/shorthand2xccdf.xslt
+++ b/Fedora/transforms/shorthand2xccdf.xslt
@@ -36,6 +36,11 @@
     </xsl:attribute>
   </xsl:template>
 
+  <!-- insert SSG version -->
+  <xsl:template match="Benchmark/version">
+    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/Fedora/transforms/shorthand2xccdf.xslt
+++ b/Fedora/transforms/shorthand2xccdf.xslt
@@ -14,6 +14,8 @@
 
 <xsl:include href="constants.xslt"/>
 
+<xsl:param name="ssg_version">unknown</xsl:param>
+
 <xsl:variable name="ovalfile">unlinked-fedora-oval.xml</xsl:variable>
 <xsl:variable name="defaultseverity" select="'low'" />
 

--- a/Firefox/Makefile
+++ b/Firefox/Makefile
@@ -1,3 +1,5 @@
+include ../VERSION
+
 IN = input
 OUT = output
 TRANS = transforms
@@ -29,7 +31,7 @@ endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide
-	xsltproc -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
+	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml
 	$(SHARED)/$(UTILS)/unselect-empty-xccdf-groups.py --input $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml --output $(OUT)/unlinked-$(PROD)-xccdf.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-xccdf.xml $(OUT)/unlinked-$(PROD)-xccdf.xml

--- a/Firefox/transforms/shorthand2xccdf.xslt
+++ b/Firefox/transforms/shorthand2xccdf.xslt
@@ -14,6 +14,8 @@
 
 <xsl:include href="constants.xslt"/>
 
+<xsl:param name="ssg_version">unknown</xsl:param>
+
 <xsl:variable name="ovalfile">unlinked-firefox-oval.xml</xsl:variable>
 <xsl:variable name="defaultseverity" select="'low'" />
 
@@ -34,6 +36,11 @@
     <xsl:attribute name="date">
        <xsl:value-of select="date:date()"/>
     </xsl:attribute>
+  </xsl:template>
+
+  <!-- insert SSG version -->
+  <xsl:template match="Benchmark/version">
+    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/JRE/Makefile
+++ b/JRE/Makefile
@@ -1,3 +1,5 @@
+include ../VERSION
+
 IN = input
 OUT = output
 TRANS = transforms
@@ -29,7 +31,7 @@ endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide
-	xsltproc -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
+	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml
 	$(SHARED)/$(UTILS)/unselect-empty-xccdf-groups.py --input $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml --output $(OUT)/unlinked-$(PROD)-xccdf.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-xccdf.xml $(OUT)/unlinked-$(PROD)-xccdf.xml

--- a/JRE/transforms/shorthand2xccdf.xslt
+++ b/JRE/transforms/shorthand2xccdf.xslt
@@ -36,6 +36,11 @@
     </xsl:attribute>
   </xsl:template>
 
+  <!-- insert SSG version -->
+  <xsl:template match="Benchmark/version">
+    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/JRE/transforms/shorthand2xccdf.xslt
+++ b/JRE/transforms/shorthand2xccdf.xslt
@@ -14,6 +14,8 @@
 
 <xsl:include href="constants.xslt"/>
 
+<xsl:param name="ssg_version">unknown</xsl:param>
+
 <xsl:variable name="ovalfile">unlinked-jre-oval.xml</xsl:variable>
 <xsl:variable name="defaultseverity" select="'low'" />
 

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ tarball: rpmroot
 	# Copy in the source trees for both RHEL
 	# and JBossEAP5 content
 	mkdir -p $(RPMBUILD)/$(PKG)
-	cp BUILD.md Contributors.md LICENSE README.md  $(RPMBUILD)/$(PKG)/
+	cp BUILD.md Contributors.md LICENSE VERSION README.md  $(RPMBUILD)/$(PKG)/
 	cp -r config/ $(RPMBUILD)/$(PKG)
 	cp -r docs/ $(RPMBUILD)/$(PKG)
 	cp -r shared/ $(RPMBUILD)/$(PKG)

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -1,3 +1,5 @@
+include ../../VERSION
+
 IN = input
 OUT = output
 BUILD = build
@@ -29,7 +31,7 @@ endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide
-	xsltproc -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
+	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml
 	$(SHARED)/$(UTILS)/unselect-empty-xccdf-groups.py --input $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml --output $(OUT)/unlinked-$(PROD)-xccdf.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-xccdf.xml $(OUT)/unlinked-$(PROD)-xccdf.xml

--- a/RHEL/5/transforms/shorthand2xccdf.xslt
+++ b/RHEL/5/transforms/shorthand2xccdf.xslt
@@ -14,6 +14,8 @@
 
 <xsl:include href="constants.xslt"/>
 
+<xsl:param name="ssg_version">unknown</xsl:param>
+
 <xsl:variable name="ovalfile">unlinked-rhel5-oval.xml</xsl:variable>
 <xsl:variable name="defaultseverity" select="'low'" />
 
@@ -34,6 +36,11 @@
     <xsl:attribute name="date">
        <xsl:value-of select="date:date()"/>
     </xsl:attribute>
+  </xsl:template>
+
+  <!-- insert SSG version -->
+  <xsl:template match="Benchmark/version">
+    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -1,3 +1,5 @@
+include ../../VERSION
+
 IN = input
 OUT = output
 BUILD = build
@@ -33,7 +35,7 @@ endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide
-	xsltproc -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
+	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml
 	$(SHARED)/$(UTILS)/unselect-empty-xccdf-groups.py --input $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml --output $(OUT)/unlinked-$(PROD)-xccdf.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-xccdf.xml $(OUT)/unlinked-$(PROD)-xccdf.xml

--- a/RHEL/6/transforms/shorthand2xccdf.xslt
+++ b/RHEL/6/transforms/shorthand2xccdf.xslt
@@ -14,6 +14,8 @@
 
 <xsl:include href="constants.xslt"/>
 
+<xsl:param name="ssg_version">unknown</xsl:param>
+
 <xsl:variable name="ovalfile">unlinked-rhel6-oval.xml</xsl:variable>
 <xsl:variable name="defaultseverity" select="'low'" />
 
@@ -34,6 +36,11 @@
     <xsl:attribute name="date">
        <xsl:value-of select="date:date()"/>
     </xsl:attribute>
+  </xsl:template>
+
+  <!-- insert SSG version -->
+  <xsl:template match="Benchmark/version">
+    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -1,3 +1,5 @@
+include ../../VERSION
+
 IN = input
 OUT = output
 BUILD = build
@@ -34,7 +36,7 @@ endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide
-	xsltproc -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
+	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml
 	$(SHARED)/$(UTILS)/unselect-empty-xccdf-groups.py --input $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml --output $(OUT)/unlinked-$(PROD)-xccdf.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-xccdf.xml $(OUT)/unlinked-$(PROD)-xccdf.xml

--- a/RHEL/7/transforms/shorthand2xccdf.xslt
+++ b/RHEL/7/transforms/shorthand2xccdf.xslt
@@ -14,6 +14,8 @@
 
 <xsl:include href="constants.xslt"/>
 
+<xsl:param name="ssg_version">unknown</xsl:param>
+
 <xsl:variable name="ovalfile">unlinked-rhel7-oval.xml</xsl:variable>
 <xsl:variable name="defaultseverity" select="'low'" />
 
@@ -34,6 +36,11 @@
     <xsl:attribute name="date">
        <xsl:value-of select="date:date()"/>
     </xsl:attribute>
+  </xsl:template>
+
+  <!-- insert SSG version -->
+  <xsl:template match="Benchmark/version">
+    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/RHEVM3/Makefile
+++ b/RHEVM3/Makefile
@@ -1,3 +1,5 @@
+include ../VERSION
+
 IN = input
 OUT = output
 TRANS = transforms
@@ -26,7 +28,7 @@ endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide
-	xsltproc -o $(OUT)/unlinked-noprofiles-$(PROD)-shorthand.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
+	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $(OUT)/unlinked-noprofiles-$(PROD)-shorthand.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
 	xsltproc -o $(OUT)/unlinked-noprofiles-$(PROD)-xccdf.xml $(TRANS)/add_xccdf_namespace.xslt $(OUT)/unlinked-noprofiles-$(PROD)-shorthand.xml
 	xsltproc -stringparam profile "allprofiles" -o $(OUT)/unlinked-$(PROD)-xccdf-prerefs.xml \
 		$(TRANS)/xccdf-addprofiles.xslt $(OUT)/unlinked-noprofiles-$(PROD)-xccdf.xml

--- a/RHEVM3/transforms/shorthand2xccdf.xslt
+++ b/RHEVM3/transforms/shorthand2xccdf.xslt
@@ -8,8 +8,9 @@ exclude-result-prefixes="xccdf xhtml dc">
 
 <xsl:include href="constants.xslt"/>
 
-<xsl:variable name="ovalfile">unlinked-rhevm3-oval.xml</xsl:variable>
+<xsl:param name="ssg_version">unknown</xsl:param>
 
+<xsl:variable name="ovalfile">unlinked-rhevm3-oval.xml</xsl:variable>
 <xsl:variable name="defaultseverity" select="'low'" />
 
 
@@ -25,6 +26,11 @@ exclude-result-prefixes="xccdf xhtml dc">
     <xsl:attribute name="date">
        <xsl:value-of select="date:date()"/>
     </xsl:attribute>
+  </xsl:template>
+
+  <!-- insert SSG version -->
+  <xsl:template match="Benchmark/version">
+    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -1,3 +1,5 @@
+include ../VERSION
+
 IN = input
 OUT = output
 TRANS = transforms
@@ -31,7 +33,7 @@ endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide
-	xsltproc -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
+	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml $(TRANS)/shorthand2xccdf.xslt $(OUT)/$(PROD)-shorthand.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml $(OUT)/unlinked-unresolved-$(PROD)-xccdf.xml
 	$(SHARED)/$(UTILS)/unselect-empty-xccdf-groups.py --input $(OUT)/unlinked-$(PROD)-empty-groups-xccdf.xml --output $(OUT)/unlinked-$(PROD)-xccdf.xml
 	oscap xccdf resolve -o $(OUT)/unlinked-$(PROD)-xccdf.xml $(OUT)/unlinked-$(PROD)-xccdf.xml

--- a/Webmin/transforms/shorthand2xccdf.xslt
+++ b/Webmin/transforms/shorthand2xccdf.xslt
@@ -14,6 +14,8 @@
 
 <xsl:include href="constants.xslt"/>
 
+<xsl:param name="ssg_version">unknown</xsl:param>
+
 <xsl:variable name="ovalfile">unlinked-webmin-oval.xml</xsl:variable>
 <xsl:variable name="defaultseverity" select="'low'" />
 
@@ -34,6 +36,11 @@
     <xsl:attribute name="date">
        <xsl:value-of select="date:date()"/>
     </xsl:attribute>
+  </xsl:template>
+
+  <!-- insert SSG version -->
+  <xsl:template match="Benchmark/version">
+    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->


### PR DESCRIPTION
This makes the version appear in HTML report and guide and is a good explanation for users when they ask why they have some rules and don't have other rules in their SCAP content. The whole process is fully automatic, there is no additional work for the maintainer.

Check the "Revision History" column in attached screenshot of HTML guide.

![version_in_benchmarks](https://cloud.githubusercontent.com/assets/753153/10166822/0daaea76-66c6-11e5-9d7c-82f33d1230bc.png)

I have intentionally skipped OpenStack, JBoss Fuse and EAP because they are too different from other content. The same approach didn't work for them. These may be fixed in the future.
