### PR TITLE
Fix pci-dss references

### DIFF
--- a/RHEL/7/input/xccdf/system/software/updating.xml
+++ b/RHEL/7/input/xccdf/system/software/updating.xml
@@ -77,7 +77,7 @@ Authority (CA).
 </rationale>
 <ident cce="26989-4" />
 <oval id="ensure_gpgcheck_globally_activated" />
-<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" ossrg="366" pcidss="Req-5" cis="1.2.3" />
+<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" ossrg="366" pcidss="Req-6.2" cis="1.2.3" />
 <tested by="sdw" on="20150407"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/software/updating.xml
+++ b/RHEL/7/input/xccdf/system/software/updating.xml
@@ -106,7 +106,7 @@ Authority (CA).
 </rationale>
 <ident cce="26876-3" />
 <oval id="ensure_gpgcheck_never_disabled" />
-<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" ossrg="366" pcidss="Req-5" />
+<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" ossrg="366" pcidss="Req-6.2" />
 <tested by="sdw" on="20150407"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/software/updating.xml
+++ b/RHEL/7/input/xccdf/system/software/updating.xml
@@ -41,7 +41,7 @@ cryptographically verify packages are from Red Hat.
 </rationale>
 <ident cce="26957-1" />
 <oval id="ensure_redhat_gpgkey_installed" />
-<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" ossrg="366" pcidss="Req-5" cis="1.2.2" />
+<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" ossrg="366" pcidss="Req-6.2" cis="1.2.2" />
 <tested by="sdw" on="20150407"/>
 </Rule>
 

--- a/RHEL/7/input/xccdf/system/software/updating.xml
+++ b/RHEL/7/input/xccdf/system/software/updating.xml
@@ -144,7 +144,7 @@ the exploitation of publicly-known vulnerabilities.
 <ident cce="26895-3" />
 <!-- Particular OVAL check is defined directly via <check> element above -->
 <!-- DO NOT REFERENCE an OVAL id here !!! -->
-<ref nist="SI-2,MA-1(b)" disa="" pcidss="Req-6" cis="1.7" />
+<ref nist="SI-2,MA-1(b)" disa="" pcidss="Req-6.2" cis="1.7" />
 <tested by="MM" on="20120928"/>
 </Rule>
 </Group>


### PR DESCRIPTION
This should improve granularity of mapping.
I have changed references from # 5 to # 6.2


Now, only rule which has reference in form "^\d+$" is 
```service_auditd_enabled``` mapped as "#10"
<pre>$ sudo systemctl enable auditd.service</pre>
But, I think this mapping is good enough.