### PR TITLE
Revert "Allow audit=1 to be matched on any instance found"

### DIFF
--- a/shared/oval/bootloader_audit_argument.xml
+++ b/shared/oval/bootloader_audit_argument.xml
@@ -17,7 +17,7 @@
 
   <ind:textfilecontent54_test id="test_bootloader_audit_argument"
   comment="check for audit=1 in /etc/default/grub"
-  check="at least one" check_existence="all_exist" version="1">
+  check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_bootloader_audit_argument" />
     <ind:state state_ref="state_bootloader_audit_argument" />
   </ind:textfilecontent54_test>


### PR DESCRIPTION
Reverts OpenSCAP/scap-security-guide#1086

See communication in PR#1086 why this is necessary.

Thanks, Jan.