### PR TITLE
[Enhancement][Fedora][RHEL/7] Add ctrl-alt-del command line check and remediation

### DIFF
--- a/Fedora/input/xccdf/system/accounts/physical.xml
+++ b/Fedora/input/xccdf/system/accounts/physical.xml
@@ -153,29 +153,30 @@ by configuring the bootloader password.
 <Rule id="disable_ctrlaltdel_reboot" severity="high">
 <title>Disable Ctrl-Alt-Del Reboot Activation</title>
 <description>
-By default, the system includes the following line in
-<tt>/etc/init/control-alt-delete.conf</tt>
-to reboot the system when the Ctrl-Alt-Del key sequence is pressed:
-<pre>exec /sbin/shutdown -r now "Control-Alt-Delete pressed"</pre>
+By default, <tt>SystemD</tt> will reboot the system if the <tt>Ctrl-Alt-Del</tt>
+key sequence is pressed.
 <br/>
-To configure the system to log a message instead of
-rebooting the system, alter that line to read as follows:
-<pre>exec /usr/bin/logger -p security.info "Control-Alt-Delete pressed"</pre>
+To configure the system to ignore the <tt>Ctrl-Alt-Del</tt> key sequence from the 
+command line instead of rebooting the system, do either of the following:
+<pre>ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target</pre>
+or
+<pre>systemctl mask ctrl-alt-del.target</pre>
 </description>
-<ocil clause="the system is configured to run the shutdown command">
-To ensure the system is configured to log a message instead of rebooting the system when 
-Ctrl-Alt-Del is pressed, ensure the following line is in <tt>/etc/init/control-alt-delete.conf</tt>:
-<pre>exec /usr/bin/logger -p security.info "Control-Alt-Delete pressed"</pre>
+<ocil clause="the system is configured to reboot when Ctrl-Alt-Del is pressed">
+To ensure the system is configured to mask the Ctrl-Alt-Del sequence,
+enter the following command:
+<pre>sudo ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target</pre>
+or
+<pre>sudo systemctl mask ctrl-alt-del.target</pre>
 </ocil>
 <rationale>
 A locally logged-in user who presses Ctrl-Alt-Del, when at the console,
 can reboot the system. If accidentally pressed, as could happen in
 the case of mixed OS environment, this can create the risk of short-term
 loss of availability of systems due to unintentional reboot.
-In the GNOME graphical environment, risk of unintentional reboot from the
-Ctrl-Alt-Del sequence is reduced because the user will be
-prompted before any action is taken.
 </rationale>
+<oval id="disable_ctrlaltdel_reboot" />
+<!--ref nist="IA-2(1),AC-3" disa="213" /-->
 </Rule>
 
 <Rule id="disable_interactive_boot" severity="medium">

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -187,30 +187,31 @@ access when the system is rebooted.
 <Rule id="disable_ctrlaltdel_reboot" severity="high">
 <title>Disable Ctrl-Alt-Del Reboot Activation</title>
 <description>
-By default, the system includes the following line in
-<tt>/etc/init/control-alt-delete.conf</tt>
-to reboot the system when the Ctrl-Alt-Del key sequence is pressed:
-<pre>exec /sbin/shutdown -r now "Control-Alt-Delete pressed"</pre>
+By default, <tt>SystemD</tt> will reboot the system if the <tt>Ctrl-Alt-Del</tt>
+key sequence is pressed.
 <br/>
-To configure the system to log a message instead of
-rebooting the system, alter that line to read as follows:
-<pre>exec /usr/bin/logger -p security.info "Control-Alt-Delete pressed"</pre>
+To configure the system to ignore the <tt>Ctrl-Alt-Del</tt> key sequence from the
+command line instead of rebooting the system, do either of the following:
+<pre>ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target</pre>
+or
+<pre>systemctl mask ctrl-alt-del.target</pre>
 </description>
-<ocil clause="the system is configured to run the shutdown command">
-To ensure the system is configured to log a message instead of rebooting the system when 
-Ctrl-Alt-Del is pressed, ensure the following line is in <tt>/etc/init/control-alt-delete.conf</tt>:
-<pre>exec /usr/bin/logger -p security.info "Control-Alt-Delete pressed"</pre>
+<ocil clause="the system is configured to reboot when Ctrl-Alt-Del is pressed">
+To ensure the system is configured to mask the Ctrl-Alt-Del sequence,
+enter the following command:
+<pre>sudo ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target</pre>
+or
+<pre>sudo systemctl mask ctrl-alt-del.target</pre>
 </ocil>
 <rationale>
 A locally logged-in user who presses Ctrl-Alt-Del, when at the console,
 can reboot the system. If accidentally pressed, as could happen in
 the case of mixed OS environment, this can create the risk of short-term
 loss of availability of systems due to unintentional reboot.
-In the GNOME graphical environment, risk of unintentional reboot from the
-Ctrl-Alt-Del sequence is reduced because the user will be
-prompted before any action is taken.
 </rationale>
+<oval id="disable_ctrlaltdel_reboot" />
 <ident cce="RHEL7-CCE-TBD" />
+<!--ref nist="IA-2(1),AC-3" disa="213" /-->
 </Rule>
 
 <Rule id="disable_interactive_boot" severity="medium">

--- a/shared/oval/disable_ctrlaltdel_reboot.xml
+++ b/shared/oval/disable_ctrlaltdel_reboot.xml
@@ -1,0 +1,29 @@
+<def-group>
+  <definition class="compliance" id="disable_ctrlaltdel_reboot" version="1">
+    <metadata>
+      <title>Disable Ctrl-Alt-Del Reboot Activation</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>By default, the system will reboot when the
+      Ctrl-Alt-Del key sequence is pressed.</description>
+      <reference source="galford" ref_id="20160111" ref_url="test_attestation" />
+    </metadata>
+    <criteria>
+      <criterion comment="Disable Ctrl-Alt-Del systemd softlink exists" test_ref="test_disable_ctrlaltdel_exists" />
+    </criteria>
+  </definition>
+  <unix:symlink_test check="all" check_existence="all_exist" comment="Disable Ctrl-Alt-Del key sequence override exists" id="test_disable_ctrlaltdel_exists" version="1">
+    <unix:object object_ref="object_disable_ctrlaltdel_exists" />
+    <unix:state state_ref="state_disable_ctrlaltdel_exists" />
+  </unix:symlink_test>
+  <unix:symlink_object comment="Disable Ctrl-Alt-Del key sequence override exists" id="object_disable_ctrlaltdel_exists" version="1">
+    <unix:filepath>/etc/systemd/system/ctrl-alt-del.target</unix:filepath>
+  </unix:symlink_object>
+  <unix:symlink_state comment="Disable Ctrl-Alt-Del key sequence override exists" id="state_disable_ctrlaltdel_exists" version="1">
+    <unix:filepath>/etc/systemd/system/ctrl-alt-del.target</unix:filepath>
+    <unix:canonical_path>/dev/null</unix:canonical_path>
+  </unix:symlink_state>
+</def-group>
+

--- a/shared/remediations/bash/disable_ctrlaltdel_reboot.sh
+++ b/shared/remediations/bash/disable_ctrlaltdel_reboot.sh
@@ -1,0 +1,2 @@
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target


### PR DESCRIPTION
- Add disable_ctrlaltdel_reboot OVAL check and remediation script
- Gnome fix will be separate PR and XCCDF/OVAL/Remediation content
- Solution: https://access.redhat.com/solutions/1123873
- Fixes #293