### PR TITLE
The rpm utility usually resides in /bin/rpm.

### DIFF
--- a/shared/remediations/bash/templates/remediation_functions
+++ b/shared/remediations/bash/templates/remediation_functions
@@ -378,12 +378,12 @@ fi
 
 if [ "$package_operation" != 'remove' ] ; then
   # If the rpm is not installed, install the rpm
-  if ! /usr/bin/rpm -q --quiet $package; then
+  if ! /bin/rpm -q --quiet $package; then
     $install_util -y $package_operation $package
   fi
 else
   # If the rpm is installed, uninstall the rpm
-  if /usr/bin/rpm -q --quiet $package; then
+  if /bin/rpm -q --quiet $package; then
     $install_util -y $package_operation $package
   fi
 fi


### PR DESCRIPTION
While on Fedora (after UsrMove Feature) the rpm is in /usr/bin/rpm and
/bin/rpm, RHEL-6 systems have rpm utility only in /bin/rpm.

Reported by Ján Lieskovský in 409a5d4c93d36fef2f7d0b2fa110713ae5a975f9.

My understanding is that until this is merged all
"remove-package-remediations" are broken for rhel-6.