### PR TITLE
[Enhancement] [RHEL/6] [RHEL/7] Add remediation for 'rpm_verify_permissions' rule

### DIFF
--- a/RHEL/6/input/xccdf/system/software/integrity.xml
+++ b/RHEL/6/input/xccdf/system/software/integrity.xml
@@ -145,7 +145,13 @@ is expected by the RPM database:
 Permissions on system binaries and configuration files that are too generous
 could allow an unauthorized user to gain privileges that they should not have.
 The permissions set by the vendor should be maintained. Any deviations from
-this baseline should be investigated.</rationale>
+this baseline should be investigated.
+</rationale>
+<warning category="general"><b>Note: Due to a bug in the <tt>gdm</tt> package,
+the RPM verify command may continue to fail even after file permissions have
+been correctly set on <tt>/var/log/gdm</tt>. This is being tracked in Red Hat
+Bugzilla #1277603.</b>
+</warning>
 <ident cce="26731-0"  stig="RHEL-06-000518" />
 <oval id="rpm_verify_permissions" />
 <ref nist="AC-6,CM-6(d),SI-7" disa="1493,1494,1495" />

--- a/RHEL/7/input/xccdf/system/software/integrity.xml
+++ b/RHEL/7/input/xccdf/system/software/integrity.xml
@@ -145,7 +145,13 @@ is expected by the RPM database:
 Permissions on system binaries and configuration files that are too generous
 could allow an unauthorized user to gain privileges that they should not have.
 The permissions set by the vendor should be maintained. Any deviations from
-this baseline should be investigated.</rationale>
+this baseline should be investigated.
+</rationale>
+<warning category="general">Note: Due to a bug in the <tt>gdm</tt> package, the
+RPM verify command may continue to fail even after file permissions have been
+correctly set on <tt>/var/log/gdm</tt>. This is being tracked in Red Hat
+Bugzilla #1275532.
+</warning>
 <ident cce="27209-6" />
 <oval id="rpm_verify_permissions" />
 <ref nist="AC-6,CM-6(d),CM-6(3)" disa="1493,1494,1495" pcidss="Req-11" />

--- a/shared/remediations/bash/rpm_verify_permissions.sh
+++ b/shared/remediations/bash/rpm_verify_permissions.sh
@@ -1,0 +1,28 @@
+# platform = multi_platform_rhel
+
+# Declare array to hold list of RPM packages we need to correct permissions for
+declare -a SETPERMS_RPM_LIST
+
+# Create a list of files on the system having permissions different from what
+# is expected by the RPM database
+FILES_WITH_INCORRECT_PERMS=($(rpm -Va | grep '^.M'))
+
+# For each file path from that list:
+# * Determine the RPM package the file path is shipped by,
+# * Include it into SETPERMS_RPM_LIST array
+
+for FILE_PATH in "${FILES_WITH_INCORRECT_PERMS[@]}"
+do
+	RPM_PACKAGE=$(rpm -qf "$FILE_PATH")
+	SETPERMS_RPM_LIST=("${SETPERMS_RPM_LIST[@]}" "$RPM_PACKAGE")
+done
+
+# Remove duplicate mention of same RPM in $SETPERMS_RPM_LIST (if any)
+SETPERMS_RPM_LIST=( $(echo "${SETPERMS_RPM_LIST[@]}" | sort -n | uniq) )
+
+# For each of the RPM packages left in the list -- reset its permissions to the
+# correct values
+for RPM_PACKAGE in "${SETPERMS_RPM_LIST[@]}"
+do
+	rpm --setperms "${RPM_PACKAGE}"
+done


### PR DESCRIPTION

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/834

Testing report:
---------------
The proposed change has been tested manually on recent RHEL-7 system &
AFAICT from testing it's working fine.

Note:
-----
This remediation script will NOT put the system in question into 'fixed'
state. This is because even after performing the remediation (calling
permissions that saved in the RPM database there will remain one unfixed
file path, namely "/var/log/gdm". The issue here being that this is known
bug:
  [1] https://bugzilla.redhat.com/show_bug.cgi?id=1277603

reported to downstream bugzilla (till calling "# rpm --setperms gdm"
won't fix the problem also for the "/var/log/gdm" location, the returned
result of this remediation script will be 'error' instead of 'fixed').

But the proper work of this remediation can be verified by running the command:

before and after the remediation and comparing the results (the count of
files reported before the remediation will be higher than count of files
having incorrect permissions after the remediation has finished -- the
only unfixed exception should be "/var/log/gdm" file path and we have
bugs reported downstream for these).

Please review.

Thank you, Jan.