### PR TITLE
[BugFix] [Infrastructure] Fix failing [RHEL/7] 'make' on RHEL-6 system with openscap supporting just OVAL-5.10 (openscap-1.0.*)

### DIFF
--- a/RHEL/6/input/oval/dovecot_disable_plaintext_auth.xml
+++ b/RHEL/6/input/oval/dovecot_disable_plaintext_auth.xml
@@ -4,7 +4,7 @@
     <metadata>
       <title>Disable Plaintext Authentication in Dovecot</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
       <description>Plaintext authentication of mail clients should be disabled.</description>
       <reference source="galford" ref_id="20160120" ref_url="test_attestation" />

--- a/RHEL/6/input/oval/dovecot_enable_ssl.xml
+++ b/RHEL/6/input/oval/dovecot_enable_ssl.xml
@@ -3,7 +3,7 @@
     <metadata>
       <title>Enable SSL in Dovecot</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
       <description>SSL capabilities should be enabled for the mail server.</description>
       <reference source="galford" ref_id="20160120" ref_url="test_attestation" />

--- a/RHEL/6/input/oval/postfix_network_listening_disabled.xml
+++ b/RHEL/6/input/oval/postfix_network_listening_disabled.xml
@@ -3,7 +3,7 @@
     <metadata>
       <title>Postfix network listening should be disabled</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
       <description>Postfix network listening should be disabled</description>
       <reference source="galford" ref_id="20160120" ref_url="test_attestation" />

--- a/shared/oval/oval_5.11/dovecot_disable_plaintext_auth.xml
+++ b/shared/oval/oval_5.11/dovecot_disable_plaintext_auth.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="compliance" id="dovecot_disable_plaintext_auth"
+  version="1">
+    <metadata>
+      <title>Disable Plaintext Authentication in Dovecot</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>Plaintext authentication of mail clients should be disabled.</description>
+      <reference source="JL" ref_id="RHEL7_20160208" ref_url="test_attestation" />
+    </metadata>
+    <criteria comment="Disable Plaintext Authentication in Dovecot" operator="OR">
+      <extend_definition comment="dovecot service is disabled" definition_ref="service_dovecot_disabled" />
+      <criterion test_ref="test_dovecot_disable_plaintext_auth" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="Tests the value of the disable_plaintext_auth[\s]*(&lt;:nocomment:&gt;*) setting in the /etc/dovecot.conf file"
+  id="test_dovecot_disable_plaintext_auth" version="1">
+    <ind:object object_ref="obj_dovecot_disable_plaintext_auth" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_dovecot_disable_plaintext_auth"
+  version="1">
+    <ind:filepath>/etc/dovecot/conf.d/10-auth.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*disable_plaintext_auth[\s]*=[\s]*yes[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/shared/oval/oval_5.11/dovecot_enable_ssl.xml
+++ b/shared/oval/oval_5.11/dovecot_enable_ssl.xml
@@ -1,0 +1,26 @@
+<def-group>
+  <definition class="compliance" id="dovecot_enable_ssl" version="1">
+    <metadata>
+      <title>Enable SSL in Dovecot</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>SSL capabilities should be enabled for the mail server.</description>
+      <reference source="JL" ref_id="RHEL7_20160208" ref_url="test_attestation" />
+    </metadata>
+    <criteria comment="Enable SSL in Dovecot" operator="OR">
+      <extend_definition comment="dovecot service is disabled" definition_ref="service_dovecot_disabled" />
+      <criterion test_ref="test_dovecot_enable_ssl" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="Tests the value of the ssl[\s]*(&lt;:nocomment:&gt;*) setting in the /etc/dovecot.conf file"
+  id="test_dovecot_enable_ssl" version="1">
+    <ind:object object_ref="obj_dovecot_enable_ssl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_dovecot_enable_ssl" version="1">
+    <ind:filepath>/etc/dovecot/conf.d/10-ssl.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*ssl[\s]*=[\s]*yes[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/shared/oval/oval_5.11/postfix_network_listening_disabled.xml
+++ b/shared/oval/oval_5.11/postfix_network_listening_disabled.xml
@@ -1,0 +1,29 @@
+<def-group>
+  <definition class="compliance" id="postfix_network_listening_disabled" version="2">
+    <metadata>
+      <title>Postfix network listening should be disabled</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>Postfix network listening should be disabled</description>
+      <reference source="JL" ref_id="RHEL7_20160802" ref_url="test_attestation" />
+    </metadata>
+    <criteria operator="OR">
+      <!-- postfix package not installed or postfix service not configured to start -->
+      <extend_definition comment="Postfix installed and configured to start" negate="true" definition_ref="service_postfix_enabled" />
+      <!-- postfix network listening disabled -->
+      <criterion comment="Check inet_interfaces in /etc/postfix/main.cf" test_ref="test_postfix_network_listening_disabled" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_postfix_network_listening_disabled" check="all" check_existence="at_least_one_exists" comment="inet_interfaces in /etc/postfix/main.cf should be set correctly" version="1">
+    <ind:object object_ref="obj_postfix_network_listening_disabled" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_postfix_network_listening_disabled" comment="inet_interfaces in /etc/postfix/main.cf should be set correctly" version="1">
+    <ind:filepath>/etc/postfix/main.cf</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*inet_interfaces[\s]*=[\s]*localhost[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>


### PR DESCRIPTION

Fixes:
&nbsp; &nbsp;  [1] https://jenkins.open-scap.org/job/scap-security-guide/516/console

Update ```<platform>``` fields for OVAL checks depending on:
* ```service_dovecot_disabled```, and
* ```service_postfix_enabled```

OVAL checks (IOW include those dependent OVAL checks only in moment ```service_dovecot_disabled``` and ```service_postfix_enabled``` OVALs are truly included).

This fixes failing ```make``` target for ```[RHEL/7]``` product when building on RHEL-6 system with old openscap (openscap not supporting 5.11 language yet).

Please review.

Thank you, Jan.