### PR TITLE
Remove openscap-scanner from %packages section

### DIFF
--- a/RHEL/7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
+++ b/RHEL/7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
@@ -128,10 +128,6 @@ logvol swap --name=lv_swap --vgname=VolGroup --size=2016
 # CCE-27024-9: Install AIDE
 aide
 
-# Install openscap-scanner so it's possible to perform remediation once the
-# installation is complete
-openscap-scanner
-
 # Install libreswan package
 libreswan
 


### PR DESCRIPTION
There is no need to have the openscap-scanner in the %packages section because
the OSCAP Anaconda Add-on makes sure it gets installed if any content+profile is
used.

Closes #785.