### PR TITLE
Standard profiles for RHEL6 and 7

### DIFF
--- a/RHEL/6/input/guide.xslt
+++ b/RHEL/6/input/guide.xslt
@@ -13,6 +13,7 @@
 		<xsl:if test=" number($withtest) = number(0) ">
 			<xsl:apply-templates select="document('profiles/test.xml')" />
 		</xsl:if>
+		<xsl:apply-templates select="document('profiles/standard.xml')" />
 		<xsl:apply-templates select="document('profiles/CS2.xml')" />
 		<xsl:apply-templates select="document('profiles/common.xml')" />
 		<!-- <xsl:apply-templates select="document('profiles/desktop.xml')" /> -->

--- a/RHEL/6/input/profiles/standard.xml
+++ b/RHEL/6/input/profiles/standard.xml
@@ -9,13 +9,17 @@ Regardless of your system's workload all of these checks should pass.</descripti
 <select idref="rpm_verify_hashes" selected="true" />
 
 <select idref="security_patches_up_to_date" selected="true"/>
+<select idref="no_empty_passwords" selected="true"/>
 <select idref="accounts_password_all_shadowed" selected="true"/>
+
 <select idref="file_permissions_unauthorized_sgid" selected="true"/>
 <select idref="file_permissions_unauthorized_suid" selected="true"/>
+<select idref="file_permissions_unauthorized_world_writable" selected="true"/>
+<select idref="root_path_no_dot" selected="true"/>
+<select idref="accounts_root_path_dirs_no_write" selected="true"/>
+<select idref="dir_perms_world_writable_sticky_bits" selected="true" />
 
 <select idref="mount_option_dev_shm_nodev" selected="true" />
 <select idref="mount_option_dev_shm_nosuid" selected="true" />
-
-<select idref="dir_perms_world_writable_sticky_bits" selected="true" />
 
 </Profile>

--- a/RHEL/6/input/profiles/standard.xml
+++ b/RHEL/6/input/profiles/standard.xml
@@ -1,0 +1,21 @@
+<Profile id="standard">
+<title>Standard System Security Profile</title>
+<description>This profile contains rules to ensure standard security base of Red Hat Enterprise Linux 6 system.
+Regardless of your system's workload all of these checks should pass.</description>
+
+<select idref="ensure_redhat_gpgkey_installed" selected="true" />
+<select idref="ensure_gpgcheck_globally_activated" selected="true" />
+<select idref="rpm_verify_permissions" selected="true" />
+<select idref="rpm_verify_hashes" selected="true" />
+
+<select idref="security_patches_up_to_date" selected="true"/>
+<select idref="accounts_password_all_shadowed" selected="true"/>
+<select idref="file_permissions_unauthorized_sgid" selected="true"/>
+<select idref="file_permissions_unauthorized_suid" selected="true"/>
+
+<select idref="mount_option_dev_shm_nodev" selected="true" />
+<select idref="mount_option_dev_shm_nosuid" selected="true" />
+
+<select idref="dir_perms_world_writable_sticky_bits" selected="true" />
+
+</Profile>

--- a/RHEL/7/input/profiles/standard.xml
+++ b/RHEL/7/input/profiles/standard.xml
@@ -1,11 +1,15 @@
 <Profile id="standard">
 <title>Standard System Security Profile</title>
-<description>This profile contains rules to ensure standard security base of Red Hat Enterprise Linux 7 system.</description>
+<description>This profile contains rules to ensure standard security base of Red Hat Enterprise Linux 7 system.
+Regardless of your system's workload all of these checks should pass.</description>
 
-<!-- STANDARD SYSTEM SECURITY CHECKS -->
 <select idref="security_patches_up_to_date" selected="true"/>
 <select idref="accounts_password_all_shadowed" selected="true"/>
 <select idref="file_permissions_unauthorized_sgid" selected="true"/>
 <select idref="file_permissions_unauthorized_suid" selected="true"/>
 
+<select idref="mount_option_dev_shm_nodev" selected="true" />
+<select idref="mount_option_dev_shm_nosuid" selected="true" />
+
+<select idref="dir_perms_world_writable_sticky_bits" selected="true" />
 </Profile>

--- a/RHEL/7/input/profiles/standard.xml
+++ b/RHEL/7/input/profiles/standard.xml
@@ -9,13 +9,17 @@ Regardless of your system's workload all of these checks should pass.</descripti
 <select idref="rpm_verify_hashes" selected="true" />
 
 <select idref="security_patches_up_to_date" selected="true"/>
+<select idref="no_empty_passwords" selected="true"/>
 <select idref="accounts_password_all_shadowed" selected="true"/>
+
 <select idref="file_permissions_unauthorized_sgid" selected="true"/>
 <select idref="file_permissions_unauthorized_suid" selected="true"/>
+<select idref="file_permissions_unauthorized_world_writable" selected="true"/>
+<select idref="root_path_no_dot" selected="true"/>
+<select idref="accounts_root_path_dirs_no_write" selected="true"/>
+<select idref="dir_perms_world_writable_sticky_bits" selected="true" />
 
 <select idref="mount_option_dev_shm_nodev" selected="true" />
 <select idref="mount_option_dev_shm_nosuid" selected="true" />
-
-<select idref="dir_perms_world_writable_sticky_bits" selected="true" />
 
 </Profile>

--- a/RHEL/7/input/profiles/standard.xml
+++ b/RHEL/7/input/profiles/standard.xml
@@ -3,6 +3,11 @@
 <description>This profile contains rules to ensure standard security base of Red Hat Enterprise Linux 7 system.
 Regardless of your system's workload all of these checks should pass.</description>
 
+<select idref="ensure_redhat_gpgkey_installed" selected="true" />
+<select idref="ensure_gpgcheck_globally_activated" selected="true" />
+<select idref="rpm_verify_permissions" selected="true" />
+<select idref="rpm_verify_hashes" selected="true" />
+
 <select idref="security_patches_up_to_date" selected="true"/>
 <select idref="accounts_password_all_shadowed" selected="true"/>
 <select idref="file_permissions_unauthorized_sgid" selected="true"/>
@@ -12,4 +17,5 @@ Regardless of your system's workload all of these checks should pass.</descripti
 <select idref="mount_option_dev_shm_nosuid" selected="true" />
 
 <select idref="dir_perms_world_writable_sticky_bits" selected="true" />
+
 </Profile>


### PR DESCRIPTION
Hi,
I have amended the already existing standard profile for RHEL7 and ported it to RHEL6. The primary use-case of these profiles is to have a basic scan that should pass regardless of the workload of the machine. The checks should work on bare-metal, VMs and containers. In the future we want to have `atomic scan` use this profile for container scanning.

We have a lot of obsolete services rules, do you think we want these in the `standard` profile? I goes against the philosophy of it but I'd like to ban some really old insecure services like `rsh`.

Do you see other rules that should be added to the standard profiles?

EDIT: I have intentionally not included SELinux checks because inside containers libselinux will pretend SELinux is disabled even though it's enabled.