### PR TITLE
Update kickstarts with static IP references

### DIFF
--- a/RHEL/6/kickstart/ssg-rhel6-stig-ks.cfg
+++ b/RHEL/6/kickstart/ssg-rhel6-stig-ks.cfg
@@ -49,6 +49,11 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/RHEL/7/kickstart/ssg-rhel7-ospp-ks.cfg
+++ b/RHEL/7/kickstart/ssg-rhel7-ospp-ks.cfg
@@ -49,6 +49,11 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)


### PR DESCRIPTION
Static IPs are needed for compliance, however DHCP is being used for developer convenience. Add gentle reminder of this, plus example of static IP config in kickstart files.