### PR TITLE
Missing descriptions in RHEL6 and RHEL7

### DIFF
--- a/RHEL/6/input/xccdf/services/ftp.xml
+++ b/RHEL/6/input/xccdf/services/ftp.xml
@@ -13,6 +13,8 @@ data available to the public.</description>
 
 <Group id="disabling_vsftpd">
 <title>Disable vsftpd if Possible</title>
+<description>To minimize attack surface, disable vsftpd if at all
+possible.</description>
 
 <Rule id="service_vsftpd_disabled">
 <title>Disable vsftpd Service</title>

--- a/RHEL/6/input/xccdf/services/ftp.xml
+++ b/RHEL/6/input/xccdf/services/ftp.xml
@@ -56,6 +56,8 @@ accidental activation.
 
 <Group id="ftp_use_vsftpd">
 <title>Use vsftpd to Provide FTP Service if Necessary</title>
+<description>If your use-case requires FTP service, install and
+set-up vsftpd to provide it.</description>
 
 <Rule id="package_vsftpd_installed">
 <title>Install vsftpd Package</title>

--- a/RHEL/6/input/xccdf/system/system.xml
+++ b/RHEL/6/input/xccdf/system/system.xml
@@ -1,5 +1,6 @@
 <Group id="system">
 <title>System Settings</title>
+<description>Contains rules that check correct system settings.</description>
 
 </Group>
 

--- a/RHEL/7/input/xccdf/services/ftp.xml
+++ b/RHEL/7/input/xccdf/services/ftp.xml
@@ -13,6 +13,8 @@ data available to the public.</description>
 
 <Group id="disabling_vsftpd">
 <title>Disable vsftpd if Possible</title>
+<description>To minimize attack surface, disable vsftpd if at all
+possible.</description>
 
 <Rule id="service_vsftpd_disabled">
 <title>Disable vsftpd Service</title>

--- a/RHEL/7/input/xccdf/services/ftp.xml
+++ b/RHEL/7/input/xccdf/services/ftp.xml
@@ -56,6 +56,8 @@ accidental activation.
 
 <Group id="ftp_use_vsftpd">
 <title>Use vsftpd to Provide FTP Service if Necessary</title>
+<description>If your use-case requires FTP service, install and
+set-up vsftpd to provide it.</description>
 
 <Rule id="package_vsftpd_installed">
 <title>Install vsftpd Package</title>

--- a/RHEL/7/input/xccdf/system/system.xml
+++ b/RHEL/7/input/xccdf/system/system.xml
@@ -1,5 +1,6 @@
 <Group id="system">
 <title>System Settings</title>
+<description>Contains rules that check correct system settings.</description>
 
 </Group>
 


### PR DESCRIPTION
3 missing Group descriptions prevent us from passing a SCAPVal requirement. This PR fixes that for RHEL7. I also fixed RHEL6 equivalents.

See #1087 for more details.