### PR TITLE
[BugFix] [RHEL/7] 'smartcard_auth' remediation - provide full path to the 'authconfig' executable

### DIFF
--- a/RHEL/7/input/fixes/bash/smartcard_auth.sh
+++ b/RHEL/7/input/fixes/bash/smartcard_auth.sh
@@ -7,7 +7,7 @@ package_command install pam_pkcs11
 
 # Enable smartcard authentication (but allow also other ways
 # to login not to possibly cut off the system in question)
-authconfig --enablesmartcard --updateall
+/usr/sbin/authconfig --enablesmartcard --updateall
 
 # Define constants to be reused below
 SP="[:space:]"


### PR DESCRIPTION
<br/>
Reason: Yesterday (2015-10-19) tried to install clean VM / guest via RHEL-7 PCI-DSS OAA kickstart and identified the aforementioned remediation (for 'smartcard_auth' rule) doesn't work in this scenario (since authconfig binary can't be known). Therefore provide the exact full path to it to prevent this behaviour.

Testing report:
-------------------
Verified manually on recent RHEL-7 system the proposed change works as expected.

Please review.

Thank you && Regards, Jan.
