### PR TITLE
[BugFix] [RHEL/7] Equip each RHEL-7 specific remediation scripts with 'Red Hat Enterprise Linux 7' platform tag

### DIFF
--- a/RHEL/7/input/fixes/bash/account_disable_post_pw_expiration.sh
+++ b/RHEL/7/input/fixes/bash/account_disable_post_pw_expiration.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_account_disable_post_pw_expiration
 

--- a/RHEL/7/input/fixes/bash/accounts_max_concurrent_login_sessions.sh
+++ b/RHEL/7/input/fixes/bash/accounts_max_concurrent_login_sessions.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_accounts_max_concurrent_login_sessions
 

--- a/RHEL/7/input/fixes/bash/accounts_maximum_age_login_defs.sh
+++ b/RHEL/7/input/fixes/bash/accounts_maximum_age_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_accounts_maximum_age_login_defs
 

--- a/RHEL/7/input/fixes/bash/accounts_minimum_age_login_defs.sh
+++ b/RHEL/7/input/fixes/bash/accounts_minimum_age_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_accounts_minimum_age_login_defs
 

--- a/RHEL/7/input/fixes/bash/accounts_no_uid_except_zero.sh
+++ b/RHEL/7/input/fixes/bash/accounts_no_uid_except_zero.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 awk -F: '$3 == 0 && $1 != "root" { print $1 }' /etc/passwd | xargs passwd -l

--- a/RHEL/7/input/fixes/bash/accounts_password_minlen_login_defs.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_minlen_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_accounts_password_minlen_login_defs
 

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_dcredit.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_dcredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_password_pam_dcredit
 

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_difok.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_difok.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_password_pam_difok
 

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_lcredit.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_lcredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_password_pam_lcredit
 

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_maxrepeat.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_maxrepeat.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_password_pam_maxrepeat
 

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_minclass.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_minclass.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_password_pam_minclass
 

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_minlen.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_minlen.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_password_pam_minlen
 

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_ocredit.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_ocredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_password_pam_ocredit
 

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_retry.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_retry.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_password_pam_retry
 

--- a/RHEL/7/input/fixes/bash/accounts_password_pam_ucredit.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_pam_ucredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_password_pam_ucredit
 

--- a/RHEL/7/input/fixes/bash/accounts_password_warn_age_login_defs.sh
+++ b/RHEL/7/input/fixes/bash/accounts_password_warn_age_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_accounts_password_warn_age_login_defs
 

--- a/RHEL/7/input/fixes/bash/accounts_passwords_pam_faillock_unlock_time.sh
+++ b/RHEL/7/input/fixes/bash/accounts_passwords_pam_faillock_unlock_time.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_accounts_passwords_pam_faillock_unlock_time
 

--- a/RHEL/7/input/fixes/bash/accounts_umask_bashrc.sh
+++ b/RHEL/7/input/fixes/bash/accounts_umask_bashrc.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_accounts_user_umask
 

--- a/RHEL/7/input/fixes/bash/accounts_umask_cshrc.sh
+++ b/RHEL/7/input/fixes/bash/accounts_umask_cshrc.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_accounts_user_umask
 

--- a/RHEL/7/input/fixes/bash/accounts_umask_etc_profile.sh
+++ b/RHEL/7/input/fixes/bash/accounts_umask_etc_profile.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_accounts_user_umask
 

--- a/RHEL/7/input/fixes/bash/accounts_umask_login_defs.sh
+++ b/RHEL/7/input/fixes/bash/accounts_umask_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_accounts_user_umask
 

--- a/RHEL/7/input/fixes/bash/aide_build_database.sh
+++ b/RHEL/7/input/fixes/bash/aide_build_database.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 /usr/sbin/aide --init

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_chmod.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_chmod.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_chown.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_chown.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fchmod.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fchmod.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fchmodat.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fchmodat.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fchown.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fchown.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fchownat.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fchownat.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fremovexattr.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fremovexattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fsetxattr.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_fsetxattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_lchown.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_lchown.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_lremovexattr.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_lremovexattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_lsetxattr.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_lsetxattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_removexattr.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_removexattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_dac_modification_setxattr.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_dac_modification_setxattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_file_deletion_events.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_file_deletion_events.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_kernel_module_loading.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_kernel_module_loading.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_mac_modification.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_mac_modification.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_media_export.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_media_export.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_networkconfig_modification.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_networkconfig_modification.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_session_events.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_session_events.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_sysadmin_actions.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_sysadmin_actions.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_time_clock_settime.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_time_clock_settime.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_time_watch_localtime.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_time_watch_localtime.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_unsuccessful_file_modification.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_unsuccessful_file_modification.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/audit_rules_usergroup_modification.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_usergroup_modification.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/7/input/fixes/bash/auditd_audispd_syslog_plugin_activated.sh
+++ b/RHEL/7/input/fixes/bash/auditd_audispd_syslog_plugin_activated.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 grep -q ^active /etc/audisp/plugins.d/syslog.conf && \
   sed -i "s/active.*/active = yes/g" /etc/audisp/plugins.d/syslog.conf

--- a/RHEL/7/input/fixes/bash/auditd_data_retention_admin_space_left_action.sh
+++ b/RHEL/7/input/fixes/bash/auditd_data_retention_admin_space_left_action.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_auditd_admin_space_left_action
 

--- a/RHEL/7/input/fixes/bash/auditd_data_retention_space_left_action.sh
+++ b/RHEL/7/input/fixes/bash/auditd_data_retention_space_left_action.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_auditd_space_left_action
 

--- a/RHEL/7/input/fixes/bash/banner_etc_issue.sh
+++ b/RHEL/7/input/fixes/bash/banner_etc_issue.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate login_banner_text
 

--- a/RHEL/7/input/fixes/bash/bootloader_audit_argument.sh
+++ b/RHEL/7/input/fixes/bash/bootloader_audit_argument.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 
 # Correct the form of default kernel command line in /etc/default/grub
 grep -q ^GRUB_CMDLINE_LINUX=\".*audit=0.*\" /etc/default/grub && \

--- a/RHEL/7/input/fixes/bash/disable_ctrlaltdel_reboot.sh
+++ b/RHEL/7/input/fixes/bash/disable_ctrlaltdel_reboot.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 # The process to disable ctrl+alt+del has changed in RHEL7. 
 # Reference: https://access.redhat.com/solutions/1123873
 ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target

--- a/RHEL/7/input/fixes/bash/disable_interactive_boot.sh
+++ b/RHEL/7/input/fixes/bash/disable_interactive_boot.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -q ^PROMPT /etc/sysconfig/init && \
   sed -i "s/PROMPT.*/PROMPT=no/g" /etc/sysconfig/init
 if ! [ $? -eq 0 ]; then

--- a/RHEL/7/input/fixes/bash/disable_prelink.sh
+++ b/RHEL/7/input/fixes/bash/disable_prelink.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable prelinking altogether
 #

--- a/RHEL/7/input/fixes/bash/disable_users_coredumps.sh
+++ b/RHEL/7/input/fixes/bash/disable_users_coredumps.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "*     hard   core    0" >> /etc/security/limits.conf

--- a/RHEL/7/input/fixes/bash/disable_vsftp.sh
+++ b/RHEL/7/input/fixes/bash/disable_vsftp.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 if service vsftpd status >/dev/null; then
 	service vsftpd stop
 fi

--- a/RHEL/7/input/fixes/bash/disable_vsftpd.sh
+++ b/RHEL/7/input/fixes/bash/disable_vsftpd.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 if service vsftpd status >/dev/null; then
 	service vsftpd stop
 fi

--- a/RHEL/7/input/fixes/bash/file_group_owner_grub2_cfg.sh
+++ b/RHEL/7/input/fixes/bash/file_group_owner_grub2_cfg.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 chgrp root /boot/grub2/grub.cfg

--- a/RHEL/7/input/fixes/bash/file_ownership_library_dirs.sh
+++ b/RHEL/7/input/fixes/bash/file_ownership_library_dirs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 for LIBDIR in /usr/lib /usr/lib64 /lib /lib64
 do
   if [ -d $LIBDIR ]

--- a/RHEL/7/input/fixes/bash/file_permissions_binary_dirs.sh
+++ b/RHEL/7/input/fixes/bash/file_permissions_binary_dirs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 DIRS="/bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin"
 for dirPath in $DIRS; do
 	find "$dirPath" -perm /022 -exec chmod go-w '{}' \;

--- a/RHEL/7/input/fixes/bash/file_permissions_etc_shadow.sh
+++ b/RHEL/7/input/fixes/bash/file_permissions_etc_shadow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 chmod 0000 /etc/shadow

--- a/RHEL/7/input/fixes/bash/file_permissions_grub2_cfg.sh
+++ b/RHEL/7/input/fixes/bash/file_permissions_grub2_cfg.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 chmod 600 /boot/grub2/grub.cfg

--- a/RHEL/7/input/fixes/bash/file_permissions_library_dirs.sh
+++ b/RHEL/7/input/fixes/bash/file_permissions_library_dirs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 DIRS="/lib /lib64 /usr/lib /usr/lib64"
 for dirPath in $DIRS; do
 	find "$dirPath" -perm /022 -type f -exec chmod go-w '{}' \;

--- a/RHEL/7/input/fixes/bash/file_user_owner_grub2_cfg.sh
+++ b/RHEL/7/input/fixes/bash/file_user_owner_grub2_cfg.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 chown root /boot/grub2/grub.cfg

--- a/RHEL/7/input/fixes/bash/groupowner_shadow_file.sh
+++ b/RHEL/7/input/fixes/bash/groupowner_shadow_file.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 chgrp root /etc/shadow

--- a/RHEL/7/input/fixes/bash/kernel_module_cramfs_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_cramfs_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "install cramfs /bin/true" > /etc/modprobe.d/cramfs.conf

--- a/RHEL/7/input/fixes/bash/kernel_module_dccp_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_dccp_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "install dccp /bin/true" > /etc/modprobe.d/dccp.conf

--- a/RHEL/7/input/fixes/bash/kernel_module_freevxfs_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_freevxfs_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "install freevxfs /bin/true" > /etc/modprobe.d/freevxfs.conf

--- a/RHEL/7/input/fixes/bash/kernel_module_hfs_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_hfs_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "install hfs /bin/true" > /etc/modprobe.d/hfs.conf

--- a/RHEL/7/input/fixes/bash/kernel_module_hfsplus_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_hfsplus_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "install hfsplus /bin/true" > /etc/modprobe.d/hfsplus.conf

--- a/RHEL/7/input/fixes/bash/kernel_module_jffs2_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_jffs2_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "install jffs2 /bin/true" > /etc/modprobe.d/jffs2.conf

--- a/RHEL/7/input/fixes/bash/kernel_module_rds_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_rds_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "install rds /bin/true" > /etc/modprobe.d/rds.conf

--- a/RHEL/7/input/fixes/bash/kernel_module_sctp_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_sctp_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "install sctp /bin/true" > /etc/modprobe.d/sctp.conf

--- a/RHEL/7/input/fixes/bash/kernel_module_squashfs_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_squashfs_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "install squashfs /bin/true" > /etc/modprobe.d/squashfs.conf

--- a/RHEL/7/input/fixes/bash/kernel_module_tipc_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_tipc_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "install tipc /bin/true" > /etc/modprobe.d/tipc.conf

--- a/RHEL/7/input/fixes/bash/kernel_module_udf_disabled.sh
+++ b/RHEL/7/input/fixes/bash/kernel_module_udf_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "install udf /bin/true" > /etc/modprobe.d/udf.conf

--- a/RHEL/7/input/fixes/bash/network_disable_zeroconf.sh
+++ b/RHEL/7/input/fixes/bash/network_disable_zeroconf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 echo "NOZEROCONF=yes" >> /etc/sysconfig/network

--- a/RHEL/7/input/fixes/bash/no_empty_passwords.sh
+++ b/RHEL/7/input/fixes/bash/no_empty_passwords.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 sed -i 's/\<nullok\>//g' /etc/pam.d/system-auth

--- a/RHEL/7/input/fixes/bash/package_aide_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_aide_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install aide

--- a/RHEL/7/input/fixes/bash/package_audit_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_audit_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install audit

--- a/RHEL/7/input/fixes/bash/package_cronie_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_cronie_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install cronie

--- a/RHEL/7/input/fixes/bash/package_irqbalance_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_irqbalance_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install irqbalance

--- a/RHEL/7/input/fixes/bash/package_kernel-PAE_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_kernel-PAE_installed.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 if [ $(getconf LONG_BIT) = "32" ] ; then 
    yum -y install kernel-PAE
 fi

--- a/RHEL/7/input/fixes/bash/package_libreswan_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_libreswan_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install libreswan

--- a/RHEL/7/input/fixes/bash/package_ntp_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_ntp_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install ntp

--- a/RHEL/7/input/fixes/bash/package_policycoreutils_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_policycoreutils_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install policycoreutils

--- a/RHEL/7/input/fixes/bash/package_postfix_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_postfix_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install postfix

--- a/RHEL/7/input/fixes/bash/package_psacct_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_psacct_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install psacct

--- a/RHEL/7/input/fixes/bash/package_rsyslog_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_rsyslog_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install rsyslog

--- a/RHEL/7/input/fixes/bash/package_screen_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_screen_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install screen

--- a/RHEL/7/input/fixes/bash/package_telnet_removed.sh
+++ b/RHEL/7/input/fixes/bash/package_telnet_removed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y remove telnet

--- a/RHEL/7/input/fixes/bash/package_vsftpd_installed.sh
+++ b/RHEL/7/input/fixes/bash/package_vsftpd_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 yum -y install vsftpd

--- a/RHEL/7/input/fixes/bash/require_singleuser_auth.sh
+++ b/RHEL/7/input/fixes/bash/require_singleuser_auth.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -q ^SINGLE /etc/sysconfig/init && \
   sed -i "s/SINGLE.*/SINGLE=\/sbin\/sulogin/g" /etc/sysconfig/init
 if ! [ $? -eq 0 ]; then

--- a/RHEL/7/input/fixes/bash/securetty_root_login_console_only.sh
+++ b/RHEL/7/input/fixes/bash/securetty_root_login_console_only.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 sed -i '/^vc\//d' /etc/securetty

--- a/RHEL/7/input/fixes/bash/selinux_policytype.sh
+++ b/RHEL/7/input/fixes/bash/selinux_policytype.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_selinux_policy_name
 

--- a/RHEL/7/input/fixes/bash/selinux_state.sh
+++ b/RHEL/7/input/fixes/bash/selinux_state.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_selinux_state
 

--- a/RHEL/7/input/fixes/bash/service_abrtd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_abrtd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable abrtd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_acpid_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_acpid_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable acpid.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_atd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_atd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable atd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_auditd_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_auditd_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Enable auditd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_autofs_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_autofs_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable autofs.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_avahi-daemon_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_avahi-daemon_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable avahi-daemon.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_bluetooth_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_bluetooth_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -qi disable /etc/xinetd.d/bluetooth && \
 	sed -i 's/disable.*/disable	= yes/gI' /etc/xinetd.d/bluetooth
 #

--- a/RHEL/7/input/fixes/bash/service_certmonger_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_certmonger_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable certmonger.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_cgconfig_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_cgconfig_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable cgconfig.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_cgred_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_cgred_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable cgred.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_crond_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_crond_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Enable crond.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_cups_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_cups_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable cups.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_dhcpd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_dhcpd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable dhcpd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_dovecot_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_dovecot_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable dovecot.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_firewalld_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_firewalld_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Enable firewalld.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_httpd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_httpd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable httpd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_irqbalance_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_irqbalance_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Enable irqbalance.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_kdump_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_kdump_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable kdump.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_mdmonitor_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_mdmonitor_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable mdmonitor.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_messagebus_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_messagebus_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable messagebus.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_named_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_named_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable named.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_netconsole_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_netconsole_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable netconsole for all run levels
 #

--- a/RHEL/7/input/fixes/bash/service_nfs_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_nfs_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable nfs.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_nfslock_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_nfslock_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable nfs-lock.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_ntpd_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_ntpd_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Enable ntpd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_oddjobd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_oddjobd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable oddjobd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_portreserve_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_portreserve_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable portreserve.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_postfix_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_postfix_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Enable postfix.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_psacct_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_psacct_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Enable psacct.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_qpidd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_qpidd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable qpidd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_quota_nld_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_quota_nld_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable quota_nld.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_rdisc_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rdisc_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable rdisc.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_rexec_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rexec_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -qi disable /etc/xinetd.d/rexec && \
   sed -i "s/disable.*/disable         = yes/gI" /etc/xinetd.d/rexec
 

--- a/RHEL/7/input/fixes/bash/service_rhnsd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rhnsd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable rhnsd for all run levels
 #

--- a/RHEL/7/input/fixes/bash/service_rhsmcertd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rhsmcertd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable rhsmcertd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_rlogin_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rlogin_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -qi disable /etc/xinetd.d/rlogin && \
   sed -i "s/disable.*/disable         = yes/gI" /etc/xinetd.d/rlogin
 

--- a/RHEL/7/input/fixes/bash/service_rpcgssd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rpcgssd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable nfs-secure.service (rpcgssd) for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_rpcidmapd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rpcidmapd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable nfs-idmap.service (rpcidmapd) for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_rpcsvcgssd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rpcsvcgssd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable nfs-secure-server.service (rpcsvcgssd) for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_rsh_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rsh_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -qi disable /etc/xinetd.d/rsh && \
   sed -i "s/disable.*/disable         = yes/gI" /etc/xinetd.d/rsh
 

--- a/RHEL/7/input/fixes/bash/service_rsyslog_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rsyslog_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Enable rsyslog.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_saslauthd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_saslauthd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable saslauthd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_smartd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_smartd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable smartd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_smb_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_smb_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable smb.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_snmpd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_snmpd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable snmpd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_squid_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_squid_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable squid.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_sshd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_sshd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable sshd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_sysstat_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_sysstat_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable sysstat.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_telnet_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_telnet_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -qi disable /etc/xinetd.d/telnet && \
   sed -i "s/disable.*/disable         = yes/gI" /etc/xinetd.d/telnet
 

--- a/RHEL/7/input/fixes/bash/service_vsftpd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_vsftpd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable vsftpd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_xinetd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_xinetd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable xinetd.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/service_ypbind_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_ypbind_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Disable ypbind.service for all systemd targets
 #

--- a/RHEL/7/input/fixes/bash/sshd_disable_empty_passwords.sh
+++ b/RHEL/7/input/fixes/bash/sshd_disable_empty_passwords.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -qi ^PermitEmptyPasswords /etc/ssh/sshd_config && \
   sed -i "s/PermitEmptyPasswords.*/PermitEmptyPasswords no/gI" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/7/input/fixes/bash/sshd_do_not_permit_user_env.sh
+++ b/RHEL/7/input/fixes/bash/sshd_do_not_permit_user_env.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -qi ^PermitUserEnvironment /etc/ssh/sshd_config && \
   sed -i "s/PermitUserEnvironment.*/PermitUserEnvironment no/gI" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/7/input/fixes/bash/sshd_enable_warning_banner.sh
+++ b/RHEL/7/input/fixes/bash/sshd_enable_warning_banner.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -qi ^Banner /etc/ssh/sshd_config && \
   sed -i "s/Banner.*/Banner \/etc\/issue/gI" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/7/input/fixes/bash/sshd_set_idle_timeout.sh
+++ b/RHEL/7/input/fixes/bash/sshd_set_idle_timeout.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate sshd_idle_timeout_value
 

--- a/RHEL/7/input/fixes/bash/sshd_set_keepalive.sh
+++ b/RHEL/7/input/fixes/bash/sshd_set_keepalive.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -qi ^ClientAliveCountMax /etc/ssh/sshd_config && \
   sed -i "s/ClientAliveCountMax.*/ClientAliveCountMax 0/gI" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/7/input/fixes/bash/sshd_use_approved_ciphers.sh
+++ b/RHEL/7/input/fixes/bash/sshd_use_approved_ciphers.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 grep -qi ^Ciphers /etc/ssh/sshd_config && \
   sed -i "s/Ciphers.*/Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc/gI" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/7/input/fixes/bash/sysctl_fs_suid_dumpable.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_fs_suid_dumpable.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for fs.suid_dumpable
 #

--- a/RHEL/7/input/fixes/bash/sysctl_kernel_dmesg_restrict.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_kernel_dmesg_restrict.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for kernel.dmesg_restrict
 #

--- a/RHEL/7/input/fixes/bash/sysctl_kernel_exec_shield.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_kernel_exec_shield.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 if [ $(getconf LONG_BIT) = "32" ] ; then
   #
   # Set runtime for kernel.exec-shield

--- a/RHEL/7/input/fixes/bash/sysctl_kernel_randomize_va_space.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_kernel_randomize_va_space.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for kernel.randomize_va_space
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_redirects.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.conf.all.accept_redirects
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_source_route.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_source_route.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.conf.all.accept_source_route
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_log_martians.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_log_martians.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.conf.all.log_martians
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_rp_filter.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_rp_filter.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.conf.all.rp_filter
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_secure_redirects.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_secure_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.conf.all.secure_redirects
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_send_redirects.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_all_send_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.conf.all.send_redirects
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_redirects.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.conf.default.accept_redirects
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_source_route.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_source_route.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.conf.default.accept_source_route
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_default_rp_filter.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_default_rp_filter.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.conf.default.rp_filter
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_default_secure_redirects.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_default_secure_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.conf.default.secure_redirects
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_default_send_redirects.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_conf_default_send_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.conf.default.send_redirects
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_icmp_echo_ignore_broadcasts.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_icmp_echo_ignore_broadcasts.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.icmp_echo_ignore_broadcasts
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_icmp_ignore_bogus_error_responses.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_icmp_ignore_bogus_error_responses.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.icmp_ignore_bogus_error_responses
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_ip_forward.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_ip_forward.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.ip_forward
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv4_tcp_syncookies.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv4_tcp_syncookies.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv4.tcp_syncookies
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_ra.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_ra.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv6.conf.default.accept_ra
 #

--- a/RHEL/7/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_redirects.sh
+++ b/RHEL/7/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 #
 # Set runtime for net.ipv6.conf.default.accept_redirects
 #

--- a/RHEL/7/input/fixes/bash/umask_for_daemons.sh
+++ b/RHEL/7/input/fixes/bash/umask_for_daemons.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 source ./templates/support.sh
 populate var_umask_for_daemons
 

--- a/RHEL/7/input/fixes/bash/uninstall_telnet_server.sh
+++ b/RHEL/7/input/fixes/bash/uninstall_telnet_server.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 if rpm -qa | grep -q telnet-server; then
 	yum -y remove telnet-server
 fi

--- a/RHEL/7/input/fixes/bash/uninstall_xinetd.sh
+++ b/RHEL/7/input/fixes/bash/uninstall_xinetd.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 if rpm -qa | grep -q xinetd; then
 	yum -y remove xinetd
 fi

--- a/RHEL/7/input/fixes/bash/uninstall_ypserv.sh
+++ b/RHEL/7/input/fixes/bash/uninstall_ypserv.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
 if rpm -qa | grep -q ypserv; then
 	yum -y remove ypserv
 fi

--- a/RHEL/7/input/fixes/bash/userowner_shadow_file.sh
+++ b/RHEL/7/input/fixes/bash/userowner_shadow_file.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 7
 chown root /etc/shadow


### PR DESCRIPTION

in order RHEL-7 specific remediation scripts to be included into the final XCCDF once the
symlinks mechanism has been removed.

Since the mechanism for the way how remediation scripts are included now has changed
(see https://github.com/OpenSCAP/scap-security-guide/commit/e7c8b216c56161fa93ff07277fe911040d1ff41e for the corresponding change)

now each remediation script in order to be included into the final XCCDF needs to have commented out platform tag (something like OVAL is doing via it's <platform> element).

This change is adding '# platform = Red Hat Enterprise Linux 7' to all RHEL-7 specific remediation scripts existing up to now.

Please review.

Thank you, Jan.
