### PR TITLE
[BugFix] [RHEL/6] Add "cpe:/o:redhat:enterprise_linux:6::computenode" <xccdf:Platform>  definition into RHEL-6 CPE dictionary (issue #1060)

### DIFF
--- a/RHEL/6/input/oval/platform/rhel6-cpe-dictionary.xml
+++ b/RHEL/6/input/oval/platform/rhel6-cpe-dictionary.xml
@@ -12,6 +12,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel6</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:redhat:enterprise_linux:6::computenode">
+            <title xml:lang="en-us">Red Hat Enterprise Linux ComputeNode</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel6</check>
+      </cpe-item>
       <cpe-item name="cpe:/o:centos:centos:6">
             <title xml:lang="en-us">CentOS 6</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/shared/oval/installed_OS_is_rhel6.xml
+++ b/shared/oval/installed_OS_is_rhel6.xml
@@ -20,7 +20,7 @@
       <criteria operator="OR">
         <criterion comment="RHEL 6 Workstation is installed" test_ref="test_rhel_workstation" />
         <criterion comment="RHEL 6 Server is installed" test_ref="test_rhel_server" />
-        <criterion comment="RHEL 6 Compute Node is installed" test_ref="test_rhel_server" />
+        <criterion comment="RHEL 6 Compute Node is installed" test_ref="test_rhel_computenode" />
       </criteria>
     </criteria>
   </definition>


### PR DESCRIPTION

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1060

[BugFix] [RHEL/6] shared/oval/installed_OS_is_rhel6.xml - Fix test
name so on RHEL6 ComputeNode we would truly use ComputeNode test

Please review.

Thank you, Jan.