### PR TITLE
[BugFix] [Enhancement] [RHEL/7] [Fedora] bootloader_nousb_argument fixes

### DIFF
--- a/Fedora/input/profiles/common.xml
+++ b/Fedora/input/profiles/common.xml
@@ -101,6 +101,9 @@
   <select idref="audit_rules_kernel_module_loading" selected="true"/>
   <select idref="audit_rules_immutable" selected="true" />
 
+  <!-- Configure USB interfaces -->
+  <select idref="bootloader_nousb_argument" selected="true" />
+
 <!-- Services -->
   <!-- Network Time Protocol -->
   <select idref="service_chronyd_enabled" selected="true"/>

--- a/Fedora/input/xccdf/system/permissions/mounting.xml
+++ b/Fedora/input/xccdf/system/permissions/mounting.xml
@@ -47,7 +47,7 @@ infeasible for systems which require USB devices, which is common.</i></descript
 protect against potentially malicious USB devices, although it is only practical
 in specialized systems.
 </rationale>
-<!--oval id="bootloader_nousb_argument" /-->
+<oval id="bootloader_nousb_argument" />
 <ref nist="AC-19(a),AC-19(d),AC-19(e)" disa="1250" />
 </Rule>
 

--- a/Fedora/input/xccdf/system/permissions/mounting.xml
+++ b/Fedora/input/xccdf/system/permissions/mounting.xml
@@ -38,7 +38,7 @@ malicious software.</rationale>
 <description>
 All USB support can be disabled by adding the <tt>nousb</tt>
 argument to the kernel's boot loader configuration. To do so, 
-append "nousb" to the kernel line in <tt>/etc/grub.conf</tt> as shown:
+append "nousb" to the kernel line in <tt>/etc/default/grub</tt> as shown:
 <pre>kernel /vmlinuz-<i>VERSION</i> ro vga=ext root=/dev/VolGroup00/LogVol00 rhgb quiet nousb</pre>
 <i><b>WARNING:</b> Disabling all kernel support for USB will cause problems for
 systems with USB-based keyboards, mice, or printers. This configuration is

--- a/Fedora/input/xccdf/system/selinux.xml
+++ b/Fedora/input/xccdf/system/selinux.xml
@@ -46,14 +46,14 @@ appropriate.
 </Value>
 
 <Rule id="enable_selinux_bootloader" severity="medium">
-<title>Ensure SELinux Not Disabled in /etc/grub.conf</title>
+<title>Ensure SELinux Not Disabled in /etc/default/grub</title>
 <description>SELinux can be disabled at boot time by an argument in
-<tt>/etc/grub.conf</tt>.
+<tt>/etc/default/grub</tt>.
 Remove any instances of <tt>selinux=0</tt> from the kernel arguments in that
 file to prevent SELinux from being disabled at boot.
 </description>
 <ocil clause="SELinux is disabled at boot time">
-Inspect <tt>/etc/grub.conf</tt> for any instances of <tt>selinux=0</tt>
+Inspect <tt>/etc/default/grub</tt> for any instances of <tt>selinux=0</tt>
 in the kernel boot arguments.  Presence of <tt>selinux=0</tt> indicates
 that SELinux is disabled at boot time.
 </ocil>

--- a/RHEL/7/input/profiles/C2S.xml
+++ b/RHEL/7/input/profiles/C2S.xml
@@ -106,7 +106,7 @@ baseline.
 <!-- 1.3.2 Implement Periodic Execution of File Integrity (Scored) -->
 <select idref="aide_periodic_cron_checking" selected="true" />
 
-<!-- 1.4.1 Enable SELinux in /etc/grub.conf (Scored) -->
+<!-- 1.4.1 Enable SELinux in /etc/default/grub (Scored) -->
 <select idref="enable_selinux_bootloader" selected="true" />
 
 <!-- 1.4.2 Set the SELinux State (Scored) -->
@@ -130,10 +130,7 @@ baseline.
 <select idref="file_user_owner_grub2_cfg" selected="true" />
 <select idref="file_group_owner_grub2_cfg" selected="true" />
 
-<!-- 1.5.2 Set Permissions on /etc/grub.conf (Scored) -->
-<!-- NOTE: CIS guidance improperly uses /etc/grub.conf. 
-           In RHEL7, this was changed to /boot/grub2/grub.cfg,
-	   which is what SSG content will check -->
+<!-- 1.5.2 Set Permissions on /boot/grub2/grub.cfg (Scored) -->
 <select idref="file_permissions_grub2_cfg" selected="true" />
 
 <!-- 1.5.3 Set Boot Loader Password (Scored) -->

--- a/RHEL/7/input/xccdf/system/permissions/mounting.xml
+++ b/RHEL/7/input/xccdf/system/permissions/mounting.xml
@@ -39,7 +39,7 @@ malicious software.</rationale>
 <description>
 All USB support can be disabled by adding the <tt>nousb</tt>
 argument to the kernel's boot loader configuration. To do so, 
-append "nousb" to the kernel line in <tt>/etc/grub.conf</tt> as shown:
+append "nousb" to the kernel line in <tt>/etc/default/grub</tt> as shown:
 <pre>kernel /vmlinuz-<i>VERSION</i> ro vga=ext root=/dev/VolGroup00/LogVol00 rhgb quiet nousb</pre>
 <i><b>WARNING:</b> Disabling all kernel support for USB will cause problems for
 systems with USB-based keyboards, mice, or printers. This configuration is

--- a/RHEL/7/input/xccdf/system/selinux.xml
+++ b/RHEL/7/input/xccdf/system/selinux.xml
@@ -46,14 +46,14 @@ appropriate.
 </Value>
 
 <Rule id="enable_selinux_bootloader" severity="medium">
-<title>Ensure SELinux Not Disabled in /etc/grub.conf</title>
+<title>Ensure SELinux Not Disabled in /etc/default/grub</title>
 <description>SELinux can be disabled at boot time by an argument in
-<tt>/etc/grub.conf</tt>.
+<tt>/etc/default/grub</tt>.
 Remove any instances of <tt>selinux=0</tt> from the kernel arguments in that
 file to prevent SELinux from being disabled at boot.
 </description>
 <ocil clause="SELinux is disabled at boot time">
-Inspect <tt>/etc/grub.conf</tt> for any instances of <tt>selinux=0</tt>
+Inspect <tt>/etc/default/grub</tt> for any instances of <tt>selinux=0</tt>
 in the kernel boot arguments.  Presence of <tt>selinux=0</tt> indicates
 that SELinux is disabled at boot time.
 </ocil>

--- a/shared/oval/bootloader_nousb_argument.xml
+++ b/shared/oval/bootloader_nousb_argument.xml
@@ -1,0 +1,35 @@
+<def-group>
+  <definition class="compliance" id="bootloader_nousb_argument" version="1">
+    <metadata>
+      <title>Disable Kernel Support for USB via Bootloader Configuration</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>Look for 'nousb' argument in the kernel line in /etc/default/grub</description>
+      <reference source="JL" ref_id="RHEL7_20160209" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA22_20160209" ref_url="test_attestation" />
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_bootloader_nousb_argument" comment="Check for 'nousb' argument in /etc/default/grub" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_bootloader_nousb_argument"
+  comment="Check for 'nousb' argument in /etc/default/grub"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_bootloader_nousb_argument" />
+    <ind:state state_ref="state_bootloader_nousb_argument" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_bootloader_nousb_argument" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_bootloader_nousb_argument" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^.*nousb.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>

--- a/shared/remediations/bash/bootloader_nousb_argument.sh
+++ b/shared/remediations/bash/bootloader_nousb_argument.sh
@@ -1,0 +1,12 @@
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+
+# Correct the form of default kernel command line in /etc/default/grub
+if ! grep -q ^GRUB_CMDLINE_LINUX=\".*nousb.*\" /etc/default/grub;
+then
+  # Edit configuration setting
+  # Append 'nousb' argument to /etc/default/grub (if not present yet)
+  sed -i "s/\(GRUB_CMDLINE_LINUX=\)\"\(.*\)\"/\1\"\2 nousb\"/" /etc/default/grub
+  # Edit runtime setting
+  # Correct the form of kernel command line for each installed kernel in the bootloader
+  /sbin/grubby --update-kernel=ALL --args="nousb"
+fi


### PR DESCRIPTION
This changeset is doing the following:
* (patch https://github.com/OpenSCAP/scap-security-guide/commit/a1d3e2dc011238b6551c049de610339be73ad8c6 ) Replace occurrences of ```/etc/grub.conf``` in [RHEL/7] and [Fedora] XCCDF with ```/etc/default/grub``` (RHEL7+ is using grub2 instead of grub, for which ```/etc/default/grub``` is the default grub2 config path),
* (patch https://github.com/OpenSCAP/scap-security-guide/commit/b0200eecc88b053147121465594817dcf18d6488 ) Is adding RHEL/7 and Fedora OVAL for ```bootloader_nousb_argument``` rule, and finally
* (patch https://github.com/OpenSCAP/scap-security-guide/commit/23bc5a62d8f25a7ecfd060e1537e77ca527de670 ) Is adding RHEL/7 and Fedora remediation for ```bootloader_nousb_argument``` rule

Fixes:
https://github.com/OpenSCAP/scap-security-guide/issues/671
https://github.com/OpenSCAP/scap-security-guide/issues/672

Replaces:
https://github.com/OpenSCAP/scap-security-guide/pull/767

Please review.

Thank you, Jan.