### PR TITLE
[BugFix] [RHEL/6] Modify / optimize RHEL-6 OVAL check for 'audit_rules_privileged_commands' rule (not to return an 'error' on systems with not enough memory)

### DIFF
--- a/RHEL/6/input/oval/audit_rules_privileged_commands.xml
+++ b/RHEL/6/input/oval/audit_rules_privileged_commands.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_privileged_commands"
-  version="1">
+  version="2">
     <metadata>
       <title>
         Ensure auditd Collects Information on the Use of Privileged Commands
@@ -10,7 +10,7 @@
       </affected>
       <description>Audit rules about the Information on the Use of Privileged
       Commands are enabled</description>
-      <reference source="JL" ref_id="RHEL6_20140703" ref_url="test_attestation"/>
+      <reference source="JL" ref_id="RHEL6_20151119" ref_url="test_attestation"/>
     </metadata>
     <criteria>
 
@@ -37,19 +37,20 @@
   version="1">
     <unix:behaviors recurse="directories" recurse_direction="down"
     recurse_file_system="local" max_depth="-1" />
-    <unix:path operation="equals">/</unix:path>
+    <!-- Skip selected directories (like /dev, /proc, and /sys) when traversing
+         filesystem hierarchy, since:
+         * these directories don't contain executables, but
+         * can contain lot of symbolic link entries, possibly leading this OVAL
+         rule scan to return 'error' on systems with not enough memory. Fixes:
+         https://github.com/OpenSCAP/scap-security-guide/issues/841 -->
+    <unix:path operation="pattern match">\/(?:(?!dev|proc|sys).)+</unix:path>
     <unix:filename operation="pattern match">^.*$</unix:filename>
     <filter action="include">state_setuid_or_setgid_set</filter>
-    <filter action="exclude">state_irrelevant_system_dirs</filter>
   </unix:file_object>
 
   <unix:file_state id="state_setuid_or_setgid_set" version="1" operator="OR">
     <unix:suid datatype="boolean">true</unix:suid>
     <unix:sgid datatype="boolean">true</unix:sgid>
-  </unix:file_state>
-
-  <unix:file_state id="state_irrelevant_system_dirs" version="1">
-    <unix:filepath operation="pattern match">^/(dev|proc|sys)/.*$</unix:filepath>
   </unix:file_state>
 
   <!-- Based on the above list create a variable holding full / expanded

--- a/RHEL/6/input/oval/audit_rules_privileged_commands.xml
+++ b/RHEL/6/input/oval/audit_rules_privileged_commands.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_privileged_commands"
-  version="2">
+  version="3">
     <metadata>
       <title>
         Ensure auditd Collects Information on the Use of Privileged Commands
@@ -35,8 +35,7 @@
   <unix:file_object id="object_system_privileged_commands"
   comment="system files with setuid or setgid permission set"
   version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down"
-    recurse_file_system="local" max_depth="-1" />
+    <unix:behaviors recurse_file_system="local" />
     <!-- Skip selected directories (like /dev, /proc, and /sys) when traversing
          filesystem hierarchy, since:
          * these directories don't contain executables, but


### PR DESCRIPTION
</br>

For the OVAL check for 'audit_rules_privileged_commands' rule modify the way we
are excluding directories:
* not containing executables,
* but possibly containing lot of symlinks (like /dev, /sys, or /proc).

Instead of:
* First collecting all OVAL file objects on the system,
* Then including the setuid / setgid binaries, and excluding /dev, /sys,
  and /proc directories

exclude the /dev, /proc, and /sys paths directly in the path element specification
of the corresponding unix:file_object OVAL element (since filter are applied only
after all requested OVAL objects have been collected, the current implementation
might lead to situation where on RHEL-6 systems with not enough memory the final
OVAL will end up with 'error' since all OVAL file objects would not fit into the memory).

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/841

As for RHEL-7 / Fedora the similar change is not required / necessary AFAICT from
testing, since openscap version on these systems already contains fix for:
  [1] https://fedorahosted.org/openscap/ticket/457

issue, thus:
  [2] https://git.fedorahosted.org/cgit/openscap.git/commit/?id=840ee0cfb5f78b5415e3be182d87c3528ae65362

Testing report:
--------------
Verified manually on recent RHEL-6 system the proposed change works as expected
(the system scan against this rule doesn't return 'error' as a result anymore even
on systems with not enough memory [returns ```pass``` or ```fail``` depending on the configuration]).

Please review.

Thank you, Jan.