### PR TITLE
[BugFix] [RHEL/6] Fix multiple issues in 'smartcard_auth' remediation script for RHEL-6

### DIFF
--- a/RHEL/6/input/remediations/bash/smartcard_auth.sh
+++ b/RHEL/6/input/remediations/bash/smartcard_auth.sh
@@ -2,10 +2,10 @@
 . /usr/share/scap-security-guide/remediation_functions
 
 # Install required packages
-package_command install esc
-package_command install pam_pkcs11
+yum -y install esc
+yum -y install pam_pkcs11
 
-# Enable pcscd.socket systemd activation socket
+# Enable pcscd service
 service_command enable pcscd
 
 # Configure the expected /etc/pam.d/system-auth{,-ac} settings directly
@@ -26,27 +26,49 @@ service_command enable pcscd
 #
 #	Therefore we configure /etc/pam.d/system-auth{,-ac} settings directly.
 #
-# First define system-auth config location
+
+# Define system-auth config location
 SYSTEM_AUTH_CONF="/etc/pam.d/system-auth"
-# Then define expected 'pam_env.so' row in $SYSTEM_AUTH_CONF
-SYSTEM_AUTH_ENV_SO="\
-auth.*required.*pam_env.so"
-# Next define 'pam_succeed_if.so' row to be appended past $SYSTEM_AUTH_ENV_SO row
+# Define expected 'pam_env.so' row in $SYSTEM_AUTH_CONF
+PAM_ENV_SO="auth.*required.*pam_env.so"
+
+# Define 'pam_succeed_if.so' row to be appended past $PAM_ENV_SO row into $SYSTEM_AUTH_CONF
 SYSTEM_AUTH_PAM_SUCCEED="\
 auth        \[success=1 default=ignore\] pam_succeed_if.so service notin \
 login:gdm:xdm:kdm:xscreensaver:gnome-screensaver:kscreensaver quiet use_uid"
-# Finally define 'pam_pkcs11.so' row to be appended past $SYSTEM_AUTH_PAM_SUCCEED
+# Define 'pam_pkcs11.so' row to be appended past $SYSTEM_AUTH_PAM_SUCCEED
 # row into SYSTEM_AUTH_CONF file
 SYSTEM_AUTH_PAM_PKCS11="\
 auth        \[success=done authinfo_unavail=ignore ignore=ignore default=die\] \
 pam_pkcs11.so card_only"
-# Perform the correction itself
-if ! grep -q 'pam_pkcs11.so' "$SYSTEM_AUTH"
+
+# Define smartcard-auth config location
+SMARTCARD_AUTH_CONF="/etc/pam.d/smartcard-auth"
+# Define 'pam_pkcs11.so' auth section to be appended past $PAM_ENV_SO into $SMARTCARD_AUTH_CONF
+SMARTCARD_AUTH_SECTION="\
+auth        [success=done ignore=ignore default=die] pam_pkcs11.so wait_for_card card_only"
+# Define expected 'pam_permit.so' row in $SMARTCARD_AUTH_CONF
+PAM_PERMIT_SO="account.*required.*pam_permit.so"
+# Define 'pam_pkcs11.so' password section
+SMARTCARD_PASSWORD_SECTION="\
+password    required      pam_pkcs11.so"
+
+# First Correct the SYSTEM_AUTH_CONF configuration
+if ! grep -q 'pam_pkcs11.so' "$SYSTEM_AUTH_CONF"
 then
 	# Append (expected) pam_succeed_if.so row past the pam_env.so into SYSTEM_AUTH_CONF file
-	sed -i --follow-symlinks -e '/^'"$SYSTEM_AUTH_ENV_SO"'/a '"$SYSTEM_AUTH_PAM_SUCCEED" "$SYSTEM_AUTH_CONF"
+	sed -i --follow-symlinks -e '/^'"$PAM_ENV_SO"'/a '"$SYSTEM_AUTH_PAM_SUCCEED" "$SYSTEM_AUTH_CONF"
 	# Append (expected) pam_pkcs11.so row past the pam_succeed_if.so into SYSTEM_AUTH_CONF file
 	sed -i --follow-symlinks -e '/^'"$SYSTEM_AUTH_PAM_SUCCEED"'/a '"$SYSTEM_AUTH_PAM_PKCS11" "$SYSTEM_AUTH_CONF"
+fi
+
+# Then also correct the SMARTCARD_AUTH_CONF
+if ! grep -q 'pam_pkcs11.so' "$SMARTCARD_AUTH_CONF"
+then
+	# Append (expected) SMARTCARD_AUTH_SECTION row past the pam_env.so into SMARTCARD_AUTH_CONF file
+	sed -i --follow-symlinks -e '/^'"$PAM_ENV_SO"'/a '"$SMARTCARD_AUTH_SECTION" "$SMARTCARD_AUTH_CONF"
+	# Append (expected) SMARTCARD_PASSWORD_SECTION row past the pam_permit.so into SMARTCARD_AUTH_CONF file
+	sed -i --follow-symlinks -e '/^'"$PAM_PERMIT_SO"'/a '"$SMARTCARD_PASSWORD_SECTION" "$SMARTCARD_AUTH_CONF"
 fi
 
 # Perform /etc/pam_pkcs11/pam_pkcs11.conf settings below


### PR DESCRIPTION

Namely:
* the ```package_command``` routine is complaining on RHEL-6 ('/usr/bin/rpm
  not found) => use direct yum call instead,

  (this avoids issue: https://github.com/OpenSCAP/scap-security-guide/issues/972 till it's fixed)

* there's no pcscd.socket on RHEL-6,
* fix the obvious variable name typo (incorrect 'SYSTEM_AUTH' used
  instead of 'SYSTEM_AUTH_CONF') leading to remediation not to be
  invariant (subsequent calls always added new entries into ```/etc/pam.d/system-auth``` config file)

 and

* mainly set also necessary ```/etc/pam.d/smartcard-auth``` configuration for the rule

Testing report:
--
Verified manually on recent RHEL-6 system the proposed change is working fine.

Please review.

Thank you, Jan.