### PR TITLE
[Enhancement] [RHEL/7] Add RHEL-7 specific remediation functions for the

### DIFF
--- a/RHEL/7/input/fixes/bash/audit_rules_time_adjtimex.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_time_adjtimex.sh
@@ -1,0 +1,6 @@
+# platform = Red Hat Enterprise Linux 7
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+rhel7_fedora_perform_audit_adjtimex_settimeofday_stime_remediation

--- a/RHEL/7/input/fixes/bash/audit_rules_time_settimeofday.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_time_settimeofday.sh
@@ -1,0 +1,6 @@
+# platform = Red Hat Enterprise Linux 7
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+rhel7_fedora_perform_audit_adjtimex_settimeofday_stime_remediation

--- a/RHEL/7/input/fixes/bash/audit_rules_time_stime.sh
+++ b/RHEL/7/input/fixes/bash/audit_rules_time_stime.sh
@@ -1,0 +1,6 @@
+# platform = Red Hat Enterprise Linux 7
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+rhel7_fedora_perform_audit_adjtimex_settimeofday_stime_remediation

--- a/shared/fixes/bash/templates/remediation_functions
+++ b/shared/fixes/bash/templates/remediation_functions
@@ -338,3 +338,42 @@ do
 	fi
 done
 }
+
+
+##### OS-specific remediation functions below #####
+
+
+function rhel7_fedora_perform_audit_adjtimex_settimeofday_stime_remediation {
+
+# Perform the remediation for the 'adjtimex', 'settimeofday', and 'stime' audit
+# system calls on Red Hat Enterprise Linux 7 or Fedora OSes
+#
+# Retrieve hardware architecture of the underlying system
+[ $(getconf LONG_BIT) = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
+
+for ARCH in "${RULE_ARCHS[@]}"
+do
+
+	PATTERN="-a always,exit -F arch=${ARCH} -S .* -k *"
+	# Create expected audit group and audit rule form for particular system call & architecture
+	if [ ${ARCH} = "b32" ]
+	then
+		# stime system call is known at 32-bit arch (see e.g "$ ausyscall i386 stime" 's output)
+		# so append it to the list of time group system calls to be audited
+		GROUP="\(adjtimex\|settimeofday\|stime\)"
+		FULL_RULE="-a always,exit -F arch=${ARCH} -S adjtimex -S settimeofday -S stime -k audit_time_rules"
+	elif [ ${ARCH} = "b64" ]
+	then
+		# stime system call isn't known at 64-bit arch (see "$ ausyscall x86_64 stime" 's output)
+		# therefore don't add it to the list of time group system calls to be audited
+		GROUP="\(adjtimex\|settimeofday\)"
+		FULL_RULE="-a always,exit -F arch=${ARCH} -S adjtimex -S settimeofday -k audit_time_rules"
+	fi
+
+	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+
+done
+
+}


### PR DESCRIPTION
following three audit rules:
* ```audit_rules_time_adjtimex```,
* ```audit_rules_time_settimeofday```, and
* ```audit_rules_time_stime```.

Re-implementation of https://github.com/OpenSCAP/scap-security-guide/pull/625 (but placing the core of the implementation into the ```remediation_functions``` file && calling the routine just externally).

Testing report:
---------------
Verified:
* the change successfully builds on RHEL-7 && the remediations are working as expected,
* the change successfully builds on RHEL-6 system.

Please review.

Thank you, Jan.
