### PR TITLE
Edge case fix for var_password_pam_unix_remember

### DIFF
--- a/shared/remediations/bash/accounts_password_pam_unix_remember.sh
+++ b/shared/remediations/bash/accounts_password_pam_unix_remember.sh
@@ -3,7 +3,7 @@ source ./templates/support.sh
 populate var_password_pam_unix_remember
 
 if grep -q "remember=" /etc/pam.d/system-auth; then   
-	sed -i --follow-symlink "s/\(remember *= *\).*[[:space:]]/\1$var_password_pam_unix_remember /" /etc/pam.d/system-auth
+	sed -i --follow-symlinks "s/\(^password.*sufficient.*pam_unix.so.*\)\(\(remember *= *\)[^ $]*\)/\1remember=$var_password_pam_unix_remember/" /etc/pam.d/system-auth
 else
 	sed -i --follow-symlink "/^password[[:space:]]\+sufficient[[:space:]]\+pam_unix.so/ s/$/ remember=$var_password_pam_unix_remember/" /etc/pam.d/system-auth
 fi

--- a/shared/remediations/bash/accounts_password_pam_unix_remember.sh
+++ b/shared/remediations/bash/accounts_password_pam_unix_remember.sh
@@ -3,7 +3,7 @@ source ./templates/support.sh
 populate var_password_pam_unix_remember
 
 if grep -q "remember=" /etc/pam.d/system-auth; then   
-	sed -i --follow-symlink "s/\(remember *= *\).*/\1$var_password_pam_unix_remember/" /etc/pam.d/system-auth
+	sed -i --follow-symlink "s/\(remember *= *\).*[[:space:]]/\1$var_password_pam_unix_remember /" /etc/pam.d/system-auth
 else
 	sed -i --follow-symlink "/^password[[:space:]]\+sufficient[[:space:]]\+pam_unix.so/ s/$/ remember=$var_password_pam_unix_remember/" /etc/pam.d/system-auth
 fi


### PR DESCRIPTION
In RHEL6 GNU sed version 4.2.1:

Current sed line will truncate everything after "remember="

EX:
password    sufficient    pam_unix.so sha512 try_first_pass use_authtok remember=24 shadow

Becomes:
password    sufficient    pam_unix.so sha512 try_first_pass use_authtok remember=24

Fix accounts for remember not being last on line.