### PR TITLE
Add RHEL6 & RHEL7 "Compute Node" CPEs

### DIFF
--- a/RHEL/6/input/guide.xml
+++ b/RHEL/6/input/guide.xml
@@ -42,6 +42,7 @@ countries. All other names are registered trademarks or trademarks of their
 respective companies.</rear-matter>
 <platform idref="cpe:/o:redhat:enterprise_linux:6" />
 <platform idref="cpe:/o:redhat:enterprise_linux:6::client" />
+<platform idref="cpe:/o:redhat:enterprise_linux:6::computenode" />
 <version>0.9</version>
 <metadata>
 	<dc:publisher>SCAP Security Guide Project</dc:publisher>

--- a/RHEL/7/input/guide.xml
+++ b/RHEL/7/input/guide.xml
@@ -38,5 +38,6 @@ countries. All other names are registered trademarks or trademarks of their
 respective companies.</rear-matter>
 <platform idref="cpe:/o:redhat:enterprise_linux:7" />
 <platform idref="cpe:/o:redhat:enterprise_linux:7::client" />
+<platform idref="cpe:/o:redhat:enterprise_linux:7::computenode" />
 <version>0.9</version>
 </Benchmark>

--- a/shared/oval/installed_OS_is_rhel6.xml
+++ b/shared/oval/installed_OS_is_rhel6.xml
@@ -18,10 +18,9 @@
       <criterion comment="Installed operating system is part of the unix family"
       test_ref="test_unix_family" />
       <criteria operator="OR">
-        <criterion comment="Red Hat Enterprise Linux 6 Workstation is installed"
-        test_ref="test_rhel_workstation" />
-        <criterion comment="Red Hat Enterprise Linux 6 Server is installed"
-        test_ref="test_rhel_server" />
+        <criterion comment="RHEL 6 Workstation is installed" test_ref="test_rhel_workstation" />
+        <criterion comment="RHEL 6 Server is installed" test_ref="test_rhel_server" />
+        <criterion comment="RHEL 6 Compute Node is installed" test_ref="test_rhel_server" />
       </criteria>
     </criteria>
   </definition>
@@ -55,5 +54,16 @@
   </linux:rpminfo_state>
   <linux:rpminfo_object id="obj_rhel_server" version="1">
     <linux:name>redhat-release-server</linux:name>
+  </linux:rpminfo_object>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-computenode is version 6" id="test_rhel_computenode" version="1">
+    <linux:object object_ref="obj_rhel_computenode" />
+    <linux:state state_ref="state_rhel_computenode" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel_computenode" version="1">
+    <linux:version operation="pattern match">^6.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel_computenode" version="1">
+    <linux:name>redhat-release-computenode</linux:name>
   </linux:rpminfo_object>
 </def-group>

--- a/shared/oval/installed_OS_is_rhel7.xml
+++ b/shared/oval/installed_OS_is_rhel7.xml
@@ -16,10 +16,9 @@
       <criterion comment="Installed operating system is part of the unix family"
       test_ref="test_rhel7_unix_family" />
       <criteria operator="OR">
-        <criterion comment="Red Hat Enterprise Linux 7 Workstation is installed"
-        test_ref="test_rhel7_workstation" />
-        <criterion comment="Red Hat Enterprise Linux 7 Server is installed"
-        test_ref="test_rhel7_server" />
+        <criterion comment="RHEL 7 Workstation is installed" test_ref="test_rhel7_workstation" />
+        <criterion comment="RHEL 7 Server is installed" test_ref="test_rhel7_server" />
+        <criterion comment="RHEL 7 Compute Node is installed" test_ref="test_rhel7_computenode" />
       </criteria>
     </criteria>
   </definition>
@@ -53,5 +52,16 @@
   </linux:rpminfo_state>
   <linux:rpminfo_object id="obj_rhel7_server" version="1">
     <linux:name>redhat-release-server</linux:name>
+  </linux:rpminfo_object>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-computenode is version 7" id="test_rhel7_computenode" version="1">
+    <linux:object object_ref="obj_rhel7_computenode" />
+    <linux:state state_ref="state_rhel7_computenode" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel7_computenode" version="1">
+    <linux:version operation="pattern match">^7.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel7_computenode" version="1">
+    <linux:name>redhat-release-computenode</linux:name>
   </linux:rpminfo_object>
 </def-group>


### PR DESCRIPTION
Reported by Rick Ring on behalf of US Gov customer, the SSG content does not properly run on RHEL for Compute Node (receive "notapplicable"). Added CPEs.