### PR TITLE
[Enhancement] [RHEL/6] Add RHEL-6 remediations for selected PCI-DSS rules

### DIFF
--- a/RHEL/6/input/remediations/bash/accounts_password_pam_minlen.sh
+++ b/RHEL/6/input/remediations/bash/accounts_password_pam_minlen.sh
@@ -1,0 +1,10 @@
+# platform = Red Hat Enterprise Linux 6
+source ./templates/support.sh
+populate var_password_pam_minlen
+
+if grep -q "minlen=" /etc/pam.d/system-auth
+then
+	sed -i --follow-symlink "s/\(minlen *= *\).*/\1$var_password_pam_minlen/" /etc/pam.d/system-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ minlen=$var_password_pam_minlen/" /etc/pam.d/system-auth
+fi

--- a/RHEL/6/input/remediations/bash/audit_rules_login_events.sh
+++ b/RHEL/6/input/remediations/bash/audit_rules_login_events.sh
@@ -1,0 +1,10 @@
+# platform = Red Hat Enterprise Linux 6
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+# Perform the remediation
+
+fix_audit_watch_rule "auditctl" "/var/log/tallylog" "wa" "logins"
+fix_audit_watch_rule "auditctl" "/var/run/faillock/" "wa" "logins"
+fix_audit_watch_rule "auditctl" "/var/log/lastlog" "wa" "logins"

--- a/RHEL/7/input/remediations/bash/aide_build_database.sh
+++ b/RHEL/7/input/remediations/bash/aide_build_database.sh
@@ -1,2 +1,0 @@
-# platform = Red Hat Enterprise Linux 7
-/usr/sbin/aide --init

--- a/shared/remediations/bash/aide_build_database.sh
+++ b/shared/remediations/bash/aide_build_database.sh
@@ -1,0 +1,2 @@
+# platform = multi_platform_rhel
+/usr/sbin/aide --init

--- a/shared/remediations/bash/auditd_audispd_syslog_plugin_activated.sh
+++ b/shared/remediations/bash/auditd_audispd_syslog_plugin_activated.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = multi_platform_rhel
 
 grep -q ^active /etc/audisp/plugins.d/syslog.conf && \
   sed -i "s/active.*/active = yes/g" /etc/audisp/plugins.d/syslog.conf


### PR DESCRIPTION
This changeset adds the RHEL-6 remediation scripts for the following rules:
* ```audit_rules_login_events```,
* ```auditd_audispd_syslog_plugin_activated```,
* ```accounts_password_pam_minlen```, and
* ```aide_build_database```

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/840
Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/837
Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/835
Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/833

Testing report:
------------------
All of the changes have been tested on recent RHEL-6 system and AFAICT
from testing all of them are working fine.

Please review.

Thank you, Jan.

