### PR TITLE
PCI-DSS references - improve granularity

### DIFF
--- a/RHEL/7/input/xccdf/services/ntp.xml
+++ b/RHEL/7/input/xccdf/services/ntp.xml
@@ -137,7 +137,7 @@ logs from multiple sources or correlate computer events with real time events.
 </rationale>
 <ident cce="27278-1" />
 <oval id="chronyd_or_ntpd_specify_remote_server" />
-<ref nist="AU-8(1)" disa="160" pcidss="Req-10" />
+<ref nist="AU-8(1)" disa="160" pcidss="Req-10.4.1" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/services/ntp.xml
+++ b/RHEL/7/input/xccdf/services/ntp.xml
@@ -93,7 +93,7 @@ information on this is available at
 http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate</rationale>
 <ident cce="27444-9" />
 <oval id="service_chronyd_or_ntpd_enabled" />
-<ref nist="AU-8(1)" disa="160" pcidss="Req-10" />
+<ref nist="AU-8(1)" disa="160" pcidss="Req-10.4" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/services/ntp.xml
+++ b/RHEL/7/input/xccdf/services/ntp.xml
@@ -170,7 +170,7 @@ other systems.
 </rationale>
 <ident cce="27012-4" />
 <oval id="chronyd_or_ntpd_specify_multiple_servers"/>
-<ref nist="AU-8(1)" pcidss="Req-10" />
+<ref nist="AU-8(1)" pcidss="Req-10.4.3" />
 </Rule>
 
 <!-- future Rules (for later profiles/enhancements):

--- a/RHEL/7/input/xccdf/services/ssh.xml
+++ b/RHEL/7/input/xccdf/services/ssh.xml
@@ -169,7 +169,7 @@ to compromises on another.
 </rationale>
 <ident cce="27433-2" />
 <oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value"/>
-<ref nist="AC-2(5),SA-8" disa="" pcidss="Req-8" />
+<ref nist="AC-2(5),SA-8" disa="" pcidss="Req-8.1.8" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -349,7 +349,7 @@ required to compromise the password.
 </rationale>
 <ident cce="27293-0" />
 <oval id="accounts_password_pam_minlen" value="var_password_pam_minlen" />
-<ref nist="IA-5(1)(a)" disa="205" srg="78" pcidss="Req-8" />
+<ref nist="IA-5(1)(a)" disa="205" srg="78" pcidss="Req-8.2.3" />
 <tested by="swells" on="20140928" />
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -662,7 +662,7 @@ ensure that the <tt>pam_unix.so</tt> module includes the argument
 Using a stronger hashing algorithm makes password cracking attacks more difficult.
 </rationale>
 <ident cce="27104-9" />
-<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="" pcidss="Req-8" />
+<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="" pcidss="Req-8.2.1" />
 <tested by="DS" on="20121024"/>
 <oval id="set_password_hashing_algorithm_systemauth" />
 </Rule>

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -326,7 +326,7 @@ search space.
 </rationale>
 <ident cce="27214-6" />
 <oval id="accounts_password_pam_dcredit" value="var_password_pam_dcredit"/>
-<ref nist="IA-5(b),IA-5(c),194" disa="194" srg="71" pcidss="Req-8" />
+<ref nist="IA-5(b),IA-5(c),194" disa="194" srg="71" pcidss="Req-8.2.3" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -682,7 +682,7 @@ Inspect <tt>/etc/login.defs</tt> and ensure the following line appears:
 Using a stronger hashing algorithm makes password cracking attacks more difficult.
 </rationale>
 <ident cce="27124-7" />
-<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="" pcidss="Req-8" />
+<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="" pcidss="Req-8.2.1" />
 <tested by="DS" on="20121024"/>
 <oval id="set_password_hashing_algorithm_logindefs" />
 </Rule>

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -567,7 +567,7 @@ situations.
 </rationale>
 <ident cce="26884-7" />
 <oval id="accounts_passwords_pam_faillock_unlock_time" value="var_accounts_passwords_pam_faillock_unlock_time"/>
-<ref nist="AC-7(b)" disa="47" pcidss="Req-8" />
+<ref nist="AC-7(b)" disa="47" pcidss="Req-8.1.7" />
 </Rule>
 
 <Rule id="accounts_passwords_pam_faillock_interval" severity="medium">

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -425,7 +425,7 @@ more difficult by ensuring a larger search space.
 </rationale>
 <ident cce="27345-8" />
 <oval id="accounts_password_pam_lcredit" value="var_password_pam_lcredit"/>
-<ref nist="IA-5(b),IA-5(c),IA-5(1)(a)" disa="193" srg="70" pcidss="Req-8" />
+<ref nist="IA-5(b),IA-5(c),IA-5(1)(a)" disa="193" srg="70" pcidss="Req-8.2.3" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -535,7 +535,7 @@ prevents direct password guessing attacks.
 </rationale>
 <ident cce="27350-8" />
 <oval id="accounts_passwords_pam_faillock_deny" value="var_accounts_passwords_pam_faillock_deny"/>
-<ref nist="AC-7(a)" disa="44" srg="21" pcidss="Req-8" />
+<ref nist="AC-7(a)" disa="44" srg="21" pcidss="Req-8.1.6" />
 </Rule>
 
 <Rule id="accounts_passwords_pam_faillock_unlock_time" severity="medium">

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -704,7 +704,7 @@ in the <tt>[default]</tt> section:
 Using a stronger hashing algorithm makes password cracking attacks more difficult.
 </rationale>
 <ident cce="27053-8" />
-<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="" pcidss="Req-8" />
+<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="" pcidss="Req-8.2.1" />
 <tested by="DS" on="20121026"/>
 <oval id="set_password_hashing_algorithm_libuserconf" />
 </Rule>

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -629,7 +629,7 @@ Preventing re-use of previous passwords helps ensure that a compromised password
 </rationale>
 <ident cce="26923-3" />
 <oval id="accounts_password_pam_unix_remember" value="var_password_pam_unix_remember" />
-<ref nist="IA-5(f),IA-5(1)(e)" disa="200" srg="77" pcidss="Req-8" />
+<ref nist="IA-5(f),IA-5(1)(e)" disa="200" srg="77" pcidss="Req-8.2.5" />
 <tested by="DS" on="20121024"/>
 </Rule>
 </Group>

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -80,7 +80,7 @@ and gives them an opportunity to notify administrators.
 </rationale>
 <ident cce="27275-7" />
 <oval id="display_login_attempts" />
-<ref disa="53" pcidss="Req-10" />
+<ref disa="53" pcidss="Req-10.2.4" />
 </Rule>
 
 <Group id="password_quality">

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -375,7 +375,7 @@ more difficult by ensuring a larger search space.
 </rationale>
 <ident cce="27200-5" />
 <oval id="accounts_password_pam_ucredit" value="var_password_pam_ucredit"/>
-<ref nist="IA-5(b),IA-5(c),IA-5(1)(a)" disa="192" srg="69" pcidss="Req-8" />
+<ref nist="IA-5(b),IA-5(c),IA-5(1)(a)" disa="192" srg="69" pcidss="Req-8.2.3" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -370,7 +370,7 @@ access the system, preventing access by passersby.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="dconf_gnome_screensaver_lock_enabled" />
-<ref nist="AC-11(a)" disa="57" pcidss="Req-8" />
+<ref nist="AC-11(a)" disa="57" pcidss="Req-8.1.8" />
 </Rule>
 
 <Rule id="dconf_gnome_screensaver_mode_blank">

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -311,7 +311,7 @@ screen locking to prevent access from passersby.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="dconf_gnome_screensaver_idle_delay" value="inactivity_timeout_value" />
-<ref nist="AC-11(a)" disa="57" pcidss="Req-8" />
+<ref nist="AC-11(a)" disa="57" pcidss="Req-8.1.8" />
 </Rule>
 
 <Rule id="dconf_gnome_screensaver_idle_activation_enabled" severity="medium">

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -339,7 +339,7 @@ controlled-access area.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="dconf_gnome_screensaver_idle_activation_enabled" />
-<ref nist="AC-11(a)" disa="57" pcidss="Req-8" />
+<ref nist="AC-11(a)" disa="57" pcidss="Req-8.1.8" />
 </Rule>
 
 <Rule id="dconf_gnome_screensaver_lock_enabled" severity="medium">

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -35,7 +35,7 @@ Only root should be able to modify important boot parameters.
 </rationale>
 <ident cce="26860-7" />
 <oval id="file_user_owner_grub2_cfg" />
-<ref nist="AC-6(7)" disa="225" pcidss="Req-7" />
+<ref nist="AC-6(7)" disa="225" pcidss="Req-7.1" />
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -396,7 +396,7 @@ contents of the display from passersby.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="dconf_gnome_screensaver_mode_blank" />
-<ref nist="AC-11(b)" disa="60" pcidss="Req-8" />
+<ref nist="AC-11(b)" disa="60" pcidss="Req-8.1.8" />
 </Rule>
 
 </Group>

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -53,7 +53,7 @@ file should not have any access privileges anyway.
 </rationale>
 <ident cce="26812-8" />
 <oval id="file_group_owner_grub2_cfg" />
-<ref nist="AC-6(7)" disa="225" pcidss="Req-7" />
+<ref nist="AC-6(7)" disa="225" pcidss="Req-7.1" />
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -474,7 +474,7 @@ that provided by a username and password combination. Smart cards leverage PKI
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="smartcard_auth" />
-<ref disa="765,766,767,768,771,772,884" pcidss="Req-8" />
+<ref disa="765,766,767,768,771,772,884" pcidss="Req-8.3" />
 </Rule>
 
 </Group>

--- a/RHEL/7/input/xccdf/system/accounts/restrictions/account_expiration.xml
+++ b/RHEL/7/input/xccdf/system/accounts/restrictions/account_expiration.xml
@@ -78,7 +78,7 @@ Unique usernames allow for accountability on the system.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="account_unique_name" />
-<ref disa="770,804" pcidss="Req-8" />
+<ref disa="770,804" pcidss="Req-8.1.1" />
 </Rule>
 
 <Rule id="account_temp_expire_date">

--- a/RHEL/7/input/xccdf/system/accounts/restrictions/account_expiration.xml
+++ b/RHEL/7/input/xccdf/system/accounts/restrictions/account_expiration.xml
@@ -60,7 +60,7 @@ who may have compromised their credentials.
 </rationale>
 <ident cce="TBD" />
 <oval id="account_disable_post_pw_expiration" value="var_account_disable_post_pw_expiration"/>
-<ref nist="AC-2(2), AC-2(3)" disa="16,17,795" pcidss="Req-8" />
+<ref nist="AC-2(2), AC-2(3)" disa="16,17,795" pcidss="Req-8.1.4" />
 </Rule>
 
 <Rule id="account_unique_name">

--- a/RHEL/7/input/xccdf/system/accounts/restrictions/password_expiration.xml
+++ b/RHEL/7/input/xccdf/system/accounts/restrictions/password_expiration.xml
@@ -159,7 +159,7 @@ increases the risk of users writing down the password in a convenient
 location subject to physical compromise.</rationale>
 <ident cce="27051-2" />
 <oval id="accounts_maximum_age_login_defs" value="var_accounts_maximum_age_login_defs"/>
-<ref nist="IA-5(f),IA-5(g),IA-5(1)(d)" disa="180,199" srg="76" pcidss="Req-8" />
+<ref nist="IA-5(f),IA-5(g),IA-5(1)(d)" disa="180,199" srg="76" pcidss="Req-8.2.4" />
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/accounts/restrictions/password_storage.xml
+++ b/RHEL/7/input/xccdf/system/accounts/restrictions/password_storage.xml
@@ -64,7 +64,7 @@ which is readable by all users.
 </rationale>
 <ident cce="27352-4" />
 <oval id="accounts_password_all_shadowed" />
-<ref nist="IA-5(h)" disa="" pcidss="Req-8" />
+<ref nist="IA-5(h)" disa="" pcidss="Req-8.2.1" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/accounts/restrictions/password_storage.xml
+++ b/RHEL/7/input/xccdf/system/accounts/restrictions/password_storage.xml
@@ -38,7 +38,7 @@ environments.
 </rationale>
 <ident cce="27286-4" />
 <oval id="no_empty_passwords" />
-<ref nist="IA-5(b),IA-5(c),IA-5(1)(a)" pcidss="Req-8" />
+<ref nist="IA-5(b),IA-5(c),IA-5(1)(a)" pcidss="Req-8.2.3" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/accounts/restrictions/password_storage.xml
+++ b/RHEL/7/input/xccdf/system/accounts/restrictions/password_storage.xml
@@ -84,7 +84,7 @@ Inconsistency in GIDs between <tt>/etc/passwd</tt> and <tt>/etc/group</tt> could
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="gid_passwd_group_same" />
-<ref disa="366" pcidss="Req-8" />
+<ref disa="366" pcidss="Req-8.5" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -351,7 +351,7 @@ log data, or which use external processes to transfer it and reclaim space,
 <tt>keep_logs</tt> can be employed.</rationale>
 <ident cce="27231-0" />
 <oval id="auditd_data_retention_max_log_file_action" value="var_auditd_max_log_file_action" />
-<ref nist="AU-1(b),AU-4,AU-11,IR-5" pcidss="Req-10" />
+<ref nist="AU-1(b),AU-4,AU-11,IR-5" pcidss="Req-10.7" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -1472,7 +1472,7 @@ unusual activity.
 </rationale>
 <ident cce="27437-3" />
 <oval id="audit_rules_privileged_commands" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-2(4),AU-12(a),AU-12(c),IR-5" disa="40" pcidss="Req-10" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-2(4),AU-12(a),AU-12(c),IR-5" disa="40" pcidss="Req-10.2.2" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -435,7 +435,7 @@ is used, running low on space for audit records should never occur.
 </rationale>
 <ident cce="27370-6" />
 <oval id="auditd_data_retention_admin_space_left_action" value="var_auditd_admin_space_left_action" />
-<ref nist="AU-1(b),AU-4,AU-5(b),IR-5" disa="140,1343" pcidss="Req-10" />
+<ref nist="AU-1(b),AU-4,AU-5(b),IR-5" disa="140,1343" pcidss="Req-10.7" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -290,7 +290,7 @@ log information over the period required. This is a function of the maximum log
 file size and the number of logs retained.</rationale>
 <ident cce="27348-2" />
 <oval id="auditd_data_retention_num_logs" value="var_auditd_num_logs" />
-<ref nist="AU-1(b),AU-11,IR-5" pcidss="Req-10" />
+<ref nist="AU-1(b),AU-11,IR-5" pcidss="Req-10.7" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -830,7 +830,7 @@ If users can write to audit logs, audit trails can be modified or destroyed.
 </rationale>
 <ident cce="27205-4" />
 <oval id="file_permissions_var_log_audit" />
-<ref nist="AC-6,AU-1(b),AU-9,IR-5" disa="" pcidss="Req-10" />
+<ref nist="AC-6,AU-1(b),AU-9,IR-5" disa="" pcidss="Req-10.5" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -1555,7 +1555,7 @@ To verify that auditing is configured for system administrator actions, run the 
 of what was executed on the system, as well as, for accountability purposes.</rationale>
 <ident cce="27461-3" />
 <oval id="audit_rules_sysadmin_actions" />
-<ref nist="AC-2(7)(b),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126" pcidss="Req-10" />
+<ref nist="AC-2(7)(b),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126" pcidss="Req-10.2.2" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -1611,7 +1611,7 @@ problematic if legitimate changes are needed during system
 operation</rationale>
 <ident cce="27097-5" />
 <oval id="audit_rules_immutable" />
-<ref nist="AC-6,AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" pcidss="Req-10" />
+<ref nist="AC-6,AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" pcidss="Req-10.5.5" />
 </Rule>
 </Group>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -770,7 +770,7 @@ will alert the system administrator(s) to any modifications. Any unexpected
 users, groups, or modifications should be investigated for legitimacy.</rationale>
 <ident cce="27192-4" />
 <oval id="audit_rules_usergroup_modification" />
-<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,1404,1405,1684,1683,1685,1686" ossrg="476,239" pcidss="Req-10" />
+<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,1404,1405,1684,1683,1685,1686" ossrg="476,239" pcidss="Req-10.2.5" />
 </Rule>
 
 <Rule id="audit_rules_networkconfig_modification">

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -1587,7 +1587,7 @@ the kernel and potentially introduce malicious code into kernel space. It is imp
 to have an audit trail of modules that have been introduced into the kernel.</rationale>
 <ident cce="27129-6" />
 <oval id="audit_rules_kernel_module_loading" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" ossrg="477" pcidss="Req-10" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" ossrg="477" pcidss="Req-10.2.7" />
 </Rule>
 
 <Rule id="audit_rules_immutable">

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -1501,7 +1501,7 @@ trail should be created each time a filesystem is mounted to help identify and g
 loss.</rationale>
 <ident cce="27447-2" />
 <oval id="audit_rules_media_export" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126" pcidss="Req-10" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126" pcidss="Req-10.2.7" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -1369,7 +1369,7 @@ edits of files involved in storing logon events:
 as an attacker attempting to remove evidence of an intrusion.</rationale>
 <ident cce="27204-7" />
 <oval id="audit_rules_login_events" />
-<ref nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" pcidss="Req-10" />
+<ref nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" pcidss="Req-10.2.3" />
 </Rule>
 
 <Rule id="audit_rules_session_events">

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -1395,7 +1395,7 @@ edits of files involved in storing such process information:
 as an attacker attempting to remove evidence of an intrusion.</rationale>
 <ident cce="27301-1" />
 <oval id="audit_rules_session_events" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" pcidss="Req-10" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" pcidss="Req-10.2.3" />
 </Rule>
 
 <Rule id="audit_rules_unsuccessful_file_modification">

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -504,7 +504,7 @@ records to a centralized server for management directly. It does, however,
 include a plug-in for audit event multiplexor (audispd) to pass audit records
 to the local syslog server</rationale>
 <oval id="auditd_audispd_syslog_plugin_activated" />
-<ref nist="AU-1(b),AU-3(2),IR-5" disa="136" pcidss="Req-10" />
+<ref nist="AU-1(b),AU-3(2),IR-5" disa="136" pcidss="Req-10.5.3" />
 <ident cce="27341-7" />
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -151,7 +151,7 @@ file. To update the GRUB 2 configuration file manually, use the
 </warning>
 <ident cce="27212-0" />
 <oval id="bootloader_audit_argument" />
-<ref nist="AC-17(1),AU-14(1),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-10,IR-5" disa="1464,130" pcidss="Req-10" />
+<ref nist="AC-17(1),AU-14(1),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-10,IR-5" disa="1464,130" pcidss="Req-10.3" />
 </Rule>
 
 <Group id="configure_auditd_data_retention">

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -404,7 +404,7 @@ Acceptable values are <tt>email</tt>, <tt>suspend</tt>, <tt>single</tt>, and <tt
 allow them to take corrective action prior to any disruption.</rationale>
 <ident cce="27375-5" />
 <oval id="auditd_data_retention_space_left_action" value="var_auditd_space_left_action"/>
-<ref nist="AU-1(b),AU-4,AU-5(b),IR-5" disa="140,143" pcidss="Req-10" />
+<ref nist="AU-1(b),AU-4,AU-5(b),IR-5" disa="140,143" pcidss="Req-10.7" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -846,7 +846,7 @@ If users can write to audit logs, audit trails can be modified or destroyed.
 owner, and unauthorized users, potential access to sensitive information.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="file_ownership_var_log_audit" />
-<ref nist="AC-6,AU-1(b),AU-9,IR-5" disa="166" pcidss="Req-10" />
+<ref nist="AC-6,AU-1(b),AU-9,IR-5" disa="166" pcidss="Req-10.5.1" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -315,7 +315,7 @@ log information over the period required. This is a function of the maximum
 log file size and the number of logs retained.</rationale>
 <ident cce="27319-3" />
 <oval id="auditd_data_retention_max_log_file" value="var_auditd_max_log_file" />
-<ref nist="AU-1(b),AU-11,IR-5" pcidss="Req-10" />
+<ref nist="AU-1(b),AU-11,IR-5" pcidss="Req-10.7" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/logging.xml
+++ b/RHEL/7/input/xccdf/system/logging.xml
@@ -122,7 +122,7 @@ configuration, user authentication, and other such information. Log files should
 protected from unauthorized access.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="rsyslog_files_ownership" />
-<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10" />
+<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10.5.1,Req-10.5.2" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/logging.xml
+++ b/RHEL/7/input/xccdf/system/logging.xml
@@ -184,7 +184,7 @@ users could change the logged data, eliminating their forensic value.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="rsyslog_files_permissions" />
-<ref nist="SI-11" disa="1314" pcidss="Req-10" />
+<ref nist="SI-11" disa="1314" pcidss="Req-10.5.1,Req-10.5.2" />
 <tested by="DS" on="20121024"/>
 </Rule>
 </Group>

--- a/RHEL/7/input/xccdf/system/logging.xml
+++ b/RHEL/7/input/xccdf/system/logging.xml
@@ -151,7 +151,7 @@ configuration, user authentication, and other such information. Log files should
 protected from unauthorized access.</rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="rsyslog_files_groupownership" />
-<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10" />
+<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10.5.1,Req-10.5.2" />
 <tested by="DS" on="20121024"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/logging.xml
+++ b/RHEL/7/input/xccdf/system/logging.xml
@@ -375,7 +375,7 @@ If logrotate is configured properly, output should include references to
 </ocil>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="ensure_logrotate_activated" />
-<ref nist="AU-9" disa="366" pcidss="Req-10" />
+<ref nist="AU-9" disa="366" pcidss="Req-10.7" />
 </Rule>
 </Group>
 

--- a/RHEL/7/input/xccdf/system/network/ipsec.xml
+++ b/RHEL/7/input/xccdf/system/network/ipsec.xml
@@ -19,7 +19,7 @@ transmitted over a wide area network.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="package_libreswan_installed" />
-<ref nist="AC-17, MA-4, SC-9" disa="1130,1131" pcidss="Req-4" />
+<ref nist="AC-17, MA-4, SC-9" disa="1130,1131" pcidss="Req-4.1" />
 </Rule>
 </Group>
 

--- a/RHEL/7/input/xccdf/system/permissions/files.xml
+++ b/RHEL/7/input/xccdf/system/permissions/files.xml
@@ -151,7 +151,7 @@ the system. Protection of this file is critical for system security.</rationale>
 the system. Protection of this file is critical for system security.</rationale>
 <ident cce="26639-5" />
 <oval id="file_groupowner_etc_passwd" />
-<ref nist="AC-6" disa="" pcidss="Req-8" />
+<ref nist="AC-6" disa="" pcidss="Req-8.7.c" />
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/permissions/files.xml
+++ b/RHEL/7/input/xccdf/system/permissions/files.xml
@@ -79,7 +79,7 @@ on the system. Protection of this file is important for system security.</ration
 on the system. Protection of this file is important for system security.</rationale>
 <ident cce="27037-1" />
 <oval id="file_groupowner_etc_group" />
-<ref nist="AC-6" disa="" pcidss="Req-8" />
+<ref nist="AC-6" disa="" pcidss="Req-8.7.c" />
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/permissions/files.xml
+++ b/RHEL/7/input/xccdf/system/permissions/files.xml
@@ -165,7 +165,7 @@ accounts on the system and associated information, and protection of this file
 is critical for system security.</rationale>
 <ident cce="26887-0" />
 <oval id="file_permissions_etc_passwd" />
-<ref nist="AC-6" disa="" pcidss="Req-8" />
+<ref nist="AC-6" disa="" pcidss="Req-8.7.c" />
 <tested by="DS" on="20121026"/>
 </Rule>
 </Group>

--- a/RHEL/7/input/xccdf/system/permissions/files.xml
+++ b/RHEL/7/input/xccdf/system/permissions/files.xml
@@ -28,7 +28,7 @@ to root provides the designated owner with access to sensitive information
 which could weaken the system security posture.</rationale>
 <ident cce="26795-5" />
 <oval id="userowner_shadow_file" />
-<ref nist="AC-6" disa="" pcidss="Req-8" />
+<ref nist="AC-6" disa="" pcidss="Req-8.2.1" />
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/permissions/files.xml
+++ b/RHEL/7/input/xccdf/system/permissions/files.xml
@@ -91,7 +91,7 @@ on the system. Protection of this file is important for system security.</ration
 on the system. Protection of this file is important for system security.</rationale>
 <ident cce="26949-8" />
 <oval id="file_permissions_etc_group" />
-<ref nist="AC-6" disa="" pcidss="Req-8" />
+<ref nist="AC-6" disa="" pcidss="Req-8.7.c" />
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/permissions/files.xml
+++ b/RHEL/7/input/xccdf/system/permissions/files.xml
@@ -67,7 +67,7 @@ which could weaken the system security posture.</rationale>
 on the system. Protection of this file is important for system security.</rationale>
 <ident cce="26933-2" />
 <oval id="file_owner_etc_group" />
-<ref nist="AC-6" pcidss="Req-8" />
+<ref nist="AC-6" pcidss="Req-8.7.c" />
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/permissions/files.xml
+++ b/RHEL/7/input/xccdf/system/permissions/files.xml
@@ -40,7 +40,7 @@ which could weaken the system security posture.</rationale>
 critical for system security.</rationale>
 <ident cce="27125-4" />
 <oval id="groupowner_shadow_file" />
-<ref nist="AC-6" disa="" pcidss="Req-8" />
+<ref nist="AC-6" disa="" pcidss="Req-8.2.1" />
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/permissions/files.xml
+++ b/RHEL/7/input/xccdf/system/permissions/files.xml
@@ -139,7 +139,7 @@ is critical for system security.</rationale>
 the system. Protection of this file is critical for system security.</rationale>
 <ident cce="27138-7" />
 <oval id="file_owner_etc_passwd" />
-<ref nist="AC-6" disa="" pcidss="Req-8" />
+<ref nist="AC-6" disa="" pcidss="Req-8.7.c" />
 <tested by="DS" on="20121026"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/software/integrity.xml
+++ b/RHEL/7/input/xccdf/system/software/integrity.xml
@@ -61,7 +61,7 @@ of AIDE, because it changes binaries.
 </rationale>
 <ident cce="27078-5" />
 <oval id="disable_prelink" />
-<ref nist="CM-6(d),CM-6(3),SC-28, SI-7" pcidss="Req-11" />
+<ref nist="CM-6(d),CM-6(3),SC-28, SI-7" pcidss="Req-11.5" />
 </Rule>
 
 <Rule id="aide_build_database" severity="medium">

--- a/RHEL/7/input/xccdf/system/software/integrity.xml
+++ b/RHEL/7/input/xccdf/system/software/integrity.xml
@@ -215,7 +215,7 @@ Host-based intrusion detection tools provide a system-level defense when an
 intruder gains access to a system or network.  
 </rationale>
 <ident cce="26818-5" />
-<ref nist="SC-7" disa="1263" pcidss="Req-11" />
+<ref nist="SC-7" disa="1263" pcidss="Req-11.4" />
 </Rule>
 
 <Rule id="install_antivirus">

--- a/RHEL/7/input/xccdf/system/software/integrity.xml
+++ b/RHEL/7/input/xccdf/system/software/integrity.xml
@@ -148,7 +148,7 @@ The permissions set by the vendor should be maintained. Any deviations from
 this baseline should be investigated.</rationale>
 <ident cce="27209-6" />
 <oval id="rpm_verify_permissions" />
-<ref nist="AC-6,CM-6(d),CM-6(3)" disa="1493,1494,1495" pcidss="Req-11" />
+<ref nist="AC-6,CM-6(d),CM-6(3)" disa="1493,1494,1495" pcidss="Req-11.5" />
 </Rule>
 
 <Rule id="rpm_verify_hashes">

--- a/RHEL/7/input/xccdf/system/software/integrity.xml
+++ b/RHEL/7/input/xccdf/system/software/integrity.xml
@@ -87,7 +87,7 @@ must be captured and it should be able to be verified against the installed file
 </rationale>
 <ident cce="27220-3" />
 <oval id="aide_build_database" />
-<ref nist="CM-3(d),CM-3(e),CM-6(d),CM-6(3),SC-28,SI-7" pcidss="Req-11" />
+<ref nist="CM-3(d),CM-3(e),CM-6(d),CM-6(3),SC-28,SI-7" pcidss="Req-11.5" />
 </Rule>
 
 <Rule id="aide_periodic_cron_checking" severity="medium">

--- a/RHEL/7/input/xccdf/system/software/integrity.xml
+++ b/RHEL/7/input/xccdf/system/software/integrity.xml
@@ -179,7 +179,7 @@ information given by the RPM database. Executables with erroneous hashes could
 be a sign of nefarious activity on the system.</rationale>
 <ident cce="27157-7" />
 <oval id="rpm_verify_hashes" />
-<ref nist="CM-6(d),CM-6(3),SI-7" disa="1496" pcidss="Req-11" />
+<ref nist="CM-6(d),CM-6(3),SI-7" disa="1496" pcidss="Req-11.5" />
 </Rule>
 
 </Group>

--- a/RHEL/7/input/xccdf/system/software/integrity.xml
+++ b/RHEL/7/input/xccdf/system/software/integrity.xml
@@ -107,7 +107,7 @@ running AIDE is necessary to reveal unexpected changes in installed files.
 </rationale>
 <ident cce="26952-2" />
 <oval id="aide_periodic_cron_checking"/>
-<ref nist="CM-3(d),CM-3(e),CM-6(d),CM-6(3),SC-28,SI-7" disa="374,416,1069,1263,1297,1589" pcidss="Req-11" />
+<ref nist="CM-3(d),CM-3(e),CM-6(d),CM-6(3),SC-28,SI-7" disa="374,416,1069,1263,1297,1589" pcidss="Req-11.5" />
 </Rule>
 </Group>
 

--- a/RHEL/7/input/xccdf/system/software/integrity.xml
+++ b/RHEL/7/input/xccdf/system/software/integrity.xml
@@ -41,7 +41,7 @@ The AIDE package must be installed if it is to be available for integrity checki
 </rationale>
 <ident cce="27096-7" />
 <oval id="package_aide_installed" />
-<ref nist="CM-3(d),CM-3(e),CM-6(d),CM-6(3),SC-28, SI-7" disa="" pcidss="Req-11" />
+<ref nist="CM-3(d),CM-3(e),CM-6(d),CM-6(3),SC-28, SI-7" disa="" pcidss="Req-11.5" />
 <tested by="DS" on="20121024"/>
 </Rule>
 


### PR DESCRIPTION
I have automatically patched pci-dss references from my previous commits.

If you are not satisfied with form of commits, it is not problem to re-run the script with different parameters.

It solves ONLY PART of
https://github.com/OpenSCAP/scap-security-guide/issues/865