### PR TITLE
[BugFix] [Infrastructure] Modify "count_oval_objects" helper script not to act on remotely referenced OVAL

### DIFF
--- a/shared/utils/count_oval_objects.py
+++ b/shared/utils/count_oval_objects.py
@@ -117,7 +117,7 @@ def main():
             try:
                 oval_name = ref.attrib['name']
             except KeyError:
-                if ref.attrib['href'] is not None:
+                if 'href' in ref.attrib:
                     print("\nInfo: Skipping remotely referenced OVAL:")
                     continue
                 else:

--- a/shared/utils/count_oval_objects.py
+++ b/shared/utils/count_oval_objects.py
@@ -111,7 +111,13 @@ def main():
         rule_id = rule.attrib['id']
         oval_refs = []
         for ref in rule.findall(".//check-content-ref"):
-            oval_name = ref.attrib['name']
+            # Skip remotely referenced OVAL checks since they won't have the
+            # 'name' attribute set (just 'href' would be set in that case)
+            try:
+                oval_name = ref.attrib['name']
+            except KeyError:
+                print "\nInfo: Skipping remotely referenced OVAL:"
+                continue
             oval_file = ref.attrib['href']
             oval_refs.append((oval_name, oval_file))
         if oval_refs:

--- a/shared/utils/count_oval_objects.py
+++ b/shared/utils/count_oval_objects.py
@@ -111,13 +111,19 @@ def main():
         rule_id = rule.attrib['id']
         oval_refs = []
         for ref in rule.findall(".//check-content-ref"):
+
             # Skip remotely referenced OVAL checks since they won't have the
             # 'name' attribute set (just 'href' would be set in that case)
             try:
                 oval_name = ref.attrib['name']
             except KeyError:
-                print "\nInfo: Skipping remotely referenced OVAL:"
-                continue
+                if ref.attrib['href'] is not None:
+                    print("\nInfo: Skipping remotely referenced OVAL:")
+                    continue
+                else:
+                    print("\nError: Invalid OVAL check detected! Exiting..")
+                    sys.exit(1)
+
             oval_file = ref.attrib['href']
             oval_refs.append((oval_name, oval_file))
         if oval_refs:


### PR DESCRIPTION

Because:
* remote OVAL won't have 'name' attribute set,
* we don't want to count the stats for remote OVAL referenced
from the benchmarks

Tested locally on Fedora 22 system:
* output before (KeyError traceback)
* output after (remotely referenced OVAL is skipped and the helper script provides the stats without traceback)

Please review.

Thank you, Jan.