### PR TITLE
Create a shorthand target that emulates what jenkins runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ DOCDIR=$(DATADIR)/doc
 
 all: validate-buildsystem fedora rhel5 rhel6 rhel7 openstack rhevm3 webmin firefox jre chromium debian8 rpm
 dist: chromium-dist firefox-dist fedora-dist jre-dist rhel6-dist rhel7-dist debian8-dist
+jenkins: clean all validate dist rpm
 
 fedora:
 	cd Fedora/ && $(MAKE)


### PR DESCRIPTION
1) People are confused what jenkins runs, so I want to give them an
short-cut to what they need to run before submitting a pull-request.

2) The jenkins job takes a too long by having the same target rebuilds
many times. There are savings greater than 35% per single jenkins run.

Data from my system:

Before:
	real	9m44.857s
	user	14m14.457s
	sys	0m27.178s

After:
	real	6m21.564s
	user	9m2.878s
	sys	0m15.800s