### PR TITLE
[BugFix] [RHEL/6] Point 'DISA FSO' RHEL-6 <rule_version> IDs to official URI of DISA FSO RHEL-6 STIG Zip archive (instead of to http://cce.mitre.org)

### DIFF
--- a/RHEL/6/transforms/shorthand2xccdf.xslt
+++ b/RHEL/6/transforms/shorthand2xccdf.xslt
@@ -19,10 +19,6 @@
 <xsl:variable name="ovalfile">unlinked-rhel6-oval.xml</xsl:variable>
 <xsl:variable name="defaultseverity" select="'low'" />
 
-<!-- Specify location of official DISA FSO Zip benchmark (RHEL-6 specific URI) -->
-<!-- Fix for issue https://github.com/OpenSCAP/scap-security-guide/issues/1035 -->
-<xsl:variable name="disa_fso_rhel6_uri">http://iasecontent.disa.mil/stigs/zip/Jan2016/U_RedHat_6_V1R10_STIG.zip</xsl:variable>
-
 <!-- put elements created in this stylesheet into the xccdf namespace,
      if no namespace explicitly indicated -->
 <xsl:namespace-alias result-prefix="xccdf" stylesheet-prefix="#default" />
@@ -109,7 +105,7 @@
           </xsl:when>
           <xsl:when test="name() = 'stig'">
             <xsl:attribute name="system">
-              <xsl:value-of select="$disa_fso_rhel6_uri" />
+              <xsl:value-of select="$disa-stigs-os-unix-linux-uri" />
             </xsl:attribute>
             <xsl:value-of select="concat('DISA FSO ', .)" />
           </xsl:when>

--- a/RHEL/6/transforms/shorthand2xccdf.xslt
+++ b/RHEL/6/transforms/shorthand2xccdf.xslt
@@ -19,6 +19,10 @@
 <xsl:variable name="ovalfile">unlinked-rhel6-oval.xml</xsl:variable>
 <xsl:variable name="defaultseverity" select="'low'" />
 
+<!-- Specify location of official DISA FSO Zip benchmark (RHEL-6 specific URI) -->
+<!-- Fix for issue https://github.com/OpenSCAP/scap-security-guide/issues/1035 -->
+<xsl:variable name="disa_fso_rhel6_uri">http://iasecontent.disa.mil/stigs/zip/Jan2016/U_RedHat_6_V1R10_STIG.zip</xsl:variable>
+
 <!-- put elements created in this stylesheet into the xccdf namespace,
      if no namespace explicitly indicated -->
 <xsl:namespace-alias result-prefix="xccdf" stylesheet-prefix="#default" />
@@ -105,7 +109,7 @@
           </xsl:when>
           <xsl:when test="name() = 'stig'">
             <xsl:attribute name="system">
-              <xsl:value-of select="$cceuri" />
+              <xsl:value-of select="$disa_fso_rhel6_uri" />
             </xsl:attribute>
             <xsl:value-of select="concat('DISA FSO ', .)" />
           </xsl:when>

--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -12,6 +12,8 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-srguri">http://iase.disa.mil/stigs/srgs/Pages/index.aspx</xsl:variable>
+<!-- Fix for issue https://github.com/OpenSCAP/scap-security-guide/issues/1035 -->
+<xsl:variable name="disa-stigs-os-unix-linux-uri">http://iase.disa.mil/stigs/os/unix-linux/Pages/index.aspx</xsl:variable>
 <xsl:variable name="pcidssuri">https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-1.pdf</xsl:variable>
 <xsl:variable name="anssiuri">http://www.ssi.gouv.fr/administration/bonnes-pratiques/</xsl:variable>
 <xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>


### PR DESCRIPTION
The provided ```DISA FSO RHEL-*``` entries in current RHEL-6 benchmark are intended to be a convenient way how SSG users should be able to map SSG rule IDs to official DISA FSO RHEL-6 rule IDs. Their introduction is discussed in more detail in the following two SSG ML threads:
* https://lists.fedorahosted.org/pipermail/scap-security-guide/2013-September/thread.html#3944
* https://lists.fedorahosted.org/pipermail/scap-security-guide/2013-September/thread.html#3948
  
But these IDS (e.g. ```DISA FSO RHEL-06-000001```) are not listed elsewhere than in:
* SSG RHEL-6 benchmarks,
* official DISA FSO RHEL-6 Zip archive (as the ```<rule_version``` elements)

=> it doesn't make sense to point these items to ```$cceuri``` (e.g. ```http://cce.mitre.org```) like we are doing currently. Therefore instead of that point them to URI of the Zip archive / form of the official DISA FSO RHEL-6 benchmark.

Fixes:
  https://github.com/OpenSCAP/scap-security-guide/issues/1035

Please review.

Thank you, Jan.