### PR TITLE
[Enhancement] [RHEL/7] [Fedora] Add new RHEL-7 and Fedora remediation for 'audit_rules_immutable' rule

### DIFF
--- a/shared/fixes/bash/audit_rules_immutable.sh
+++ b/shared/fixes/bash/audit_rules_immutable.sh
@@ -1,0 +1,23 @@
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+
+# Traverse all of:
+#
+# /etc/audit/audit.rules,			(for auditctl case)
+# /etc/audit/rules.d/*.rules			(for augenrules case)
+#
+# files to check if '-e .*' setting is present in that '*.rules' file already.
+# If found, delete such occurrence since auditctl(8) manual page instructs the
+# '-e 2' rule should be placed as the last rule in the configuration
+find /etc/audit /etc/audit/rules.d -maxdepth 1 -type f -name *.rules -exec sed -i '/-e[[:space:]]\+.*/d' {} ';'
+
+# Append '-e 2' requirement at the end of both:
+# * /etc/audit/audit.rules file 		(for auditctl case)
+# * /etc/audit/rules.d/immutable.rules		(for augenrules case)
+
+for AUDIT_FILE in "/etc/audit/audit.rules" "/etc/audit/rules.d/immutable.rules"
+do
+	echo '' >> $AUDIT_FILE
+	echo '# Set the audit.rules configuration immutable per security requirements' >> $AUDIT_FILE
+	echo '# Reboot is required to change audit rules once this setting is applied' >> $AUDIT_FILE
+	echo '-e 2' >> $AUDIT_FILE
+done


### PR DESCRIPTION


Testing report:
--------------
Verified manually on both types of systems the proposed change works
fine in the following scenarios:
* '-e .*' option not present at all in /etc/audit/audit.rules (auditctl case),
  and /etc/audit/rules.d/*.rules files (augenrules case),
* some of '-e != 2' setting present either in /etc/audit/audit.rules file
  (auditctl case) or some of /etc/audit/rules.d/*.rules file (augenrules case).

Please review.

Thank you, Jan.