### PR TITLE
[BugFix] [Debian/8] Fix 'make validate' on Debian/8 content issue when content build on RHEL-6 with openscap-1.0.10-3.el6.*

### DIFF
--- a/Debian/8/input/oval/templates/packages_installed.csv
+++ b/Debian/8/input/oval/templates/packages_installed.csv
@@ -7,3 +7,4 @@
 # SHOULD NOT be listed here, but rather in the 'packages_installed.csv'
 # file under oval_5.11/templates directory!!!
 #
+ntp,

--- a/Debian/8/input/xccdf/services/basics.xml
+++ b/Debian/8/input/xccdf/services/basics.xml
@@ -70,7 +70,7 @@ The ntpd service should be installed.
 Time synchronization (using NTP) is required by almost all network and administrative tasks (syslog, cryptographic based services (authentication, etc.), etc.). Ntpd is regulary maintained and updated, supporting security features such as RFC 5906.
 </rationale>
 <ident cce="27323-5" />
-<!-- <oval id="package_ntp_installed" /> -->
+<oval id="package_ntp_installed" />
 <ref nist="AU-8(1)" disa="160" pcidss="Req-10.4" />
 </Rule>
 


### PR DESCRIPTION
<br/>

This fixes:
  https://jenkins.open-scap.org/job/scap-security-guide-pull-requests/327/consoleFull

Testing report:
--

Verified on both RHEL-6 system with openscap-1.0.10-* and RHEL-7 system with newer openscap the ```Debian/8``` ```make validates``` target now passes.

Please review.

Thank you, Jan.