### PR TITLE
Don't build the RPM by default when running `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ DOCDIR=$(DATADIR)/doc
 
 # Define Makefile targets below
 
-all: validate-buildsystem fedora rhel5 rhel6 rhel7 rhel-osp7 rhevm3 webmin firefox jre chromium debian8 rpm
+all: validate-buildsystem fedora rhel5 rhel6 rhel7 rhel-osp7 rhevm3 webmin firefox jre chromium debian8
 dist: chromium-dist firefox-dist fedora-dist jre-dist rhel6-dist rhel7-dist rhel-osp7-dist debian8-dist
 jenkins: clean all validate dist
 


### PR DESCRIPTION
This improves build times and enables people without rpmbuild and other tools to build the content without resorting to non-default special targets.

The patch is very simple, this is more of a question whether we all agree building RPMs all the time was a bad idea. The RPM can still be built using `make rpm`.