### PR TITLE
Refactor the very first make target: the guide.xml

### DIFF
--- a/Chromium/Makefile
+++ b/Chromium/Makefile
@@ -5,13 +5,8 @@ include $(SHARED)/product-make.include
 
 PROD = chromium
 
-shorthand-guide:
-ifeq ($(OPENSCAP_SVG), 0)
-	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+shorthand-guide: $(OUT)/guide.xml
 	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
-else
-	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
-endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -9,13 +9,8 @@ PROD_REMEDIATIONS = $(BUILD)/$(PROD)_remediations
 
 SHELLCHECK_AVAIL := $(shell which shellcheck >& /dev/null; echo $$?)
 
-shorthand-guide:
-ifeq ($(OPENSCAP_SVG), 0)
-	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+shorthand-guide: $(OUT)/guide.xml
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
-else
-	xsltproc -o $(OUT)/$(ID)-$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
-endif
 	xmllint --format --output $(OUT)/$(ID)-$(PROD)-shorthand.xml $(OUT)/$(ID)-$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide

--- a/Firefox/Makefile
+++ b/Firefox/Makefile
@@ -8,13 +8,8 @@ PROD = firefox
 #stats:
 #	$(SHARED)/$(TRANS)/stats.sh
 
-shorthand-guide:
-ifeq ($(OPENSCAP_SVG), 0)
-	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+shorthand-guide: $(OUT)/guide.xml
 	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
-else
-	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
-endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide

--- a/JRE/Makefile
+++ b/JRE/Makefile
@@ -8,13 +8,8 @@ PROD = jre
 #stats:
 #	$(SHARED)/$(TRANS)/stats.sh
 
-shorthand-guide:
-ifeq ($(OPENSCAP_SVG), 0)
-	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+shorthand-guide: $(OUT)/guide.xml
 	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
-else
-	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
-endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide

--- a/OpenStack/Makefile
+++ b/OpenStack/Makefile
@@ -8,13 +8,8 @@ REFS = references
 
 PROD = openstack
 
-shorthand-guide:
-ifeq ($(OPENSCAP_SVG), 0)
-	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+shorthand-guide: $(OUT)/guide.xml
 	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
-else
-	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
-endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -9,13 +9,8 @@ PROD_REMEDIATIONS = $(BUILD)/$(PROD)_remediations
 
 all: shorthand2xccdf tables guide content dist
 
-shorthand-guide:
-ifeq ($(OPENSCAP_SVG), 0)
-	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+shorthand-guide: $(OUT)/guide.xml
 	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
-else
-	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
-endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -11,13 +11,8 @@ PROD_REMEDIATIONS = $(BUILD)/$(PROD)_remediations
 # Value '0' means 'test' will be included. Value '1' means 'test' will NOT be included.
 INCLUDE_TEST_PROFILE := $(shell false; echo $$?)
 
-shorthand-guide:
-ifeq ($(OPENSCAP_SVG), 0)
-	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+shorthand-guide: $(OUT)/guide.xml
 	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
-else
-	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
-endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -11,13 +11,8 @@ PROD_REMEDIATIONS = $(BUILD)/$(PROD)_remediations
 # Value '0' means 'test' will be included. Value '1' means 'test' will NOT be included.
 INCLUDE_TEST_PROFILE := $(shell false; echo $$?)
 
-shorthand-guide:
-ifeq ($(OPENSCAP_SVG), 0)
-	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+shorthand-guide: $(OUT)/guide.xml
 	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
-else
-	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
-endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide

--- a/RHEVM3/Makefile
+++ b/RHEVM3/Makefile
@@ -8,13 +8,8 @@ REFS = references
 
 PROD = rhevm3
 
-shorthand-guide:
-ifeq ($(OPENSCAP_SVG), 0)
-	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+shorthand-guide: $(OUT)/guide.xml
 	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
-else
-	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
-endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -10,13 +10,8 @@ PROD = webmin
 # stats:
 #	$(SHARED)/$(TRANS)/stats.sh
 
-shorthand-guide:
-ifeq ($(OPENSCAP_SVG), 0)
-	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+shorthand-guide: $(OUT)/guide.xml
 	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(OUT)/guide.xml
-else
-	xsltproc -o $(OUT)/$(PROD)-shorthand.xml $(IN)/guide.xslt $(IN)/guide.xml
-endif
 	xmllint --format --output $(OUT)/$(PROD)-shorthand.xml $(OUT)/$(PROD)-shorthand.xml
 
 shorthand2xccdf: shorthand-guide

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -34,3 +34,11 @@ OPENSCAP_1_1_OR_LATER := $(shell oscap --version | grep -q -E "OpenSCAP command 
 
 # Query environment - ask openscap if it has SVG support in guides
 OPENSCAP_SVG := $(shell $(SHARED)/$(TRANS)/oscapsupportssvg.py; echo $$?)
+
+# Common build targets - include the SSG logo into the XCCDF header
+$(OUT)/guide.xml: $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+ifeq ($(OPENSCAP_SVG), 0)
+	xsltproc -o $(OUT)/guide.xml $(SHARED)/$(TRANS)/includelogo.xslt $(IN)/guide.xml
+else
+	cp $(IN)/guide.xml $(OUT)/
+endif


### PR DESCRIPTION
This brings smallish *performance* improvement to the build system. However, it opens the door for much greater performance improvements to come.

Here are multiple things heppening:
 * shorthand target is split into a two targets
 * the targets are dependent on each other and also on other files
   - this brings real performance improvements
   - try running 'make output/guide.xml' twice in a row
 * a common snippet moved to the common product-make.include
 * a short documentation describes what is happening