### PR TITLE
[BugFix] [RHEL/6] Fixes scapval failures related to xccdf:check (issue #1037, issue #1038)

### DIFF
--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -73,7 +73,7 @@ $(OUT)/ocil-unlinked.xml: $(OUT)/xccdf-unlinked-resolved.xml $(SHARED)/$(TRANS)/
 	xsltproc -o $@ $(SHARED)/$(TRANS)/xccdf-create-ocil.xslt $<
 	xmllint --format --output $@ $@
 
-# Common build targets - an XCCDF that refers to OCIL document
+# Common build targets - an XCCDF witch OCIL checks in the form of official OCIL-2.0 syntax
 $(OUT)/xccdf-unlinked-ocilrefs.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/ocil-unlinked.xml $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $(SHARED)/$(TRANS)/shared_constants.xslt
 	xsltproc -o $@ $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $<
 
@@ -88,8 +88,11 @@ $(OUT)/bash-remediations.xml: $(SHARED)/$(TRANS)/combineremediations.py $(bash_r
 	$(SHARED)/$(TRANS)/combineremediations.py $(PROD) $(BUILD_REMEDIATIONS) $(OUT)/bash-remediations.xml
 
 # Common build targets - an XCCDF with remediations but not linked to OVAL yet
+# Prefer "$(OUT)/xccdf-unlinked-ocilrefs.xml" document below since it contains OCIL expanded to official OCIL-2.0 syntax
+# Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1037
+# Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1038
 $(OUT)/xccdf-unlinked-withremediations.xml: $(OUT)/xccdf-unlinked-ocilrefs.xml $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/bash-remediations.xml $(SHARED)/$(TRANS)/xccdf-addremediations.xslt
-	xsltproc -stringparam remediations "$(realpath $(OUT)/bash-remediations.xml)" -o $@ $(SHARED)/$(TRANS)/xccdf-addremediations.xslt $<
+	xsltproc -stringparam remediations "$(realpath $(OUT)/bash-remediations.xml)" -o $@ $(SHARED)/$(TRANS)/xccdf-addremediations.xslt $(OUT)/xccdf-unlinked-ocilrefs.xml
 	xmllint --format --output $@ $@
 
 # Sanity check to verify if intended remediations got truly included into the benchmark being currently build

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -88,7 +88,7 @@ $(OUT)/bash-remediations.xml: $(SHARED)/$(TRANS)/combineremediations.py $(bash_r
 	$(SHARED)/$(TRANS)/combineremediations.py $(PROD) $(BUILD_REMEDIATIONS) $(OUT)/bash-remediations.xml
 
 # Common build targets - an XCCDF with remediations but not linked to OVAL yet
-$(OUT)/xccdf-unlinked-withremediations.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/xccdf-unlinked-ocilrefs.xml $(OUT)/bash-remediations.xml $(SHARED)/$(TRANS)/xccdf-addremediations.xslt
+$(OUT)/xccdf-unlinked-withremediations.xml: $(OUT)/xccdf-unlinked-ocilrefs.xml $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/bash-remediations.xml $(SHARED)/$(TRANS)/xccdf-addremediations.xslt
 	xsltproc -stringparam remediations "$(realpath $(OUT)/bash-remediations.xml)" -o $@ $(SHARED)/$(TRANS)/xccdf-addremediations.xslt $<
 	xmllint --format --output $@ $@
 

--- a/shared/transforms/relabelids.py
+++ b/shared/transforms/relabelids.py
@@ -66,17 +66,20 @@ def main():
                 checks = rule.find("./{%s}check" % xccdf_ns)
                 if checks is not None:
                     for check in checks:
-                        oval_id = check.get("name")
+                        check_name = check.get("name")
                         # Verify match of XCCDF vs OVAL / OCIL IDs for
                         # * the case of OVAL <check>
                         # * the case of OCIL <check>
-                        if not xccdf_rule == oval_id and oval_id is not None \
-                            and not xccdf_rule + '_ocil' == oval_id \
-                            and not xccdf_rule == 'sample_rule':
-                            print("The OVAL ID does not match the XCCDF Rule ID!\n"
-                                  "\n  OVAL ID:       \'%s\'"
-                                  "\n  XCCDF Rule ID: \'%s\'"
-                                  "\n\nBoth OVAL and XCCDF Rule IDs must match!") % (oval_id, xccdf_rule)
+                        if (not xccdf_rule == check_name and check_name is not None \
+                            and not xccdf_rule + '_ocil' == check_name \
+                            and not xccdf_rule == 'sample_rule'):
+                            print("The OVAL / OCIL ID does not match the XCCDF Rule ID!\n")
+                            if '_ocil' in check_name:
+                                print("\n  OCIL ID:       \'%s\'" % check_name)
+                            else:
+                                print("\n  OVAL ID:       \'%s\'" % check_name)
+                            print("\n  XCCDF Rule ID: \'%s\'"
+                                  "\n\nBoth OVAL and XCCDF Rule IDs must match!" % xccdf_rule)
                             sys.exit(1)
 
     checks = xccdftree.findall(".//{%s}check" % xccdf_ns)

--- a/shared/transforms/relabelids.py
+++ b/shared/transforms/relabelids.py
@@ -67,7 +67,11 @@ def main():
                 if checks is not None:
                     for check in checks:
                         oval_id = check.get("name")
+                        # Verify match of XCCDF vs OVAL / OCIL IDs for
+                        # * the case of OVAL <check>
+                        # * the case of OCIL <check>
                         if not xccdf_rule == oval_id and oval_id is not None \
+                            and not xccdf_rule + '_ocil' == oval_id \
                             and not xccdf_rule == 'sample_rule':
                             print("The OVAL ID does not match the XCCDF Rule ID!\n"
                                   "\n  OVAL ID:       \'%s\'"

--- a/shared/transforms/xccdf-create-ocil.xslt
+++ b/shared/transforms/xccdf-create-ocil.xslt
@@ -13,7 +13,7 @@ xmlns:date="http://exslt.org/dates-and-times" extension-element-prefixes="date" 
   <ocil xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://scap.nist.gov/schema/ocil/2.0" >
    <generator>
    <schema_version>2.0</schema_version>
-   <timestamp><xsl:value-of select="date:date()"/></timestamp>
+   <timestamp><xsl:value-of as="xs:dateTime" select="date:date-time()"/></timestamp>
    </generator>
 
 	<questionnaires>

--- a/shared/utils/verify-references.py
+++ b/shared/utils/verify-references.py
@@ -34,6 +34,7 @@ Usage:
 
 xccdf_ns = "http://checklists.nist.gov/xccdf/1.1"
 oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
+ocil_cs = "http://scap.nist.gov/schema/ocil/2"
 
 # we use these strings to look for references within the XCCDF rules
 nist_ref_href = "http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf"
@@ -98,7 +99,7 @@ def get_ovalfiles(checks):
             if not checkcontentref_hrefattr.startswith("http://") and \
                not checkcontentref_hrefattr.startswith("https://"):
                 ovalfiles.add(checkcontentref_hrefattr)
-        elif check.get("system") != "ocil-transitional":
+        elif check.get("system") != ocil_cs:
             print "Non-OVAL checking system found: " + check.get("system")
             exit_value = 1
     return ovalfiles
@@ -165,6 +166,11 @@ def main():
     # now we can actually do the verification work here
     if options.rules_with_invalid_checks or options.all_checks:
         for check_content_ref in check_content_refs:
+
+            # Skip those <check-content-ref> elements using OCIL as the checksystem
+            # (since we are checking just referenced OVAL definitions)
+            if check_content_ref.getparent().get("system") == ocil_cs:
+                continue
 
             # Obtain the value of the 'href' attribute of particular
             # <check-content-ref> element


### PR DESCRIPTION
This is version 2 of a patchset to fix the following issues:
* https://github.com/OpenSCAP/scap-security-guide/issues/1037 and
* https://github.com/OpenSCAP/scap-security-guide/issues/1038

Basically is a replacement of / reimplementation of https://github.com/OpenSCAP/scap-security-guide/pull/1039 using @isimluk 's hint from https://github.com/OpenSCAP/scap-security-guide/pull/1039#issuecomment-185254662 and reducing the count of necessary changes to the minimum, so the produced XCCDF / DataStream files would contain official OCIL-2.0 as a check system.

Please review.

Thank you, Jan.