### PR TITLE
[Enhancement] [RHEL/7] Add PCI-DSS ID mappings to selected rules

### DIFF
--- a/RHEL/7/input/services/ntp.xml
+++ b/RHEL/7/input/services/ntp.xml
@@ -129,7 +129,7 @@ logs from multiple sources or correlate computer events with real time events.
 </rationale>
 <ident cce="27278-1" />
 <oval id="chronyd_or_ntpd_specify_remote_server" />
-<ref nist="AU-8(1)" disa="160" />
+<ref nist="AU-8(1)" disa="160" pcidss="Req-10" />
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -162,7 +162,7 @@ other systems.
 </rationale>
 <ident cce="27012-4" />
 <oval id="chronyd_or_ntpd_specify_multiple_servers"/>
-<ref nist="AU-8(1)" />
+<ref nist="AU-8(1)" pcidss="Req-10" />
 </Rule>
 
 <!-- future Rules (for later profiles/enhancements):

--- a/RHEL/7/input/system/accounts/pam.xml
+++ b/RHEL/7/input/system/accounts/pam.xml
@@ -80,7 +80,7 @@ and gives them an opportunity to notify administrators.
 </rationale>
 <ident cce="27275-7" />
 <oval id="display_login_attempts" />
-<ref disa="53" />
+<ref disa="53" pcidss="Req-10" />
 </Rule>
 
 <Group id="password_quality">

--- a/RHEL/7/input/system/accounts/pam.xml
+++ b/RHEL/7/input/system/accounts/pam.xml
@@ -629,7 +629,7 @@ Preventing re-use of previous passwords helps ensure that a compromised password
 </rationale>
 <ident cce="26923-3" />
 <oval id="accounts_password_pam_unix_remember" value="var_password_pam_unix_remember" />
-<ref nist="IA-5(f),IA-5(1)(e)" disa="200" srg="77" />
+<ref nist="IA-5(f),IA-5(1)(e)" disa="200" srg="77" pcidss="Req-8" />
 <tested by="DS" on="20121024"/>
 </Rule>
 </Group>

--- a/RHEL/7/input/system/accounts/physical.xml
+++ b/RHEL/7/input/system/accounts/physical.xml
@@ -371,7 +371,7 @@ contents of the display from passersby.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="dconf_gnome_screensaver_mode_blank" />
-<ref nist="AC-11(b)" disa="60" />
+<ref nist="AC-11(b)" disa="60" pcidss="Req-8" />
 </Rule>
 
 </Group>

--- a/RHEL/7/input/system/accounts/physical.xml
+++ b/RHEL/7/input/system/accounts/physical.xml
@@ -449,7 +449,7 @@ that provided by a username and password combination. Smart cards leverage PKI
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="smartcard_auth" />
-<ref disa="765,766,767,768,771,772,884" />
+<ref disa="765,766,767,768,771,772,884" pcidss="Req-8" />
 </Rule>
 
 </Group>

--- a/RHEL/7/input/system/accounts/physical.xml
+++ b/RHEL/7/input/system/accounts/physical.xml
@@ -35,7 +35,7 @@ Only root should be able to modify important boot parameters.
 </rationale>
 <ident cce="26860-7" />
 <oval id="file_user_owner_grub2_cfg" />
-<ref nist="AC-6(7)" disa="225"/>
+<ref nist="AC-6(7)" disa="225" pcidss="Req-7" />
 <tested by="DS" on="20121026"/>
 </Rule>
 
@@ -53,7 +53,7 @@ file should not have any access privileges anyway.
 </rationale>
 <ident cce="26812-8" />
 <oval id="file_group_owner_grub2_cfg" />
-<ref nist="AC-6(7)" disa="225"/>
+<ref nist="AC-6(7)" disa="225" pcidss="Req-7" />
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/system/accounts/restrictions/account_expiration.xml
+++ b/RHEL/7/input/system/accounts/restrictions/account_expiration.xml
@@ -78,7 +78,7 @@ Unique usernames allow for accountability on the system.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="account_unique_name" />
-<ref disa="770,804"/>
+<ref disa="770,804" pcidss="Req-8" />
 </Rule>
 
 <Rule id="account_temp_expire_date">

--- a/RHEL/7/input/system/accounts/restrictions/password_storage.xml
+++ b/RHEL/7/input/system/accounts/restrictions/password_storage.xml
@@ -84,7 +84,7 @@ Inconsistency in GIDs between <tt>/etc/passwd</tt> and <tt>/etc/group</tt> could
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="gid_passwd_group_same" />
-<ref disa="366" />
+<ref disa="366" pcidss="Req-8" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/system/auditing.xml
+++ b/RHEL/7/input/system/auditing.xml
@@ -1497,7 +1497,7 @@ trail should be created each time a filesystem is mounted to help identify and g
 loss.</rationale>
 <ident cce="27447-2" />
 <oval id="audit_rules_media_export" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126" pcidss="Req-10" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/system/logging.xml
+++ b/RHEL/7/input/system/logging.xml
@@ -122,7 +122,7 @@ configuration, user authentication, and other such information. Log files should
 protected from unauthorized access.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="rsyslog_files_ownership" />
-<ref nist="AC-6,SI-11" disa="1314"/>
+<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10" />
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -151,7 +151,7 @@ configuration, user authentication, and other such information. Log files should
 protected from unauthorized access.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="rsyslog_files_groupownership" />
-<ref nist="AC-6,SI-11" disa="1314"/>
+<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10" />
 <tested by="DS" on="20121024"/>
 </Rule>
 
@@ -184,7 +184,7 @@ users could change the logged data, eliminating their forensic value.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="rsyslog_files_permissions" />
-<ref nist="SI-11" disa="1314"/>
+<ref nist="SI-11" disa="1314" pcidss="Req-10" />
 <tested by="DS" on="20121024"/>
 </Rule>
 </Group>

--- a/RHEL/7/input/system/permissions/files.xml
+++ b/RHEL/7/input/system/permissions/files.xml
@@ -67,7 +67,7 @@ which could weaken the system security posture.</rationale>
 on the system. Protection of this file is important for system security.</rationale>
 <ident cce="26933-2" />
 <oval id="file_owner_etc_group" />
-<ref nist="AC-6"/>
+<ref nist="AC-6" pcidss="Req-8" />
 <tested by="DS" on="20121026"/>
 </Rule>
 
@@ -79,7 +79,7 @@ on the system. Protection of this file is important for system security.</ration
 on the system. Protection of this file is important for system security.</rationale>
 <ident cce="27037-1" />
 <oval id="file_groupowner_etc_group" />
-<ref nist="AC-6" disa=""/>
+<ref nist="AC-6" disa="" pcidss="Req-8" />
 <tested by="DS" on="20121026"/>
 </Rule>
 
@@ -91,7 +91,7 @@ on the system. Protection of this file is important for system security.</ration
 on the system. Protection of this file is important for system security.</rationale>
 <ident cce="26949-8" />
 <oval id="file_permissions_etc_group" />
-<ref nist="AC-6" disa=""/>
+<ref nist="AC-6" disa="" pcidss="Req-8" />
 <tested by="DS" on="20121026"/>
 </Rule>
 
@@ -139,7 +139,7 @@ is critical for system security.</rationale>
 the system. Protection of this file is critical for system security.</rationale>
 <ident cce="27138-7" />
 <oval id="file_owner_etc_passwd" />
-<ref nist="AC-6" disa=""/>
+<ref nist="AC-6" disa="" pcidss="Req-8" />
 <tested by="DS" on="20121026"/>
 </Rule>
 
@@ -151,7 +151,7 @@ the system. Protection of this file is critical for system security.</rationale>
 the system. Protection of this file is critical for system security.</rationale>
 <ident cce="26639-5" />
 <oval id="file_groupowner_etc_passwd" />
-<ref nist="AC-6" disa=""/>
+<ref nist="AC-6" disa="" pcidss="Req-8" />
 <tested by="DS" on="20121026"/>
 </Rule>
 
@@ -165,7 +165,7 @@ accounts on the system and associated information, and protection of this file
 is critical for system security.</rationale>
 <ident cce="26887-0" />
 <oval id="file_permissions_etc_passwd" />
-<ref nist="AC-6" disa=""/>
+<ref nist="AC-6" disa="" pcidss="Req-8" />
 <tested by="DS" on="20121026"/>
 </Rule>
 </Group>

--- a/RHEL/7/input/system/software/integrity.xml
+++ b/RHEL/7/input/system/software/integrity.xml
@@ -87,7 +87,7 @@ must be captured and it should be able to be verified against the installed file
 </rationale>
 <ident cce="27220-3" />
 <oval id="aide_build_database" />
-<ref nist="CM-3(d),CM-3(e),CM-6(d),CM-6(3),SC-28,SI-7" />
+<ref nist="CM-3(d),CM-3(e),CM-6(d),CM-6(3),SC-28,SI-7" pcidss="Req-11" />
 </Rule>
 
 <Rule id="aide_periodic_cron_checking" severity="medium">

--- a/RHEL/7/input/system/software/integrity.xml
+++ b/RHEL/7/input/system/software/integrity.xml
@@ -215,7 +215,7 @@ Host-based intrusion detection tools provide a system-level defense when an
 intruder gains access to a system or network.  
 </rationale>
 <ident cce="26818-5" />
-<ref nist="SC-7" disa="1263"/>
+<ref nist="SC-7" disa="1263" pcidss="Req-11" />
 </Rule>
 
 <Rule id="install_antivirus">


### PR DESCRIPTION
This changeset adds PCI-DSS ID mappings to the following rules:
<br/>
* ```audit_rules_media_export```, 
* ```chronyd_or_ntpd_specify_remote_server```,
* ```chronyd_or_ntpd_specify_multiple_servers```,
* ```install_hids```,
* ```rsyslog_files_permissions```,
* ```rsyslog_files_ownership```,
* ```rsyslog_files_groupownership```,
* ```aide_build_database```,
* ```account_unique_name```,
* ```gid_passwd_group_same```,
* ```display_login_attempts```,
* ```dconf_gnome_screensaver_mode_blank```,
* ```accounts_password_pam_unix_remember```,
* ```smartcard_auth```,
* ```file_owner_etc_group```,
* ```file_groupowner_etc_group```,
* ```file_permissions_etc_group```,
* ```file_owner_etc_passwd```,
* ```file_groupowner_etc_passwd```,
* ```file_permissions_etc_passwd```,
* ```file_user_owner_grub2_cfg```, and
* ```file_group_owner_grub2_cfg```

rules.

The changeset is separated into multiple commits (each commit involves related rules). The commit message for each commit contains additional information (concrete PCI-DSS v3 standard subsection) this rule maps to.

Please review.

Thank you, Jan.