### PR TITLE
[RHEL/6] Replace SSG specific 'ocil-transitional' check system with the official OCIL check system in the produced RHEL-6 benchmark

### DIFF
--- a/Chromium/Makefile
+++ b/Chromium/Makefile
@@ -56,7 +56,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/oval/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
-	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
+#	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 #	Once things are relabelled, create a datastream

--- a/Chromium/transforms/shorthand2xccdf.xslt
+++ b/Chromium/transforms/shorthand2xccdf.xslt
@@ -209,7 +209,7 @@
   <!-- expand reference to would-be OCIL (inline) -->
   <xsl:template match="Rule/ocil">
       <check>
-        <xsl:attribute name="system">ocil-transitional</xsl:attribute>
+        <xsl:attribute name="system"><xsl:value-of select="$ocil_cs" /></xsl:attribute>
           <check-export>
 
           <xsl:attribute name="export-name">

--- a/Chromium/transforms/xccdf-apply-overlay-stig.xslt
+++ b/Chromium/transforms/xccdf-apply-overlay-stig.xslt
@@ -8,6 +8,8 @@
      content will be projected.  New Rules can thus be created based on external
      parties' identifiers or titles. -->
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
 <xsl:variable name="overlays" select="document($overlay)/xccdf:overlays" />
 
   <xsl:template match="xccdf:Benchmark">
@@ -33,9 +35,9 @@
           	<title><xsl:value-of select="$overlay_title"/></title>
           	<description><xsl:copy-of select="xccdf:rationale/node()" /></description>
           	<check system="C-{$overlay_id}_chk">
-          		<check-content><xsl:copy-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-content/node()" />
+          		<check-content><xsl:copy-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-content/node()" />
 
-          		If <xsl:value-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-export/@export-name" />, this is a finding.
+          		If <xsl:value-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-export/@export-name" />, this is a finding.
           		</check-content>
           	</check>
 		  	<ident system="http://iase.disa.mil/cci"><xsl:value-of select="concat('CCI-', format-number($overlay_ref,'000000'))" /></ident>

--- a/Chromium/transforms/xccdf2html.xslt
+++ b/Chromium/transforms/xccdf2html.xslt
@@ -56,6 +56,9 @@
 <!-- Set up an id key to match on all Profiles -->
 <xsl:key name="profiles" match="cdf:Profile" use="@id"/>
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <!-- TEMPLATE for cdf:Benchmark
   -  This template takes care of the top-level structure of the
   -  generated XHTML document.  It handles the Benchmark element
@@ -630,9 +633,9 @@
      </xsl:for-each>
   </xsl:if>
 
-  <xsl:if test="./cdf:check[@system='ocil-transitional']">
+  <xsl:if test="./cdf:check[@system=$ocil_cs]">
   <xsl:variable name="manualcheck" select="concat('manualcheck-', @id)"/>
-    <xsl:for-each select="./cdf:check[@system='ocil-transitional']/cdf:check-content">
+    <xsl:for-each select="./cdf:check[@system=$ocil_cs]/cdf:check-content">
       <h4 class="expandstyle">
         <a href="javascript:toggle('{$manualcheck}', 'link-{$manualcheck}');" style="height:25px; line-height: 25px">
       	<span style="display:inline-block; vertical-align:middle"><img id="link-{$manualcheck}" src="images/collapsed.png" height="15" width="15" style="vertical-align: middle"/> Check Procedure</span>

--- a/Chromium/transforms/xccdf2stigformat.xslt
+++ b/Chromium/transforms/xccdf2stigformat.xslt
@@ -85,7 +85,7 @@ xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/sch
 		</fixtext>
 		<check system="{concat('C-',position(),'_chk')}">
 			<check-content>
-				<xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
+				<xsl:value-of select="cdf:check[@system=$ocil_cs]/cdf:check-content"/>
 			</check-content>
 		</check>
     </Rule>

--- a/Debian/8/Makefile
+++ b/Debian/8/Makefile
@@ -70,7 +70,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/oval/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
-	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
+#	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 #	Once things are relabelled, create a datastream

--- a/Debian/8/transforms/shorthand2xccdf.xslt
+++ b/Debian/8/transforms/shorthand2xccdf.xslt
@@ -205,7 +205,7 @@
   <!-- expand reference to would-be OCIL (inline) -->
   <xsl:template match="Rule/ocil">
       <check>
-        <xsl:attribute name="system">ocil-transitional</xsl:attribute>
+        <xsl:attribute name="system"><xsl:value-of select="$ocil_cs" /></xsl:attribute>
           <check-export>
 
           <xsl:attribute name="export-name">

--- a/Debian/8/transforms/xccdf-apply-overlay-stig.xslt
+++ b/Debian/8/transforms/xccdf-apply-overlay-stig.xslt
@@ -8,6 +8,9 @@
      content will be projected.  New Rules can thus be created based on external
      parties' identifiers or titles. -->
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <xsl:variable name="overlays" select="document($overlay)/xccdf:overlays" />
 
   <xsl:template match="xccdf:Benchmark">
@@ -33,9 +36,9 @@
           	<title><xsl:value-of select="$overlay_title"/></title>
           	<description><xsl:copy-of select="xccdf:rationale/node()" /></description>
           	<check system="C-{$overlay_id}_chk">
-          		<check-content><xsl:copy-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-content/node()" />
+          		<check-content><xsl:copy-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-content/node()" />
 
-          		If <xsl:value-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-export/@export-name" />, this is a finding.
+          		If <xsl:value-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-export/@export-name" />, this is a finding.
           		</check-content>
           	</check>
 		  	<ident system="http://iase.disa.mil/cci"><xsl:value-of select="concat('CCI-', format-number($overlay_ref,'000000'))" /></ident>

--- a/Fedora/transforms/shorthand2xccdf.xslt
+++ b/Fedora/transforms/shorthand2xccdf.xslt
@@ -203,7 +203,7 @@
   <!-- expand reference to would-be OCIL (inline) -->
   <xsl:template match="Rule/ocil">
       <check>
-        <xsl:attribute name="system">ocil-transitional</xsl:attribute>
+        <xsl:attribute name="system"><xsl:value-of select="$ocil_cs" /></xsl:attribute>
           <check-export>
 
           <xsl:attribute name="export-name">

--- a/Firefox/Makefile
+++ b/Firefox/Makefile
@@ -59,7 +59,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/oval/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
-	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
+#	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 #	Once things are relabelled, create a datastream

--- a/Firefox/transforms/shorthand2xccdf.xslt
+++ b/Firefox/transforms/shorthand2xccdf.xslt
@@ -209,7 +209,7 @@
   <!-- expand reference to would-be OCIL (inline) -->
   <xsl:template match="Rule/ocil">
       <check>
-        <xsl:attribute name="system">ocil-transitional</xsl:attribute>
+        <xsl:attribute name="system"><xsl:value-of select="$ocil_cs" /></xsl:attribute>
           <check-export>
 
           <xsl:attribute name="export-name">

--- a/Firefox/transforms/xccdf-apply-overlay-stig.xslt
+++ b/Firefox/transforms/xccdf-apply-overlay-stig.xslt
@@ -8,6 +8,9 @@
      content will be projected.  New Rules can thus be created based on external
      parties' identifiers or titles. -->
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <xsl:variable name="overlays" select="document($overlay)/xccdf:overlays" />
 
   <xsl:template match="xccdf:Benchmark">
@@ -33,9 +36,9 @@
           	<title><xsl:value-of select="$overlay_title"/></title>
           	<description><xsl:copy-of select="xccdf:rationale/node()" /></description>
           	<check system="C-{$overlay_id}_chk">
-          		<check-content><xsl:copy-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-content/node()" />
+          		<check-content><xsl:copy-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-content/node()" />
 
-          		If <xsl:value-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-export/@export-name" />, this is a finding.
+          		If <xsl:value-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-export/@export-name" />, this is a finding.
           		</check-content>
           	</check>
 		  	<ident system="http://iase.disa.mil/cci"><xsl:value-of select="concat('CCI-', format-number($overlay_ref,'000000'))" /></ident>

--- a/Firefox/transforms/xccdf2html.xslt
+++ b/Firefox/transforms/xccdf2html.xslt
@@ -56,6 +56,9 @@
 <!-- Set up an id key to match on all Profiles -->
 <xsl:key name="profiles" match="cdf:Profile" use="@id"/>
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <!-- TEMPLATE for cdf:Benchmark
   -  This template takes care of the top-level structure of the
   -  generated XHTML document.  It handles the Benchmark element
@@ -630,9 +633,9 @@
      </xsl:for-each>
   </xsl:if>
 
-  <xsl:if test="./cdf:check[@system='ocil-transitional']">
+  <xsl:if test="./cdf:check[@system=$ocil_cs]">
   <xsl:variable name="manualcheck" select="concat('manualcheck-', @id)"/>
-    <xsl:for-each select="./cdf:check[@system='ocil-transitional']/cdf:check-content">
+    <xsl:for-each select="./cdf:check[@system=$ocil_cs]/cdf:check-content">
       <h4 class="expandstyle">
         <a href="javascript:toggle('{$manualcheck}', 'link-{$manualcheck}');" style="height:25px; line-height: 25px">
       	<span style="display:inline-block; vertical-align:middle"><img id="link-{$manualcheck}" src="images/collapsed.png" height="15" width="15" style="vertical-align: middle"/> Check Procedure</span>

--- a/Firefox/transforms/xccdf2stigformat.xslt
+++ b/Firefox/transforms/xccdf2stigformat.xslt
@@ -85,7 +85,7 @@ xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/sch
 		</fixtext>
 		<check system="{concat('C-',position(),'_chk')}">
 			<check-content>
-				<xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
+				<xsl:value-of select="cdf:check[@system=$ocil_cs]/cdf:check-content"/>
 			</check-content>
 		</check>
     </Rule>

--- a/JRE/Makefile
+++ b/JRE/Makefile
@@ -59,7 +59,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/oval/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
-	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
+#	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 #	Once things are relabelled, create a datastream

--- a/JRE/transforms/shorthand2xccdf.xslt
+++ b/JRE/transforms/shorthand2xccdf.xslt
@@ -209,7 +209,7 @@
   <!-- expand reference to would-be OCIL (inline) -->
   <xsl:template match="Rule/ocil">
       <check>
-        <xsl:attribute name="system">ocil-transitional</xsl:attribute>
+        <xsl:attribute name="system"><xsl:value-of select="$ocil_cs" /></xsl:attribute>
           <check-export>
 
           <xsl:attribute name="export-name">

--- a/JRE/transforms/xccdf-apply-overlay-stig.xslt
+++ b/JRE/transforms/xccdf-apply-overlay-stig.xslt
@@ -8,6 +8,9 @@
      content will be projected.  New Rules can thus be created based on external
      parties' identifiers or titles. -->
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <xsl:variable name="overlays" select="document($overlay)/xccdf:overlays" />
 
   <xsl:template match="xccdf:Benchmark">
@@ -33,9 +36,9 @@
           	<title><xsl:value-of select="$overlay_title"/></title>
           	<description><xsl:copy-of select="xccdf:rationale/node()" /></description>
           	<check system="C-{$overlay_id}_chk">
-          		<check-content><xsl:copy-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-content/node()" />
+          		<check-content><xsl:copy-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-content/node()" />
 
-          		If <xsl:value-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-export/@export-name" />, this is a finding.
+          		If <xsl:value-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-export/@export-name" />, this is a finding.
           		</check-content>
           	</check>
 		  	<ident system="http://iase.disa.mil/cci"><xsl:value-of select="concat('CCI-', format-number($overlay_ref,'000000'))" /></ident>

--- a/JRE/transforms/xccdf2html.xslt
+++ b/JRE/transforms/xccdf2html.xslt
@@ -56,6 +56,9 @@
 <!-- Set up an id key to match on all Profiles -->
 <xsl:key name="profiles" match="cdf:Profile" use="@id"/>
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <!-- TEMPLATE for cdf:Benchmark
   -  This template takes care of the top-level structure of the
   -  generated XHTML document.  It handles the Benchmark element
@@ -630,9 +633,9 @@
      </xsl:for-each>
   </xsl:if>
 
-  <xsl:if test="./cdf:check[@system='ocil-transitional']">
+  <xsl:if test="./cdf:check[@system=$ocil_cs]">
   <xsl:variable name="manualcheck" select="concat('manualcheck-', @id)"/>
-    <xsl:for-each select="./cdf:check[@system='ocil-transitional']/cdf:check-content">
+    <xsl:for-each select="./cdf:check[@system=$ocil_cs]/cdf:check-content">
       <h4 class="expandstyle">
         <a href="javascript:toggle('{$manualcheck}', 'link-{$manualcheck}');" style="height:25px; line-height: 25px">
       	<span style="display:inline-block; vertical-align:middle"><img id="link-{$manualcheck}" src="images/collapsed.png" height="15" width="15" style="vertical-align: middle"/> Check Procedure</span>

--- a/JRE/transforms/xccdf2stigformat.xslt
+++ b/JRE/transforms/xccdf2stigformat.xslt
@@ -85,7 +85,7 @@ xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/sch
 		</fixtext>
 		<check system="{concat('C-',position(),'_chk')}">
 			<check-content>
-				<xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
+				<xsl:value-of select="cdf:check[@system=$ocil_cs]/cdf:check-content"/>
 			</check-content>
 		</check>
     </Rule>

--- a/OpenStack/RHEL-OSP/7/Makefile
+++ b/OpenStack/RHEL-OSP/7/Makefile
@@ -77,7 +77,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/oval/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
-	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
+#	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 #	Once things are relabelled, create a datastream

--- a/OpenStack/RHEL-OSP/7/transforms/shorthand2xccdf.xslt
+++ b/OpenStack/RHEL-OSP/7/transforms/shorthand2xccdf.xslt
@@ -206,7 +206,7 @@
   <!-- expand reference to would-be OCIL (inline) -->
   <xsl:template match="Rule/ocil">
       <check>
-        <xsl:attribute name="system">ocil-transitional</xsl:attribute>
+        <xsl:attribute name="system"><xsl:value-of select="$ocil_cs" /></xsl:attribute>
           <check-export>
 
           <xsl:attribute name="export-name">

--- a/OpenStack/RHEL-OSP/7/transforms/xccdf-apply-overlay-stig.xslt
+++ b/OpenStack/RHEL-OSP/7/transforms/xccdf-apply-overlay-stig.xslt
@@ -8,6 +8,9 @@
      content will be projected.  New Rules can thus be created based on external
      parties' identifiers or titles. -->
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <xsl:variable name="overlays" select="document($overlay)/xccdf:overlays" />
 
   <xsl:template match="xccdf:Benchmark">
@@ -33,9 +36,9 @@
           	<title><xsl:value-of select="$overlay_title"/></title>
           	<description><xsl:copy-of select="xccdf:rationale/node()" /></description>
           	<check system="C-{$overlay_id}_chk">
-          		<check-content><xsl:copy-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-content/node()" />
+          		<check-content><xsl:copy-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-content/node()" />
 
-          		If <xsl:value-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-export/@export-name" />, this is a finding.
+          		If <xsl:value-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-export/@export-name" />, this is a finding.
           		</check-content>
           	</check>
 		  	<ident system="http://iase.disa.mil/cci"><xsl:value-of select="concat('CCI-', format-number($overlay_ref,'000000'))" /></ident>

--- a/OpenStack/RHEL-OSP/7/transforms/xccdf2html.xslt
+++ b/OpenStack/RHEL-OSP/7/transforms/xccdf2html.xslt
@@ -56,6 +56,9 @@
 <!-- Set up an id key to match on all Profiles -->
 <xsl:key name="profiles" match="cdf:Profile" use="@id"/>
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <!-- TEMPLATE for cdf:Benchmark
   -  This template takes care of the top-level structure of the
   -  generated XHTML document.  It handles the Benchmark element
@@ -630,9 +633,9 @@
      </xsl:for-each>
   </xsl:if>
 
-  <xsl:if test="./cdf:check[@system='ocil-transitional']">
+  <xsl:if test="./cdf:check[@system=$ocil_cs]">
   <xsl:variable name="manualcheck" select="concat('manualcheck-', @id)"/>
-    <xsl:for-each select="./cdf:check[@system='ocil-transitional']/cdf:check-content">
+    <xsl:for-each select="./cdf:check[@system=$ocil_cs]/cdf:check-content">
       <h4 class="expandstyle">
         <a href="javascript:toggle('{$manualcheck}', 'link-{$manualcheck}');" style="height:25px; line-height: 25px">
       	<span style="display:inline-block; vertical-align:middle"><img id="link-{$manualcheck}" src="images/collapsed.png" height="15" width="15" style="vertical-align: middle"/> Check Procedure</span>

--- a/OpenStack/RHEL-OSP/7/transforms/xccdf2stigformat.xslt
+++ b/OpenStack/RHEL-OSP/7/transforms/xccdf2stigformat.xslt
@@ -85,7 +85,7 @@ xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/sch
 		</fixtext>
 		<check system="{concat('C-',position(),'_chk')}">
 			<check-content>
-				<xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
+				<xsl:value-of select="cdf:check[@system=$ocil_cs]/cdf:check-content"/>
 			</check-content>
 		</check>
     </Rule>

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -64,7 +64,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/oval/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
-	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
+#	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 #	Once things are relabelled, create a datastream

--- a/RHEL/5/transforms/shorthand2xccdf.xslt
+++ b/RHEL/5/transforms/shorthand2xccdf.xslt
@@ -209,7 +209,7 @@
   <!-- expand reference to would-be OCIL (inline) -->
   <xsl:template match="Rule/ocil">
       <check>
-        <xsl:attribute name="system">ocil-transitional</xsl:attribute>
+        <xsl:attribute name="system"><xsl:value-of select="$ocil_cs" /></xsl:attribute>
           <check-export>
 
           <xsl:attribute name="export-name">

--- a/RHEL/5/transforms/xccdf-apply-overlay-stig.xslt
+++ b/RHEL/5/transforms/xccdf-apply-overlay-stig.xslt
@@ -8,6 +8,9 @@
      content will be projected.  New Rules can thus be created based on external
      parties' identifiers or titles. -->
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <xsl:variable name="overlays" select="document($overlay)/xccdf:overlays" />
 
   <xsl:template match="xccdf:Benchmark">
@@ -33,9 +36,9 @@
           	<title><xsl:value-of select="$overlay_title"/></title>
           	<description><xsl:copy-of select="xccdf:rationale/node()" /></description>
           	<check system="C-{$overlay_id}_chk">
-          		<check-content><xsl:copy-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-content/node()" />
+          		<check-content><xsl:copy-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-content/node()" />
 
-          		If <xsl:value-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-export/@export-name" />, this is a finding.
+          		If <xsl:value-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-export/@export-name" />, this is a finding.
           		</check-content>
           	</check>
 		  	<ident system="http://iase.disa.mil/cci"><xsl:value-of select="concat('CCI-', format-number($overlay_ref,'000000'))" /></ident>

--- a/RHEL/5/transforms/xccdf2html.xslt
+++ b/RHEL/5/transforms/xccdf2html.xslt
@@ -56,6 +56,9 @@
 <!-- Set up an id key to match on all Profiles -->
 <xsl:key name="profiles" match="cdf:Profile" use="@id"/>
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <!-- TEMPLATE for cdf:Benchmark
   -  This template takes care of the top-level structure of the
   -  generated XHTML document.  It handles the Benchmark element
@@ -630,9 +633,9 @@
      </xsl:for-each>
   </xsl:if>
 
-  <xsl:if test="./cdf:check[@system='ocil-transitional']">
+  <xsl:if test="./cdf:check[@system=$ocil_cs]">
   <xsl:variable name="manualcheck" select="concat('manualcheck-', @id)"/>
-    <xsl:for-each select="./cdf:check[@system='ocil-transitional']/cdf:check-content">
+    <xsl:for-each select="./cdf:check[@system=$ocil_cs]/cdf:check-content">
       <h4 class="expandstyle">
         <a href="javascript:toggle('{$manualcheck}', 'link-{$manualcheck}');" style="height:25px; line-height: 25px">
       	<span style="display:inline-block; vertical-align:middle"><img id="link-{$manualcheck}" src="images/collapsed.png" height="15" width="15" style="vertical-align: middle"/> Check Procedure</span>

--- a/RHEL/5/transforms/xccdf2stigformat.xslt
+++ b/RHEL/5/transforms/xccdf2stigformat.xslt
@@ -85,7 +85,7 @@ xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/sch
 		</fixtext>
 		<check system="{concat('C-',position(),'_chk')}">
 			<check-content>
-				<xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
+				<xsl:value-of select="cdf:check[@system=$ocil_cs]/cdf:check-content"/>
 			</check-content>
 		</check>
     </Rule>

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -77,8 +77,9 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Its second argument controls the IDs, as well as the output filenames.
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/oval/platform/$(PROD)-cpe-dictionary.xml $(ID)
+#	We replace OCIL <check-content> elements with OCIL <check-content-ref> elements directly in the XCCDF,
+#	thus there's no need to call relabelids on 'xccdf-unlinked-ocilrefs.xml' anymore
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
-	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 #	Once things are relabelled, create a datastream

--- a/RHEL/6/transforms/shorthand2xccdf.xslt
+++ b/RHEL/6/transforms/shorthand2xccdf.xslt
@@ -12,6 +12,7 @@
        whether it be xccdf, xhtml, or simply maintained from the
        input. -->
 
+<!-- Include shared XSLT constants -->
 <xsl:include href="constants.xslt"/>
 
 <xsl:param name="ssg_version">unknown</xsl:param>
@@ -209,7 +210,7 @@
   <!-- expand reference to would-be OCIL (inline) -->
   <xsl:template match="Rule/ocil">
       <check>
-        <xsl:attribute name="system">ocil-transitional</xsl:attribute>
+        <xsl:attribute name="system"><xsl:value-of select="$ocil_cs" /></xsl:attribute>
           <check-export>
 
           <xsl:attribute name="export-name">

--- a/RHEL/6/transforms/xccdf-apply-overlay-stig.xslt
+++ b/RHEL/6/transforms/xccdf-apply-overlay-stig.xslt
@@ -8,6 +8,8 @@
      content will be projected.  New Rules can thus be created based on external
      parties' identifiers or titles. -->
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
 <xsl:variable name="overlays" select="document($overlay)/xccdf:overlays" />
 
   <xsl:template match="xccdf:Benchmark">
@@ -33,9 +35,9 @@
           	<title><xsl:value-of select="$overlay_title"/></title>
           	<description><xsl:copy-of select="xccdf:rationale/node()" /></description>
           	<check system="C-{$overlay_id}_chk">
-          		<check-content><xsl:copy-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-content/node()" />
+			<check-content><xsl:copy-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-content/node()" />
 
-          		If <xsl:value-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-export/@export-name" />, this is a finding.
+			If <xsl:value-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-export/@export-name" />, this is a finding.
           		</check-content>
           	</check>
 		  	<ident system="http://iase.disa.mil/cci"><xsl:value-of select="concat('CCI-', format-number($overlay_ref,'000000'))" /></ident>

--- a/RHEL/6/transforms/xccdf2html.xslt
+++ b/RHEL/6/transforms/xccdf2html.xslt
@@ -56,6 +56,9 @@
 <!-- Set up an id key to match on all Profiles -->
 <xsl:key name="profiles" match="cdf:Profile" use="@id"/>
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <!-- TEMPLATE for cdf:Benchmark
   -  This template takes care of the top-level structure of the
   -  generated XHTML document.  It handles the Benchmark element
@@ -630,9 +633,9 @@
      </xsl:for-each>
   </xsl:if>
 
-  <xsl:if test="./cdf:check[@system='ocil-transitional']">
+  <xsl:if test="./cdf:check[@system=$ocil_cs]">
   <xsl:variable name="manualcheck" select="concat('manualcheck-', @id)"/>
-    <xsl:for-each select="./cdf:check[@system='ocil-transitional']/cdf:check-content">
+    <xsl:for-each select="./cdf:check[@system=$ocil_cs]/cdf:check-content">
       <h4 class="expandstyle">
         <a href="javascript:toggle('{$manualcheck}', 'link-{$manualcheck}');" style="height:25px; line-height: 25px">
       	<span style="display:inline-block; vertical-align:middle"><img id="link-{$manualcheck}" src="images/collapsed.png" height="15" width="15" style="vertical-align: middle"/> Check Procedure</span>

--- a/RHEL/6/transforms/xccdf2stigformat.xslt
+++ b/RHEL/6/transforms/xccdf2stigformat.xslt
@@ -5,6 +5,7 @@
      STIG. It expects an XCCDF file with exactly one Profile.
      -->
 
+<!-- Include shared XSLT constants -->
 <xsl:include href="constants.xslt"/>
 
 <xsl:strip-space elements="*" />
@@ -85,7 +86,7 @@ xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/sch
 		</fixtext>
 		<check system="{concat('C-',position(),'_chk')}">
 			<check-content>
-				<xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
+				<xsl:value-of select="cdf:check[@system=$ocil_cs]/cdf:check-content"/>
 			</check-content>
 		</check>
     </Rule>

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -82,7 +82,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/oval/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
-	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
+#	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 #	Once things are relabelled, create a datastream

--- a/RHEL/7/transforms/shorthand2xccdf.xslt
+++ b/RHEL/7/transforms/shorthand2xccdf.xslt
@@ -209,7 +209,7 @@
   <!-- expand reference to would-be OCIL (inline) -->
   <xsl:template match="Rule/ocil">
       <check>
-        <xsl:attribute name="system">ocil-transitional</xsl:attribute>
+        <xsl:attribute name="system"><xsl:value-of select="$ocil_cs" /></xsl:attribute>
           <check-export>
 
           <xsl:attribute name="export-name">

--- a/RHEL/7/transforms/xccdf-apply-overlay-stig.xslt
+++ b/RHEL/7/transforms/xccdf-apply-overlay-stig.xslt
@@ -8,6 +8,9 @@
      content will be projected.  New Rules can thus be created based on external
      parties' identifiers or titles. -->
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <xsl:variable name="overlays" select="document($overlay)/xccdf:overlays" />
 
   <xsl:template match="xccdf:Benchmark">
@@ -33,9 +36,9 @@
           	<title><xsl:value-of select="$overlay_title"/></title>
           	<description><xsl:copy-of select="xccdf:rationale/node()" /></description>
           	<check system="C-{$overlay_id}_chk">
-          		<check-content><xsl:copy-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-content/node()" />
+          		<check-content><xsl:copy-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-content/node()" />
 
-          		If <xsl:value-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-export/@export-name" />, this is a finding.
+          		If <xsl:value-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-export/@export-name" />, this is a finding.
           		</check-content>
           	</check>
 		  	<ident system="http://iase.disa.mil/cci"><xsl:value-of select="concat('CCI-', format-number($overlay_ref,'000000'))" /></ident>

--- a/RHEL/7/transforms/xccdf2html.xslt
+++ b/RHEL/7/transforms/xccdf2html.xslt
@@ -56,6 +56,9 @@
 <!-- Set up an id key to match on all Profiles -->
 <xsl:key name="profiles" match="cdf:Profile" use="@id"/>
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <!-- TEMPLATE for cdf:Benchmark
   -  This template takes care of the top-level structure of the
   -  generated XHTML document.  It handles the Benchmark element
@@ -630,9 +633,9 @@
      </xsl:for-each>
   </xsl:if>
 
-  <xsl:if test="./cdf:check[@system='ocil-transitional']">
+  <xsl:if test="./cdf:check[@system=$ocil_cs]">
   <xsl:variable name="manualcheck" select="concat('manualcheck-', @id)"/>
-    <xsl:for-each select="./cdf:check[@system='ocil-transitional']/cdf:check-content">
+    <xsl:for-each select="./cdf:check[@system=$ocil_cs]/cdf:check-content">
       <h4 class="expandstyle">
         <a href="javascript:toggle('{$manualcheck}', 'link-{$manualcheck}');" style="height:25px; line-height: 25px">
       	<span style="display:inline-block; vertical-align:middle"><img id="link-{$manualcheck}" src="images/collapsed.png" height="15" width="15" style="vertical-align: middle"/> Check Procedure</span>

--- a/RHEL/7/transforms/xccdf2stigformat.xslt
+++ b/RHEL/7/transforms/xccdf2stigformat.xslt
@@ -85,7 +85,7 @@ xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/sch
 		</fixtext>
 		<check system="{concat('C-',position(),'_chk')}">
 			<check-content>
-				<xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
+				<xsl:value-of select="cdf:check[@system=$ocil_cs]/cdf:check-content"/>
 			</check-content>
 		</check>
     </Rule>

--- a/RHEVM3/Makefile
+++ b/RHEVM3/Makefile
@@ -71,7 +71,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/oval/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
-	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
+#	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 

--- a/RHEVM3/transforms/shorthand2xccdf.xslt
+++ b/RHEVM3/transforms/shorthand2xccdf.xslt
@@ -206,7 +206,7 @@
   <!-- expand reference to would-be OCIL (inline) -->
   <xsl:template match="Rule/ocil">
       <check>
-        <xsl:attribute name="system">ocil-transitional</xsl:attribute>
+        <xsl:attribute name="system"><xsl:value-of select="$ocil_cs" /></xsl:attribute>
           <check-export>
 
           <xsl:attribute name="export-name">

--- a/RHEVM3/transforms/xccdf2stigformat.xslt
+++ b/RHEVM3/transforms/xccdf2stigformat.xslt
@@ -85,7 +85,7 @@ xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/sch
 		</fixtext>
 		<check system="{concat('C-',position(),'_chk')}">
 			<check-content>
-				<xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
+				<xsl:value-of select="cdf:check[@system=$ocil_cs]/cdf:check-content"/>
 			</check-content>
 		</check>
     </Rule>

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -61,7 +61,7 @@ content: $(OUT)/xccdf-unlinked-final.xml guide checks
 #	Thus, with ID set to ssg, this creates ssg-$(PROD)-xccdf.xml and ssg-$(PROD)-oval.xml.
 	$(SHARED)/$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/oval/platform/$(PROD)-cpe-dictionary.xml $(ID)
 	$(SHARED)/$(TRANS)/relabelids.py unlinked-$(PROD)-xccdf.xml $(ID)
-	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
+#	$(SHARED)/$(TRANS)/relabelids.py xccdf-unlinked-ocilrefs.xml $(ID)
 #	Expand 'test_attestation' URLs in OVAL document to valid SSG Contributors wiki link (fixes RHBZ#1155809 for OVAL)
 	xsltproc -o $(OUT)/$(ID)-$(PROD)-oval.xml $(TRANS)/oval-fix-test-attestation-urls.xslt $(OUT)/$(ID)-$(PROD)-oval.xml
 #	Once things are relabelled, create a datastream

--- a/Webmin/transforms/shorthand2xccdf.xslt
+++ b/Webmin/transforms/shorthand2xccdf.xslt
@@ -203,7 +203,7 @@
   <!-- expand reference to would-be OCIL (inline) -->
   <xsl:template match="Rule/ocil">
       <check>
-        <xsl:attribute name="system">ocil-transitional</xsl:attribute>
+        <xsl:attribute name="system"><xsl:value-of select="$ocil_cs" /></xsl:attribute>
           <check-export>
 
           <xsl:attribute name="export-name">

--- a/Webmin/transforms/xccdf-apply-overlay-stig.xslt
+++ b/Webmin/transforms/xccdf-apply-overlay-stig.xslt
@@ -8,6 +8,9 @@
      content will be projected.  New Rules can thus be created based on external
      parties' identifiers or titles. -->
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <xsl:variable name="overlays" select="document($overlay)/xccdf:overlays" />
 
   <xsl:template match="xccdf:Benchmark">
@@ -33,9 +36,9 @@
           	<title><xsl:value-of select="$overlay_title"/></title>
           	<description><xsl:copy-of select="xccdf:rationale/node()" /></description>
           	<check system="C-{$overlay_id}_chk">
-          		<check-content><xsl:copy-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-content/node()" />
+          		<check-content><xsl:copy-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-content/node()" />
 
-          		If <xsl:value-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-export/@export-name" />, this is a finding.
+          		If <xsl:value-of select="xccdf:check[@system=$ocil_cs]/xccdf:check-export/@export-name" />, this is a finding.
           		</check-content>
           	</check>
 		  	<ident system="http://iase.disa.mil/cci"><xsl:value-of select="concat('CCI-', format-number($overlay_ref,'000000'))" /></ident>

--- a/Webmin/transforms/xccdf2html.xslt
+++ b/Webmin/transforms/xccdf2html.xslt
@@ -56,6 +56,9 @@
 <!-- Set up an id key to match on all Profiles -->
 <xsl:key name="profiles" match="cdf:Profile" use="@id"/>
 
+<!-- Include shared XSLT constants -->
+<xsl:include href="constants.xslt"/>
+
 <!-- TEMPLATE for cdf:Benchmark
   -  This template takes care of the top-level structure of the
   -  generated XHTML document.  It handles the Benchmark element
@@ -630,9 +633,9 @@
      </xsl:for-each>
   </xsl:if>
 
-  <xsl:if test="./cdf:check[@system='ocil-transitional']">
+  <xsl:if test="./cdf:check[@system=$ocil_cs]">
   <xsl:variable name="manualcheck" select="concat('manualcheck-', @id)"/>
-    <xsl:for-each select="./cdf:check[@system='ocil-transitional']/cdf:check-content">
+    <xsl:for-each select="./cdf:check[@system=$ocil_cs]/cdf:check-content">
       <h4 class="expandstyle">
         <a href="javascript:toggle('{$manualcheck}', 'link-{$manualcheck}');" style="height:25px; line-height: 25px">
       	<span style="display:inline-block; vertical-align:middle"><img id="link-{$manualcheck}" src="images/collapsed.png" height="15" width="15" style="vertical-align: middle"/> Check Procedure</span>

--- a/Webmin/transforms/xccdf2stigformat.xslt
+++ b/Webmin/transforms/xccdf2stigformat.xslt
@@ -85,7 +85,7 @@ xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/sch
 		</fixtext>
 		<check system="{concat('C-',position(),'_chk')}">
 			<check-content>
-				<xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
+				<xsl:value-of select="cdf:check[@system=$ocil_cs]/cdf:check-content"/>
 			</check-content>
 		</check>
     </Rule>

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -73,10 +73,9 @@ $(OUT)/ocil-unlinked.xml: $(OUT)/xccdf-unlinked-resolved.xml $(SHARED)/$(TRANS)/
 	xsltproc -o $@ $(SHARED)/$(TRANS)/xccdf-create-ocil.xslt $<
 	xmllint --format --output $@ $@
 
-# Common build targets - an XCCDF that refers to OCIL document
-# Replace OCIL <check-content> elements with <check-content-ref> elements directly in the produced XCCDF file
+# Common build targets - produce separate XCCDF with OCIL <check-content> elements replaced with OCIL <check-content-ref> elements
 $(OUT)/xccdf-unlinked-ocilrefs.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/ocil-unlinked.xml $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $(SHARED)/$(TRANS)/shared_constants.xslt
-	xsltproc -o $< $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $<
+	xsltproc -o $@ $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $<
 
 # Common build targets - a catalogue of XCCDF remediations
 bash_remediations_deps= $(wildcard $(IN)/remediations/bash/*.sh) $(wildcard $(SHARED_REMEDIATIONS)/*.sh)
@@ -88,8 +87,10 @@ $(OUT)/bash-remediations.xml: $(SHARED)/$(TRANS)/combineremediations.py $(bash_r
 	find $(SHARED_REMEDIATIONS) $(IN)/remediations/bash -maxdepth 1 -type f -name *.sh -exec cp {} $(BUILD_REMEDIATIONS) ';'
 	$(SHARED)/$(TRANS)/combineremediations.py $(PROD) $(BUILD_REMEDIATIONS) $(OUT)/bash-remediations.xml
 
-# Common build targets - an XCCDF with remediations but not linked to OVAL yet
-$(OUT)/xccdf-unlinked-withremediations.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/xccdf-unlinked-ocilrefs.xml $(OUT)/bash-remediations.xml $(SHARED)/$(TRANS)/xccdf-addremediations.xslt
+# Common build targets - an XCCDF with remediations and OCIL <check-content-ref> expanded but not linked to OVAL yet
+$(OUT)/xccdf-unlinked-withremediations.xml: $(OUT)/xccdf-unlinked-ocilrefs.xml $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/bash-remediations.xml $(SHARED)/$(TRANS)/xccdf-addremediations.xslt
+	# Fixes https://github.com/OpenSCAP/scap-security-guide/issues/1037
+	# Fixes https://github.com/OpenSCAP/scap-security-guide/issues/1038
 	xsltproc -stringparam remediations "$(realpath $(OUT)/bash-remediations.xml)" -o $@ $(SHARED)/$(TRANS)/xccdf-addremediations.xslt $<
 	xmllint --format --output $@ $@
 

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -74,8 +74,9 @@ $(OUT)/ocil-unlinked.xml: $(OUT)/xccdf-unlinked-resolved.xml $(SHARED)/$(TRANS)/
 	xmllint --format --output $@ $@
 
 # Common build targets - an XCCDF that refers to OCIL document
+# Replace OCIL <check-content> elements with <check-content-ref> elements directly in the produced XCCDF file
 $(OUT)/xccdf-unlinked-ocilrefs.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/ocil-unlinked.xml $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $(SHARED)/$(TRANS)/shared_constants.xslt
-	xsltproc -o $@ $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $<
+	xsltproc -o $< $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $<
 
 # Common build targets - a catalogue of XCCDF remediations
 bash_remediations_deps= $(wildcard $(IN)/remediations/bash/*.sh) $(wildcard $(SHARED_REMEDIATIONS)/*.sh)

--- a/shared/transforms/relabelids.py
+++ b/shared/transforms/relabelids.py
@@ -67,7 +67,11 @@ def main():
                 if checks is not None:
                     for check in checks:
                         oval_id = check.get("name")
+                        # Verify match of XCCDF vs OVAL / OCIL IDs for
+                        # * the case of OVAL <check>
+                        # * the case of OCIL <check>
                         if not xccdf_rule == oval_id and oval_id is not None \
+                            and not xccdf_rule + '_ocil' == oval_id \
                             and not xccdf_rule == 'sample_rule':
                             print("The OVAL ID does not match the XCCDF Rule ID!\n"
                                   "\n  OVAL ID:       \'%s\'"

--- a/shared/transforms/xccdf-create-ocil.xslt
+++ b/shared/transforms/xccdf-create-ocil.xslt
@@ -5,9 +5,12 @@ xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" exclude-result-prefixes="cdf"
 xmlns:xhtml="http://www.w3.org/1999/xhtml"
 xmlns:date="http://exslt.org/dates-and-times" extension-element-prefixes="date" >
 
-<!-- This transform expects checks with system "ocil-transitional" and that these contain check-content
+<!-- This transform expects checks with system "$ocil_cs" and that these contain check-content
      that can transformed into OCIL questionnaires.
      -->
+
+<!-- Include shared XSLT constants -->
+<xsl:include href="shared_constants.xslt"/>
 
   <xsl:template match="/">
   <ocil xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://scap.nist.gov/schema/ocil/2.0" >
@@ -18,7 +21,7 @@ xmlns:date="http://exslt.org/dates-and-times" extension-element-prefixes="date" 
 
 	<questionnaires>
 	<xsl:for-each select=".//cdf:Rule">
-	<xsl:if test="cdf:check[@system='ocil-transitional']/cdf:check-content">
+	<xsl:if test="cdf:check[@system=$ocil_cs]/cdf:check-content">
 		<questionnaire id="{@id}_ocil">
 			<title><xsl:value-of select="cdf:title"/></title>
 			<actions>
@@ -31,7 +34,7 @@ xmlns:date="http://exslt.org/dates-and-times" extension-element-prefixes="date" 
 
 	<test_actions>
 	<xsl:for-each select=".//cdf:Rule">
-	<xsl:if test="cdf:check[@system='ocil-transitional']/cdf:check-content">
+	<xsl:if test="cdf:check[@system=$ocil_cs]/cdf:check-content">
 		<boolean_question_test_action id="{@id}_action" question_ref="{@id}_question">
 			<when_true>
 				<result>PASS</result>
@@ -46,11 +49,11 @@ xmlns:date="http://exslt.org/dates-and-times" extension-element-prefixes="date" 
 
 	<questions>
 	<xsl:for-each select=".//cdf:Rule">
-	<xsl:if test="cdf:check[@system='ocil-transitional']/cdf:check-content">
+	<xsl:if test="cdf:check[@system=$ocil_cs]/cdf:check-content">
 		<boolean_question id="{@id}_question">
 			<question_text>
-			<xsl:apply-templates select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
-			Is it the case that <xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-export/@export-name"/>?
+			<xsl:apply-templates select="cdf:check[@system=$ocil_cs]/cdf:check-content"/>
+			Is it the case that <xsl:value-of select="cdf:check[@system=$ocil_cs]/cdf:check-export/@export-name"/>?
 			</question_text>
 		</boolean_question>
 	</xsl:if>

--- a/shared/transforms/xccdf-create-ocil.xslt
+++ b/shared/transforms/xccdf-create-ocil.xslt
@@ -13,7 +13,7 @@ xmlns:date="http://exslt.org/dates-and-times" extension-element-prefixes="date" 
   <ocil xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://scap.nist.gov/schema/ocil/2.0" >
    <generator>
    <schema_version>2.0</schema_version>
-   <timestamp><xsl:value-of select="date:date()"/></timestamp>
+   <timestamp><xsl:value-of as="xs:dateTime" select="date:date-time()"/></timestamp>
    </generator>
 
 	<questionnaires>

--- a/shared/transforms/xccdf-ocilcheck2ref.xslt
+++ b/shared/transforms/xccdf-ocilcheck2ref.xslt
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" exclude-result-prefixes="xccdf">
 
+<!-- Include shared XSLT constants -->
 <xsl:include href="shared_constants.xslt"/>
 
 <!-- This transform replaces check-content with a check-content-ref, using the enclosing Rule id to create

--- a/shared/utils/verify-references.py
+++ b/shared/utils/verify-references.py
@@ -34,6 +34,7 @@ Usage:
 
 xccdf_ns = "http://checklists.nist.gov/xccdf/1.1"
 oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
+ocil_cs = "http://scap.nist.gov/schema/ocil/2"
 
 # we use these strings to look for references within the XCCDF rules
 nist_ref_href = "http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf"
@@ -98,7 +99,7 @@ def get_ovalfiles(checks):
             if not checkcontentref_hrefattr.startswith("http://") and \
                not checkcontentref_hrefattr.startswith("https://"):
                 ovalfiles.add(checkcontentref_hrefattr)
-        elif check.get("system") != "ocil-transitional":
+        elif check.get("system") != ocil_cs:
             print "Non-OVAL checking system found: " + check.get("system")
             exit_value = 1
     return ovalfiles
@@ -165,6 +166,11 @@ def main():
     # now we can actually do the verification work here
     if options.rules_with_invalid_checks or options.all_checks:
         for check_content_ref in check_content_refs:
+
+            # Skip those <check-content-ref> elements using OCIL as the checksystem
+            # (since we are checking just referenced OVAL definitions)
+            if check_content_ref.getparent().get("system") == ocil_cs:
+                continue
 
             # Obtain the value of the 'href' attribute of particular
             # <check-content-ref> element


### PR DESCRIPTION
The NIST SCAP content validation testsuite currently (https://jlieskov.fedorapeople.org/scap-scapversion-1.2-validation-result.html) reports numerous errors:
* that only OVAL and OCIL check systems are supported:
&nbsp; &nbsp; [1] https://github.com/OpenSCAP/scap-security-guide/issues/1037
* and that each OCIL ```<check>``` element needs to contain at least one ```<check-content-ref>``` element:
&nbsp; &nbsp; [2] https://github.com/OpenSCAP/scap-security-guide/issues/1038

Therefore:
* replace SSG specific ```ocil-transitional``` check system with the more official OCIL one (this suppresses first type of errors), and
* in the produced XCCDF file replace OCIL ```<check-content>``` element with the corresponding ```<check-content-ref>``` element (this suppresses second type of errors).

Fixes:
* https://github.com/OpenSCAP/scap-security-guide/issues/1037
* https://github.com/OpenSCAP/scap-security-guide/issues/1038

Note: Is it intentional that the ```ocil-transitional``` check system has been replaced with official OCIL one just for the case of ```RHEL/6``` benchmark (since replacing it everywhere in the repo would increase the scope of this change too much). We will do the same for the remaining products in future PRs.

Please review.

Thank you, Jan.