### PR TITLE
[BugFix] [Infrastructure] Include the remediation scripts back into the benchmarks

### DIFF
--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -89,15 +89,27 @@ $(OUT)/bash-remediations.xml: $(SHARED)/$(TRANS)/combineremediations.py $(bash_r
 
 # Common build targets - an XCCDF with remediations but not linked to OVAL yet
 $(OUT)/xccdf-unlinked-withremediations.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/xccdf-unlinked-ocilrefs.xml $(OUT)/bash-remediations.xml $(SHARED)/$(TRANS)/xccdf-addremediations.xslt
-	# $(CURDIR) Makefile variable represents pathname of the CWD:
-	# https://www.gnu.org/software/make/manual/html_node/Recursion.html (last paragraph)
-	# Therefore from the $(CURDIR) value extract the relative pathname of the current product, turning
-	# e.g. "/tmp/github/scap-security-guide/OpenStack/RHEL-OSP/7" => "OpenStack/RHEL-OSP/7",
-	# or   "/tmp/github/scap-security-guide/RHEL/7" =>  "RHEL/7"
-	$(eval PROD_PATH=$(shell expr "$(CURDIR)" : '.*scap-security-guide\/\(.*\)'))
-	# And use that extracted relative pathname to construct proper path to the "$(OUT)/bash-remediations.xml" external
-	# XML entity which needs to be loaded properly in order the remediations to get actually included into the benchmark
-	xsltproc -stringparam remediations "../../$(PROD_PATH)/$(OUT)/bash-remediations.xml" -o $@ $(SHARED)/$(TRANS)/xccdf-addremediations.xslt $<
+	# What's happening below? We need to obtain the correct product path (e.g. "OpenStack/RHEL-OSP/7") \
+	# from the value of ${PWD} of current Makefile and realpath of ${SHARED}/${TRANS} string. \
+	# And use that product path to specify correct location of "$(OUT)/bash-remediations.xml" \
+	# depending on the particular Makefile for a concrete product we are currently building \
+	# \
+	# Therefore: \
+	# 1) Get real path for "$(SHARED)/$(TRANS)" location \
+	SHARED_TRANS_REAL_PATH=$(realpath $(SHARED)/$(TRANS)); \
+	# 2) Drop every '../' sequence from beginning of "$(SHARED)/$(TRANS)" string \
+	SHARED_TRANS="${SHARED}/${TRANS}"; \
+	SHARED_TRANS_WITHOUT_DOTS=$${SHARED_TRANS//\.\.\/}; \
+	# 3) Find the common directory prefix for ${PWD} and "${SHARED}/${TRANS}" realpath by \
+	# deleting the longest match of ${SHARED_TRANS_WITHOUT_DOTS} from the back of \
+	# ${SHARED_TRANS_REAL_PATH} string \
+	SSG_DIR_LOCATION=$${SHARED_TRANS_REAL_PATH%%$${SHARED_TRANS_WITHOUT_DOTS}}; \
+	# 4) Finally obtain the current product path by deleting the longest match of ${SSD_DIR_LOCATION} \
+	# from the front of ${PWD} string \
+	PRODUCT_PATH=$${PWD##$${SSG_DIR_LOCATION}}; \
+	# 5) Use the obtained ${PRODUCT_PATH} (e.g. "OpenStack/RHEL-OSP/7" or "RHEL/6") to specify the \
+	# correct path to $(OUT)/bash-remediations.xml external XML entity file \
+	xsltproc -stringparam remediations "../../$${PRODUCT_PATH}/$(OUT)/bash-remediations.xml" -o $@ $(SHARED)/$(TRANS)/xccdf-addremediations.xslt $<
 	xmllint --format --output $@ $@
 
 # Sanity check to verify if intended remediations got truly included into the benchmark being currently build

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -133,9 +133,8 @@ $(OUT)/xccdf-unlinked-final.xml: $(OUT)/xccdf-unlinked-withremediations.xml $(OU
 		\
 			echo -e "\n\tError: Can't locate remediation (\"<fix system\") elements in \"$(OUT)/xccdf-unlinked-withremediations.xml\". Exiting!\n"; \
 			exit 1; \
-		else \
-		# Remediations got included properly => \
-		# Move "$(OUT)/xccdf-unlinked-withremediations.xml" to "$(OUT)/xccdf-unlinked-final.xml" \
-			mv "$(OUT)/xccdf-unlinked-withremediations.xml" "$(OUT)/xccdf-unlinked-final.xml"; \
 		fi \
-	fi
+	fi \
+	# Rename "$(OUT)/xccdf-unlinked-withremediations.xml" to "$(OUT)/xccdf-unlinked-final.xml" \
+	# (so subsequent targets can find the "$(OUT)/xccdf-unlinked-final.xml" prerequisite) \
+	mv "$(OUT)/xccdf-unlinked-withremediations.xml" "$(OUT)/xccdf-unlinked-final.xml"

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -102,7 +102,7 @@ $(OUT)/xccdf-unlinked-withremediations.xml: $(OUT)/xccdf-unlinked-resolved.xml $
 # Resign to continue building the benchmark in that case (since it would miss the remediations), print out an error
 # message and exit with failure
 #
-$(OUT)/xccdf-unlinked-final.xml: $(OUT)/bash-remediations.xml $(OUT)/xccdf-unlinked-withremediations.xml
+$(OUT)/xccdf-unlinked-final.xml: $(OUT)/xccdf-unlinked-withremediations.xml $(OUT)/bash-remediations.xml
 	@if grep -q '<fix rule' "$(OUT)/bash-remediations.xml"; \
 	then \
 	# At least one "<fix rule" element is included in "$(OUT)/bash-remediations.xml" \

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -88,6 +88,34 @@ $(OUT)/bash-remediations.xml: $(SHARED)/$(TRANS)/combineremediations.py $(bash_r
 	$(SHARED)/$(TRANS)/combineremediations.py $(PROD) $(BUILD_REMEDIATIONS) $(OUT)/bash-remediations.xml
 
 # Common build targets - an XCCDF with remediations but not linked to OVAL yet
-$(OUT)/xccdf-unlinked-final.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/xccdf-unlinked-ocilrefs.xml $(OUT)/bash-remediations.xml $(SHARED)/$(TRANS)/xccdf-addremediations.xslt
+$(OUT)/xccdf-unlinked-withremediations.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/xccdf-unlinked-ocilrefs.xml $(OUT)/bash-remediations.xml $(SHARED)/$(TRANS)/xccdf-addremediations.xslt
 	xsltproc -stringparam remediations "../$(OUT)/bash-remediations.xml" -o $@ $(SHARED)/$(TRANS)/xccdf-addremediations.xslt $<
 	xmllint --format --output $@ $@
+
+# Sanity check to verify if intended remediations got truly included into the benchmark being currently build
+#
+# In the case "$(OUT)/bash-remediations.xml" contains at least one "<fix rule" element and remediations got included
+# properly, there needs to exist at least one "<fix system" element in the "xccdf-unlinked-withremediations.xml" file.
+# If not "xsltproc" call in the $(OUT)/xccdf-unlinked-withremediations.xml target above didn't include the remediations
+# (due to "warning: failed to load external entity" problem or some other error)
+#
+# Resign to continue building the benchmark in that case (since it would miss the remediations), print out an error
+# message and exit with failure
+#
+$(OUT)/xccdf-unlinked-final.xml: $(OUT)/bash-remediations.xml $(OUT)/xccdf-unlinked-withremediations.xml
+	@if grep -q '<fix rule' "$(OUT)/bash-remediations.xml"; \
+	then \
+	# At least one "<fix rule" element is included in "$(OUT)/bash-remediations.xml" \
+	\
+		if ! grep -q '<fix system' "$(OUT)/xccdf-unlinked-withremediations.xml"; \
+		then \
+		# But "xccdf-unlinked-withremediations.xml" doesn't contain "<fix system" element \
+		\
+			echo -e "\n\tError: Can't locate remediation (\"<fix system\") elements in \"$(OUT)/xccdf-unlinked-withremediations.xml\". Exiting!\n"; \
+			exit 1; \
+		else \
+		# Remediations got included properly => \
+		# Move "$(OUT)/xccdf-unlinked-withremediations.xml" to "$(OUT)/xccdf-unlinked-final.xml" \
+			mv "$(OUT)/xccdf-unlinked-withremediations.xml" "$(OUT)/xccdf-unlinked-final.xml"; \
+		fi \
+	fi

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -89,7 +89,15 @@ $(OUT)/bash-remediations.xml: $(SHARED)/$(TRANS)/combineremediations.py $(bash_r
 
 # Common build targets - an XCCDF with remediations but not linked to OVAL yet
 $(OUT)/xccdf-unlinked-withremediations.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/xccdf-unlinked-ocilrefs.xml $(OUT)/bash-remediations.xml $(SHARED)/$(TRANS)/xccdf-addremediations.xslt
-	xsltproc -stringparam remediations "../$(OUT)/bash-remediations.xml" -o $@ $(SHARED)/$(TRANS)/xccdf-addremediations.xslt $<
+	# $(CURDIR) Makefile variable represents pathname of the CWD:
+	# https://www.gnu.org/software/make/manual/html_node/Recursion.html (last paragraph)
+	# Therefore from the $(CURDIR) value extract the relative pathname of the current product, turning
+	# e.g. "/tmp/github/scap-security-guide/OpenStack/RHEL-OSP/7" => "OpenStack/RHEL-OSP/7",
+	# or   "/tmp/github/scap-security-guide/RHEL/7" =>  "RHEL/7"
+	$(eval PROD_PATH=$(shell expr "$(CURDIR)" : '.*scap-security-guide\/\(.*\)'))
+	# And use that extracted relative pathname to construct proper path to the "$(OUT)/bash-remediations.xml" external
+	# XML entity which needs to be loaded properly in order the remediations to get actually included into the benchmark
+	xsltproc -stringparam remediations "../../$(PROD_PATH)/$(OUT)/bash-remediations.xml" -o $@ $(SHARED)/$(TRANS)/xccdf-addremediations.xslt $<
 	xmllint --format --output $@ $@
 
 # Sanity check to verify if intended remediations got truly included into the benchmark being currently build


### PR DESCRIPTION
The provided remediation scripts aren't currently included into the benchmark being build -- this is due to the following warning:
```
[iankko@host Fedora]$ pwd
/tmp/test/scap-security-guide/Fedora
[iankko@host Fedora]$ make output/xccdf-unlinked-final.xml
...
Notification: Merged 23 remediation scripts into XML document.
xsltproc -stringparam remediations "../output/bash-remediations.xml" -o output/xccdf-unlinked-final.xml ../shared/transforms/xccdf-addremediations.xslt output/xccdf-unlinked-resolved.xml
warning: failed to load external entity "../shared/output/bash-remediations.xml"
warning: failed to load external entity "../shared/output/bash-remediations.xml"
xmllint --format --output output/xccdf-unlinked-final.xml output/xccdf-unlinked-final.xml
[iankko@host Fedora]$ grep '<fix' output/xccdf-unlinked-final.xml 
[iankko@host Fedora]$ grep '<fix' output/xccdf-unlinked-final.xml | wc -l
0
```

This is because the ```$(OUT)/xccdf-unlinked-final.xml``` target of ```shared/product-make.include``` specifies an incorrect path to the ```$(OUT)/bash-remediations.xml``` external XML entity file.

Therefore:
* add a sanity check to detect this problem sooner, when / if it happens again in the future -- patch 1 -- https://github.com/OpenSCAP/scap-security-guide/commit/4ccb4fd7d9d4b7799139577997014d167ef809b7 ,
* and fix the actual ```$(OUT)/bash-remediations.xml``` path to point to the proper location -- patch 3 -- https://github.com/OpenSCAP/scap-security-guide/commit/f0f04835b526825045be81ea80aea80d5fe9c37e

(patch 2 -- https://github.com/OpenSCAP/scap-security-guide/commit/2a6a964093d3e001e68f987d766a1dddd5b7003b is just intermediary -- I realized that one to be needed too post committing the first one)

Testing report:
--
Verified:
* the added sanity check works fine, reports error and bails out for any product containing remediations, when remediations aren't included in ```$(OUT)/xccdf-unlinked-final.xml```,
* the updated ```$(OUT)/bash-remediations.xml``` location adds the previously available remediation scripts back into the benchmarks.

Please review.

Thank you, Jan.