### PR TITLE
[BugFix] [Enhancement] Add RHEL-7 GSettings remediations

### DIFF
--- a/RHEL/7/input/fixes/bash/dconf_gnome_screensaver_idle_activation_enabled.sh
+++ b/RHEL/7/input/fixes/bash/dconf_gnome_screensaver_idle_activation_enabled.sh
@@ -1,0 +1,42 @@
+# platform = Red Hat Enterprise Linux 7
+
+# Define constants to be reused below
+ORG_GNOME_DESKTOP_SCREENSAVER="org/gnome/desktop/screensaver"
+SSG_DCONF_IDLE_ACTIVATION_FILE="/etc/dconf/db/local.d/10-scap-security-guide"
+SCREENSAVER_LOCKS_FILE="/etc/dconf/db/local.d/locks/screensaver"
+IDLE_ACTIVATION_DEFINED="FALSE"
+
+# First update '[org/gnome/desktop/screensaver] idle-activation-enabled' settings in
+# /etc/dconf/db/local.d/* if already defined
+for FILE in /etc/dconf/db/local.d/*
+do
+	if grep -q -d skip "$ORG_GNOME_DESKTOP_SCREENSAVER" "$FILE"
+	then
+		if grep 'idle-activation-enabled' "$FILE"
+		then
+			sed -i "s/idle-activation-enabled=.*/idle-activation-enabled=true/g" "$FILE"
+			IDLE_ACTIVATION_DEFINED="TRUE"
+		fi
+	fi
+done
+
+# Then define '[org/gnome/desktop/screensaver] idle-activation-enabled' setting
+# if still not defined yet
+if [ "$IDLE_ACTIVATION_DEFINED" != "TRUE" ]
+then
+	echo "" >> $SSG_DCONF_IDLE_ACTIVATION_FILE
+	echo "[org/gnome/desktop/screensaver]" >>  $SSG_DCONF_IDLE_ACTIVATION_FILE
+	echo "idle-activation-enabled=true" >> $SSG_DCONF_IDLE_ACTIVATION_FILE
+fi
+
+# Verify if 'idle-activation-enabled' modification is locked. If not, lock it
+if ! grep -q "^/${ORG_GNOME_DESKTOP_SCREENSAVER}/idle-activation-enabled$" /etc/dconf/db/local.d/locks/*
+then
+	# Check if "$SCREENSAVER_LOCK_FILE" exists. If not, create it.
+	if [ ! -f "$SCREENSAVER_LOCKS_FILE" ]
+	then
+		touch "$SCREENSAVER_LOCKS_FILE"
+	fi
+	echo "/${ORG_GNOME_DESKTOP_SCREENSAVER}/idle-activation-enabled" >> "$SCREENSAVER_LOCKS_FILE"
+fi
+

--- a/RHEL/7/input/fixes/bash/dconf_gnome_screensaver_idle_delay.sh
+++ b/RHEL/7/input/fixes/bash/dconf_gnome_screensaver_idle_delay.sh
@@ -1,0 +1,44 @@
+# platform = Red Hat Enterprise Linux 7
+source ./templates/support.sh
+populate inactivity_timeout_value
+
+# Define constants to be reused below
+ORG_GNOME_DESKTOP_SESSION="org/gnome/desktop/session"
+SSG_DCONF_IDLE_DELAY_FILE="/etc/dconf/db/local.d/10-scap-security-guide"
+SESSION_LOCKS_FILE="/etc/dconf/db/local.d/locks/session"
+IDLE_DELAY_DEFINED="FALSE"
+
+# First update '[org/gnome/desktop/session] idle-delay' settings in
+# /etc/dconf/db/local.d/* if already defined
+for FILE in /etc/dconf/db/local.d/*
+do
+	if grep -q -d skip "$ORG_GNOME_DESKTOP_SESSION" "$FILE"
+	then
+		if grep 'idle-delay' "$FILE"
+		then
+			sed -i "s/idle-delay=.*/idle-delay=uint32 ${inactivity_timeout_value}/g" "$FILE"
+			IDLE_DELAY_DEFINED="TRUE"
+		fi
+	fi
+done
+
+# Then define '[org/gnome/desktop/session] idle-delay' setting
+# if still not defined yet
+if [ "$IDLE_DELAY_DEFINED" != "TRUE" ]
+then
+	echo "" >> $SSG_DCONF_IDLE_DELAY_FILE
+	echo "[org/gnome/desktop/session]" >>  $SSG_DCONF_IDLE_DELAY_FILE
+	echo "idle-delay=uint32 ${inactivity_timeout_value}" >> $SSG_DCONF_IDLE_DELAY_FILE
+fi
+
+# Verify if 'idle-delay' modification is locked. If not, lock it
+if ! grep -q "^/${ORG_GNOME_DESKTOP_SESSION}/idle-delay$" /etc/dconf/db/local.d/locks/*
+then
+	# Check if "$SESSION_LOCK_FILE" exists. If not, create it.
+	if [ ! -f "$SESSION_LOCKS_FILE" ]
+	then
+		touch "$SESSION_LOCKS_FILE"
+	fi
+	echo "/${ORG_GNOME_DESKTOP_SESSION}/idle-delay" >> "$SESSION_LOCKS_FILE"
+fi
+

--- a/RHEL/7/input/fixes/bash/dconf_gnome_screensaver_lock_enabled.sh
+++ b/RHEL/7/input/fixes/bash/dconf_gnome_screensaver_lock_enabled.sh
@@ -1,0 +1,61 @@
+# platform = Red Hat Enterprise Linux 7
+
+# Define constants to be reused below
+ORG_GNOME_DESKTOP_SCREENSAVER="org/gnome/desktop/screensaver"
+SSG_DCONF_LOCK_ENABLED_FILE="/etc/dconf/db/local.d/10-scap-security-guide"
+SCREENSAVER_LOCKS_FILE="/etc/dconf/db/local.d/locks/screensaver"
+LOCK_ENABLED_DEFINED="FALSE"
+LOCK_DELAY_DEFINED="FALSE"
+
+# First update '[org/gnome/desktop/screensaver] lock-enabled' and
+# '[org/gnome/desktop/screensaver] lock-delay' settings in
+# /etc/dconf/db/local.d/* if already defined
+for FILE in /etc/dconf/db/local.d/*
+do
+	if grep -q -d skip "$ORG_GNOME_DESKTOP_SCREENSAVER" "$FILE"
+	then
+		if grep 'lock-enabled' "$FILE"
+		then
+			sed -i "s/lock-enabled=.*/lock-enabled=true/g" "$FILE"
+			LOCK_ENABLED_DEFINED="TRUE"
+		fi
+		if grep 'lock-delay' "$FILE"
+		then
+			sed -i "s/lock-delay=.*/lock-delay=uint32 0/g" "$FILE"
+			LOCK_DELAY_DEFINED="TRUE"
+		fi
+	fi
+done
+
+# Then define '[org/gnome/desktop/screensaver] lock-enabled' setting
+# if still not defined yet
+if [ "$LOCK_ENABLED_DEFINED" != "TRUE" ] || [ "$LOCK_DELAY_DEFINED" != "TRUE" ]
+then
+	echo "" >> $SSG_DCONF_LOCK_ENABLED_FILE
+	echo "[org/gnome/desktop/screensaver]" >>  $SSG_DCONF_LOCK_ENABLED_FILE
+	echo "lock-enabled=true" >> $SSG_DCONF_LOCK_ENABLED_FILE
+	echo "lock-delay=uint32 0" >> $SSG_DCONF_LOCK_ENABLED_FILE
+fi
+
+# Verify if 'lock-enabled' modification is locked. If not, lock it
+if ! grep -q "^/${ORG_GNOME_DESKTOP_SCREENSAVER}/lock-enabled$" /etc/dconf/db/local.d/locks/*
+then
+	# Check if "$SCREENSAVER_LOCK_FILE" exists. If not, create it.
+	if [ ! -f "$SCREENSAVER_LOCKS_FILE" ]
+	then
+		touch "$SCREENSAVER_LOCKS_FILE"
+	fi
+	echo "/${ORG_GNOME_DESKTOP_SCREENSAVER}/lock-enabled" >> "$SCREENSAVER_LOCKS_FILE"
+fi
+
+
+# Verify if 'lock-delay' modification is locked. If not, lock it
+if ! grep -q "^/${ORG_GNOME_DESKTOP_SCREENSAVER}/lock-delay$" /etc/dconf/db/local.d/locks/*
+then
+        # Check if "$SCREENSAVER_LOCK_FILE" exists. If not, create it.
+        if [ ! -f "$SCREENSAVER_LOCKS_FILE" ]
+        then
+                touch "$SCREENSAVER_LOCKS_FILE"
+        fi
+        echo "/${ORG_GNOME_DESKTOP_SCREENSAVER}/lock-delay" >> "$SCREENSAVER_LOCKS_FILE"
+fi

--- a/RHEL/7/input/fixes/bash/dconf_gnome_screensaver_mode_blank.sh
+++ b/RHEL/7/input/fixes/bash/dconf_gnome_screensaver_mode_blank.sh
@@ -1,0 +1,41 @@
+# platform = Red Hat Enterprise Linux 7
+
+# Define constants to be reused below
+ORG_GNOME_DESKTOP_SCREENSAVER="org/gnome/desktop/screensaver"
+SSG_DCONF_MODE_BLANK_FILE="/etc/dconf/db/local.d/10-scap-security-guide"
+SCREENSAVER_LOCKS_FILE="/etc/dconf/db/local.d/locks/screensaver"
+MODE_BLANK_DEFINED="FALSE"
+
+# First update '[org/gnome/desktop/screensaver] picture-uri' settings in
+# /etc/dconf/db/local.d/* if already defined
+for FILE in /etc/dconf/db/local.d/*
+do
+	if grep -q -d skip "$ORG_GNOME_DESKTOP_SCREENSAVER" "$FILE"
+	then
+		if grep 'picture-uri' "$FILE"
+		then
+			sed -i "s/picture-uri=.*/picture-uri=string ''/g" "$FILE"
+			MODE_BLANK_DEFINED="TRUE"
+		fi
+	fi
+done
+
+# Then define '[org/gnome/desktop/screensaver] picture-uri' setting
+# if still not defined yet
+if [ "$MODE_BLANK_DEFINED" != "TRUE" ]
+then
+	echo "" >> $SSG_DCONF_MODE_BLANK_FILE
+	echo "[org/gnome/desktop/screensaver]" >>  $SSG_DCONF_MODE_BLANK_FILE
+	echo "picture-uri=string ''" >> $SSG_DCONF_MODE_BLANK_FILE
+fi
+
+# Verify if 'picture-uri' modification is locked. If not, lock it
+if ! grep -q "^/${ORG_GNOME_DESKTOP_SCREENSAVER}/picture-uri$" /etc/dconf/db/local.d/locks/*
+then
+	# Check if "$SCREENSAVER_LOCK_FILE" exists. If not, create it.
+	if [ ! -f "$SCREENSAVER_LOCKS_FILE" ]
+	then
+		touch "$SCREENSAVER_LOCKS_FILE"
+	fi
+	echo "/${ORG_GNOME_DESKTOP_SCREENSAVER}/picture-uri" >> "$SCREENSAVER_LOCKS_FILE"
+fi

--- a/shared/oval/dconf_gnome_screensaver_idle_delay.xml
+++ b/shared/oval/dconf_gnome_screensaver_idle_delay.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="dconf_gnome_screensaver_idle_delay" version="1">
+  <definition class="compliance" id="dconf_gnome_screensaver_idle_delay" version="2">
     <metadata>
       <title>Configure the GNOME3 GUI Screen locking</title>
       <affected family="unix">
@@ -29,7 +29,10 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^\[org/gnome/desktop/session]([^\n]*\n+)+?idle-delay=[0-9]*$</ind:pattern>
+    <!-- GSettings expects unsigned integer when setting 'idle-delay' per:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
+         Thus require the proper datatype to be specified in 'idle-delay' configuration too -->
+    <ind:pattern operation="pattern match">^\[org/gnome/desktop/session]([^\n]*\n+)+?idle-delay=uint32[\s][0-9]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -56,7 +59,10 @@
   version="1"> 
     <ind:path>/etc/dconf/db/local.d/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^idle-delay[\s=]*([^=\s]*)</ind:pattern>
+    <!-- GSettings expects unsigned integer when setting 'idle-delay' per:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
+         Thus require the proper datatype to be specified in 'idle-delay' configuration too -->
+    <ind:pattern operation="pattern match">^idle-delay[\s=]*uint32[\s]([^=\s]*)</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/oval/dconf_gnome_screensaver_lock_enabled.xml
+++ b/shared/oval/dconf_gnome_screensaver_lock_enabled.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="dconf_gnome_screensaver_lock_enabled" version="1">
+  <definition class="compliance" id="dconf_gnome_screensaver_lock_enabled" version="2">
     <metadata>
       <title>Enable GNOME3 Screensaver Lock After Idle Period</title>
       <affected family="unix">
@@ -58,7 +58,10 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver]([^\n]*\n+)+?lock-delay=0$</ind:pattern>
+    <!-- GSettings expects unsigned integer when setting 'lock-delay' per:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
+         Thus require the proper datatype to be specified in 'lock-delay' configuration too -->
+    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver]([^\n]*\n+)+?lock-delay=uint32[\s]0$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/oval/dconf_gnome_screensaver_mode_blank.xml
+++ b/shared/oval/dconf_gnome_screensaver_mode_blank.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="dconf_gnome_screensaver_mode_blank" version="1">
+  <definition class="compliance" id="dconf_gnome_screensaver_mode_blank" version="2">
     <metadata>
       <title>Implement Blank Screensaver</title>
       <affected family="unix">
@@ -28,7 +28,10 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver]([^\n]*\n+)+?picture-uri=\'\'$</ind:pattern>
+    <!-- GSettings expects proper datatype specifier when setting 'picture-uri' per:
+         https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
+         Thus require 'string' datatype to be specified in 'picture-uri' configuration too -->
+    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver]([^\n]*\n+)+?picture-uri=string[\s]\'\'$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
This changeset is performing the following:
* adding requirement to proper ```GSettings``` datatype to selected ```shared/``` OVALs related with GSettings,
* adding new RHEL-7 remediations for four GSettings related rules.

More detailed patch description below:
* patch https://github.com/OpenSCAP/scap-security-guide/commit/3ac6decad8f2dec54d20a3eb334d56a7d614ed22 updates existing ```shared/``` OVAL for ```dconf_gnome_screensaver_idle_delay``` rule it to require proper datatype (unsigned integer) for ```idle-delay``` key setting. See: <br/>
&nbsp; &nbsp; [1] https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3 <br/>
for reasons why it's required,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/ad7a8deeed0c9a524f489f3bd7eeaf550b23d09b is adding new RHEL-7 remediation for ```dconf_gnome_screensaver_idle_delay``` rule,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/038776f0aed3d43c4c0494371f43b846707621b9 is adding new RHEL-7 remediation for ```dconf_gnome_screensaver_idle_activation_enabled``` rule,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/c0e577514d981e8403938da30c40a55237e4a1a6 updates existing ```shared/``` OVAL check for ```dconf_gnome_screensaver_lock_enabled``` rule to require proper datatype (unsigned integer) for ```lock-delay``` key of ```org.gnome.desktop.screensaver``` schema. Again [1] is the reason why proper datatype needs to be specified,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/a3e22808a6f7b109c5b313694a62d208f1c6668e is adding new RHEL-7 remediation for ```dconf_gnome_screensaver_lock_enabled``` rule,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/3df701bf836ce05cc9045659acadf722df7eac4d is adding ```string``` datatype requirement (again due to [1]) for the existing ```shared/``` OVAL check for ```dconf_gnome_screensaver_mode_blank``` rule (for ```picture-uri``` key of the ```org.gnome.desktop.screensaver``` schema this time), and finally
* patch https://github.com/OpenSCAP/scap-security-guide/commit/afb02c51b5a99b5ffe859486375e27047ecf68b7 is adding new RHEL-7 remediation for the ```dconf_gnome_screensaver_mode_blank``` rule.

Testing report:
-------------------
All of the proposed changes above has been tested on recent RHEL-7.2 Beta system, and all of them are working properly (AFAICT from testing). Testing covered the following three scenarios / use cases:
* the required locks file was missing (remediation fixed the configuration),
* the required dconf settings was completely missing (remediation fixed the configuration),
* some part of the dconf settings was missing / or particular key was configured to different value than required by the requirement (and remediation fixed the configuration).

Please review.

Thank you, Jan.
