### PR TITLE
[bugfix][infrastructure] fix combinefixes.py platform tag issue

### DIFF
--- a/shared/transforms/combinefixes.py
+++ b/shared/transforms/combinefixes.py
@@ -85,9 +85,10 @@ def fix_is_applicable_for_product(platform, product):
         product_name = map_product(product) + ' ' + product_version
     else:
         product_name = map_product(product)
-    
+
     # Test if this is for the concrete product version
-    if product_name == platform:
+    for pf in platform.split(','):
+        if product_name == pf.strip():
             return True
 
     # Remediation script isn't neither a multi platform one, nor isn't applicable


### PR DESCRIPTION
- Adding '# platform = <product>, <multi_platform_product> to remediation scripts was causing combinefixes.py not to add the remediation script to bash-remediations.xml.