### PR TITLE
[BugFix] [RHEL/6] Add XCCDF, OVAL, and remediation for 'kernel_disable_entropy_contribution_for_solid_state_drives' rule

### DIFF
--- a/RHEL/6/input/guide.xslt
+++ b/RHEL/6/input/guide.xslt
@@ -41,6 +41,7 @@
   <xsl:template match="Group[@id='system']">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document('xccdf/system/entropy.xml')" />
       <xsl:apply-templates select="document('xccdf/system/software/software.xml')" />
       <xsl:apply-templates select="document('xccdf/system/permissions/permissions.xml')" />
       <xsl:apply-templates select="document('xccdf/system/selinux.xml')" />

--- a/RHEL/6/input/oval/kernel_disable_entropy_contribution_for_solid_state_drives.xml
+++ b/RHEL/6/input/oval/kernel_disable_entropy_contribution_for_solid_state_drives.xml
@@ -6,23 +6,45 @@
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
       <description>The add_random sysfs variable should be set correctly for each SSD drive on the system.</description>
-      <reference source="JL" ref_id="RHEL6_20151111" ref_url="test_attestation"/>
+      <reference source="JL" ref_id="RHEL6_20151112" ref_url="test_attestation"/>
     </metadata>
 
     <criteria>
       <criterion comment="Check add_random sysfs variable set to '0' for each SSD drive. Fail if not"
                  test_ref="test_kernel_disable_entropy_contribution_for_solid_state_drives" />
     </criteria>
+
   </definition>
 
+  <!-- OVAL object to hold the list of all directory names in /sys/block -->
+  <unix:file_object id="object_system_block_devices"
+  comment="Block device names on the system" version="1">
+    <!-- Traverse /sys/block directory hierarchy only one level to optimize efficiency -->
+    <unix:behaviors recurse="directories" recurse_direction="down"
+    recurse_file_system="local" max_depth="1" />
+    <unix:path operation="equals">/sys/block/</unix:path>
+    <unix:filename operation="pattern match">[^\/]+</unix:filename>
+  </unix:file_object>
+
+  <!-- Append '/queue/rotational' suffix to above retrieved filepaths of all block
+       devices on the system -->
+  <local_variable id="variable_system_block_devices_rotational_paths" datatype="string"
+  comment="Path to 'rotational' tunable for all block devices on the system" version="1">
+    <concat>
+      <object_component item_field="filepath" object_ref="object_system_block_devices" />
+      <literal_component>/queue/rotational</literal_component>
+    </concat>
+  </local_variable>
+
+  <!-- OVAL object to restrict the set of system block devices to SSD drives only
+       (having /sys/block/BLOCK_DEVICE/queue/rotational set to '0') -->
   <ind:textfilecontent54_object id="object_system_ssd_drives" version="1">
-    <ind:behaviors recurse="symlinks and directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-    <ind:filepath operation="pattern match">/sys/block/(.*)/queue/rotational</ind:filepath>
+    <ind:filepath var_ref="variable_system_block_devices_rotational_paths" var_check="at least one" />
     <ind:pattern operation="pattern match">^0$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- Construct final path to "add_random" tunable of particular system's SSD drive -->
+  <!-- Append '/add_random' tunable suffix to list of all SSD system block device paths -->
   <local_variable id="variable_system_solid_state_drives_paths" datatype="string"
   comment="Path to 'add_random' tunable for all SSD drives on system" version="1">
     <concat>

--- a/RHEL/6/input/oval/kernel_disable_entropy_contribution_for_solid_state_drives.xml
+++ b/RHEL/6/input/oval/kernel_disable_entropy_contribution_for_solid_state_drives.xml
@@ -1,0 +1,46 @@
+<def-group>
+  <definition class="compliance" id="kernel_disable_entropy_contribution_for_solid_state_drives" version="1">
+    <metadata>
+      <title>Configure solid-state drives (SSDs) not to contribute to random-number entropy pool</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 6</platform>
+      </affected>
+      <description>The add_random sysfs variable should be set correctly for each SSD drive on the system.</description>
+      <reference source="JL" ref_id="RHEL6_20151111" ref_url="test_attestation"/>
+    </metadata>
+
+    <criteria>
+      <criterion comment="Check add_random sysfs variable set to '0' for each SSD drive. Fail if not"
+                 test_ref="test_kernel_disable_entropy_contribution_for_solid_state_drives" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_object id="object_system_ssd_drives" version="1">
+    <ind:behaviors recurse="symlinks and directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
+    <ind:filepath operation="pattern match">/sys/block/(.*)/queue/rotational</ind:filepath>
+    <ind:pattern operation="pattern match">^0$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Construct final path to "add_random" tunable of particular system's SSD drive -->
+  <local_variable id="variable_system_solid_state_drives_paths" datatype="string"
+  comment="Path to 'add_random' tunable for all SSD drives on system" version="1">
+    <concat>
+      <object_component item_field="path" object_ref="object_system_ssd_drives" />
+      <literal_component>/add_random</literal_component>
+    </concat>
+  </local_variable>
+
+  <ind:textfilecontent54_test id="test_kernel_disable_entropy_contribution_for_solid_state_drives"
+  comment="Verify there doesn't exist SSD drive on system with 'add_random' set to '1'"
+  check="all" check_existence="none_exist" version="1">
+    <ind:object object_ref="object_kernel_disable_entropy_contribution_for_solid_state_drives" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_kernel_disable_entropy_contribution_for_solid_state_drives" version="1">
+    <ind:filepath var_ref="variable_system_solid_state_drives_paths" var_check="at least one" datatype="string" />
+    <ind:pattern operation="pattern match">^1$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/RHEL/6/input/profiles/stig-rhel6-server-upstream.xml
+++ b/RHEL/6/input/profiles/stig-rhel6-server-upstream.xml
@@ -15,7 +15,7 @@ upstream project homepage is https://fedorahosted.org/scap-security-guide/.
 </description>
 
 <select idref="encrypt_partitions" selected="true"/>
-
+<select idref="kernel_disable_entropy_contribution_for_solid_state_drives" selected="true" />
 <select idref="rpm_verify_permissions" selected="true"/>
 <select idref="rpm_verify_hashes" selected="true"/>
 <select idref="mount_option_nodev_removable_partitions" selected="true" />

--- a/RHEL/6/input/profiles/usgcb-rhel6-server.xml
+++ b/RHEL/6/input/profiles/usgcb-rhel6-server.xml
@@ -2,6 +2,7 @@
 <title>United States Government Configuration Baseline (USGCB)</title>
 <description>This profile is a working draft for a USGCB submission against RHEL6 Server.</description>
 
+<select idref="kernel_disable_entropy_contribution_for_solid_state_drives" selected="true" />
 <select idref="partition_for_tmp" selected="true" />
 <select idref="partition_for_var" selected="true" />
 <select idref="partition_for_var_log" selected="true" />

--- a/RHEL/6/input/remediations/bash/kernel_disable_entropy_contribution_for_solid_state_drives.sh
+++ b/RHEL/6/input/remediations/bash/kernel_disable_entropy_contribution_for_solid_state_drives.sh
@@ -1,0 +1,26 @@
+# platform = Red Hat Enterprise Linux 6
+
+# First obtain the list of block devices present on system into array
+#
+# Used lsblk options:
+# -o NAME	Display only block device name
+# -a		Display all devices (including empty ones) in the list
+# -d		Don't print device holders or slaves information
+# -n		Suppress printing of introductory heading line in the list
+SYSTEM_BLOCK_DEVICES=($(/bin/lsblk -o NAME -a -d -n))
+
+# For each SSD block device from that list
+# (device where /sys/block/DEVICE/queue/rotation == 0)
+for BLOCK_DEVICE in "${SYSTEM_BLOCK_DEVICES[@]}"
+do
+	# Verify the block device is SSD
+	if grep -q "0" /sys/block/${BLOCK_DEVICE}/queue/rotational
+	then
+		# If particular SSD is configured to contribute to
+		# random-number entropy pool, disable it
+		if grep -q "1" /sys/block/${BLOCK_DEVICE}/queue/add_random
+		then
+			echo "0" > /sys/block/${BLOCK_DEVICE}/queue/add_random
+		fi
+	fi
+done

--- a/RHEL/6/input/xccdf/system/entropy.xml
+++ b/RHEL/6/input/xccdf/system/entropy.xml
@@ -1,0 +1,24 @@
+<Group id="entropy">
+<title>Protect Random-Number Entropy Pool</title>
+<description>
+The I/O operations of the Linux kernel block layer due to their inherently
+unpredictable execution times have been traditionally considered as a reliable
+source to contribute to random-number entropy pool of the Linux kernel. This
+has changed with introduction of solid-state storage devices (SSDs) though.
+</description>
+
+<Rule id="kernel_disable_entropy_contribution_for_solid_state_drives" severity="medium">
+<title>Ensure Solid State Drives Do Not Contribute To Random-Number Entropy Pool</title>
+<description>For each solid-state drive on the system, run:
+<pre> # echo 0 > /sys/block/DRIVE/queue/add_random</pre>
+</description>
+<rationale>
+In contrast to traditional electromechanical magnetic disks, containing
+spinning disks and / or movable read / write heads, the solid-state storage
+devices (SSDs) do not contain moving / mechanical components. Therefore the
+I/O operation completion times are much more predictable for them.</rationale>
+<tested by="JL" on="20151111"/>
+<!-- <oval id="kernel_disable_entropy_contribution_for_solid_state_drives" /> -->
+</Rule>
+
+</Group>

--- a/RHEL/6/input/xccdf/system/entropy.xml
+++ b/RHEL/6/input/xccdf/system/entropy.xml
@@ -18,7 +18,7 @@ spinning disks and / or movable read / write heads, the solid-state storage
 devices (SSDs) do not contain moving / mechanical components. Therefore the
 I/O operation completion times are much more predictable for them.</rationale>
 <tested by="JL" on="20151111"/>
-<!-- <oval id="kernel_disable_entropy_contribution_for_solid_state_drives" /> -->
+<oval id="kernel_disable_entropy_contribution_for_solid_state_drives" />
 </Rule>
 
 </Group>


### PR DESCRIPTION
This changeset is performing the following:
* introducing RHEL-6 XCCDF, OVAL, and remediation script for ```kernel_disable_entropy_contribution_for_solid_state_drives``` rule as requested in ticket: </br/>
&nbsp; &nbsp; [1] https://github.com/OpenSCAP/scap-security-guide/issues/824

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/824

Testing report:
------------------
All of the XCCDF, OVAL, and remediation add-ons have been manually tested on recent RHEL-6 system and AFAICT from testing all of them are working fine:
* for XCCDF -- the benchmark still builds successfully. New rule is displayed in HTML guide for RHEL-6 USGCB & DISA STIG profiles,
* OVAL is able to detect SSD device (```/sys/block/DEVICE/queue/rotational == 0``` contributing to kernel random-number entropy pool ```/sys/block/DEVICE/queue/add_random == 1```), and finally
* the provided remediation script fixes the issue

Please review.

Thank you, Jan.

P.S.: The overview of the changes performed by particular commits is as follows:
* patch https://github.com/OpenSCAP/scap-security-guide/commit/96d99fa65c564c7393a309e9803aca45d1b0aa2b is adding new ```entropy.xml``` section into the XCCDF, and one new rule ```kernel_disable_entropy_contribution_for_solid_state_drives``` (describing in description & rationale why contributing random-number entropy pool from SSD drives is a bad idea). It also enables that rule for RHEL-6 USGCB & DISA STIG profiles,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/e5a22e29d4777c2b00d6077cc4bd5a1ffae30860 is adding initial version of the OVAL check for this rule,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/809fc7c9220621b068c4b786cedf6ca061be19f6 is adding corresponding remediation script for this rule, and finally
* patch https://github.com/OpenSCAP/scap-security-guide/commit/7eaddb3f904f41ab13e0569532dbece64f5534c4 is optimizing the existing / former provided OVAL check for speed & efficiency.