### PR TITLE
Allow audit=1 to be matched on GRUB_CMDLINE_LINUX_DEFAULT

### DIFF
--- a/shared/oval/bootloader_audit_argument.xml
+++ b/shared/oval/bootloader_audit_argument.xml
@@ -10,13 +10,17 @@
       <reference source="JL" ref_id="RHEL7_20150817" ref_url="test_attestation" />
       <reference source="JL" ref_id="FEDORA22_20150817" ref_url="test_attestation" />
     </metadata>
-    <criteria>
-      <criterion test_ref="test_bootloader_audit_argument" comment="check for audit=1 in /etc/default/grub" />
+    <criteria operator="OR">
+      <criterion test_ref="test_bootloader_audit_argument" comment="check for audit=1 in /etc/default/grub via GRUB_CMDLINE_LINUX" />
+      <criteria operator="AND">
+        <criterion test_ref="test_bootloader_audit_argument_default" comment="check for audit=1 in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT" />
+        <criterion test_ref="test_bootloader_recovery_disabled" comment="check for GRUB_DISABLE_RECOVERY=true in /etc/default/grub" />
+      </criteria>
     </criteria>
   </definition>
 
   <ind:textfilecontent54_test id="test_bootloader_audit_argument"
-  comment="check for audit=1 in /etc/default/grub"
+  comment="check for audit=1 in /etc/default/grub via GRUB_CMDLINE_LINUX"
   check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_bootloader_audit_argument" />
     <ind:state state_ref="state_bootloader_audit_argument" />
@@ -28,8 +32,38 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  <ind:textfilecontent54_test id="test_bootloader_audit_argument_default"
+  comment="check for audit=1 in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_bootloader_audit_argument_default" />
+    <ind:state state_ref="state_bootloader_audit_argument" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_bootloader_audit_argument_default" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
   <ind:textfilecontent54_state id="state_bootloader_audit_argument" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^.*audit=1.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test id="test_bootloader_recovery_disabled"
+  comment="check for GRUB_DISABLE_RECOVERY=true in /etc/default/grub"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_bootloader_disable_recovery_argument" />
+    <ind:state state_ref="state_bootloader_disable_recovery_argument" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_bootloader_disable_recovery_argument" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_DISABLE_RECOVERY=(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_bootloader_disable_recovery_argument" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^true|"true"$</ind:subexpression>
   </ind:textfilecontent54_state>
 
 </def-group>


### PR DESCRIPTION
/etc/default/grub's GRUB_CMDLINE_LINUX variable contains system-specific
information.  GRUB_CMDLINE_LINUX_DEFAULT is used on all lines except for
the recovery kernel.  This commit allows audit=1 to be matched on the
GRUB_CMDLINE_LINUX_DEFAULT variable iff GRUB_DISABLE_RECOVERY=true.

Rework of https://github.com/OpenSCAP/scap-security-guide/pull/1086

I tested the following combinations:
pass: GCL_DEFAULT w/audit=1, DISABLE_RECOVERY="true"
pass: GCL_DEFAULT w/audit=1, DISABLE_RECOVERY=true
pass: GCL w/audit=1
fail: GCL_DEFAULT w/audit, DISABLE_RECOVERY=false
fail: GCL_DEFAULT w/audit
fail: DISABLE_RECOVERY=true