### PR TITLE
[Enhancement] [RHEL/5] [RHEL/6] [RHEL/7] Fetch remote resources -- add OVAL and remediation

### DIFF
--- a/RHEL/5/input/remediations/bash/security_patches_up_to_date.sh
+++ b/RHEL/5/input/remediations/bash/security_patches_up_to_date.sh
@@ -1,0 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
+yum -y update

--- a/RHEL/5/input/xccdf/system/software/updating.xml
+++ b/RHEL/5/input/xccdf/system/software/updating.xml
@@ -43,6 +43,13 @@ or a yum server, run the following command to install updates:
 If the system is not configured to use one of these sources, updates (in the form of RPM packages)
 can be manually downloaded from the Red Hat Network and installed using <tt>rpm</tt>.
 </description>
+<!-- Directly define remotely located OVAL to be executed when scanning this rule -->
+<!-- Since OpenSCAP for now supports only "http://" protocol being specified when
+     fetching remote resources (see https://fedorahosted.org/openscap/ticket/213
+     for further details) use "http://" version of the remotely located OVAL below -->
+<check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+  <check-content-ref href="http://www.redhat.com/security/data/oval/Red_Hat_Enterprise_Linux_5.xml" />
+</check>
 <ocil clause="updates are not installed">
 If the system is joined to the Red Hat Network, a Red Hat Satellite Server, or
 a yum server which provides updates, invoking the following command will
@@ -51,7 +58,7 @@ indicate if updates are available:
 If the system is not configured to update from one of these sources,
 run the following command to list when each package was last updated:
 <pre>$ rpm -qa -last</pre>
-Compare this to Red Hat Security Advisories (RHSA) listed at 
+Compare this to Red Hat Security Advisories (RHSA) listed at
 https://access.redhat.com/security/updates/active/
 to determine if the system is missing applicable updates.
 </ocil>
@@ -59,8 +66,9 @@ to determine if the system is missing applicable updates.
 Installing software updates is a fundamental mitigation against
 the exploitation of publicly-known vulnerabilities.
 </rationale>
-<!--oval id="security_patches_up_to_date" /-->
 <ref nist="VIVM-1" disa="1227" />
+<!-- Particular OVAL check is defined directly via <check> element above -->
+<!-- DO NOT REFERENCE an OVAL id here !!! -->
 <ident stig="GEN000120" />
 </Rule>
 </Group>

--- a/RHEL/6/input/xccdf/system/software/updating.xml
+++ b/RHEL/6/input/xccdf/system/software/updating.xml
@@ -107,6 +107,13 @@ or a yum server, run the following command to install updates:
 If the system is not configured to use one of these sources, updates (in the form of RPM packages)
 can be manually downloaded from the Red Hat Network and installed using <tt>rpm</tt>.
 </description>
+<!-- Directly define remotely located OVAL to be executed when scanning this rule -->
+<!-- Since OpenSCAP for now supports only "http://" protocol being specified when
+     fetching remote resources (see https://fedorahosted.org/openscap/ticket/213
+     for further details) use "http://" version of the remotely located OVAL below -->
+<check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+  <check-content-ref href="http://www.redhat.com/security/data/oval/Red_Hat_Enterprise_Linux_6.xml" />
+</check>
 <ocil clause="updates are not installed">
 If the system is joined to the Red Hat Network, a Red Hat Satellite Server, or
 a yum server which provides updates, invoking the following command will
@@ -115,7 +122,7 @@ indicate if updates are available:
 If the system is not configured to update from one of these sources,
 run the following command to list when each package was last updated:
 <pre>$ rpm -qa -last</pre>
-Compare this to Red Hat Security Advisories (RHSA) listed at 
+Compare this to Red Hat Security Advisories (RHSA) listed at
 https://access.redhat.com/security/updates/active/
 to determine if the system is missing applicable updates.
 </ocil>
@@ -124,6 +131,8 @@ Installing software updates is a fundamental mitigation against
 the exploitation of publicly-known vulnerabilities.
 </rationale>
 <ident cce="27635-2" stig="RHEL-06-000011" />
+<!-- Particular OVAL check is defined directly via <check> element above -->
+<!-- DO NOT REFERENCE an OVAL id here !!! -->
 <ref nist="SI-2,MA-1(b)" disa="1227,1233"/>
 <tested by="MM" on="20120928"/>
 </Rule>

--- a/RHEL/7/input/xccdf/system/software/updating.xml
+++ b/RHEL/7/input/xccdf/system/software/updating.xml
@@ -118,6 +118,13 @@ or a yum server, run the following command to install updates:
 If the system is not configured to use one of these sources, updates (in the form of RPM packages)
 can be manually downloaded from the Red Hat Network and installed using <tt>rpm</tt>.
 </description>
+<!-- Directly define remotely located OVAL to be executed when scanning this rule -->
+<!-- Since OpenSCAP for now supports only "http://" protocol being specified when
+     fetching remote resources (see https://fedorahosted.org/openscap/ticket/213
+     for further details) use "http://" version of the remotely located OVAL below -->
+<check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+  <check-content-ref href="http://www.redhat.com/security/data/oval/Red_Hat_Enterprise_Linux_7.xml" />
+</check>
 <ocil clause="updates are not installed">
 If the system is joined to the Red Hat Network, a Red Hat Satellite Server, or
 a yum server which provides updates, invoking the following command will
@@ -126,7 +133,7 @@ indicate if updates are available:
 If the system is not configured to update from one of these sources,
 run the following command to list when each package was last updated:
 <pre>$ rpm -qa -last</pre>
-Compare this to Red Hat Security Advisories (RHSA) listed at 
+Compare this to Red Hat Security Advisories (RHSA) listed at
 https://access.redhat.com/security/updates/active/
 to determine if the system is missing applicable updates.
 </ocil>
@@ -135,6 +142,8 @@ Installing software updates is a fundamental mitigation against
 the exploitation of publicly-known vulnerabilities.
 </rationale>
 <ident cce="26895-3" />
+<!-- Particular OVAL check is defined directly via <check> element above -->
+<!-- DO NOT REFERENCE an OVAL id here !!! -->
 <ref nist="SI-2,MA-1(b)" disa="" pcidss="Req-6" />
 <tested by="MM" on="20120928"/>
 </Rule>

--- a/shared/remediations/bash/security_patches_up_to_date.sh
+++ b/shared/remediations/bash/security_patches_up_to_date.sh
@@ -1,0 +1,2 @@
+# platform = multi_platform_rhel
+yum -y update


### PR DESCRIPTION
This changeset is performing the following:
* patch https://github.com/OpenSCAP/scap-security-guide/commit/ff40b9064bcefd42dac31994e3748f91f8b66c4a is modifying the build process (namely ```relabelids.py``` transformation script) not to count remote OVAL files (having ```htttp://``` and ```https://``` prefix) as another files for OVAL check system, and not to try to relabel IDs in the case ```<check-content-ref>``` element with ```href``` attribute containing either ```http://``` or ```https://``` substrings. This allows to directly inline remotely located OVAL content into the XCCDF "shorthand" definitions for particular product,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/11ea0da67b11b04c28abea90c10b2b1fbca54a93 is using the previous change to provide / reference remotely located OVAL content (official Red Hat RHSA / CVE OVAL content) for that product to be executed when system in question is scanned against that rule, and finally
* patch https://github.com/OpenSCAP/scap-security-guide/commit/99feba7aca204134f989cff370a27cfa0aa64fbb is providing remediation scripts for ```RHEL/5```, ```RHEL/6```, and ```RHEL/7``` products to get the systems into compliance state when the OVAL scan fails.

Testing report:
--------------------
All of the changes have been tested on recent RHEL-6 & RHEL-7 systems, and AFAICT from testing they are working fine:
* outdated system is reported as failing (when ```--fetch-remote-resources``` oscap / SCAP Workbench option is used),
* outdated system is updated within performing remediation.

Please review.

Thank you, Jan.