### PR TITLE
[Enhancement] [RHEL/7] New RHEL-7 remediation for 'rsyslog_files_permissions' rule

### DIFF
--- a/RHEL/7/input/fixes/bash/rsyslog_files_permissions.sh
+++ b/RHEL/7/input/fixes/bash/rsyslog_files_permissions.sh
@@ -1,0 +1,67 @@
+# platform = Red Hat Enterprise Linux 7
+
+# List of log file paths to be inspected for correct permissions
+# * Primarily inspect log file paths listed in /etc/rsyslog.conf
+RSYSLOG_ETC_CONFIG="/etc/rsyslog.conf"
+# * And also the log file paths listed after rsyslog's $IncludeConfig directive
+RSYSLOG_INCLUDE_CONFIG=$(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2)
+# Declare an array to hold the final list of different log file paths
+declare -a LOG_FILE_PATHS
+
+# Browse each file selected above as containing paths of log files
+# ('/etc/rsyslog.conf' and '/etc/rsyslog.d/*.conf' in the default configuration)
+for LOG_FILE in "$RSYSLOG_ETC_CONFIG" "$RSYSLOG_INCLUDE_CONFIG"
+do
+	# From each of these files extract just particular log file path(s), thus:
+	# * Ignore lines starting with space (' '), comment ('#"), or variable syntax ('$') characters,
+	# * Ignore empty lines,
+	# * From the remaining valid rows select only fields constituting a log file path
+	# Text file column is understood to represent a log file path if and only if all of the following are met:
+	# * it contains at least one slash '/' character,
+	# * it doesn't contain space (' '), colon (':'), and semicolon (';') characters
+	#
+	# IMPORTANT NOTE: The $LOG_FILE variable in the next statement is intentionally kept unquoted!!!
+	#		  To properly handle the case when rsyslog's $IncludeConfig directive value
+	#		  would contain glob expression in order this glob to be expanded to all possible log file names.
+	#
+	MATCHED_ITEMS=$(sed -e "/^[[:space:]|#|$]/d ; s/[^\/]*[[:space:]]*\([^:;[:space:]]*\)/\1/g ; /^$/d" $LOG_FILE)
+	# Since above sed command might return more than one item (delimited by newline), split the particular
+	# matches entries into new array specific for this log file
+	readarray -t ARRAY_FOR_LOG_FILE <<< "$MATCHED_ITEMS"
+	# Concatenate the two arrays - previous content of $LOG_FILE_PATHS array with
+	# items from newly created array for this log file
+	LOG_FILE_PATHS=("${LOG_FILE_PATHS[@]}" "${ARRAY_FOR_LOG_FILE[@]}")
+	# Delete the temporary array
+	unset ARRAY_FOR_LOG_FILE
+done
+
+for PATH in "${LOG_FILE_PATHS[@]}"
+do
+
+	# Sanity check - if particular $PATH is empty string, skip it from further processing
+	if [ -z "$PATH" ]
+	then
+		continue
+	fi
+	# Per https://access.redhat.com/solutions/66805 '/var/log/boot.log' log file needs special care => perform it
+	if [ "$PATH" == "/var/log/boot.log" ]
+	then
+		# Ensure permissions of /var/log/boot.log are configured to be updated in /etc/rc.local
+		if ! /usr/bin/grep -q "boot.log" "/etc/rc.local"
+		then
+			echo "chmod 600 /var/log/boot.log" >> /etc/rc.local
+		fi
+		# Ensure /etc/rc.d/rc.local has user-executable permission
+		# (in order to be actually executed during boot)
+		if [ "$(/usr/bin/stat -c %a /etc/rc.d/rc.local)" -ne 744 ]
+		then
+			/usr/bin/chmod u+x /etc/rc.d/rc.local
+		fi
+	# For any other log file just check if its permissions differ from 600. If so, correct them
+	else
+		if [ "$(/usr/bin/stat -c %a "$PATH")" -ne 600 ]
+		then
+			chmod 600 "$PATH"
+		fi
+	fi
+done


### PR DESCRIPTION

* <b>NOTE #1:</b> The machine in question needs to be rebooted before the system is put into the true compliance (this is due to handling of "/var/log/boot.log" case), therefore <b>IT IS EXPECTED</b> this remediation when run <b>will return ERROR</b> when attempted in openscap. To truly verify if the system is corrected, the system needs to be rebooted, and the scan for the 'rsyslog_files_permissions' rule repeated.

Since right now there's isn't a way how to instruct ```combinefixes.py``` SSG transformation it to include the ```reboot=true``` attribute into the remediation script (filed RFE for this for the future under:

&nbsp; &nbsp; [1] https://github.com/OpenSCAP/scap-security-guide/issues/790

 ), we as of right now don't have a way how to transmit the information that a reboot is required in order the remediation to be truly completed to the user, for now we will not include the ```reboot``` attribute in the remediation.

This situation might be corrected in the future once the fix for [1] is implemented in SSG.

* <b>NOTE #2:</b> Running ```shellcheck``` on the proposed remediation script will return one failure as follows:
```
$ shellcheck RHEL/7/input/fixes/bash/rsyslog_files_permissions.sh 

In RHEL/7/input/fixes/bash/rsyslog_files_permissions.sh line 27:
	MATCHED_ITEMS=$(sed -e "/^[[:space:]|#|$]/d ; s/[^\/]*[[:space:]]*\([^:;[:space:]]*\)/\1/g ; /^$/d" $LOG_FILE)
                                                                                                            ^-- SC2086: Double quote to prevent globbing and word splitting.
```

The ```$LOG_FILE``` variable has been intentionally / on purpose kept unquoted. This is to properly handle the case, when rsyslog]s ```$IncludeConfig``` directive's value would contain some shell glob expression (this glob to be first properly expanded before further processing), like it is the case in the default RHEL-7 configuration (default ```$IncludeConfig``` directive value is set to ```/etc/rsyslog.d/*.conf``` -- here we want to inspect all of the file names matching that pattern for potential log file paths definitions).

So it is <b>EXPECTED</b> the ```shellcheck``` warning to be present when checking this script, and added a note to prevent possible quoting of that ```$LOG_FILE``` variable in the future (which would break the proper work of the script).

Testing report:
---------------
Verified on RHEL-7 system the proposed change works fine (after reboot the ```rsyslog_files_permissions``` rule passes).

Please review.

Thank you, Jan.
