### PR TITLE
Fedora 21 reached end of life

### DIFF
--- a/Fedora/input/guide.xml
+++ b/Fedora/input/guide.xml
@@ -38,6 +38,5 @@ respective companies.</rear-matter>
 <platform idref="cpe:/o:fedoraproject:fedora:24" />
 <platform idref="cpe:/o:fedoraproject:fedora:23" />
 <platform idref="cpe:/o:fedoraproject:fedora:22" />
-<platform idref="cpe:/o:fedoraproject:fedora:21" />
 <version>0.0.4</version>
 </Benchmark>

--- a/Fedora/input/xccdf/system/auditing.xml
+++ b/Fedora/input/xccdf/system/auditing.xml
@@ -34,7 +34,7 @@ requirements.
 Examining some example audit records demonstrates how the Linux audit system
 satisfies common requirements.
 The following example from Fedora Documentation available at
-<tt>http://docs.fedoraproject.org/en-US/Fedora/21/html/SELinux_Users_and_Administrators_Guide/sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages.html</tt>
+<tt>http://docs.fedoraproject.org/en-US/Fedora/22/html/SELinux_Users_and_Administrators_Guide/sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages.html</tt>
 shows the substantial amount of information captured in a
 two typical "raw" audit messages, followed by a breakdown of the most important
 fields. In this example the message is SELinux-related and reports an AVC

--- a/config/oval.config
+++ b/config/oval.config
@@ -6,9 +6,9 @@
 # multi_platform_ variables allow developers to easily specify the multiple
 # operating system versions supported by a specific OVAL check. For example:
 # 
-#     <platform>Fedora 21</platform>
 #     <platform>Fedora 22</platform>
 #     <platform>Fedora 23</platform>
+#     <platform>Fedora 24</platform>
 # 
 # would be written in the OVAL check as:
 #
@@ -16,13 +16,13 @@
 #
 # with the multi_platform_fedora variable set as the following in this file:
 #
-# multi_platform_fedora = 23,22,21
+# multi_platform_fedora = 24,23,22
 #
 # Note: this file uses .ini style formatting
 #
 [Platform]
 multi_platform_oval = multi_platform_fedora, multi_platform_rhel
-multi_platform_fedora = 24,23,22,21
+multi_platform_fedora = 24,23,22
 multi_platform_rhel = 6,7
 multi_platform_openstack = 
 multi_platform_rhev = 

--- a/shared/oval/installed_OS_is_fedora.xml
+++ b/shared/oval/installed_OS_is_fedora.xml
@@ -5,7 +5,6 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <reference ref_id="cpe:/o:fedoraproject:fedora:21" source="CPE" />
       <reference ref_id="cpe:/o:fedoraproject:fedora:22" source="CPE" />
       <reference ref_id="cpe:/o:fedoraproject:fedora:23" source="CPE" />
       <description>The operating system installed on the system is Fedora</description>


### PR DESCRIPTION
Update list of CPEs for Fedora benchmark because F21 is end of life now.

- https://lists.fedoraproject.org/pipermail/devel/2015-November/216679.html
- Fixes #853