### PR TITLE
Fixed OSPP profile title and description in RHEL7

### DIFF
--- a/RHEL/7/input/profiles/ospp-rhel7-server.xml
+++ b/RHEL/7/input/profiles/ospp-rhel7-server.xml
@@ -1,6 +1,6 @@
 <Profile id="ospp-rhel7-server">
-<title override="true">United States Government Configuration Baseline</title>
-<description override="true">This profile is being developed under the National Information Assurance Partnership. The scope of this profile is to configure Red Hat Enteprise Linux 7 against the NIAP Protection Profile for General Purpose Operating Systems v4.0</description>
+<title>United States Government Configuration Baseline (USGCB / STIG)</title>
+<description override="true">This is a *draft* profile for NIAP OSPP v4.0. This profile is being developed under the National Information Assurance Partnership. The scope of this profile is to configure Red Hat Enteprise Linux 7 against the NIAP Protection Profile for General Purpose Operating Systems v4.0. The NIAP OSPP profile also serves as a working draft for USGCB submission against RHEL7 Server.</description>
 
 <!-- OSPP v4.0 is available here:
      https://www.niap-ccevs.org/pp/PP_OS_v4.0/ 


### PR DESCRIPTION
The OSPP profile title said USGCB which was confusing in the GUI tools and HTML guides.