### PR TITLE
[Enhancement][RHEL/7] Add firewalld_sshd_disabled check and enable RHEL/7 make validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ validate-buildsystem:
 validate: fedora rhel5 rhel6 rhel7 debian8 rhel-osp7 rhevm3 chromium firefox jre
 	cd Fedora/ && $(MAKE) validate
 	cd RHEL/6/ && $(MAKE) validate
+	cd RHEL/7/ && $(MAKE) validate
 	#cd Debian/8/ && $(MAKE) validate
 	cd Chromium/ && $(MAKE) validate
 	cd Firefox/ && $(MAKE) validate
@@ -112,7 +113,6 @@ validate: fedora rhel5 rhel6 rhel7 debian8 rhel-osp7 rhevm3 chromium firefox jre
 	cd OpenStack/RHEL-OSP/7/ && $(MAKE) validate
 	# Enable below when content validates correctly
 	#cd RHEL/5/ && $(MAKE) validate
-	#cd RHEL/7/ && $(MAKE) validate
 	#cd RHEVM3 && $(MAKE) validate
 
 rpmroot:

--- a/shared/oval/firewalld_sshd_disabled.xml
+++ b/shared/oval/firewalld_sshd_disabled.xml
@@ -1,0 +1,60 @@
+<def-group>
+  <definition class="compliance" id="firewalld_sshd_disabled" version="1">
+    <metadata>
+      <title>Disallow inbound firewall access to the SSH Server port</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>If inbound SSH access is not needed, the firewall should disallow or reject access to
+      the SSH port (22).</description>
+      <reference source="galford" ref_id="20160215" ref_url="test_attestation" />
+    </metadata>
+    <criteria operator="AND">
+      <criterion comment="ssh service is not enabled in services" test_ref="test_firewalld_service_sshd" />
+      <criterion comment="ssh port is not enabled in services" test_ref="test_firewalld_service_sshd_port" />
+      <criterion comment="ssh service is not enabled in zones" test_ref="test_firewalld_zone_sshd" />
+      <criterion comment="ssh port is not enabled in zones" test_ref="test_firewalld_zone_sshd_port" />
+    </criteria>
+  </definition>
+
+  <ind:xmlfilecontent_test check="all" check_existence="none_exist" comment="ssh service is not enabled in services"
+  id="test_firewalld_service_sshd" version="1">
+    <ind:object object_ref="object_firewalld_service_sshd" />
+  </ind:xmlfilecontent_test>
+  <ind:xmlfilecontent_object id="object_firewalld_service_sshd" version="1">
+    <ind:path>/etc/firewalld/services</ind:path>
+    <ind:filename operation="pattern match">^.*\.xml$</ind:filename>
+    <ind:xpath>/service/service[@name='ssh']</ind:xpath>
+  </ind:xmlfilecontent_object>
+
+  <ind:xmlfilecontent_test check="all" check_existence="none_exist" comment="ssh port is not enabled in services"
+  id="test_firewalld_service_sshd_port" version="1">
+    <ind:object object_ref="object_firewalld_service_sshd_port" />
+  </ind:xmlfilecontent_test>
+  <ind:xmlfilecontent_object id="object_firewalld_service_sshd_port" version="1">
+    <ind:path>/etc/firewalld/services</ind:path>
+    <ind:filename operation="pattern match">^.*\.xml$</ind:filename>
+    <ind:xpath>/service/port[@port='22']</ind:xpath>
+  </ind:xmlfilecontent_object>
+
+  <ind:xmlfilecontent_test check="all" check_existence="none_exist" comment="ssh service is not enabled in zones"
+  id="test_firewalld_zone_sshd" version="1">
+    <ind:object object_ref="object_firewalld_zone_sshd" />
+  </ind:xmlfilecontent_test>
+  <ind:xmlfilecontent_object id="object_firewalld_zone_sshd" version="1">
+    <ind:path>/etc/firewalld/zones</ind:path>
+    <ind:filename operation="pattern match">^.*\.xml$</ind:filename>
+    <ind:xpath>/zone/service[@name='ssh']</ind:xpath>
+  </ind:xmlfilecontent_object>
+
+  <ind:xmlfilecontent_test check="all" check_existence="none_exist" comment="ssh port is not enabled in zones"
+  id="test_firewalld_zone_sshd_port" version="1">
+    <ind:object object_ref="object_firewalld_zone_sshd_port" />
+  </ind:xmlfilecontent_test>
+  <ind:xmlfilecontent_object id="object_firewalld_zone_sshd_port" version="1">
+    <ind:path>/etc/firewalld/zones</ind:path>
+    <ind:filename operation="pattern match">^.*\.xml$</ind:filename>
+    <ind:xpath>/zone/port[@port='22']</ind:xpath>
+  </ind:xmlfilecontent_object>
+
+</def-group>


### PR DESCRIPTION
- Add firewalld_sshd_disabled OVAL check
- Enable RHEL/7 `make validate` in global Makefile
- Fixes #635