### PR TITLE
[Enhancement][Infrastructure] testcheck.py: detect oscap version

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,8 +1,8 @@
 # Build from source
 
-1. On Red Hat Enterprise Linux and Fedora make sure the packages `openscap-utils` and `python-lxml` and their dependencies are installed. We require version `1.0.8` or later of `openscap-utils` (available in Red Hat Enterprise Linux) as well as `git`. 
+1. On Red Hat Enterprise Linux and Fedora make sure the packages `openscap-utils`, `openscap-python`, and `python-lxml` and their dependencies are installed. We require version `1.0.8` or later of `openscap-utils` (available in Red Hat Enterprise Linux) as well as `git`. 
 
- `# yum -y install git openscap-utils python-lxml`
+ `# yum -y install git openscap-utils openscap-python python-lxml`
 
 1a. FEDORA ONLY: Install the ShellCheck package.
 

--- a/shared/modules/testcheck_module.py
+++ b/shared/modules/testcheck_module.py
@@ -4,6 +4,7 @@ import re
 import tempfile
 import subprocess
 import datetime
+from openscap import oscap_get_version
 import lxml.etree as ET
 from ConfigParser import SafeConfigParser
 
@@ -199,7 +200,14 @@ def main():
         usage()
 
     if not len(sys.argv) == 4:
-        schema = parse_conf_file(conf_file)
+        try:
+            from openscap import oscap_get_version
+            if oscap_get_version() < 1.2:
+                schema = 5.10
+            else:
+                schema = 5.11
+        except ImportError:
+            schema = parse_conf_file(conf_file)
     else:
         # FUTURE: replace with sys arg
         schema = '5.10'

--- a/shared/modules/testcheck_module.py
+++ b/shared/modules/testcheck_module.py
@@ -4,7 +4,6 @@ import re
 import tempfile
 import subprocess
 import datetime
-from openscap import oscap_get_version
 import lxml.etree as ET
 from ConfigParser import SafeConfigParser
 


### PR DESCRIPTION
- Detect oscap version from openscap.py to determine OVAL version
  If testcheck.py cannot determine the OVAL version, use version in oval.config