### PR TITLE
starting French ANSSI references integration

### DIFF
--- a/Debian/8/input/oval/file_permissions_systemmap.xml
+++ b/Debian/8/input/oval/file_permissions_systemmap.xml
@@ -14,7 +14,7 @@
     </criteria>
   </definition>
 
-  <unix:file_test  check="all" check_existence="none_exist" comment="system.map files readable only by root" id="test_permissions_systemmap_files" version="1">
+  <unix:file_test  check="all" check_existence="all_exist" comment="system.map files readable only by root" id="test_permissions_systemmap_files" version="1">
     <unix:object object_ref="object_file_permissions_systemmap_files" />
     <unix:state state_ref="state_owner_systemmap" />
     <unix:state state_ref="state_file_permissions_systemmap" />

--- a/Debian/8/input/oval/file_permissions_systemmap.xml
+++ b/Debian/8/input/oval/file_permissions_systemmap.xml
@@ -16,14 +16,14 @@
 
   <unix:file_test  check="all" check_existence="none_exist" comment="system.map files readable only by root" id="test_permissions_systemmap_files" version="1">
     <unix:object object_ref="object_file_permissions_systemmap_files" />
+    <unix:state state_ref="state_owner_systemmap" />
+    <unix:state state_ref="state_file_permissions_systemmap" />
   </unix:file_test>
 
   <unix:file_object comment="system.mapfiles" id="object_file_permissions_systemmap_files" version="1">
     <!-- Check that /boot/System.map-* files is readable only by root -->
-    <unix:path operation="pattern match">^\/boot\/</unix:path>
+    <unix:path>/boot</unix:path>
     <unix:filename operation="pattern match">^System\.map.*$</unix:filename>
-    <unix:state state_ref="state_owner_systemmap" />
-    <unix:state state_ref="state_file_permissions_systemmap" />
   </unix:file_object>
 
   <unix:file_state id="state_owner_systemmap" version="1">
@@ -35,10 +35,10 @@
     <unix:sgid datatype="boolean">false</unix:sgid>
     <unix:sticky datatype="boolean">false</unix:sticky>
     <unix:uexec datatype="boolean">false</unix:uexec>
-    <unix:gread datatype="boolean">false</unix:gwrite>
+    <unix:gread datatype="boolean">false</unix:gread>
     <unix:gwrite datatype="boolean">false</unix:gwrite>
     <unix:gexec datatype="boolean">false</unix:gexec>
-    <unix:oread datatype="boolean">false</unix:owrite>
+    <unix:oread datatype="boolean">false</unix:oread>
     <unix:owrite datatype="boolean">false</unix:owrite>
     <unix:oexec datatype="boolean">false</unix:oexec>
   </unix:file_state>

--- a/Debian/8/input/oval/file_permissions_systemmap.xml
+++ b/Debian/8/input/oval/file_permissions_systemmap.xml
@@ -1,0 +1,46 @@
+<def-group>
+  <definition class="compliance" id="file_permissions_systemmap" version="1">
+    <metadata>
+      <title>Verify that System.map files are readable only by root</title>
+      <affected family="unix">
+        <platform>multi_platform_debian</platform>
+      </affected>
+      <description>
+        Checks that /boot/System.map-* are only readable by root.
+      </description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_permissions_systemmap_files" />
+    </criteria>
+  </definition>
+
+  <unix:file_test  check="all" check_existence="none_exist" comment="system.map files readable only by root" id="test_permissions_systemmap_files" version="1">
+    <unix:object object_ref="object_file_permissions_systemmap_files" />
+  </unix:file_test>
+
+  <unix:file_object comment="system.mapfiles" id="object_file_permissions_systemmap_files" version="1">
+    <!-- Check that /boot/System.map-* files is readable only by root -->
+    <unix:path operation="pattern match">^\/boot\/</unix:path>
+    <unix:filename operation="pattern match">^System\.map.*$</unix:filename>
+    <unix:state state_ref="state_owner_systemmap" />
+    <unix:state state_ref="state_file_permissions_systemmap" />
+  </unix:file_object>
+
+  <unix:file_state id="state_owner_systemmap" version="1">
+    <unix:user_id datatype="int" operation="equals">0</unix:user_id>
+  </unix:file_state>
+
+  <unix:file_state id="state_file_permissions_systemmap" version="1">
+    <unix:suid datatype="boolean">false</unix:suid>
+    <unix:sgid datatype="boolean">false</unix:sgid>
+    <unix:sticky datatype="boolean">false</unix:sticky>
+    <unix:uexec datatype="boolean">false</unix:uexec>
+    <unix:gread datatype="boolean">false</unix:gwrite>
+    <unix:gwrite datatype="boolean">false</unix:gwrite>
+    <unix:gexec datatype="boolean">false</unix:gexec>
+    <unix:oread datatype="boolean">false</unix:owrite>
+    <unix:owrite datatype="boolean">false</unix:owrite>
+    <unix:oexec datatype="boolean">false</unix:oexec>
+  </unix:file_state>
+
+</def-group>

--- a/Debian/8/input/oval/partition_for_srv.xml
+++ b/Debian/8/input/oval/partition_for_srv.xml
@@ -1,0 +1,25 @@
+<def-group>
+  <definition class="compliance" id="partition_for_srv" version="1">
+    <metadata>
+      <title>Ensure /srv Located On Separate Partition</title>
+      <affected family="unix">
+        <platform>Debian 8</platform>
+      </affected>
+      <description>If a file server (FTP, TFTP...) is hosted locally, create a separate partition
+      for /srv at installation time (or migrate it later using LVM). If
+      /srv will be mounted from another system such as an NFS server, then
+      creating a separate partition is not necessary at installation time, and the
+      mountpoint can instead be configured later.</description>
+      <!-- RHEL7:  <reference source="SDW" ref_id="20131222" ref_url="test_attestation" /> -->
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_srv_partition" comment="/srv on own partition" />
+    </criteria>
+  </definition>
+  <linux:partition_test check="all" check_existence="all_exist" id="test_srv_partition" version="1" comment="/srv on own partition">
+    <linux:object object_ref="object_mount_srv_own_partition" />
+  </linux:partition_test>
+  <linux:partition_object id="object_mount_srv_own_partition" version="1">
+    <linux:mount_point>/srv</linux:mount_point>
+  </linux:partition_object>
+</def-group>

--- a/Debian/8/input/profiles/common.xml
+++ b/Debian/8/input/profiles/common.xml
@@ -44,6 +44,8 @@
 <select idref="ensure_logrotate_activated" selected="true" />
 
 <!-- critical files -->
+<select idref="file_permissions_systemmap" selected="true"/>
+
 <select idref="file_permissions_etc_shadow" selected="true"/>
 <select idref="file_permissions_etc_gshadow" selected="true"/>
 <select idref="file_permissions_etc_passwd" selected="true"/>

--- a/Debian/8/input/xccdf/services/basics.xml
+++ b/Debian/8/input/xccdf/services/basics.xml
@@ -15,6 +15,7 @@ The auditd service is an access monitoring and accounting daemon, watching syste
 </rationale>
 <ident cce="27407-6" />
 <oval id="package_auditd_installed" />
+<ref anssi="NT28(R50)" />
 </Rule>
 
 
@@ -31,7 +32,7 @@ The auditd service is an access monitoring and accounting daemon, watching syste
 </ocil>
 <ident cce="27407-6" />
 <oval id="service_auditd_enabled" />
-<ref nist="AC-17(1),AU-1(b),AU-10,AU-12(a),AU-12(c),IR-5" disa="347,157,172,880,1353,1462,1487,1115,1454,067,158,831,1190,1312,1263,130,120,1589" pcidss="Req-10" />
+<ref anssi="NT28(R50)" nist="AC-17(1),AU-1(b),AU-10,AU-12(a),AU-12(c),IR-5" disa="347,157,172,880,1353,1462,1487,1115,1454,067,158,831,1190,1312,1263,130,120,1589" pcidss="Req-10" />
 </Rule>
 
 <Rule id="package_cron_installed" severity="medium">
@@ -44,7 +45,7 @@ The cron service allow periodic job execution, needed for almost all administrat
 </rationale>
 <ident cce="27323-5" />
 <oval id="package_cron_installed" />
-<ref nist="CM-7" />
+<ref nist="CM-7" anssi="NT28(R50)" />
 </Rule>
 
 

--- a/Debian/8/input/xccdf/services/deprecated.xml
+++ b/Debian/8/input/xccdf/services/deprecated.xml
@@ -15,7 +15,7 @@ telnet allows clear text communications, and does not protect any data transmiss
 </rationale>
 <ident cce="27165-0" />
 <oval id="package_telnetd_removed" />
-<ref nist="AC-17(8),CM-7" disa=""/>
+<ref nist="AC-17(8),CM-7" disa="" anssi="NT07(R03)" />
 </Rule>
 
 <Rule id="package_inetutils-telnetd_removed" severity="high">
@@ -28,7 +28,7 @@ telnet allows clear text communications, and does not protect any data transmiss
 </rationale>
 <ident cce="27165-0" />
 <oval id="package_inetutils-telnetd_removed" />
-<ref nist="AC-17(8),CM-7" disa=""/>
+<ref nist="AC-17(8),CM-7" disa="" anssi="NT07(R03)"/>
 </Rule>
 
 <Rule id="package_telnetd-ssl_removed" severity="high">
@@ -41,7 +41,7 @@ telnet, even with ssl support, should not be installed. When remote shell is req
 </rationale>
 <ident cce="4330-7" />
 <oval id="package_telnetd-ssl_removed" />
-<ref nist="AC-17(8),CM-7"/>
+<ref nist="AC-17(8),CM-7" anssi="NT07(R02)"/>
 </Rule>
 
 

--- a/Debian/8/input/xccdf/services/deprecated.xml
+++ b/Debian/8/input/xccdf/services/deprecated.xml
@@ -15,7 +15,7 @@ telnet allows clear text communications, and does not protect any data transmiss
 </rationale>
 <ident cce="27165-0" />
 <oval id="package_telnetd_removed" />
-<ref nist="AC-17(8),CM-7" disa="" anssi="NT07(R03)" />
+<ref nist="AC-17(8),CM-7" disa="" anssi="NT007(R03)" />
 </Rule>
 
 <Rule id="package_inetutils-telnetd_removed" severity="high">
@@ -28,7 +28,7 @@ telnet allows clear text communications, and does not protect any data transmiss
 </rationale>
 <ident cce="27165-0" />
 <oval id="package_inetutils-telnetd_removed" />
-<ref nist="AC-17(8),CM-7" disa="" anssi="NT07(R03)"/>
+<ref nist="AC-17(8),CM-7" disa="" anssi="NT007(R03)"/>
 </Rule>
 
 <Rule id="package_telnetd-ssl_removed" severity="high">
@@ -41,7 +41,7 @@ telnet, even with ssl support, should not be installed. When remote shell is req
 </rationale>
 <ident cce="4330-7" />
 <oval id="package_telnetd-ssl_removed" />
-<ref nist="AC-17(8),CM-7" anssi="NT07(R02)"/>
+<ref nist="AC-17(8),CM-7" anssi="NT007(R02)"/>
 </Rule>
 
 

--- a/Debian/8/input/xccdf/services/ssh.xml
+++ b/Debian/8/input/xccdf/services/ssh.xml
@@ -60,7 +60,7 @@ should not be used.
 </rationale>
 <ident cce="27320-1" />
 <oval id="sshd_allow_only_protocol2" />
-<ref nist="AC-17(7),IA-5(1)(c)" />
+<ref nist="AC-17(7),IA-5(1)(c)" anssi="NT07(R1)" />
 </Rule>
 
 <Rule id="sshd_set_idle_timeout">
@@ -136,7 +136,7 @@ and also allows direct attack attempts on root's password.
 </rationale>
 <ident cce="27445-6" />
 <oval id="sshd_disable_root_login" />
-<ref nist="AC-3,AC-6(2),IA-2(1)"  />
+<ref nist="AC-3,AC-6(2),IA-2(1)" anssi="NT07(R21)"  />
 </Rule>
 
 
@@ -159,7 +159,7 @@ even in the event of misconfiguration elsewhere.
 </rationale>
 <ident cce="27471-2" />
 <oval id="sshd_disable_empty_passwords" />
-<ref nist="AC-3" />
+<ref nist="AC-3" anssi="NT07(R17)" />
 </Rule>
 
 </Group>

--- a/Debian/8/input/xccdf/services/ssh.xml
+++ b/Debian/8/input/xccdf/services/ssh.xml
@@ -60,7 +60,7 @@ should not be used.
 </rationale>
 <ident cce="27320-1" />
 <oval id="sshd_allow_only_protocol2" />
-<ref nist="AC-17(7),IA-5(1)(c)" anssi="NT07(R1)" />
+<ref nist="AC-17(7),IA-5(1)(c)" anssi="NT007(R1)" />
 </Rule>
 
 <Rule id="sshd_set_idle_timeout">
@@ -136,7 +136,7 @@ and also allows direct attack attempts on root's password.
 </rationale>
 <ident cce="27445-6" />
 <oval id="sshd_disable_root_login" />
-<ref nist="AC-3,AC-6(2),IA-2(1)" anssi="NT07(R21)"  />
+<ref nist="AC-3,AC-6(2),IA-2(1)" anssi="NT007(R21)"  />
 </Rule>
 
 
@@ -159,7 +159,7 @@ even in the event of misconfiguration elsewhere.
 </rationale>
 <ident cce="27471-2" />
 <oval id="sshd_disable_empty_passwords" />
-<ref nist="AC-3" anssi="NT07(R17)" />
+<ref nist="AC-3" anssi="NT007(R17)" />
 </Rule>
 
 </Group>

--- a/Debian/8/input/xccdf/system/logging.xml
+++ b/Debian/8/input/xccdf/system/logging.xml
@@ -47,7 +47,7 @@ system logging services.
 logging services, which are essential to system administration.
 </rationale>
 <oval id="service_rsyslog_enabled" />
-<ref nist="AU-4(1),AU-12" disa="1311,1312,1557,1851" cis="5.1.2" />
+<ref nist="AU-4(1),AU-12" disa="1311,1312,1557,1851" cis="5.1.2" anssi-nt28="R46" />
 <tested by="PT" on="20160106"/>
 </Rule>
 
@@ -125,7 +125,7 @@ To see the owner of a given log file, run the following command:
 configuration, user authentication, and other such information. Log files should be
 protected from unauthorized access.</rationale>
 <oval id="rsyslog_files_ownership" />
-<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10.5.1,Req-10.5.2" />
+<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10.5.1,Req-10.5.2"  anssi-nt28="R46"/>
 <tested by="PT" on="20160106"/>
 </Rule>
 

--- a/Debian/8/input/xccdf/system/logging.xml
+++ b/Debian/8/input/xccdf/system/logging.xml
@@ -30,7 +30,7 @@ The rsyslog package provides the rsyslog daemon, which provides
 system logging services.
 </rationale>
 <oval id="package_rsyslog_installed" />
-<ref nist="AU-9(2)" disa="1311,1312" cis="5.1.1" />
+<ref nist="AU-9(2)" disa="1311,1312" cis="5.1.1" anssi="NT28(R46)" />
 <tested by="PT" on="20160106"/>
 </Rule>
 
@@ -47,7 +47,7 @@ system logging services.
 logging services, which are essential to system administration.
 </rationale>
 <oval id="service_rsyslog_enabled" />
-<ref nist="AU-4(1),AU-12" disa="1311,1312,1557,1851" cis="5.1.2" anssi-nt28="R46" />
+<ref nist="AU-4(1),AU-12" disa="1311,1312,1557,1851" cis="5.1.2" anssi="NT28(R46)" />
 <tested by="PT" on="20160106"/>
 </Rule>
 
@@ -125,7 +125,7 @@ To see the owner of a given log file, run the following command:
 configuration, user authentication, and other such information. Log files should be
 protected from unauthorized access.</rationale>
 <oval id="rsyslog_files_ownership" />
-<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10.5.1,Req-10.5.2"  anssi-nt28="R46"/>
+<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10.5.1,Req-10.5.2"  anssi="NT28(R46)"/>
 <tested by="PT" on="20160106"/>
 </Rule>
 
@@ -153,7 +153,7 @@ To see the group-owner of a given log file, run the following command:
 configuration, user authentication, and other such information. Log files should be
 protected from unauthorized access.</rationale>
 <oval id="rsyslog_files_groupownership" />
-<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10.5.1,Req-10.5.2" />
+<ref nist="AC-6,SI-11" disa="1314" pcidss="Req-10.5.1,Req-10.5.2" anssi="NT28(R46)" />
 <tested by="PT" on="20160106"/>
 </Rule>
 
@@ -185,7 +185,7 @@ configuration. If the system log files are not protected unauthorized
 users could change the logged data, eliminating their forensic value.
 </rationale>
 <oval id="rsyslog_files_permissions" />
-<ref nist="SI-11" disa="1314" pcidss="Req-10.5.1,Req-10.5.2" cis="5.1.4" />
+<ref nist="SI-11" disa="1314" pcidss="Req-10.5.1,Req-10.5.2" cis="5.1.4"  anssi="NT28(R36)"/>
 <tested by="PT" on="20160106"/>
 </Rule>
 </Group>

--- a/Debian/8/input/xccdf/system/partitions.xml
+++ b/Debian/8/input/xccdf/system/partitions.xml
@@ -70,7 +70,7 @@ and other files in <tt>/var/</tt>.
 </rationale>
 <ident cce="26967-0" />
 <oval id="partition_for_var_log" />
-<ref nist="AU-9,SC-32" disa=""  anssi="NT28(R12,R47)"/>
+<ref nist="AU-9,SC-32" disa=""  anssi="NT28(R12),NT28(R47)"/>
 <tested by="MM" on="20120928"/>
 </Rule>
 

--- a/Debian/8/input/xccdf/system/partitions.xml
+++ b/Debian/8/input/xccdf/system/partitions.xml
@@ -31,7 +31,7 @@ restrictive mount options, which can help protect programs which use it.
 <ocil><partition-check-macro part="/tmp "/></ocil>
 <ident cce="27173-4" />
 <oval id="partition_for_tmp" />
-<ref nist="SC-32" anssi-nt28="R12" />
+<ref nist="SC-32" anssi="NT28(R12)" />
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -51,7 +51,7 @@ world-writable directories installed by other software packages.
 </rationale>
 <ident cce="26404-4" />
 <oval id="partition_for_var" />
-<ref nist="SC-32"  anssi-nt28="R12" />
+<ref nist="SC-32"  anssi="NT28(R12)" />
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -70,7 +70,7 @@ and other files in <tt>/var/</tt>.
 </rationale>
 <ident cce="26967-0" />
 <oval id="partition_for_var_log" />
-<ref nist="AU-9,SC-32" disa=""  anssi-nt28="R12,R47"/>
+<ref nist="AU-9,SC-32" disa=""  anssi="NT28(R12,R47)"/>
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -112,7 +112,7 @@ setting of more restrictive mount options, and also helps ensure that
 users cannot trivially fill partitions used for log or audit data storage.
 </rationale>
 <oval id="partition_for_home" />
-<ref nist="SC-32" disa="1208" anssi-nt28="R12" />
+<ref nist="SC-32" disa="1208" anssi="NT28(R12)" />
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -133,7 +133,7 @@ more restrictive mount options, and also helps ensure that
 users cannot trivially fill partitions used for log or audit data storage.
 </rationale>
 <oval id="partition_for_srv" />
-<ref anssi-nt28="R12" />
+<ref anssi="NT28(R12)" />
 </Rule>
 
 

--- a/Debian/8/input/xccdf/system/partitions.xml
+++ b/Debian/8/input/xccdf/system/partitions.xml
@@ -31,7 +31,7 @@ restrictive mount options, which can help protect programs which use it.
 <ocil><partition-check-macro part="/tmp "/></ocil>
 <ident cce="27173-4" />
 <oval id="partition_for_tmp" />
-<ref nist="SC-32" />
+<ref nist="SC-32" anssi-nt28="R12" />
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -51,7 +51,7 @@ world-writable directories installed by other software packages.
 </rationale>
 <ident cce="26404-4" />
 <oval id="partition_for_var" />
-<ref nist="SC-32"  />
+<ref nist="SC-32"  anssi-nt28="R12" />
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -70,7 +70,7 @@ and other files in <tt>/var/</tt>.
 </rationale>
 <ident cce="26967-0" />
 <oval id="partition_for_var_log" />
-<ref nist="AU-9,SC-32" disa="" />
+<ref nist="AU-9,SC-32" disa=""  anssi-nt28="R12,R47"/>
 <tested by="MM" on="20120928"/>
 </Rule>
 
@@ -112,8 +112,29 @@ setting of more restrictive mount options, and also helps ensure that
 users cannot trivially fill partitions used for log or audit data storage.
 </rationale>
 <oval id="partition_for_home" />
-<ref nist="SC-32" disa="1208" />
+<ref nist="SC-32" disa="1208" anssi-nt28="R12" />
 <tested by="MM" on="20120928"/>
 </Rule>
+
+<Rule id="partition_for_srv">
+<title>Ensure /srv Located On Separate Partition</title>
+<description>
+If a file server (FTP, TFTP...) is hosted locally, create a separate partition
+for <tt>/srv</tt> at installation time (or migrate it later using LVM). If
+<tt>/srv</tt> will be mounted from another system such as an NFS server, then
+creating a separate partition is not necessary at installation time, and the
+mountpoint can instead be configured later.
+</description>
+<ocil><partition-check-macro part="/home "/></ocil>
+<rationale>
+Srv deserves files for local network file server such as FTP. Ensuring
+that <tt>/srv</tt> is mounted on its own partition enables the setting of
+more restrictive mount options, and also helps ensure that
+users cannot trivially fill partitions used for log or audit data storage.
+</rationale>
+<oval id="partition_for_srv" />
+<ref anssi-nt28="R12" />
+</Rule>
+
 
 </Group>

--- a/Debian/8/input/xccdf/system/permissions/files.xml
+++ b/Debian/8/input/xccdf/system/permissions/files.xml
@@ -8,6 +8,31 @@ permission restrictions which can be verified
 to ensure that no harmful discrepancies have
 arisen.</description>
 
+<Group id="permission_important_state_files">
+<title>Verify permissions on files containing sensitive informations about the system</title>
+<description>Various files contains sensitive informations that can leads to specific weaknesses or
+give structural informations for local exploits.</description>
+
+<Rule id="file_permissions_systemmap">
+  <title>Verify that local System.map file (if exists) is readable only by root</title>
+  <description>Files containing sensitive informations should be protected by restrictive
+  permissions. Most of the time, there is no need that these files need to be read by any non-root user
+    <fileperms-desc-macro file="/boot/System.map-*" perms="0600"/>
+    <fileowner-desc-macro file="/boot/System.map-*" owner="root"/>
+  </description>
+  <ocil>
+    <fileperms-check-macro file="/boot/Sysem.map-*" perms="-rw-------"/>
+    <fileowner-check-macro file="/boot/System.map-*" owner="root"/>
+  </ocil>
+  <rationale>The <tt>System.map</tt> file contains information about kernel symbols and
+  can give some hints to generate local exploitation.
+  </rationale>
+  <oval id="file_permissions_systemmap" />
+  <ref anssi-nt28="R13" />
+</Rule>
+
+</Group>
+
 <Group id="permissions_important_account_files">
 <title>Verify Permissions on Files with Local Account Information and Credentials</title>
 <description>The default restrictive permissions for files which act as

--- a/Debian/8/input/xccdf/system/permissions/files.xml
+++ b/Debian/8/input/xccdf/system/permissions/files.xml
@@ -28,7 +28,7 @@ give structural informations for local exploits.</description>
   can give some hints to generate local exploitation.
   </rationale>
   <oval id="file_permissions_systemmap" />
-  <ref anssi-nt28="R13" />
+  <ref anssi="NT28(R13)" />
 </Rule>
 
 </Group>
@@ -60,7 +60,7 @@ critical for system security. Failure to give ownership of this file
 to root provides the designated owner with access to sensitive information
 which could weaken the system security posture.</rationale>
 <oval id="file_permissions_etc_shadow" />
-<ref nist="AC-6" disa="" pcidss="Req-8.7.c" />
+<ref nist="AC-6" disa="" pcidss="Req-8.7.c" anssi="NT28(R36)" />
 </Rule>
 
 <Rule id="file_permissions_etc_gshadow" severity="medium">
@@ -78,7 +78,7 @@ which could weaken the system security posture.</rationale>
 <rationale>The <tt>/etc/shadow</tt> file contains group password hashes. Protection of this file
 is critical for system security.</rationale>
 <oval id="file_permissions_etc_gshadow" />
-<ref nist="AC-6" disa=""/>
+<ref nist="AC-6" disa="" anssi="NT28(R36)"/>
 </Rule>
 
 <Rule id="file_permissions_etc_passwd" severity="medium">

--- a/Debian/8/transforms/shorthand2xccdf.xslt
+++ b/Debian/8/transforms/shorthand2xccdf.xslt
@@ -161,8 +161,8 @@
           <xsl:if test="$refsource = 'pcidss'">
             <xsl:value-of select="$pcidssuri" />
           </xsl:if>
-          <xsl:if test="$refsource = 'anssi-nt28'">
-            <xsl:value-of select="$anssi-nt28uri" />
+          <xsl:if test="$refsource = 'anssi'">
+            <xsl:value-of select="$anssiuri" />
           </xsl:if>
           <xsl:if test="$refsource = 'cis'">
             <xsl:value-of select="$cisuri" />

--- a/Debian/8/transforms/shorthand2xccdf.xslt
+++ b/Debian/8/transforms/shorthand2xccdf.xslt
@@ -161,6 +161,9 @@
           <xsl:if test="$refsource = 'pcidss'">
             <xsl:value-of select="$pcidssuri" />
           </xsl:if>
+          <xsl:if test="$refsource = 'anssi-nt28'">
+            <xsl:value-of select="$anssi-nt28uri" />
+          </xsl:if>
           <xsl:if test="$refsource = 'cis'">
             <xsl:value-of select="$cisuri" />
           </xsl:if>

--- a/Debian/8/transforms/xccdf2table-byref.xslt
+++ b/Debian/8/transforms/xccdf2table-byref.xslt
@@ -69,8 +69,8 @@
 				</xsl:for-each>
 			</xsl:if>
 
-			<xsl:if test="$ref='anssi-nt28'">
-				<xsl:for-each select="//cdf:reference[@href=$anssi-nt28uri]" >
+			<xsl:if test="$ref='anssi'">
+				<xsl:for-each select="//cdf:reference[@href=$anssiuri]" >
 					<xsl:call-template name="rule-output">
 						<xsl:with-param name="refinfo" select="." />
 					</xsl:call-template>

--- a/Debian/8/transforms/xccdf2table-byref.xslt
+++ b/Debian/8/transforms/xccdf2table-byref.xslt
@@ -69,9 +69,37 @@
 				</xsl:for-each>
 			</xsl:if>
 
+			<xsl:if test="$ref='anssi-nt28'">
+				<xsl:for-each select="//cdf:reference[@href=$anssi-nt28uri]" >
+					<xsl:call-template name="rule-output">
+						<xsl:with-param name="refinfo" select="." />
+					</xsl:call-template>
+				</xsl:for-each>
+			</xsl:if>
+
 		</table>
 	</xsl:template>
 
+	<xsl:template name="pci-dss-rule-output">
+		<xsl:param name="refinfo"/>
+		<tr>
+			<td>
+			<a>
+				<xsl:attribute name="href">
+					<xsl:call-template name="get-pci-dss-href">
+						<xsl:with-param name="ref" select="$refinfo" />
+					</xsl:call-template>
+				</xsl:attribute>
+				<xsl:value-of select="$refinfo" />
+			</a>
+			</td>
+
+			<td> <xsl:value-of select="../cdf:title" /></td>
+			<td> <xsl:apply-templates select="../cdf:description"/> </td>
+			<td> <xsl:apply-templates select="../cdf:rationale"/> </td>
+			<td> <!-- TODO: print refine-value from profile associated with rule --> </td>
+		</tr>
+	</xsl:template>
 
 	<xsl:template name="rule-output">
           <xsl:param name="refinfo"/>

--- a/shared/oval/oval_5.11/rsyslog_files_ownership.xml
+++ b/shared/oval/oval_5.11/rsyslog_files_ownership.xml
@@ -5,7 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
-        <platform>Debian 8</platform>
+        <platform>multi_platform_debian</platform>
       </affected>
       <description>All syslog log files should be owned by the appropriate user.</description>
       <reference source="JL" ref_id="RHEL6_20160115" ref_url="test_attestation" />

--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -13,6 +13,7 @@
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/stigs/srgs/Pages/index.aspx</xsl:variable>
 <xsl:variable name="pcidssuri">https://www.pcisecuritystandards.org/documents/PCI_DSS_v3.pdf</xsl:variable>
+<xsl:variable name="anssi-nt28uri">http://www.ssi.gouv.fr/uploads/2012/07/NP_Linux_Configuration.pdf</xsl:variable>
 <xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>

--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -13,7 +13,7 @@
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/stigs/srgs/Pages/index.aspx</xsl:variable>
 <xsl:variable name="pcidssuri">https://www.pcisecuritystandards.org/documents/PCI_DSS_v3.pdf</xsl:variable>
-<xsl:variable name="anssi-nt28uri">http://www.ssi.gouv.fr/uploads/2012/07/NP_Linux_Configuration.pdf</xsl:variable>
+<xsl:variable name="anssiuri">http://www.ssi.gouv.fr/administration/bonnes-pratiques/</xsl:variable>
 <xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>


### PR DESCRIPTION
I've started French ANSSI (trad. National Agency for Information Systems Security) reference documents integration, as discussed with @shawndwells last week.

The following documents are interesting in our case (I've translated the title):
- NT-28 (technical recommendations for GNU/Linux system security) (the one we have discussed of)
- NT-007 (secure usage of (Open)SSH)
- NT-012 (Security recommendations for log system usage)
- NT-009 (recommendation for websites hardening)
- NT-006 (recommendations for defining a firewall network filtering policy)
- NT-011 (Security considerations associated to information systems virtualization)

In order to avoid multiplicity of references, and because some of these documents cross-references themselves (e.g. NT-28, for the OpenSSH part, references the NT-007 instead of duplicating its content), I've defined only one reference for general ANSSI documents suite (named "good practice", as a suite of procedures and/or technical recommandations to respect in the ANSSI web site).

The reference is pointing to the head page : http://www.ssi.gouv.fr/administration/bonnes-pratiques/
All the above documents use the same formalism for the requirements definition. I've tested the reference in the Debian 8 XCCDF content by using the following syntax:
<pre>
anssi="NT28(R2),NT007(R5)"
</pre>

Don't hesitate to review this if you have any remarks. Depending on your consideration I can update the references of other OSes afterward.
