### PR TITLE
[BugFix] [RHEL/6] Fix invalid selectors in the RHEL-6's CNSS No.1253 profile

### DIFF
--- a/RHEL/6/input/profiles/nist-CL-IL-AL.xml
+++ b/RHEL/6/input/profiles/nist-CL-IL-AL.xml
@@ -30,7 +30,7 @@ assurance."</description>
 <!--	AC-4:	TBD 
 
 	-->
-<refine-value idref="sysctl_net_ipv4_conf_all_secure_redirects_value" selector="1" />
+<refine-value idref="sysctl_net_ipv4_conf_all_secure_redirects_value" selector="enabled" />
 
 
 <!--	AC-6: Least privilege
@@ -81,17 +81,17 @@ assurance."</description>
 		- 5	(minutes)
 		- 10	(minutes)
 		- 15	(minutes) -->
-<refine-value idref="inactivity_timeout_value" selector="15" />
+<refine-value idref="inactivity_timeout_value" selector="15_minutes" />
 
 
 <!-- STATIC VARIABLES: DO NOT ALTER -->
 <refine-value idref="login_banner_text" selector="usgcb_default" />
-<refine-value idref="sysctl_net_ipv4_conf_all_accept_source_route_value" selector="0" />
-<refine-value idref="sysctl_net_ipv4_conf_all_accept_redirects_value" selector="0" />
-<refine-value idref="sysctl_net_ipv4_conf_all_log_martians_value" selector="1" />
-<refine-value idref="sysctl_net_ipv4_conf_default_secure_redirects_value" selector="1" />
-<refine-value idref="sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" selector="1" />
-<refine-value idref="sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value" selector="1" />
+<refine-value idref="sysctl_net_ipv4_conf_all_accept_source_route_value" selector="disabled" />
+<refine-value idref="sysctl_net_ipv4_conf_all_accept_redirects_value" selector="disabled" />
+<refine-value idref="sysctl_net_ipv4_conf_all_log_martians_value" selector="enabled" />
+<refine-value idref="sysctl_net_ipv4_conf_default_secure_redirects_value" selector="enabled" />
+<refine-value idref="sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" selector="enabled" />
+<refine-value idref="sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value" selector="enabled" />
 
 
 <!-- MAYBE

--- a/RHEL/6/input/xccdf/system/accounts/restrictions/account_expiration.xml
+++ b/RHEL/6/input/xccdf/system/accounts/restrictions/account_expiration.xml
@@ -23,6 +23,7 @@ normal command line utilities.
 <value selector="">35</value>
 <value selector="30">30</value>
 <value selector="35">35</value>
+<value selector="40">40</value>
 <value selector="60">60</value>
 <value selector="90">90</value>
 <value selector="180">180</value>


### PR DESCRIPTION

This is another from the set of fixes for:
  https://bugzilla.redhat.com/show_bug.cgi?id=1284045

Testing report:
--
Verified manually on RHEL-6 system once this change is applied oscap / scap-workbench doesn't print warnings about invalid selectors being present in the CNSS No.1253 RHEL-6 profile any more.

Please review.

Thank you, Jan.