### PR TITLE
Cleaning Debian 8 directory

### DIFF
--- a/Debian/8/Makefile
+++ b/Debian/8/Makefile
@@ -45,13 +45,13 @@ shorthand2xccdf: shorthand-guide
 checks:
 	# Make intermediate $(PROD_OVAL) directory to hold final list of OVAL checks for $(PROD)
 	mkdir -p $(PROD_OVAL)
+	$(MAKE) -C $(IN)/oval/templates all
+	$(MAKE) -C $(IN)/oval/templates copy
 	# Search $(SHARED_OVAL) and $(IN)/oval directories to find all product specific OVAL checks,
 	# which are regular files (not symlinks). Merge the final list into $(PROD_OVAL) directory
 	find $(SHARED_OVAL) $(IN)/oval -maxdepth 1 -type f -name *.xml -exec cp {} $(PROD_OVAL) ';'
 	# If openscap on the system supports OVAL-5.11 language version, include also OVAL-5.11 checks
 	# add local Debian8 specific templated ovals
-	$(MAKE) -C $(IN)/oval/templates all
-	$(MAKE) -C $(IN)/oval/templates copy
 	# into final list of OVAL checks
 ifeq ($(OVAL_5_11), 0)
 	$(MAKE) -C $(IN)/oval/oval_5.11/templates all

--- a/Debian/8/input/oval/installed_OS_is_debian8.xml
+++ b/Debian/8/input/oval/installed_OS_is_debian8.xml
@@ -3,9 +3,9 @@
     <metadata>
       <title>Debian 8</title>
       <affected family="unix">
-        <platform>Debian 8</platform>
+        <platform>multi_platform_all</platform>
       </affected>
-      <reference ref_id="cpe:/o:debian:debian:8" source="CPE" />
+      <reference ref_id="cpe:/o:debian:debian_linux:8" source="CPE" />
       <description>The operating system installed on the system is Debian 8</description>
       <reference source="JL" ref_id="DEBIAN8_20151210" ref_url="test_attestation" />
     </metadata>

--- a/Debian/8/input/oval/installed_OS_is_debian8.xml
+++ b/Debian/8/input/oval/installed_OS_is_debian8.xml
@@ -28,16 +28,13 @@
   <unix:file_test check="all" check_existence="all_exist" comment="/etc/debian_version exists" id="test_debian" version="1">
     <unix:object object_ref="obj_debian" />
   </unix:file_test>
-
   <unix:file_object comment="check /etc/debian_version file" id="obj_debian" version="1">
     <unix:filepath>/etc/debian_version</unix:filepath>
-    <!-- <filter action="include">state_file</filter>-->
   </unix:file_object>
 
   <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check Debian version" id="test_debian_8" version="1">
     <ind:object object_ref="obj_debian_8" />
   </ind:textfilecontent54_test>
-
   <ind:textfilecontent54_object id="obj_debian_8" version="1" comment="Check Debian version">
     <ind:filepath>/etc/debian_version</ind:filepath>
     <ind:pattern operation="pattern match">^8.[0-9]+$</ind:pattern>

--- a/Debian/8/input/oval/installed_OS_is_debian8.xml
+++ b/Debian/8/input/oval/installed_OS_is_debian8.xml
@@ -9,8 +9,9 @@
       <description>The operating system installed on the system is Debian 8</description>
       <reference source="JL" ref_id="DEBIAN8_20151210" ref_url="test_attestation" />
     </metadata>
-    <criteria>
+    <criteria comment="current Debian version is Debian jessie" operator="AND">
       <criterion comment="Installed operating system is part of the unix family" test_ref="test_unix_family" />
+      <criterion comment="Debian is installed" test_ref="test_debian" />
       <criterion comment="Debian8 is installed" test_ref="test_debian_8" />
     </criteria>
   </definition>
@@ -23,6 +24,15 @@
     <ind:family>unix</ind:family>
   </ind:family_state>
   <ind:family_object id="obj_unix_family" version="1" />
+
+  <unix:file_test check="all" check_existence="all_exist" comment="/etc/debian_version exists" id="test_debian" version="1">
+    <unix:object object_ref="obj_debian" />
+  </unix:file_test>
+
+  <unix:file_object comment="check /etc/debian_version file" id="obj_debian" version="1">
+    <unix:filepath>/etc/debian_version</unix:filepath>
+    <!-- <filter action="include">state_file</filter>-->
+  </unix:file_object>
 
   <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check Debian version" id="test_debian_8" version="1">
     <ind:object object_ref="obj_debian_8" />

--- a/Debian/8/input/oval/templates/Makefile
+++ b/Debian/8/input/oval/templates/Makefile
@@ -8,7 +8,7 @@ all:
 
 copy:
 	cp output/*.sh ../../remediations/bash/
-	cp output/*.xml ../../../build/debian8_oval/
+	cp output/*.xml ..
 
 clean:
 	rm -rf output/*.xml

--- a/Debian/8/input/profiles/common.xml
+++ b/Debian/8/input/profiles/common.xml
@@ -10,22 +10,21 @@
 <select idref="partition_for_home" selected="true"/>
 
 <!-- services -->
-<select idref="service_auditd_installed" selected="true"/>
-<select idref="service_cron_installed" selected="true"/>
-<select idref="service_ntpd_installed" selected="true"/>
-<select idref="service_rsyslog_installed" selected="true"/>
+<select idref="package_auditd_installed" selected="true"/>
+<select idref="package_cron_installed" selected="true"/>
+<select idref="package_ntp_installed" selected="true"/>
+<select idref="package_rsyslog_installed" selected="true"/>
 
 <select idref="package_telnetd_removed" selected="true"/>
 <select idref="package_inetutils-telnetd_removed" selected="true"/>
 <select idref="package_telnetd-ssl_removed" selected="true"/>
-<select idref="package_gpm_removed" selected="true"/>
 <select idref="package_nis_removed" selected="true"/>
 <select idref="package_ntpdate_removed" selected="true"/>
 
-<select idref="service_auditd_enable" selected="true"/>
-<select idref="service_cron_enable" selected="true"/>
-<select idref="service_ntpd_enable" selected="true"/>
-<select idref="service_rsyslog_enable" selected="true"/>
+<select idref="service_auditd_enabled" selected="true"/>
+<select idref="service_cron_enabled" selected="true"/>
+<select idref="service_ntpd_enabled" selected="true"/>
+<select idref="service_rsyslog_enabled" selected="true"/>
 
 <!-- critical files -->
 <select idref="file_owner_etc_group" selected="true"/>

--- a/Debian/8/input/xccdf/services/basics.xml
+++ b/Debian/8/input/xccdf/services/basics.xml
@@ -35,7 +35,7 @@ The auditd service is an access monitoring and accounting daemon, watching syste
 </Rule>
 
 <Rule id="package_cron_installed" severity="medium">
-<title>Enable the cron service</title>
+<title>Install the cron service</title>
 <description>
 The Cron service should be installed.
 </description>
@@ -62,7 +62,7 @@ The cron service allow periodic job execution, needed for almost all administrat
 </Rule>
 
 <Rule id="package_ntp_installed" severity="high">
-<title>Enable the ntp service</title>
+<title>Install the ntp service</title>
 <description>
 The ntpd service should be installed.
 </description>
@@ -92,7 +92,7 @@ Time synchronization (using NTP) is required by almost all network and administr
 </Rule>
 
 <Rule id="package_rsyslog_installed" severity="high">
-<title>Enable the rsyslog service</title>
+<title>Install the rsyslog service</title>
 <description>
 The rsyslog service should be installed.
 </description>


### PR DESCRIPTION
* Updated CPE name to official NVD 2.2 (cpe:/o:debian:debian_linux:8)
* Cleaning various undefined ref due to errors in xccdf document.
* Add better OS check (checking debian_version existence before reading its content)
* updated sequence errors in Debian Makefile.