### PR TITLE
[BugFix] [RHEL/6] [Fedora] Add platform tags for platform specific remediations scripts

### DIFF
--- a/Fedora/input/fixes/bash/accounts_maximum_age_login_defs.sh
+++ b/Fedora/input/fixes/bash/accounts_maximum_age_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_fedora
 source ./templates/support.sh
 populate var_accounts_maximum_age_login_defs
 

--- a/Fedora/input/fixes/bash/accounts_minimum_age_login_defs.sh
+++ b/Fedora/input/fixes/bash/accounts_minimum_age_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_fedora
 source ./templates/support.sh
 populate var_accounts_minimum_age_login_defs
 

--- a/Fedora/input/fixes/bash/accounts_password_minlen_login_defs.sh
+++ b/Fedora/input/fixes/bash/accounts_password_minlen_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_fedora
 source ./templates/support.sh
 populate var_accounts_password_minlen_login_defs
 

--- a/Fedora/input/fixes/bash/accounts_password_warn_age_login_defs.sh
+++ b/Fedora/input/fixes/bash/accounts_password_warn_age_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_fedora
 source ./templates/support.sh
 populate var_accounts_password_warn_age_login_defs
 

--- a/Fedora/input/fixes/bash/disable_prelink.sh
+++ b/Fedora/input/fixes/bash/disable_prelink.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_fedora
 #
 # Disable prelinking altogether
 #

--- a/Fedora/input/fixes/bash/package_audit_installed.sh
+++ b/Fedora/input/fixes/bash/package_audit_installed.sh
@@ -1,1 +1,2 @@
+# platform = multi_platform_fedora
 yum -y install audit

--- a/Fedora/input/fixes/bash/package_chrony_installed.sh
+++ b/Fedora/input/fixes/bash/package_chrony_installed.sh
@@ -1,1 +1,2 @@
+# platform = multi_platform_fedora
 yum -y install chrony

--- a/Fedora/input/fixes/bash/service_chronyd_enabled.sh
+++ b/Fedora/input/fixes/bash/service_chronyd_enabled.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_fedora
 #
 # Install chrony package if necessary
 #

--- a/RHEL/6/input/fixes/bash/account_disable_post_pw_expiration.sh
+++ b/RHEL/6/input/fixes/bash/account_disable_post_pw_expiration.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_account_disable_post_pw_expiration
 

--- a/RHEL/6/input/fixes/bash/accounts_max_concurrent_login_sessions.sh
+++ b/RHEL/6/input/fixes/bash/accounts_max_concurrent_login_sessions.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_accounts_max_concurrent_login_sessions
 

--- a/RHEL/6/input/fixes/bash/accounts_maximum_age_login_defs.sh
+++ b/RHEL/6/input/fixes/bash/accounts_maximum_age_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_accounts_maximum_age_login_defs
 

--- a/RHEL/6/input/fixes/bash/accounts_minimum_age_login_defs.sh
+++ b/RHEL/6/input/fixes/bash/accounts_minimum_age_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_accounts_minimum_age_login_defs
 

--- a/RHEL/6/input/fixes/bash/accounts_no_uid_except_zero.sh
+++ b/RHEL/6/input/fixes/bash/accounts_no_uid_except_zero.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 awk -F: '$3 == 0 && $1 != "root" { print $1 }' /etc/passwd | xargs passwd -l

--- a/RHEL/6/input/fixes/bash/accounts_password_minlen_login_defs.sh
+++ b/RHEL/6/input/fixes/bash/accounts_password_minlen_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_accounts_password_minlen_login_defs
 

--- a/RHEL/6/input/fixes/bash/accounts_password_pam_cracklib_minclass.sh
+++ b/RHEL/6/input/fixes/bash/accounts_password_pam_cracklib_minclass.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_password_pam_minclass
 

--- a/RHEL/6/input/fixes/bash/accounts_password_pam_dcredit.sh
+++ b/RHEL/6/input/fixes/bash/accounts_password_pam_dcredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_password_pam_dcredit
 

--- a/RHEL/6/input/fixes/bash/accounts_password_pam_difok.sh
+++ b/RHEL/6/input/fixes/bash/accounts_password_pam_difok.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_password_pam_difok
 

--- a/RHEL/6/input/fixes/bash/accounts_password_pam_lcredit.sh
+++ b/RHEL/6/input/fixes/bash/accounts_password_pam_lcredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_password_pam_lcredit
 

--- a/RHEL/6/input/fixes/bash/accounts_password_pam_maxrepeat.sh
+++ b/RHEL/6/input/fixes/bash/accounts_password_pam_maxrepeat.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_password_pam_maxrepeat
 

--- a/RHEL/6/input/fixes/bash/accounts_password_pam_ocredit.sh
+++ b/RHEL/6/input/fixes/bash/accounts_password_pam_ocredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_password_pam_ocredit
 

--- a/RHEL/6/input/fixes/bash/accounts_password_pam_ucredit.sh
+++ b/RHEL/6/input/fixes/bash/accounts_password_pam_ucredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_password_pam_ucredit
 

--- a/RHEL/6/input/fixes/bash/accounts_password_warn_age_login_defs.sh
+++ b/RHEL/6/input/fixes/bash/accounts_password_warn_age_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_accounts_password_warn_age_login_defs
 

--- a/RHEL/6/input/fixes/bash/accounts_passwords_pam_faillock_interval.sh
+++ b/RHEL/6/input/fixes/bash/accounts_passwords_pam_faillock_interval.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_accounts_passwords_pam_faillock_fail_interval
 

--- a/RHEL/6/input/fixes/bash/accounts_passwords_pam_faillock_unlock_time.sh
+++ b/RHEL/6/input/fixes/bash/accounts_passwords_pam_faillock_unlock_time.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_accounts_passwords_pam_faillock_unlock_time
 

--- a/RHEL/6/input/fixes/bash/accounts_umask_bashrc.sh
+++ b/RHEL/6/input/fixes/bash/accounts_umask_bashrc.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_accounts_user_umask
 

--- a/RHEL/6/input/fixes/bash/accounts_umask_cshrc.sh
+++ b/RHEL/6/input/fixes/bash/accounts_umask_cshrc.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_accounts_user_umask
 

--- a/RHEL/6/input/fixes/bash/accounts_umask_etc_profile.sh
+++ b/RHEL/6/input/fixes/bash/accounts_umask_etc_profile.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_accounts_user_umask
 

--- a/RHEL/6/input/fixes/bash/accounts_umask_login_defs.sh
+++ b/RHEL/6/input/fixes/bash/accounts_umask_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_accounts_user_umask
 

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_chmod.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_chmod.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_chown.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_chown.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fchmod.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fchmod.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fchmodat.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fchmodat.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fchown.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fchown.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fchownat.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fchownat.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fremovexattr.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fremovexattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fsetxattr.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_fsetxattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_lchown.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_lchown.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_lremovexattr.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_lremovexattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_lsetxattr.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_lsetxattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_removexattr.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_removexattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_dac_modification_setxattr.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_dac_modification_setxattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_file_deletion_events.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_file_deletion_events.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_immutable.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_immutable.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 readonly AUDIT_RULES='/etc/audit/audit.rules'
 

--- a/RHEL/6/input/fixes/bash/audit_rules_kernel_module_loading.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_kernel_module_loading.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_mac_modification.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_mac_modification.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_media_export.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_media_export.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_networkconfig_modification.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_networkconfig_modification.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_privileged_commands.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_privileged_commands.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 readonly AUDIT_RULES='/etc/audit/audit.rules'
 

--- a/RHEL/6/input/fixes/bash/audit_rules_session_events.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_session_events.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_sysadmin_actions.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_sysadmin_actions.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_time_adjtimex.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_time_adjtimex.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # audit.rules file to operate at
 AUDIT_RULES_FILE="/etc/audit/audit.rules"

--- a/RHEL/6/input/fixes/bash/audit_rules_time_clock_settime.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_time_clock_settime.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_time_watch_localtime.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_time_watch_localtime.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_unsuccessful_file_modification.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_unsuccessful_file_modification.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/audit_rules_usergroup_modification.sh
+++ b/RHEL/6/input/fixes/bash/audit_rules_usergroup_modification.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/RHEL/6/input/fixes/bash/auditd_data_retention_admin_space_left_action.sh
+++ b/RHEL/6/input/fixes/bash/auditd_data_retention_admin_space_left_action.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_auditd_admin_space_left_action
 

--- a/RHEL/6/input/fixes/bash/banner_etc_issue.sh
+++ b/RHEL/6/input/fixes/bash/banner_etc_issue.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate login_banner_text
 

--- a/RHEL/6/input/fixes/bash/disable_ctrlaltdel_reboot.sh
+++ b/RHEL/6/input/fixes/bash/disable_ctrlaltdel_reboot.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 # If system does not contain control-alt-delete.override,
 if [ ! -f /etc/init/control-alt-delete.override ]; then
 

--- a/RHEL/6/input/fixes/bash/disable_interactive_boot.sh
+++ b/RHEL/6/input/fixes/bash/disable_interactive_boot.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 grep -q ^PROMPT /etc/sysconfig/init && \
   sed -i "s/PROMPT.*/PROMPT=no/g" /etc/sysconfig/init
 if ! [ $? -eq 0 ]; then

--- a/RHEL/6/input/fixes/bash/disable_prelink.sh
+++ b/RHEL/6/input/fixes/bash/disable_prelink.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable prelinking altogether
 #

--- a/RHEL/6/input/fixes/bash/disable_users_coredumps.sh
+++ b/RHEL/6/input/fixes/bash/disable_users_coredumps.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "*     hard   core    0" >> /etc/security/limits.conf

--- a/RHEL/6/input/fixes/bash/disable_vsftp.sh
+++ b/RHEL/6/input/fixes/bash/disable_vsftp.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 if service vsftpd status >/dev/null; then
 	service vsftpd stop
 fi

--- a/RHEL/6/input/fixes/bash/disable_vsftpd.sh
+++ b/RHEL/6/input/fixes/bash/disable_vsftpd.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 if service vsftpd status >/dev/null; then
 	service vsftpd stop
 fi

--- a/RHEL/6/input/fixes/bash/display_login_attempts.sh
+++ b/RHEL/6/input/fixes/bash/display_login_attempts.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 sed -i --follow-symlinks '/pam_limits.so/a session\t    required\t  pam_lastlog.so showfailed' /etc/pam.d/system-auth

--- a/RHEL/6/input/fixes/bash/file_group_owner_grub_conf.sh
+++ b/RHEL/6/input/fixes/bash/file_group_owner_grub_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 chgrp root /etc/grub.conf

--- a/RHEL/6/input/fixes/bash/file_ownership_library_dirs.sh
+++ b/RHEL/6/input/fixes/bash/file_ownership_library_dirs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 for LIBDIR in /usr/lib /usr/lib64 /lib /lib64
 do
   if [ -d $LIBDIR ]

--- a/RHEL/6/input/fixes/bash/file_permissions_binary_dirs.sh
+++ b/RHEL/6/input/fixes/bash/file_permissions_binary_dirs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 DIRS="/bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin"
 for dirPath in $DIRS; do
 	find $dirPath -perm /022 -exec chmod go-w '{}' \;

--- a/RHEL/6/input/fixes/bash/file_permissions_etc_shadow.sh
+++ b/RHEL/6/input/fixes/bash/file_permissions_etc_shadow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 chmod 0000 /etc/shadow

--- a/RHEL/6/input/fixes/bash/file_permissions_grub_conf.sh
+++ b/RHEL/6/input/fixes/bash/file_permissions_grub_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 chmod 600 /boot/grub/grub.conf

--- a/RHEL/6/input/fixes/bash/file_permissions_library_dirs.sh
+++ b/RHEL/6/input/fixes/bash/file_permissions_library_dirs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 DIRS="/lib /lib64 /usr/lib /usr/lib64"
 for dirPath in $DIRS; do
 	find $dirPath -perm /022 -type f -exec chmod go-w '{}' \;

--- a/RHEL/6/input/fixes/bash/file_user_owner_grub_conf.sh
+++ b/RHEL/6/input/fixes/bash/file_user_owner_grub_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 chown root /etc/grub.conf

--- a/RHEL/6/input/fixes/bash/gconf_gdm_disable_user_list.sh
+++ b/RHEL/6/input/fixes/bash/gconf_gdm_disable_user_list.sh
@@ -1,4 +1,5 @@
 # platform = Red Hat Enterprise Linux 6
+# platform = Red Hat Enterprise Linux 6
 # Install GConf2 package if not installed
 if ! rpm -q GConf2; then
   yum -y install GConf2

--- a/RHEL/6/input/fixes/bash/gconf_gdm_enable_warning_gui_banner.sh
+++ b/RHEL/6/input/fixes/bash/gconf_gdm_enable_warning_gui_banner.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 # Install GConf2 package if not installed
 if ! rpm -q GConf2; then
   yum -y install GConf2

--- a/RHEL/6/input/fixes/bash/gconf_gdm_set_login_banner_text.sh
+++ b/RHEL/6/input/fixes/bash/gconf_gdm_set_login_banner_text.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate login_banner_text
 

--- a/RHEL/6/input/fixes/bash/gconf_gnome_screensaver_idle_activation_enabled.sh
+++ b/RHEL/6/input/fixes/bash/gconf_gnome_screensaver_idle_activation_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 # Install GConf2 package if not installed
 if ! rpm -q GConf2; then
   yum -y install GConf2

--- a/RHEL/6/input/fixes/bash/gconf_gnome_screensaver_idle_delay.sh
+++ b/RHEL/6/input/fixes/bash/gconf_gnome_screensaver_idle_delay.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate inactivity_timeout_value
 

--- a/RHEL/6/input/fixes/bash/gconf_gnome_screensaver_lock_enabled.sh
+++ b/RHEL/6/input/fixes/bash/gconf_gnome_screensaver_lock_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 # Install GConf2 package if not installed
 if ! rpm -q GConf2; then
   yum -y install GConf2

--- a/RHEL/6/input/fixes/bash/gconf_gnome_screensaver_mode_blank.sh
+++ b/RHEL/6/input/fixes/bash/gconf_gnome_screensaver_mode_blank.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 # Install GConf2 package if not installed
 if ! rpm -q GConf2; then
   yum -y install GConf2

--- a/RHEL/6/input/fixes/bash/groupowner_shadow_file.sh
+++ b/RHEL/6/input/fixes/bash/groupowner_shadow_file.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 chgrp root /etc/shadow

--- a/RHEL/6/input/fixes/bash/kernel_module_cramfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_cramfs_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install cramfs /bin/true" > /etc/modprobe.d/cramfs.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_dccp_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_dccp_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install dccp /bin/true" > /etc/modprobe.d/dccp.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_freevxfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_freevxfs_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install freevxfs /bin/true" > /etc/modprobe.d/freevxfs.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_hfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_hfs_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install hfs /bin/true" > /etc/modprobe.d/hfs.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_hfsplus_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_hfsplus_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install hfsplus /bin/true" > /etc/modprobe.d/hfsplus.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_ipv6_option_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_ipv6_option_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Prevent the IPv6 kernel module (ipv6) from loading the IPv6 networking stack
 echo "options ipv6 disable=1" > /etc/modprobe.d/ipv6.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_jffs2_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_jffs2_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install jffs2 /bin/true" > /etc/modprobe.d/jffs2.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_rds_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_rds_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install rds /bin/true" > /etc/modprobe.d/rds.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_sctp_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_sctp_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install sctp /bin/true" > /etc/modprobe.d/sctp.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_squashfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_squashfs_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install squashfs /bin/true" > /etc/modprobe.d/squashfs.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_tipc_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_tipc_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install tipc /bin/true" > /etc/modprobe.d/tipc.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_udf_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_udf_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install udf /bin/true" > /etc/modprobe.d/udf.conf

--- a/RHEL/6/input/fixes/bash/kernel_module_usb-storage_disabled.sh
+++ b/RHEL/6/input/fixes/bash/kernel_module_usb-storage_disabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "install usb-storage /bin/true" > /etc/modprobe.d/usb-storage.conf

--- a/RHEL/6/input/fixes/bash/mount_option_dev_shm_nodev.sh
+++ b/RHEL/6/input/fixes/bash/mount_option_dev_shm_nodev.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Load /etc/fstab's /dev/shm row into DEV_SHM_FSTAB variable separating start &
 # end of the filesystem mount options (4-th field) with the '#' character

--- a/RHEL/6/input/fixes/bash/mount_option_dev_shm_noexec.sh
+++ b/RHEL/6/input/fixes/bash/mount_option_dev_shm_noexec.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Load /etc/fstab's /dev/shm row into DEV_SHM_FSTAB variable separating start &
 # end of the filesystem mount options (4-th field) with the '#' character

--- a/RHEL/6/input/fixes/bash/mount_option_dev_shm_nosuid.sh
+++ b/RHEL/6/input/fixes/bash/mount_option_dev_shm_nosuid.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Load /etc/fstab's /dev/shm row into DEV_SHM_FSTAB variable separating start &
 # end of the filesystem mount options (4-th field) with the '#' character

--- a/RHEL/6/input/fixes/bash/mount_option_nodev_nonroot_local_partitions.sh
+++ b/RHEL/6/input/fixes/bash/mount_option_nodev_nonroot_local_partitions.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # NOTE: Run-time reconfiguration of partitions' mount options is not possible.
 # After performing this remediation be sure to also subsequently reboot the

--- a/RHEL/6/input/fixes/bash/mount_option_var_tmp_bind.sh
+++ b/RHEL/6/input/fixes/bash/mount_option_var_tmp_bind.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 # Delete particular /etc/fstab's row if /var/tmp is already configured to
 # represent a mount point (for some device or filesystem other than /tmp)
 if grep -q -P '.*\/var\/tmp.*' /etc/fstab

--- a/RHEL/6/input/fixes/bash/network_disable_zeroconf.sh
+++ b/RHEL/6/input/fixes/bash/network_disable_zeroconf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 echo "NOZEROCONF=yes" >> /etc/sysconfig/network

--- a/RHEL/6/input/fixes/bash/network_ipv6_disable_rpc.sh
+++ b/RHEL/6/input/fixes/bash/network_ipv6_disable_rpc.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 
 # Drop 'tcp6' and 'udp6' entries from /etc/netconfig to prevent RPC
 # services for NFSv4 from attempting to start IPv6 network listeners

--- a/RHEL/6/input/fixes/bash/no_empty_passwords.sh
+++ b/RHEL/6/input/fixes/bash/no_empty_passwords.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 sed --follow-symlinks -i 's/\<nullok\>//g' /etc/pam.d/system-auth

--- a/RHEL/6/input/fixes/bash/package_GConf2_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_GConf2_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install GConf2

--- a/RHEL/6/input/fixes/bash/package_aide_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_aide_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install aide

--- a/RHEL/6/input/fixes/bash/package_audit_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_audit_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install audit

--- a/RHEL/6/input/fixes/bash/package_cronie_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_cronie_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install cronie

--- a/RHEL/6/input/fixes/bash/package_gdm_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_gdm_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install gdm

--- a/RHEL/6/input/fixes/bash/package_iptables-ipv6_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_iptables-ipv6_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install iptables-ipv6

--- a/RHEL/6/input/fixes/bash/package_iptables_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_iptables_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install iptables

--- a/RHEL/6/input/fixes/bash/package_irqbalance_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_irqbalance_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install irqbalance

--- a/RHEL/6/input/fixes/bash/package_ntp_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_ntp_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install ntp

--- a/RHEL/6/input/fixes/bash/package_openswan_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_openswan_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install openswan

--- a/RHEL/6/input/fixes/bash/package_policycoreutils_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_policycoreutils_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install policycoreutils

--- a/RHEL/6/input/fixes/bash/package_postfix_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_postfix_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install postfix

--- a/RHEL/6/input/fixes/bash/package_psacct_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_psacct_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install psacct

--- a/RHEL/6/input/fixes/bash/package_rsyslog_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_rsyslog_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install rsyslog

--- a/RHEL/6/input/fixes/bash/package_screen_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_screen_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install screen

--- a/RHEL/6/input/fixes/bash/package_vsftpd_installed.sh
+++ b/RHEL/6/input/fixes/bash/package_vsftpd_installed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 yum -y install vsftpd

--- a/RHEL/6/input/fixes/bash/require_singleuser_auth.sh
+++ b/RHEL/6/input/fixes/bash/require_singleuser_auth.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 grep -q ^SINGLE /etc/sysconfig/init && \
   sed -i "s/SINGLE.*/SINGLE=\/sbin\/sulogin/g" /etc/sysconfig/init
 if ! [ $? -eq 0 ]; then

--- a/RHEL/6/input/fixes/bash/securetty_root_login_console_only.sh
+++ b/RHEL/6/input/fixes/bash/securetty_root_login_console_only.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 sed -i '/^vc\//d' /etc/securetty

--- a/RHEL/6/input/fixes/bash/service_abrtd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_abrtd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable abrtd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_acpid_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_acpid_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable acpid for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_atd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_atd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable atd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_auditd_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_auditd_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Enable auditd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_autofs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_autofs_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable autofs for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_avahi-daemon_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_avahi-daemon_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable avahi-daemon for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_bluetooth_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_bluetooth_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable bluetooth for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_certmonger_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_certmonger_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable certmonger for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_cgconfig_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_cgconfig_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable cgconfig for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_cgred_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_cgred_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable cgred for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_cpuspeed_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_cpuspeed_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable cpuspeed for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_crond_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_crond_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Enable crond for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_cups_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_cups_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable cups for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_dhcpd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_dhcpd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable dhcpd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_dovecot_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_dovecot_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable dovecot for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_haldaemon_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_haldaemon_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable haldaemon for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_httpd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_httpd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable httpd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_ip6tables_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_ip6tables_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Enable ip6tables for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_iptables_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_iptables_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Enable iptables for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_irqbalance_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_irqbalance_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Enable irqbalance for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_kdump_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_kdump_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable kdump for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_mdmonitor_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_mdmonitor_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable mdmonitor for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_messagebus_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_messagebus_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable messagebus for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_named_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_named_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable named for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_netconsole_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_netconsole_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable netconsole for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_netfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_netfs_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable netfs for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_nfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_nfs_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable nfs for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_nfslock_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_nfslock_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable nfslock for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_ntpd_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_ntpd_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Enable ntpd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_oddjobd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_oddjobd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable oddjobd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_portreserve_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_portreserve_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable portreserve for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_postfix_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_postfix_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Enable postfix for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_psacct_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_psacct_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Enable psacct for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_qpidd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_qpidd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable qpidd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_quota_nld_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_quota_nld_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable quota_nld for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_rdisc_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rdisc_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable rdisc for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_restorecond_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_restorecond_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Enable restorecond for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_rhnsd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rhnsd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable rhnsd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_rhsmcertd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rhsmcertd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable rhsmcertd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_rpcgssd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rpcgssd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable rpcgssd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_rpcidmapd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rpcidmapd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable rpcidmapd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_rpcsvcgssd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rpcsvcgssd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable rpcsvcgssd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_rsyslog_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rsyslog_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Enable rsyslog for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_saslauthd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_saslauthd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable saslauthd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_smartd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_smartd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable smartd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_smb_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_smb_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable smb for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_snmpd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_snmpd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable snmpd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_squid_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_squid_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable squid for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_sshd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_sshd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable sshd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_sysstat_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_sysstat_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable sysstat for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_tftp_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_tftp_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable tftp for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_vsftpd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_vsftpd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable vsftpd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_xinetd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_xinetd_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable xinetd for all run levels
 #

--- a/RHEL/6/input/fixes/bash/service_ypbind_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_ypbind_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Disable ypbind for all run levels
 #

--- a/RHEL/6/input/fixes/bash/sshd_disable_empty_passwords.sh
+++ b/RHEL/6/input/fixes/bash/sshd_disable_empty_passwords.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 grep -q ^PermitEmptyPasswords /etc/ssh/sshd_config && \
   sed -i "s/PermitEmptyPasswords.*/PermitEmptyPasswords no/g" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/6/input/fixes/bash/sshd_do_not_permit_user_env.sh
+++ b/RHEL/6/input/fixes/bash/sshd_do_not_permit_user_env.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 grep -q ^PermitUserEnvironment /etc/ssh/sshd_config && \
   sed -i "s/PermitUserEnvironment.*/PermitUserEnvironment no/g" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/6/input/fixes/bash/sshd_enable_warning_banner.sh
+++ b/RHEL/6/input/fixes/bash/sshd_enable_warning_banner.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 grep -q ^Banner /etc/ssh/sshd_config && \
   sed -i "s/Banner.*/Banner \/etc\/issue/g" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/6/input/fixes/bash/sshd_set_idle_timeout.sh
+++ b/RHEL/6/input/fixes/bash/sshd_set_idle_timeout.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate sshd_idle_timeout_value
 

--- a/RHEL/6/input/fixes/bash/sshd_set_keepalive.sh
+++ b/RHEL/6/input/fixes/bash/sshd_set_keepalive.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 grep -q ^ClientAliveCountMax /etc/ssh/sshd_config && \
   sed -i "s/ClientAliveCountMax.*/ClientAliveCountMax 0/g" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/6/input/fixes/bash/sshd_use_approved_ciphers.sh
+++ b/RHEL/6/input/fixes/bash/sshd_use_approved_ciphers.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 grep -q ^Ciphers /etc/ssh/sshd_config && \
   sed -i "s/Ciphers.*/Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc/g" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/6/input/fixes/bash/sysctl_fs_suid_dumpable.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_fs_suid_dumpable.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for fs.suid_dumpable
 #

--- a/RHEL/6/input/fixes/bash/sysctl_kernel_dmesg_restrict.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_kernel_dmesg_restrict.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for kernel.dmesg_restrict
 #

--- a/RHEL/6/input/fixes/bash/sysctl_kernel_exec_shield.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_kernel_exec_shield.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for kernel.exec-shield
 #

--- a/RHEL/6/input/fixes/bash/sysctl_kernel_randomize_va_space.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_kernel_randomize_va_space.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for kernel.randomize_va_space
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.conf.all.accept_redirects
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_source_route.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_source_route.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.conf.all.accept_source_route
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_log_martians.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_log_martians.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.conf.all.log_martians
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_rp_filter.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_rp_filter.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.conf.all.rp_filter
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_secure_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_secure_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.conf.all.secure_redirects
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_send_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_send_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.conf.all.send_redirects
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.conf.default.accept_redirects
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_source_route.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_source_route.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.conf.default.accept_source_route
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_rp_filter.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_rp_filter.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.conf.default.rp_filter
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_secure_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_secure_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.conf.default.secure_redirects
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_send_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_send_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.conf.default.send_redirects
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_icmp_echo_ignore_broadcasts.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_icmp_echo_ignore_broadcasts.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.icmp_echo_ignore_broadcasts
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_icmp_ignore_bogus_error_responses.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_icmp_ignore_bogus_error_responses.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.icmp_ignore_bogus_error_responses
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_ip_forward.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_ip_forward.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.ip_forward
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_tcp_syncookies.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_tcp_syncookies.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv4.tcp_syncookies
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_ra.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_ra.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv6.conf.default.accept_ra
 #

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 #
 # Set runtime for net.ipv6.conf.default.accept_redirects
 #

--- a/RHEL/6/input/fixes/bash/umask_for_daemons.sh
+++ b/RHEL/6/input/fixes/bash/umask_for_daemons.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 source ./templates/support.sh
 populate var_umask_for_daemons
 

--- a/RHEL/6/input/fixes/bash/uninstall_telnet_server.sh
+++ b/RHEL/6/input/fixes/bash/uninstall_telnet_server.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 if rpm -qa | grep -q telnet-server; then
 	yum -y remove telnet-server
 fi

--- a/RHEL/6/input/fixes/bash/uninstall_xinetd.sh
+++ b/RHEL/6/input/fixes/bash/uninstall_xinetd.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 if rpm -qa | grep -q xinetd; then
 	yum -y remove xinetd
 fi

--- a/RHEL/6/input/fixes/bash/uninstall_ypserv.sh
+++ b/RHEL/6/input/fixes/bash/uninstall_ypserv.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 6
 if rpm -qa | grep -q ypserv; then
 	yum -y remove ypserv
 fi

--- a/RHEL/6/input/fixes/bash/userowner_shadow_file.sh
+++ b/RHEL/6/input/fixes/bash/userowner_shadow_file.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 6
 chown root /etc/shadow


### PR DESCRIPTION

* # platform = multi_platform_fedora		(for Fedora remediations)
* # platform = Red Hat Enterprise Linux 6	(for RHEL-6 remediations)

These platform tags are now required in order to the remediation scripts to be
successfully included into the resulting XCCDF file for that product (similarly
like <platform> elements are required for OVAL checks)

Compare the count of included remediation scripts for RHEL-6 && Fedora systems in the state before the "removing symlinks for remediations" change and now:
&nbsp; &nbsp; [1] https://github.com/OpenSCAP/scap-security-guide/pull/770#issuecomment-145563329

<b>This change brings ```RHEL/6``` and ```Fedora``` products to the state they were before "removing symlinks for remediations" change.</b> Here's the output once this change is applied:
* Fedora case:
```
$ cd Fedora/
$ make | grep remediation
..
Notification: Merged 16 remediation scripts into XML document.
..
```
* RHEL/6 case:
```
$ cd RHEL/6
..
$ make | grep remediation
# Make intermediate build/rhel6_fixes directory to hold final list of remediation scripts for rhel6
# Search ../../shared/fixes/bash and input/FIXES directories to find all product specific remediation scripts,
../../shared/transforms/combinefixes.py ../../config rhel6 build/rhel6_fixes output/bash-remediations.xml

Notification: Merged 235 remediation scripts into XML document.
...
```

Please review.

Thank you, Jan.