### PR TITLE
Update the derivatives script for rebuilds

### DIFF
--- a/shared/utils/enable-derivatives.py
+++ b/shared/utils/enable-derivatives.py
@@ -81,15 +81,15 @@ SL_NOTICE = \
     "with the following caveats:</p>\n" \
     "<ul>\n" \
     "<li><i>Scientifc Linux</i> is not an exact copy of " \
-    "<i>Red Hat Enterprise Linux</i>. Scientific Linux is a Linux distribution" \
-    "produced by <i>Fermi National Accelerator Laboratory</i>. It is a free and" \
-    "open source operating system based on <i>Red Hat Enterprise Linux</i> and aims" \
-    "to be \"as close to the commercial enterprise distribution as we can get it.\"" \
-    "There may be configuration differences that produce false positives and/or" \
+    "<i>Red Hat Enterprise Linux</i>. Scientific Linux is a Linux distribution " \
+    "produced by <i>Fermi National Accelerator Laboratory</i>. It is a free and " \
+    "open source operating system based on <i>Red Hat Enterprise Linux</i> and aims " \
+    "to be \"as close to the commercial enterprise distribution as we can get it.\" " \
+    "There may be configuration differences that produce false positives and/or " \
     "false negatives. If this occurs please file a bug report.</li>\n" \
     "\n" \
-    "<li><i>Scientifc Linux</i> is derived from the free and open source software" \
-    "made available by Red Hat, but it is not produced, maintained or supported by <i>Red Hat</i>." \
+    "<li><i>Scientifc Linux</i> is derived from the free and open source software " \
+    "made available by <i>Red Hat</i>, but it is <b>not</b> produced, maintained or supported by <i>Red Hat</i>. " \
     "<i>Scientifc Linux</i> has its own build system, compiler options, patchsets, " \
     "and is a community supported, non-commercial operating system. " \
     "<i>Scientifc Linux</i> does not inherit " \


### PR DESCRIPTION
This PR includes two fixes
e868e5cafc637d4eacce7b2f28fd2a20d0da73fc , which fixes some simple white space issues
0d6ffd6afe4f7965cf3925c1a8ab16d460f6acd2 , which will change the OS name from Red Hat Enterprise Linux to the matching name of the rebuild.