### PR TITLE
[BugFix] [Infrastructure] Fix behaviour of 'perform_audit_rules_privileged_commands_remediation helper remediation' function

### DIFF
--- a/shared/remediations/bash/templates/remediation_functions
+++ b/shared/remediations/bash/templates/remediation_functions
@@ -533,7 +533,8 @@ do
 	# Replace possible slash '/' character in sbinary definition so we could use it in sed expressions below
 	sbinary_esc=${sbinary//$'/'/$'\/'}
 	# Check if this sbinary wasn't already handled in some of the previous iterations
-	if [[ $(sed -ne "/$sbinary_esc/p" <<< ${sbinaries_to_skip[@]}) ]]
+	# Return match only if whole sbinary definition matched (not in the case just prefix matched!!!)
+	if [[ $(sed -ne "/${sbinary_esc}$/p" <<< ${sbinaries_to_skip[@]}) ]]
 	then
 		# If so, don't process it second time & go to process next sbinary
 		continue
@@ -553,7 +554,7 @@ do
 		# * existing rule contains all arguments from expected rule form (though can contain
 		#   them in arbitrary order)
 	
-		base_search=$(sed -e "/-a always,exit/!d" -e "/-F path=${sbinary_esc}/!d"   \
+		base_search=$(sed -e "/-a always,exit/!d" -e "/-F path=${sbinary_esc}$/!d"   \
 		    		  -e "/-F path=[^[:space:]]\+/!d" -e "/-F perm=.*/!d"       \
 				  -e "/-F auid>=${min_auid}/!d" -e "/-F auid!=4294967295/!d"  \
 				  -e "/-k privileged/!d" $afile)


### PR DESCRIPTION
<br/>
The ```perform_audit_rules_privileged_commands_remediation``` remediation function (which is used to implement the remediation for ```audit_rules_privileged_commands``` rule) keeps the array / list of SUID / SGID binaries, that have been previously found for meeting the requirement (and if encountering the same SUID / SGID binary second time, we don't add the rule into ```/etc/audit/audit.rules``` | ```/etc/audit/rules.d/privileged.rules``` files.

But the current comparison / check for SUID / SGID binary name match is based on prefix match (not whole SUID basename match). This way of matching (prefix match) won't work in the following case:
* the ```ping6``` binary has been handled before, and we encountered ```ping``` executable,
* since the prefix match matched, ```ping``` would be <b>incorrectly</b> added to the list of SUID / SGID executables, not to be evaluated in subsequent for loop passes,
* this leads to the result when remediation of audit rules privileged commands does not insert rule for ```ping``` binary into necessary file, despite of the fact it should be inserted there.

Therefore fix this by replacing the current prefix match, with new exact sbinary name match requirement. From now on ```ping``` is being included properly and the remediation succeeds.

Testing report:

--
The change has been tested manually on recent RHEL-6 system and it's working fine (AFAICT from testing. Old behaviours - remediation returns 'error', now it returns 'fixed').

Please review.

Thank you, Jan.
