### PR TITLE
Do not check whether a variable was assigned or not

### DIFF
--- a/Fedora/input/remediations/bash/accounts_maximum_age_login_defs.sh
+++ b/Fedora/input/remediations/bash/accounts_maximum_age_login_defs.sh
@@ -1,5 +1,6 @@
 # platform = multi_platform_fedora
 source ./templates/support.sh
+declare var_accounts_maximum_age_login_defs
 populate var_accounts_maximum_age_login_defs
 
 grep -q ^PASS_MAX_DAYS /etc/login.defs && \

--- a/Fedora/input/remediations/bash/accounts_minimum_age_login_defs.sh
+++ b/Fedora/input/remediations/bash/accounts_minimum_age_login_defs.sh
@@ -1,5 +1,6 @@
 # platform = multi_platform_fedora
 source ./templates/support.sh
+declare var_accounts_minimum_age_login_defs
 populate var_accounts_minimum_age_login_defs
 
 grep -q ^PASS_MIN_DAYS /etc/login.defs && \

--- a/Fedora/input/remediations/bash/accounts_password_minlen_login_defs.sh
+++ b/Fedora/input/remediations/bash/accounts_password_minlen_login_defs.sh
@@ -1,5 +1,6 @@
 # platform = multi_platform_fedora
 source ./templates/support.sh
+declare var_accounts_password_minlen_login_defs
 populate var_accounts_password_minlen_login_defs
 
 grep -q ^PASS_MIN_LEN /etc/login.defs && \

--- a/Fedora/input/remediations/bash/accounts_password_warn_age_login_defs.sh
+++ b/Fedora/input/remediations/bash/accounts_password_warn_age_login_defs.sh
@@ -1,5 +1,6 @@
 # platform = multi_platform_fedora
 source ./templates/support.sh
+declare var_accounts_password_warn_age_login_defs
 populate var_accounts_password_warn_age_login_defs
 
 grep -q ^PASS_WARN_AGE /etc/login.defs && \

--- a/shared/remediations/bash/sshd_set_idle_timeout.sh
+++ b/shared/remediations/bash/sshd_set_idle_timeout.sh
@@ -1,5 +1,6 @@
 # platform = multi_platform_rhel, multi_platform_fedora
 source ./templates/support.sh
+declare sshd_idle_timeout_value
 populate sshd_idle_timeout_value
 
 SSHD_CONFIG='/etc/ssh/sshd_config'

--- a/shared/transforms/combineremediations.py
+++ b/shared/transforms/combineremediations.py
@@ -97,14 +97,14 @@ def fix_is_applicable_for_product(platform, product):
 
 def substitute_vars(fix):
     # brittle and troubling code to assign environment vars to XCCDF values
-    env_var = re.match("(\s*source\s+\S+)\n+(\s*populate\s+)(\S+)\n(.*)",
+    env_var = re.match("(\s*source\s+\S+)\n+(\s*declare\s+\S+)\n+(\s*populate\s+)(\S+)\n(.*)",
                        fix.text, re.DOTALL)
     if not env_var:
         # no need to alter fix.text
         return
     # otherwise, create node to populate environment variable
-    varname = env_var.group(3)
-    mainscript = env_var.group(4)
+    varname = env_var.group(4)
+    mainscript = env_var.group(5)
     fix.text = varname + "=" + '"'
     # new <sub> element to reference XCCDF variable
     xccdf_sub = etree.SubElement(fix, "sub", idref=varname)


### PR DESCRIPTION
Since version 0.3.5 shellcheck checks for variables which are referenced but not
assigned. This causes fail with XCCDF variables which values are assigned during
the transformation process.

See: https://github.com/koalaman/shellcheck/wiki/SC2154

Tested on both Fedora 22 & 23.