### PR TITLE
[BugFix] [RHEL/6] Enhance XCCDF, OVAL & remediation script for 'disable_interactive_boot' rule to properly handle case of 'confirm' kernel boot argument being present in /etc/grub.conf

### DIFF
--- a/RHEL/6/input/oval/disable_interactive_boot.xml
+++ b/RHEL/6/input/oval/disable_interactive_boot.xml
@@ -1,0 +1,52 @@
+<def-group>
+  <definition class="compliance" id="disable_interactive_boot" version="3">
+    <metadata>
+      <title>Disable Interactive Boot</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 6</platform>
+      </affected>
+      <description>The ability for users to perform interactive startups should
+      be disabled.</description>
+      <reference source="JL" ref_id="RHEL6_20151110" ref_url="test_attestation" />
+    </metadata>
+    <criteria operator="AND">
+      <!-- Check if PROMPT option of /etc/sysconfig/init file is set to "no" value -->
+      <criterion comment="Check the value of PROMPT option in /etc/sysconfig/init. Fail if other than 'no'."
+                 test_ref="test_interactive_boot_disabled_in_sysconfig_init" />
+      <!-- Verify the "confirm" kernel boot argument not present in some of
+           kernel lines of /etc/grub.conf -->
+      <criterion comment="Check the presence of 'confirm' kernel boot argument in /etc/grub.conf. Fail if found."
+                 test_ref="test_confirm_kernel_boot_argument_not_present" />
+
+    </criteria>
+  </definition>
+
+  <!-- First verify PROMPT option is set to 'no' in /etc/sysconfig/init -->
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="Tests that PROMPT=no in /etc/sysconfig/init"
+  id="test_interactive_boot_disabled_in_sysconfig_init" version="1">
+    <ind:object object_ref="object_interactive_boot_disabled_in_sysconfig_init" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_interactive_boot_disabled_in_sysconfig_init"
+  version="2">
+    <ind:filepath>/etc/sysconfig/init</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*PROMPT=no[\s]+</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Then ensure there is no 'confirm' kernel boot argument present for some of the 'kernel'
+       command lines in /etc/grub.conf -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  comment="Check the presence of 'confirm' kernel boot argument in /etc/grub.conf. Fail if found."
+  id="test_confirm_kernel_boot_argument_not_present" version="1">
+    <ind:object object_ref="object_confirm_kernel_boot_argument_not_present" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_confirm_kernel_boot_argument_not_present" version="1">
+    <ind:filepath>/etc/grub.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*kernel[\s]+.*confirm.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/RHEL/6/input/remediations/bash/disable_interactive_boot.sh
+++ b/RHEL/6/input/remediations/bash/disable_interactive_boot.sh
@@ -1,6 +1,12 @@
 # platform = Red Hat Enterprise Linux 6
+
+# Ensure value of PROMPT key in /etc/sysconfig/init is set to 'no'
 grep -q ^PROMPT /etc/sysconfig/init && \
   sed -i "s/PROMPT.*/PROMPT=no/g" /etc/sysconfig/init
 if ! [ $? -eq 0 ]; then
     echo "PROMPT=no" >> /etc/sysconfig/init
 fi
+
+# Ensure 'confirm' kernel boot argument is not present in some of
+# kernel lines in /etc/grub.conf
+sed -i --follow-symlinks "s/confirm//gI" /etc/grub.conf

--- a/RHEL/6/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/6/input/xccdf/system/accounts/physical.xml
@@ -178,24 +178,32 @@ for additional information.
 <Rule id="disable_interactive_boot" severity="medium">
 <title>Disable Interactive Boot</title>
 <description>
-To disable the ability for users to perform interactive startups,
-edit the file <tt>/etc/sysconfig/init</tt>.
-Add or correct the line:
-<pre>PROMPT=no</pre>
-The <tt>PROMPT</tt> option allows the console user to perform an
-interactive system startup, in which it is possible to select the
-set of services which are started on boot.
+To disable the ability for users to perform interactive startups, perform both
+of the following:
+<ol>
+<li>Edit the file <tt>/etc/sysconfig/init</tt>. Add or correct the line:
+<pre>PROMPT=no</pre></li>
+<li>Inspect the kernel boot arguments (which follow the word <tt>kernel</tt>)
+in <tt>/etc/grub.conf</tt> and ensure the <tt>confirm</tt> argument is <b>not</b>
+present.</li>
+</ol>
+Both the <tt>PROMPT</tt> option of the <tt>/etc/sysconfig/init</tt> file and
+the <tt>confirm</tt> kernel boot argument of the <tt>/etc/grub.conf</tt> file
+allow the console user to perform an interactive system startup, in which it is
+possible to select the set of services which are started on boot.
 </description>
 <ocil clause="it does not">
-To check whether interactive boot is disabled, run the following command:
-<pre>$ grep PROMPT /etc/sysconfig/init</pre>
-If interactive boot is disabled, the output will show:
-<pre>PROMPT=no</pre>
+To check whether interactive boot is disabled, run the following commands:
+<ol>
+<li><pre>$ grep PROMPT /etc/sysconfig/init</pre> If interactive boot is
+disabled, the output will show: <pre>PROMPT=no</pre></li>
+<li><pre>$ grep confirm /etc/grub.conf</pre> If interactive boot is disabled,
+there should be no output.</li>
+</ol>
 </ocil>
 <rationale>
-Using interactive boot,
-the console user could disable auditing, firewalls, or other
-services, weakening system security.
+Using interactive boot, the console user could disable auditing, firewalls, or
+other services, weakening system security.
 </rationale>
 <ident cce="27043-9"  stig="RHEL-06-000070" />
 <oval id="disable_interactive_boot" />

--- a/shared/oval/disable_interactive_boot.xml
+++ b/shared/oval/disable_interactive_boot.xml
@@ -3,7 +3,7 @@
     <metadata>
       <title>Disable Interactive Boot</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Enterprise Linux 7</platform>
       </affected>
       <description>The ability for users to perform interactive startups should
       be disabled.</description>
@@ -11,6 +11,10 @@
     </metadata>
     <criteria>
       <criterion test_ref="test_disable_interactive_boot" />
+      <!-- This needs to be enhanced yet to properly cover case of 'systemd.confirm_spawn=1'
+           use case on RHEL-7 and Fedora per:
+             https://rhsummit.files.wordpress.com/2014/04/summit_demystifying_systemd1.pdf Page #20
+           SSG Upstream ticket to come yet -->
     </criteria>
   </definition>
 


### PR DESCRIPTION
Per:
&nbsp; &nbsp; [1] https://github.com/OpenSCAP/scap-security-guide/issues/823

and per:
&nbsp; &nbsp; [2] https://access.redhat.com/solutions/25950

besides of setting ```PROMPT``` directive value to value other than ```no``` in ```/etc/sysconfig/init``` file there's yet other way how a user can achieve interactive boot (OS boot model where the user can select which of the services are to be started and which not), namely by:
* adding 'confirm' kernel boot directive to some of the kernel command lines in ```/etc/grub.conf``` file.

Therefore this changeset is performing the following:
* updating RHEL-6 XCCDF prose for ```disable_interactive_boot``` rule to describe that 'confirm' setting shouldn't be set / present in ```/etc/grub.conf``` file (first patch from this changeset),
* updating the existing OVAL for ```disable_interactive_boot``` rule to also be able to detect when this configuration is used on the system in question (second patch from this changeset),
* updating the existing remediation script for this rule to correct also this use-case (if ```confirm``` is present in ```/etc/grub.conf``` on some of the kernel lines, to remove it) (third patch from this changeset).

Testing report:
-------------------
All of the changes have been tested on recent RHEL-6 system and seem to be working fine (AFAICT from testing). Namely:
* The RPM package builds successfully with the new XCCDF,
* The RHEL-6 OVAL is able to 'fail' also when 'confirm' is present in some of the kernel lines in ```/etc/grub.conf```,
* And finally the updated remediation script fixes the configuration for both:
 * the ```/etc/sysconfig/init``` case, and
 * the ```/etc/grub.conf``` cases.

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/823

Please review.

Thank you, Jan
--
P.S.: The similar issue is present also for current RHEL-7 & Fedora content. This is being tracked under separate ticket as:
&nbsp; &nbsp; [3] https://github.com/OpenSCAP/scap-security-guide/issues/851
