### PR TITLE
[Enhancement] [RHEL/6] New RHEL-6 remediation for 'rsyslog_files_permissions' rule'

### DIFF
--- a/shared/remediations/bash/rsyslog_files_permissions.sh
+++ b/shared/remediations/bash/rsyslog_files_permissions.sh
@@ -1,16 +1,17 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = multi_platform_rhel
 
 # List of log file paths to be inspected for correct permissions
 # * Primarily inspect log file paths listed in /etc/rsyslog.conf
 RSYSLOG_ETC_CONFIG="/etc/rsyslog.conf"
 # * And also the log file paths listed after rsyslog's $IncludeConfig directive
-RSYSLOG_INCLUDE_CONFIG=$(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2)
+#   (store the result into array for the case there's shell glob used as value of IncludeConfig)
+RSYSLOG_INCLUDE_CONFIG=($(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2))
 # Declare an array to hold the final list of different log file paths
 declare -a LOG_FILE_PATHS
 
 # Browse each file selected above as containing paths of log files
 # ('/etc/rsyslog.conf' and '/etc/rsyslog.d/*.conf' in the default configuration)
-for LOG_FILE in "$RSYSLOG_ETC_CONFIG" "$RSYSLOG_INCLUDE_CONFIG"
+for LOG_FILE in "${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}"
 do
 	# From each of these files extract just particular log file path(s), thus:
 	# * Ignore lines starting with space (' '), comment ('#"), or variable syntax ('$') characters,
@@ -19,25 +20,23 @@ do
 	# Text file column is understood to represent a log file path if and only if all of the following are met:
 	# * it contains at least one slash '/' character,
 	# * it doesn't contain space (' '), colon (':'), and semicolon (';') characters
-	#
-	# IMPORTANT NOTE: The $LOG_FILE variable in the next statement is intentionally kept unquoted!!!
-	#		  To properly handle the case when rsyslog's $IncludeConfig directive value
-	#		  would contain glob expression in order this glob to be expanded to all possible log file names.
-	#
-	MATCHED_ITEMS=$(sed -e "/^[[:space:]|#|$]/d ; s/[^\/]*[[:space:]]*\([^:;[:space:]]*\)/\1/g ; /^$/d" $LOG_FILE)
-	# Since above sed command might return more than one item (delimited by newline), split the particular
-	# matches entries into new array specific for this log file
-	readarray -t ARRAY_FOR_LOG_FILE <<< "$MATCHED_ITEMS"
-	# Concatenate the two arrays - previous content of $LOG_FILE_PATHS array with
-	# items from newly created array for this log file
-	LOG_FILE_PATHS=("${LOG_FILE_PATHS[@]}" "${ARRAY_FOR_LOG_FILE[@]}")
-	# Delete the temporary array
-	unset ARRAY_FOR_LOG_FILE
+	# Search log file for path(s) only in case it exists!
+	if [[ -f "${LOG_FILE}" ]]
+	then
+		MATCHED_ITEMS=$(sed -e "/^[[:space:]|#|$]/d ; s/[^\/]*[[:space:]]*\([^:;[:space:]]*\)/\1/g ; /^$/d" "${LOG_FILE}")
+		# Since above sed command might return more than one item (delimited by newline), split the particular
+		# matches entries into new array specific for this log file
+		readarray -t ARRAY_FOR_LOG_FILE <<< "$MATCHED_ITEMS"
+		# Concatenate the two arrays - previous content of $LOG_FILE_PATHS array with
+		# items from newly created array for this log file
+		LOG_FILE_PATHS=("${LOG_FILE_PATHS[@]}" "${ARRAY_FOR_LOG_FILE[@]}")
+		# Delete the temporary array
+		unset ARRAY_FOR_LOG_FILE
+	fi
 done
 
 for PATH in "${LOG_FILE_PATHS[@]}"
 do
-
 	# Sanity check - if particular $PATH is empty string, skip it from further processing
 	if [ -z "$PATH" ]
 	then
@@ -47,21 +46,20 @@ do
 	if [ "$PATH" == "/var/log/boot.log" ]
 	then
 		# Ensure permissions of /var/log/boot.log are configured to be updated in /etc/rc.local
-		if ! /usr/bin/grep -q "boot.log" "/etc/rc.local"
+		if ! /bin/grep -q "boot.log" "/etc/rc.local"
 		then
-			echo "chmod 600 /var/log/boot.log" >> /etc/rc.local
+			echo "/bin/chmod 600 /var/log/boot.log" >> /etc/rc.local
 		fi
 		# Ensure /etc/rc.d/rc.local has user-executable permission
 		# (in order to be actually executed during boot)
 		if [ "$(/usr/bin/stat -c %a /etc/rc.d/rc.local)" -ne 744 ]
 		then
-			/usr/bin/chmod u+x /etc/rc.d/rc.local
+			/bin/chmod u+x /etc/rc.d/rc.local
 		fi
-	# For any other log file just check if its permissions differ from 600. If so, correct them
-	else
-		if [ "$(/usr/bin/stat -c %a "$PATH")" -ne 600 ]
-		then
-			chmod 600 "$PATH"
-		fi
+	fi
+	# Also for each log file check if its permissions differ from 600. If so, correct them
+	if [ "$(/usr/bin/stat -c %a "$PATH")" -ne 600 ]
+	then
+		/bin/chmod 600 "$PATH"
 	fi
 done


### PR DESCRIPTION

* Move RHEL-7 'rsyslog_files_permissions' remediation to shared,
* Enable it to be applicable for RHEL-6 too,
* Make the RSYSLOG_INCLUDE_CONFIG variable an array (so in the
  case rsyslog's IncludeConfig directive is set to glob, we would
  expand to all log files),
* Retrieve paths from log files only in case corresponding log file
  exists (e.g. on RHEL-6 /etc/rsyslog.d/*.conf doesn't exist by default,
  which was previously leading remediation to exit with error),
* Update paths to 'grep' and 'chmod' tools (so they would work across
  both of RHEL-6 and RHEL-7), finally
* Perform 'chmod 600' everytime (even for '/var/log/boot.log' case,
  the remediation not to return 'error' without system reboot).

Testing status:
--
The changes have been tested on recent RHEL-6 system and AFAICT
from testing, they are working fine.

Please review.

Thank you, Jan.