### PR TITLE
Allow audit=1 to be matched on any instance found

### DIFF
--- a/shared/oval/bootloader_audit_argument.xml
+++ b/shared/oval/bootloader_audit_argument.xml
@@ -17,7 +17,7 @@
 
   <ind:textfilecontent54_test id="test_bootloader_audit_argument"
   comment="check for audit=1 in /etc/default/grub"
-  check="all" check_existence="all_exist" version="1">
+  check="at least one" check_existence="all_exist" version="1">
     <ind:object object_ref="object_bootloader_audit_argument" />
     <ind:state state_ref="state_bootloader_audit_argument" />
   </ind:textfilecontent54_test>


### PR DESCRIPTION
/etc/default/grub's GRUB_CMDLINE_LINUX variable contains system-specific
information.  The test as currently written forces audit=1 to be found
on all lines matching GRUB_CMDLINE_LINUX= which prevents appending
variables after the initial declaration like so:
GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX audit=1"

This allows puppet to configure the GRUB_CMDLINE_LINUX variable via file_line without worry of clobbering system-specific boot arguments.