### PR TITLE
[bugfix][infrastructure] Update `make clean` to remove unused content

### DIFF
--- a/Chromium/Makefile
+++ b/Chromium/Makefile
@@ -122,4 +122,5 @@ dist: tables guide content
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
-	rm -rf $(DIST)/content
+	rm -rf $(DIST)/content $(DIST)/guide
+	rm -rf $(BUILD)

--- a/JRE/Makefile
+++ b/JRE/Makefile
@@ -125,4 +125,5 @@ dist: tables guide content
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
-	rm -rf $(DIST)/content
+	rm -rf $(DIST)/content $(DIST)/guide
+	rm -rf $(BUILD)

--- a/RHEVM3/Makefile
+++ b/RHEVM3/Makefile
@@ -123,5 +123,6 @@ dist: tables guide content
 #	cp -r $(PROD)/src/dist/* /usr/share/scap-security-guide/$(PROD)
 
 clean:
-	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini
-	rm -rf $(DIST)/content $(DIST)/policytables $(DIST)/guide
+	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
+	rm -rf $(DIST)/content $(DIST)/guide
+	rm -rf $(BUILD)

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -126,4 +126,5 @@ dist: tables guide content
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
-	rm -rf $(DIST)/content
+	rm -rf $(DIST)/content $(DIST)/guide
+	rm -rf $(BUILD)


### PR DESCRIPTION
- During global build, content was added to multiple product build directories but would never be  
  cleaned up when running `make clean`.
  This fixes that.