### PR TITLE
Update the sysctl XCCDF value fix for ipv6 parameters as well.

### DIFF
--- a/RHEL/6/input/oval/sysctl_net_ipv6_conf_default_accept_ra.xml
+++ b/RHEL/6/input/oval/sysctl_net_ipv6_conf_default_accept_ra.xml
@@ -6,7 +6,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
-      <description>The "net.ipv6.conf.default.accept_ra" kernel parameter should be set to "0" in both system configuration and system runtime.</description>
+      <description>The "net.ipv6.conf.default.accept_ra" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
       <reference source="sdw" ref_id="RHEL6_20150408" ref_url="test_attestation" />
     </metadata>
     <criteria comment="IPv6 disabled or net.ipv6.conf.default.accept_ra set correctly" operator="OR">

--- a/RHEL/6/input/oval/sysctl_net_ipv6_conf_default_accept_redirects.xml
+++ b/RHEL/6/input/oval/sysctl_net_ipv6_conf_default_accept_redirects.xml
@@ -6,7 +6,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
-      <description>The "net.ipv6.conf.default.accept_redirects" kernel parameter should be set to "0" in both system configuration and system runtime.</description>
+      <description>The "net.ipv6.conf.default.accept_redirects" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
       <reference source="sdw" ref_id="RHEL6_20150408" ref_url="test_attestation" />
     </metadata>
     <criteria comment="IPv6 disabled or net.ipv6.conf.default.accept_redirects set correctly" operator="OR">

--- a/RHEL/6/input/oval/sysctl_runtime_net_ipv6_conf_default_accept_ra.xml
+++ b/RHEL/6/input/oval/sysctl_runtime_net_ipv6_conf_default_accept_ra.xml
@@ -6,11 +6,11 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
-      <description>The kernel "net.ipv6.conf.default.accept_ra" parameter should be set to "0" in system runtime.</description>
+      <description>The kernel "net.ipv6.conf.default.accept_ra" parameter should be set to the appropriate value in system runtime.</description>
       <reference source="JL" ref_id="RHEL6_20150216" ref_url="test_attestation" />
     </metadata>
     <criteria operator="AND">
-      <criterion comment="kernel runtime parameter net.ipv6.conf.default.accept_ra set to 0" test_ref="test_runtime_net_ipv6_conf_default_accept_ra" />
+      <criterion comment="kernel runtime parameter net.ipv6.conf.default.accept_ra set to the appropriate value" test_ref="test_runtime_net_ipv6_conf_default_accept_ra" />
     </criteria>
   </definition>
 
@@ -24,7 +24,8 @@
   </unix:sysctl_object>
 
   <unix:sysctl_state id="state_runtime_net_ipv6_conf_default_accept_ra" version="1">
-    <unix:value datatype="int" operation="equals">0</unix:value>
+    <unix:value datatype="int" operation="equals" var_ref="sysctl_net_ipv6_conf_default_accept_ra_value" />
   </unix:sysctl_state>
 
+  <external_variable comment="External variable for net.ipv6.conf.default.accept_ra" datatype="int" id="sysctl_net_ipv6_conf_default_accept_ra_value" version="1" />
 </def-group>

--- a/RHEL/6/input/oval/sysctl_runtime_net_ipv6_conf_default_accept_redirects.xml
+++ b/RHEL/6/input/oval/sysctl_runtime_net_ipv6_conf_default_accept_redirects.xml
@@ -6,11 +6,11 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
-      <description>The kernel "net.ipv6.conf.default.accept_redirects" parameter should be set to "0" in system runtime.</description>
+      <description>The kernel "net.ipv6.conf.default.accept_redirects" parameter should be set to the appropriate value in system runtime.</description>
       <reference source="JL" ref_id="RHEL6_20150216" ref_url="test_attestation" />
     </metadata>
     <criteria operator="AND">
-      <criterion comment="kernel runtime parameter net.ipv6.conf.default.accept_redirects set to 0" test_ref="test_runtime_net_ipv6_conf_default_accept_redirects" />
+      <criterion comment="kernel runtime parameter net.ipv6.conf.default.accept_redirects set to the appropriate value" test_ref="test_runtime_net_ipv6_conf_default_accept_redirects" />
     </criteria>
   </definition>
 
@@ -24,7 +24,8 @@
   </unix:sysctl_object>
 
   <unix:sysctl_state id="state_runtime_net_ipv6_conf_default_accept_redirects" version="1">
-    <unix:value datatype="int" operation="equals">0</unix:value>
+    <unix:value datatype="int" operation="equals" var_ref="sysctl_net_ipv6_conf_default_accept_redirects_value" />
   </unix:sysctl_state>
 
+  <external_variable comment="External variable for net.ipv6.conf.default.accept_redirects" datatype="int" id="sysctl_net_ipv6_conf_default_accept_redirects_value" version="1" />
 </def-group>

--- a/RHEL/6/input/oval/sysctl_static_net_ipv6_conf_default_accept_ra.xml
+++ b/RHEL/6/input/oval/sysctl_static_net_ipv6_conf_default_accept_ra.xml
@@ -6,7 +6,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
-      <description>The kernel "net.ipv6.conf.default.accept_ra" parameter should be set to "0" in the system configuration.</description>
+      <description>The kernel "net.ipv6.conf.default.accept_ra" parameter should be set to the appropriate value in the system configuration.</description>
       <reference source="JL" ref_id="RHEL6_20150216" ref_url="test_attestation" />
     </metadata>
     <criteria operator="OR">
@@ -33,16 +33,16 @@
            * if there's no /etc/sysctl.d/* file containing the net.ipv6.conf.default.accept_ra directive, and /etc/sysctl.conf
              contains the net.ipv6.conf.default.accept_ra directive, return PASS if the requirements are met, FAIL otherwise. -->
 
-      <criterion comment="Kernel static parameter net.ipv6.conf.default.accept_ra set to 0 in /etc/sysctl.d/*" test_ref="test_static_sysctld_net_ipv6_conf_default_accept_ra" />
+      <criterion comment="Kernel static parameter net.ipv6.conf.default.accept_ra set to the appropriate value in /etc/sysctl.d/*" test_ref="test_static_sysctld_net_ipv6_conf_default_accept_ra" />
       <criteria operator="AND">
-        <criterion comment="Kernel static paramater net.ipv6.conf.default.accept_ra set to 0 in /etc/sysctl.conf" test_ref="test_static_etc_sysctl_net_ipv6_conf_default_accept_ra" />
+        <criterion comment="Kernel static paramater net.ipv6.conf.default.accept_ra set to the appropriate value in /etc/sysctl.conf" test_ref="test_static_etc_sysctl_net_ipv6_conf_default_accept_ra" />
         <criterion comment="Kernel static parameter net.ipv6.conf.default.accept_ra not present in some /etc/sysctl.d/* file" test_ref="test_static_sysctld_net_ipv6_conf_default_accept_ra_not_used" />
       </criteria>
     </criteria>
   </definition>
 
   <!-- Check the /etc/sysctl.d/* configuration -->
-  <!-- Return PASS only in case there's only one /etc/sysctl.d/* file containing net.ipv6.conf.default.accept_ra set to 0
+  <!-- Return PASS only in case there's only one /etc/sysctl.d/* file containing net.ipv6.conf.default.accept_ra set to the appropriate value
        (otherwise we aren't able to reliably decide if the configuration is safe) -->
 
   <ind:textfilecontent54_test id="test_static_sysctld_net_ipv6_conf_default_accept_ra" check="all" check_existence="only_one_exists" comment="Check net.ipv6.conf.default.accept_ra static configuration in /etc/sysctl.d/*" version="1">
@@ -62,14 +62,14 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_static_sysctld_net_ipv6_conf_default_accept_ra" version="1">
-    <ind:subexpression operation="equals" datatype="int">0</ind:subexpression>
+    <ind:subexpression operation="equals"  var_ref="sysctl_net_ipv6_conf_default_accept_ra_value" datatype="int" />
   </ind:textfilecontent54_state>
 
   <!-- Check the /etc/sysctl.conf configuration -->
-  <!-- Return PASS only in case net.ipv6.conf.default.accept_ra is set to 0 in /etc/sysctl.conf and simultaneously net.ipv6.conf.default.accept_ra isn't used
+  <!-- Return PASS only in case net.ipv6.conf.default.accept_ra is set to the appropriate value in /etc/sysctl.conf and simultaneously net.ipv6.conf.default.accept_ra isn't used
        in some /etc/sysctl.d/* file (otherwise the previous test_static_sysctld_net_ipv6_conf_default_accept_ra test would be applied) -->
 
-  <!-- First check net.ipv6.conf.default.accept_ra set to 0 in /etc/sysctl.conf -->
+  <!-- First check net.ipv6.conf.default.accept_ra set to the appropriate value in /etc/sysctl.conf -->
   <ind:textfilecontent54_test id="test_static_etc_sysctl_net_ipv6_conf_default_accept_ra" check="all" comment="Check net.ipv6.conf.default.accept_ra static configuration in /etc/sysctl.conf" version="1">
     <ind:object object_ref="object_static_etc_sysctl_net_ipv6_conf_default_accept_ra" />
     <!-- Re-use the above defined state (since the requirement is same for both locations) -->
@@ -91,4 +91,5 @@
     <ind:object object_ref="object_static_sysctld_net_ipv6_conf_default_accept_ra" />
   </ind:textfilecontent54_test>
 
+  <external_variable comment="External variable for net.ipv6.conf.default.accept_ra" datatype="int" id="sysctl_net_ipv6_conf_default_accept_ra_value" version="1" />
 </def-group>

--- a/RHEL/6/input/oval/sysctl_static_net_ipv6_conf_default_accept_redirects.xml
+++ b/RHEL/6/input/oval/sysctl_static_net_ipv6_conf_default_accept_redirects.xml
@@ -6,7 +6,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
-      <description>The kernel "net.ipv6.conf.default.accept_redirects" parameter should be set to "0" in the system configuration.</description>
+      <description>The kernel "net.ipv6.conf.default.accept_redirects" parameter should be set to the appropriate value in the system configuration.</description>
       <reference source="JL" ref_id="RHEL6_20150216" ref_url="test_attestation" />
     </metadata>
     <criteria operator="OR">
@@ -33,16 +33,16 @@
            * if there's no /etc/sysctl.d/* file containing the net.ipv6.conf.default.accept_redirects directive, and /etc/sysctl.conf
              contains the net.ipv6.conf.default.accept_redirects directive, return PASS if the requirements are met, FAIL otherwise. -->
 
-      <criterion comment="Kernel static parameter net.ipv6.conf.default.accept_redirects set to 0 in /etc/sysctl.d/*" test_ref="test_static_sysctld_net_ipv6_conf_default_accept_redirects" />
+      <criterion comment="Kernel static parameter net.ipv6.conf.default.accept_redirects set to the appropriate value in /etc/sysctl.d/*" test_ref="test_static_sysctld_net_ipv6_conf_default_accept_redirects" />
       <criteria operator="AND">
-        <criterion comment="Kernel static paramater net.ipv6.conf.default.accept_redirects set to 0 in /etc/sysctl.conf" test_ref="test_static_etc_sysctl_net_ipv6_conf_default_accept_redirects" />
+        <criterion comment="Kernel static paramater net.ipv6.conf.default.accept_redirects set to the appropriate value in /etc/sysctl.conf" test_ref="test_static_etc_sysctl_net_ipv6_conf_default_accept_redirects" />
         <criterion comment="Kernel static parameter net.ipv6.conf.default.accept_redirects not present in some /etc/sysctl.d/* file" test_ref="test_static_sysctld_net_ipv6_conf_default_accept_redirects_not_used" />
       </criteria>
     </criteria>
   </definition>
 
   <!-- Check the /etc/sysctl.d/* configuration -->
-  <!-- Return PASS only in case there's only one /etc/sysctl.d/* file containing net.ipv6.conf.default.accept_redirects set to 0
+  <!-- Return PASS only in case there's only one /etc/sysctl.d/* file containing net.ipv6.conf.default.accept_redirects set to the appropriate value
        (otherwise we aren't able to reliably decide if the configuration is safe) -->
 
   <ind:textfilecontent54_test id="test_static_sysctld_net_ipv6_conf_default_accept_redirects" check="all" check_existence="only_one_exists" comment="Check net.ipv6.conf.default.accept_redirects static configuration in /etc/sysctl.d/*" version="1">
@@ -62,14 +62,14 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_static_sysctld_net_ipv6_conf_default_accept_redirects" version="1">
-    <ind:subexpression operation="equals" datatype="int">0</ind:subexpression>
+    <ind:subexpression operation="equals"  var_ref="sysctl_net_ipv6_conf_default_accept_redirects_value" datatype="int" />
   </ind:textfilecontent54_state>
 
   <!-- Check the /etc/sysctl.conf configuration -->
-  <!-- Return PASS only in case net.ipv6.conf.default.accept_redirects is set to 0 in /etc/sysctl.conf and simultaneously net.ipv6.conf.default.accept_redirects isn't used
+  <!-- Return PASS only in case net.ipv6.conf.default.accept_redirects is set to the appropriate value in /etc/sysctl.conf and simultaneously net.ipv6.conf.default.accept_redirects isn't used
        in some /etc/sysctl.d/* file (otherwise the previous test_static_sysctld_net_ipv6_conf_default_accept_redirects test would be applied) -->
 
-  <!-- First check net.ipv6.conf.default.accept_redirects set to 0 in /etc/sysctl.conf -->
+  <!-- First check net.ipv6.conf.default.accept_redirects set to the appropriate value in /etc/sysctl.conf -->
   <ind:textfilecontent54_test id="test_static_etc_sysctl_net_ipv6_conf_default_accept_redirects" check="all" comment="Check net.ipv6.conf.default.accept_redirects static configuration in /etc/sysctl.conf" version="1">
     <ind:object object_ref="object_static_etc_sysctl_net_ipv6_conf_default_accept_redirects" />
     <!-- Re-use the above defined state (since the requirement is same for both locations) -->
@@ -91,4 +91,5 @@
     <ind:object object_ref="object_static_sysctld_net_ipv6_conf_default_accept_redirects" />
   </ind:textfilecontent54_test>
 
+  <external_variable comment="External variable for net.ipv6.conf.default.accept_redirects" datatype="int" id="sysctl_net_ipv6_conf_default_accept_redirects_value" version="1" />
 </def-group>

--- a/RHEL/6/input/oval/templates/sysctl_ipv6_values.csv
+++ b/RHEL/6/input/oval/templates/sysctl_ipv6_values.csv
@@ -1,2 +1,4 @@
-net.ipv6.conf.default.accept_ra,0
-net.ipv6.conf.default.accept_redirects,0
+# Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
+# Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
+net.ipv6.conf.default.accept_ra,
+net.ipv6.conf.default.accept_redirects,

--- a/RHEL/6/input/oval/templates/sysctl_ipv6_values_orig.csv
+++ b/RHEL/6/input/oval/templates/sysctl_ipv6_values_orig.csv
@@ -1,0 +1,2 @@
+net.ipv6.conf.default.accept_ra,0
+net.ipv6.conf.default.accept_redirects,0

--- a/RHEL/6/input/oval/templates/template_sysctl_ipv6
+++ b/RHEL/6/input/oval/templates/template_sysctl_ipv6
@@ -6,7 +6,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
-      <description>The "SYSCTLVAR" kernel parameter should be set to "SYSCTLVAL" in both system configuration and system runtime.</description>
+      <description>The "SYSCTLVAR" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
       <reference source="sdw" ref_id="RHEL6_20150408" ref_url="test_attestation" />
     </metadata>
     <criteria comment="IPv6 disabled or SYSCTLVAR set correctly" operator="OR">

--- a/RHEL/6/input/remediations/bash/sysctl_net_ipv6_conf_default_accept_ra.sh
+++ b/RHEL/6/input/remediations/bash/sysctl_net_ipv6_conf_default_accept_ra.sh
@@ -1,16 +1,19 @@
 # platform = Red Hat Enterprise Linux 6
+. /usr/share/scap-security-guide/remediation_functions
+populate sysctl_net_ipv6_conf_default_accept_ra_value
+
 #
 # Set runtime for net.ipv6.conf.default.accept_ra
 #
-/sbin/sysctl -q -n -w net.ipv6.conf.default.accept_ra=0
+/sbin/sysctl -q -n -w net.ipv6.conf.default.accept_ra=$sysctl_net_ipv6_conf_default_accept_ra_value
 
 #
-# If net.ipv6.conf.default.accept_ra present in /etc/sysctl.conf, change value to "0"
-#	else, add "net.ipv6.conf.default.accept_ra = 0" to /etc/sysctl.conf
+# If net.ipv6.conf.default.accept_ra present in /etc/sysctl.conf, change value to appropriate value
+#	else, add "net.ipv6.conf.default.accept_ra = value" to /etc/sysctl.conf
 #
 if grep --silent ^net.ipv6.conf.default.accept_ra /etc/sysctl.conf ; then
-	sed -i 's/^net.ipv6.conf.default.accept_ra.*/net.ipv6.conf.default.accept_ra = 0/g' /etc/sysctl.conf
+	sed -i "s/^net.ipv6.conf.default.accept_ra.*/net.ipv6.conf.default.accept_ra = $sysctl_net_ipv6_conf_default_accept_ra_value/g" /etc/sysctl.conf
 else
-	echo -e "\n# Set net.ipv6.conf.default.accept_ra to 0 per security requirements" >> /etc/sysctl.conf
-	echo "net.ipv6.conf.default.accept_ra = 0" >> /etc/sysctl.conf
+	echo -e "\n# Set net.ipv6.conf.default.accept_ra to $sysctl_net_ipv6_conf_default_accept_ra_value per security requirements" >> /etc/sysctl.conf
+	echo "net.ipv6.conf.default.accept_ra = $sysctl_net_ipv6_conf_default_accept_ra_value" >> /etc/sysctl.conf
 fi

--- a/RHEL/6/input/remediations/bash/sysctl_net_ipv6_conf_default_accept_redirects.sh
+++ b/RHEL/6/input/remediations/bash/sysctl_net_ipv6_conf_default_accept_redirects.sh
@@ -1,16 +1,19 @@
 # platform = Red Hat Enterprise Linux 6
+. /usr/share/scap-security-guide/remediation_functions
+populate sysctl_net_ipv6_conf_default_accept_redirects_value
+
 #
 # Set runtime for net.ipv6.conf.default.accept_redirects
 #
-/sbin/sysctl -q -n -w net.ipv6.conf.default.accept_redirects=0
+/sbin/sysctl -q -n -w net.ipv6.conf.default.accept_redirects=$sysctl_net_ipv6_conf_default_accept_redirects_value
 
 #
-# If net.ipv6.conf.default.accept_redirects present in /etc/sysctl.conf, change value to "0"
-#	else, add "net.ipv6.conf.default.accept_redirects = 0" to /etc/sysctl.conf
+# If net.ipv6.conf.default.accept_redirects present in /etc/sysctl.conf, change value to appropriate value
+#	else, add "net.ipv6.conf.default.accept_redirects = value" to /etc/sysctl.conf
 #
 if grep --silent ^net.ipv6.conf.default.accept_redirects /etc/sysctl.conf ; then
-	sed -i 's/^net.ipv6.conf.default.accept_redirects.*/net.ipv6.conf.default.accept_redirects = 0/g' /etc/sysctl.conf
+	sed -i "s/^net.ipv6.conf.default.accept_redirects.*/net.ipv6.conf.default.accept_redirects = $sysctl_net_ipv6_conf_default_accept_redirects_value/g" /etc/sysctl.conf
 else
-	echo -e "\n# Set net.ipv6.conf.default.accept_redirects to 0 per security requirements" >> /etc/sysctl.conf
-	echo "net.ipv6.conf.default.accept_redirects = 0" >> /etc/sysctl.conf
+	echo -e "\n# Set net.ipv6.conf.default.accept_redirects to $sysctl_net_ipv6_conf_default_accept_redirects_value per security requirements" >> /etc/sysctl.conf
+	echo "net.ipv6.conf.default.accept_redirects = $sysctl_net_ipv6_conf_default_accept_redirects_value" >> /etc/sysctl.conf
 fi

--- a/RHEL/6/input/remediations/bash/templates/Makefile
+++ b/RHEL/6/input/remediations/bash/templates/Makefile
@@ -6,6 +6,7 @@ OUTPUT:=$(shell mkdir -p output)
 
 sysctls:
 	$(SHARED_DIR)/create_sysctl_bash.py ../../../oval/templates/sysctl_values.csv
+	$(SHARED_DIR)/create_sysctl_bash.py ../../../oval/templates/sysctl_ipv6_values.csv
 
 services:
 	$(SHARED_DIR)/create_services_disabled.py ../../../oval/templates/services_disabled.csv

--- a/shared/oval/templates/create_sysctl_ipv6_checks.py
+++ b/shared/oval/templates/create_sysctl_ipv6_checks.py
@@ -9,23 +9,43 @@ files = { 'template_sysctl_static' : 'sysctl_static_',
           'template_sysctl_runtime' : 'sysctl_runtime_',
           'template_sysctl_ipv6' : 'sysctl_' }
 
+files_var = { 'template_sysctl_static_var' : 'sysctl_static_',
+	  'template_sysctl_runtime_var' : 'sysctl_runtime_',
+          'template_sysctl_ipv6' : 'sysctl_' }
+
 def output_checkfile(serviceinfo):
     # get the items out of the list
     sysctl_var, sysctl_val = serviceinfo
     # convert variable name to a format suitable for 'id' tags
     sysctl_var_id = re.sub('[-\.]', '_', sysctl_var)
-    # open the template files and perform the conversions
-    for sysctlfile in files.keys():
-        with open(sysctlfile, 'r') as templatefile:
-            filestring = templatefile.read()
-            filestring = filestring.replace("SYSCTLID", sysctl_var_id)
-            filestring = filestring.replace("SYSCTLVAR", sysctl_var)
-            filestring = filestring.replace("SYSCTLVAL", sysctl_val)
-            # write the check
-            with open("./output/" + files[sysctlfile] + sysctl_var_id +
-                      ".xml", 'w+') as outputfile:
-                outputfile.write(filestring)
-                outputfile.close()
+
+    # if the sysctl value is not present, use the variable template
+    if not sysctl_val.strip():
+        # open the template files and perform the conversions
+        for sysctlfile in files_var.keys():
+            with open(sysctlfile, 'r') as templatefile:
+                filestring = templatefile.read()
+                filestring = filestring.replace("SYSCTLID", sysctl_var_id)
+                filestring = filestring.replace("SYSCTLVAR", sysctl_var)
+                # write the check
+                with open("./output/" + files_var[sysctlfile] + sysctl_var_id +
+                          ".xml", 'w+') as outputfile:
+                    outputfile.write(filestring)
+                    outputfile.close()
+
+    else:
+        # open the template files and perform the conversions
+        for sysctlfile in files.keys():
+            with open(sysctlfile, 'r') as templatefile:
+                filestring = templatefile.read()
+                filestring = filestring.replace("SYSCTLID", sysctl_var_id)
+                filestring = filestring.replace("SYSCTLVAR", sysctl_var)
+                filestring = filestring.replace("SYSCTLVAL", sysctl_val)
+                # write the check
+                with open("./output/" + files[sysctlfile] + sysctl_var_id +
+                          ".xml", 'w+') as outputfile:
+                    outputfile.write(filestring)
+                    outputfile.close()
 
 
 def main():


### PR DESCRIPTION
This PR addresses the ipv6 parameters affected by issue #932 for RHEL6.

The following are the changes:

Modified the create module to use the updated CSV file and templates.
 >modified:   shared/oval/templates/create_sysctl_ipv6_checks.py

Updated template file comment:
 >modified:   RHEL/6/input/oval/templates/template_sysctl_ipv6

Modified the SYSCTL CSV file and retained a copy of the original:
 >modified:   RHEL/6/input/oval/templates/sysctl_ipv6_values.csv
 >new file:   RHEL/6/input/oval/templates/sysctl_ipv6_values_orig.csv

Included the IPv6 sysctl build command which was missing from the Makefile:
 >modified:   RHEL/6/input/remediations/bash/templates/Makefile

The rest of the files are auto-generated.