### PR TITLE
Fix regex in combineremediations.py

### DIFF
--- a/shared/transforms/combineremediations.py
+++ b/shared/transforms/combineremediations.py
@@ -100,8 +100,9 @@ def fix_is_applicable_for_product(platform, product):
 
 def substitute_vars(fix):
     # brittle and troubling code to assign environment vars to XCCDF values
-    env_var = re.match("(\s*source\s+\S+)\n+(\s*declare\s+\S+)\n+(\s*populate\s+)(\S+)\n(.*)",
-                       fix.text, re.DOTALL)
+    env_var = re.match("(\s*source\s+\S+)\n+(\s*declare\s+\S+\n+)?(\s*populate\s+)(\S+)\n(.*)",
+        fix.text, re.DOTALL)
+
     if not env_var:
         # no need to alter fix.text
         return


### PR DESCRIPTION
This fixes [PR 870](https://github.com/OpenSCAP/scap-security-guide/pull/870) where I forgot the case when there is no `declare` line in the remediation script (I tested the case but pushed a wrong commit). This caused that some remediation scripts contained lines with `source` and `populate` in final content. The `source` line then prevent the correct execution of the script during remediation.

This was the reason of the issue: https://github.com/OpenSCAP/openscap/issues/251.