### PR TITLE
[BugFix][Fedora][RHEL6] remove pam_passwdqc references

### DIFF
--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -127,5 +127,5 @@ eval-common: content
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
 	rm -f $(IN)/remediations/bash/templates/output/*.sh
-	rm -rf $(DIST)/content
+	rm -rf $(DIST)/content $(DIST)/guide
 	rm -rf $(BUILD)

--- a/Fedora/input/xccdf/system/accounts/pam.xml
+++ b/Fedora/input/xccdf/system/accounts/pam.xml
@@ -101,13 +101,8 @@ are not the previous password reversed, and are not simply a change
 of case from the previous password. It can also require passwords to
 be in certain character classes.
 <br /><br />
-The <tt>pam_passwdqc</tt> PAM module also provides the ability to enforce
-stringent password strength requirements. It is provided
-in an RPM of the same name and can be configured by setting the configuration
-settings in <tt>/etc/passwdqc.conf</tt>.
-<br /><br />
-The man pages <tt>pam_pwquality(8)</tt>, <tt>pam_cracklib(8)</tt>, and
-<tt>pam_passwdqc(8)</tt> provide information on the capabilities and
+The man pages <tt>pam_pwquality(8)</tt> and <tt>pam_cracklib(8)</tt>
+provide information on the capabilities and
 configuration of each.</description>
 
 <Group id="password_quality_pwquality">

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -192,5 +192,5 @@ dist: tables guide content
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
-	rm -rf $(DIST)/content
+	rm -rf $(DIST)/content $(DIST)/guide
 	rm -rf $(BUILD)

--- a/RHEL/5/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/5/input/xccdf/system/accounts/pam.xml
@@ -86,13 +86,8 @@ at least a certain length, are not the previous password reversed,
 and are not simply a change of case from the previous password. It
 can also require passwords to be in certain character classes.
 <br /><br />
-The <tt>pam_passwdqc</tt> PAM module also provides the ability to enforce
-stringent password strength requirements. It is provided
-in an RPM of the same name.
-<br /><br />
-The man pages <tt>pam_cracklib(8)</tt> and <tt>pam_passwdqc(8)</tt>
-provide information on the capabilities and configuration of
-each.</description>
+The man page <tt>pam_cracklib(8)</tt> provides information on the
+capabilities and configuration of each.</description>
 
 <Group id="password_quality_pamcracklib">
 <title>Set Password Quality Requirements, if using

--- a/RHEL/6/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/6/input/xccdf/system/accounts/pam.xml
@@ -89,13 +89,8 @@ at least a certain length, are not the previous password reversed,
 and are not simply a change of case from the previous password. It
 can also require passwords to be in certain character classes.
 <br /><br />
-The <tt>pam_passwdqc</tt> PAM module also provides the ability to enforce
-stringent password strength requirements. It is provided
-in an RPM of the same name.
-<br /><br />
-The man pages <tt>pam_cracklib(8)</tt> and <tt>pam_passwdqc(8)</tt>
-provide information on the capabilities and configuration of
-each.</description>
+The man page <tt>pam_cracklib(8)</tt> provides information on the
+capabilities and configuration of each.</description>
 
 <Group id="password_quality_pamcracklib">
 <title>Set Password Quality Requirements, if using


### PR DESCRIPTION
- Fedora and RHEL/5 `make clean` did not clean up guides after build
- Fixes #812