### PR TITLE
Add a kickstart file for PCI DSS for RHEL6

### DIFF
--- a/RHEL/6/kickstart/ssg-rhel6-pci-dss-with-gui-ks.cfg
+++ b/RHEL/6/kickstart/ssg-rhel6-pci-dss-with-gui-ks.cfg
@@ -1,0 +1,203 @@
+# SCAP Security Guide PCI-DSS profile kickstart for Red Hat Enterprise Linux 6 Server
+# Version: 0.0.1
+# Date: 2015-04-11
+#
+# Based on:
+# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Install a fresh new system (optional)
+install
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+
+# Set language to use during installation and the default language to use on the
+# installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices
+# in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# encrypted password form for different plaintext password
+rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# --enableshadow	enable shadowed passwords by default
+# --passalgo		hash / crypt algorithm for new passwords
+# See the manual page for authconfig for a complete list of possible options.
+authconfig --enableshadow --passalgo=sha512
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# encrypted password form for different plaintext password
+bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+#
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=ext4 --size=512
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup vg_sys --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=ext4 --name=lv_root --vgname=vg_sys --size=12288 --grow
+# CCE-26557-9: Ensure /home Located On Separate Partition
+logvol /home --fstype=ext4 --name=lv_home --vgname=vg_sys --size=1024 --fsoptions="nodev"
+# CCE-26435-8: Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=ext4 --name=lv_tmp --vgname=vg_sys --size=1024 --fsoptions="nodev,noexec,nosuid"
+# CCE-26639-5: Ensure /var Located On Separate Partition
+logvol /var --fstype=ext4 --name=lv_var --vgname=vg_sys --size=2048 --fsoptions="nodev"
+# CCE-26215-4: Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=ext4 --name=lv_var_log --vgname=vg_sys --size=1024 --fsoptions="nodev"
+# CCE-26436-6: Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=ext4 --name=lv_var_log_audit --vgname=vg_sys --size=512 --fsoptions="nodev"
+logvol swap --name=lv_swap --vgname=vg_sys --size=2016
+
+# Packages selection (%packages section is required)
+%packages
+
+@additional-devel
+@base
+@basic-desktop
+@desktop-debugging
+@dial-up
+@directory-client
+@mail-server
+@fonts
+@general-desktop
+@graphical-admin-tools
+@hardware-monitoring
+@input-methods
+@internet-browser
+@java-platform
+@large-systems
+@legacy-unix
+@legacy-x
+@nfs-file-server
+@network-server
+@network-file-system-client
+@network-tools
+@performance
+@perl-runtime
+@print-server
+@print-client
+@system-management-snmp
+@server-platform
+@web-server
+@x11
+
+# Install git package so we can clone SCAP Security Guide repository below
+git
+
+# Install selected additional packages (required by PCI DSS profile for Red Hat
+# Enterprise Linux 6 Server)
+# CCE-27024-9: Install AIDE
+aide
+
+# Install openscap-utils so it's possible to perform remediation once the
+# installation is complete
+openscap-scanner
+
+%end # End of %packages section
+
+%post --log /root/oscap.log
+
+SSG_GIT_CONTENT="/root/scap-security-guide"
+OSCAP_GIT_CONTENT="/root/oscap"
+SSG_GIT_RHEL6="$SSG_GIT_CONTENT/RHEL/6"
+SSG_GIT_URI="https://github.com/OpenSCAP/scap-security-guide.git"
+SSG_SHARE_DIR="/usr/share/scap-security-guide"
+
+# Retrieve the most recent SCAP Security Guide repository content & build
+# the RHEL-6 benchmark.
+#
+# NOTE: Pointing to upstream SCAP Security Guide repository. Downstream/stable editions
+#       (e.g. those to ship natively with Red Hat Enterprise Linux 6) will be updated to
+#       point to natively included scap-security-guide RPM package.
+
+git clone $SSG_GIT_URI $SSG_GIT_CONTENT
+cd $SSG_GIT_RHEL6
+make
+
+# Copy the remediation functions library to the system too
+mkdir -p $SSG_SHARE_DIR
+cp -a $SSG_GIT_CONTENT/shared/remediations/bash/templates/remediation_functions $SSG_SHARE_DIR/remediation_functions
+
+# Perform post installation system remediation according to the PCI DSS profile
+# for Red Hat Enterprise Linux 6 Server via the oscap tool To create a system
+# compliant against different RHEL-6 SCAP Security Guide profile specify
+# selected profile name after the --profile oscap tool option
+
+oscap xccdf eval --remediate --profile pci-dss --report /root/oscap_pci-dss_remediation_report.html \
+"$SSG_GIT_RHEL6/output/ssg-rhel6-xccdf.xml"
+
+# Delete the retrieved GIT content
+rm -rf $SSG_GIT_CONTENT
+
+%end # End of %post section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject


### PR DESCRIPTION
Do not merge yet. It wasn't fully tested because of the [issue #251](https://github.com/OpenSCAP/openscap/issues/251).

On rhel6.7 there is also problem with kickstart downloaded from https. Use `ks=https://.../ks.cfg noverifyssl`