### PR TITLE
[BugFix] [RHEL/6] Add noexec, nosuid, and nodev rules for removable partitions and /dev/shm into RHEL-6 STIG profile

### DIFF
--- a/RHEL/6/input/profiles/stig-rhel6-server-upstream.xml
+++ b/RHEL/6/input/profiles/stig-rhel6-server-upstream.xml
@@ -18,6 +18,12 @@ upstream project homepage is https://fedorahosted.org/scap-security-guide/.
 
 <select idref="rpm_verify_permissions" selected="true"/>
 <select idref="rpm_verify_hashes" selected="true"/>
+<select idref="mount_option_nodev_removable_partitions" selected="true" />
+<select idref="mount_option_noexec_removable_partitions" selected="true" />
+<select idref="mount_option_nosuid_removable_partitions" selected="true" />
+<select idref="mount_option_dev_shm_nodev" selected="true" />
+<select idref="mount_option_dev_shm_nosuid" selected="true" />
+<select idref="mount_option_dev_shm_noexec" selected="true" />
 <select idref="file_permissions_unauthorized_world_writable" selected="true"/>
 
 <select idref="install_antivirus" selected="true"/>


### PR DESCRIPTION
<br/>
The official STIG for RHEL-6:
&nbsp; &nbsp;  [1] http://iase.disa.mil/stigs/os/unix-linux/Pages/red-hat.aspx

currently contains only the following rule (wrt to required mount options):
  "The noexec option must be added to removable media partitions."

(
```
<Rule id="SV-50456r1_rule" severity="low" weight="10.0">,
 <version>RHEL-06-000271</version>
```
)

but per:
&nbsp; &nbsp;  [2] https://github.com/OpenSCAP/scap-security-guide/issues/808
and per:
&nbsp; &nbsp;  [3] https://github.com/OpenSCAP/scap-security-guide/issues/826

the 'nodev', 'noexec', and 'nosuid' requirements should be present
for both:
* removable media partitions, and
* /dev/shm shared memory device file.

Therefore add these rules into RHEL-6 STIG profile to meet these requirements.

Fixes https://github.com/OpenSCAP/scap-security-guide/issues/808
Fixes https://github.com/OpenSCAP/scap-security-guide/issues/826

Testing report:
-------------------
Verified manually on RHEL-6 system after the change the STIG profile contains 'noexec', 'nodev', and 'nosuid' rules for removable media partitions and /dev/shm. Also verified both OVAL and remediations for all of these rules (remediations need system to be rebooted the change to be applied for mounting, but after reboot scanning the rules returns PASS for all of them).

Please review.

Thank you, Jan.