### PR TITLE
Fix python binary name

### DIFF
--- a/Chromium/utils/verify-input-sanity.py
+++ b/Chromium/utils/verify-input-sanity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # verify-input-sanity.py

--- a/Debian/8/utils/verify-input-sanity.py
+++ b/Debian/8/utils/verify-input-sanity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # verify-input-sanity.py

--- a/RHEL/5/input/oval/testcheck.py
+++ b/RHEL/5/input/oval/testcheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys, os, tempfile, subprocess, platform
 import idtranslate

--- a/RHEL/6/tests/oval/check_instances_test.py
+++ b/RHEL/6/tests/oval/check_instances_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import os

--- a/shared/modules/cce_extract_module.py
+++ b/shared/modules/cce_extract_module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import lxml.etree as ET

--- a/shared/modules/splitchecks_module.py
+++ b/shared/modules/splitchecks_module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import os

--- a/shared/modules/sync_alt_titles_module.py
+++ b/shared/modules/sync_alt_titles_module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import optparse

--- a/shared/modules/verify_cce_module.py
+++ b/shared/modules/verify_cce_module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import platform

--- a/shared/modules/xccdf2csv_stig_module.py
+++ b/shared/modules/xccdf2csv_stig_module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import csv

--- a/shared/oval/templates/create_kernel_modules_disabled.py
+++ b/shared/oval/templates/create_kernel_modules_disabled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # create_kernel_modules_disabled.py

--- a/shared/oval/templates/create_package_installed.py
+++ b/shared/oval/templates/create_package_installed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # create_package_installed.py

--- a/shared/oval/templates/create_package_removed.py
+++ b/shared/oval/templates/create_package_removed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # create_package_removed.py

--- a/shared/oval/templates/create_permission_checks.py
+++ b/shared/oval/templates/create_permission_checks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # create_permission_checks.py

--- a/shared/oval/templates/create_services_disabled.py
+++ b/shared/oval/templates/create_services_disabled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # create_services_disabled.py

--- a/shared/oval/templates/create_services_enabled.py
+++ b/shared/oval/templates/create_services_enabled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # create_services_enabled.py

--- a/shared/oval/templates/create_sockets_disabled.py
+++ b/shared/oval/templates/create_sockets_disabled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # create_sockets_disabled.py

--- a/shared/oval/templates/create_sysctl_checks.py
+++ b/shared/oval/templates/create_sysctl_checks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import csv

--- a/shared/oval/templates/create_sysctl_ipv6_checks.py
+++ b/shared/oval/templates/create_sysctl_ipv6_checks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import csv

--- a/shared/oval/templates/create_umask_checks.py
+++ b/shared/oval/templates/create_umask_checks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # create_umask_checks.py

--- a/shared/oval/templates/find_untemplated.py
+++ b/shared/oval/templates/find_untemplated.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import os

--- a/shared/remediations/bash/templates/create_kernel_module_disabled.py
+++ b/shared/remediations/bash/templates/create_kernel_module_disabled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # create_kernel_modules_disabled.py

--- a/shared/remediations/bash/templates/create_services_disabled.py
+++ b/shared/remediations/bash/templates/create_services_disabled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # create_services_disabled.py

--- a/shared/remediations/bash/templates/create_services_enabled.py
+++ b/shared/remediations/bash/templates/create_services_enabled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # create_services_enabled.py

--- a/shared/remediations/bash/templates/create_sysctl_bash.py
+++ b/shared/remediations/bash/templates/create_sysctl_bash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import csv

--- a/shared/transforms/combineovals.py
+++ b/shared/transforms/combineovals.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import os

--- a/shared/transforms/combineremediations.py
+++ b/shared/transforms/combineremediations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import os

--- a/shared/transforms/cpe_generate.py
+++ b/shared/transforms/cpe_generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import os

--- a/shared/transforms/oscapsupportssvg.py
+++ b/shared/transforms/oscapsupportssvg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 from subprocess import Popen, PIPE
 from tempfile import mkstemp

--- a/shared/transforms/relabelids.py
+++ b/shared/transforms/relabelids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import os

--- a/shared/utils/count_oval_objects.py
+++ b/shared/utils/count_oval_objects.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 '''
 count_oval_objects.py

--- a/shared/utils/verify-input-sanity.py
+++ b/shared/utils/verify-input-sanity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #
 # verify-input-sanity.py

--- a/shared/utils/verify-references.py
+++ b/shared/utils/verify-references.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import optparse


### PR DESCRIPTION
Distros such as Arch that have Python 3 as the default Python version might have /usr/bin/python linked to python3 instead of python2.