### PR TITLE
[BugFix] [Infrastructure] Fixes for issues #1092, #1095, and #1098

### DIFF
--- a/shared/transforms/relabelids.py
+++ b/shared/transforms/relabelids.py
@@ -43,6 +43,61 @@ def get_checkfiles(checks, checksystem):
     return checkfiles
 
 
+def create_xccdf_id_to_cce_id_mapping(xccdftree):
+    #
+    # Create dictionary having form of
+    #
+    # 'XCCDF ID' : 'CCE ID'
+    #
+    # for each XCCDF rule having <ident system='http://cce.mitre.org'>CCE-ID</ident>
+    # element set in the XCCDF document
+    xccdftocce_idmapping = {}
+
+    xccdfrules = xccdftree.findall(".//{%s}Rule" % xccdf_ns)
+    for rule in xccdfrules:
+        xccdfid = rule.get("id")
+        if xccdfid is not None:
+            identcce = rule.find("./{%s}ident[@system='http://cce.mitre.org']" % xccdf_ns)
+            if identcce is not None:
+                cceid = identcce.text
+                xccdftocce_idmapping[xccdfid] = cceid
+
+    return xccdftocce_idmapping
+
+
+def add_cce_id_refs_to_oval_checks(ovaltree, idmappingdict):
+    #
+    # For each XCCDF rule ID having <ident> CCE set and
+    # having OVAL check implemented (remote OVAL isn't sufficient!)
+    # add a new <reference> element into the OVAL definition having the
+    # following form:
+    #
+    # <reference source="CCE" ref_id="CCE-ID" />
+    #
+    # where "CCE-ID" is the CCE identifier for that particular rule
+    # retrieved from the XCCDF file
+    # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1092
+
+    ovalrules = ovaltree.findall(".//{%s}definition" % oval_ns)
+    for rule in ovalrules:
+        ovalid = rule.get("id")
+        ovaldesc = rule.find(".//{%s}description" % oval_ns)
+        # Assign <reference> CCE elements only to those OVAL checks whose
+        # XCCDF rule ID has <ident> CCE set
+        if ovalid is not None and \
+           ovaldesc is not None and \
+           ovalid in idmappingdict:
+            # Append the <reference source="CCE" ref_id="CCE-ID" /> element right
+            # after <description> element of specific OVAL check
+            xccdfcceid = idmappingdict[ovalid]
+            ccerefelem = ET.Element('reference', ref_id="%s" % xccdfcceid, source="CCE")
+            ovaldesc.addnext(ccerefelem)
+            # Sanity check if appending succeeded
+            if ccerefelem.getprevious() is not ovaldesc:
+                print ("\n\tError trying to add CCE ID to %s. Exiting" % ovalid)
+                sys.exit(1)
+
+
 def main():
     if len(sys.argv) < 3:
         print "Provide an XCCDF file and an ID name scheme."
@@ -54,8 +109,11 @@ def main():
     idname = sys.argv[2]
 
     os.chdir("./output")
-    # step over xccdf file, and find referenced check files
+    # Step over xccdf file, and find referenced check files
     xccdftree = parse_xml_file(xccdffile)
+
+    # Create XCCDF rule ID to assigned CCE ID mapping
+    xccdf_to_cce_id_mapping = create_xccdf_id_to_cce_id_mapping(xccdftree)
 
     # Check that OVAL IDs and XCCDF Rule IDs match
     if 'unlinked-ocilref' not in xccdffile:
@@ -94,21 +152,28 @@ def main():
 
     translator = idtranslate.idtranslator(idname)
 
-    # rename all IDs in the oval file
+    # Rename all IDs in the oval file
     if ovalfile:
         ovaltree = parse_xml_file(ovalfile)
+
+        # Add new <reference source="CCE" ref_id="CCE-ID" /> element to those OVAL
+        # checks having CCE ID already assigned in XCCDF for particular rule
+        # Exit with failure if the assignment wasn't successful
+        # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1092
+        add_cce_id_refs_to_oval_checks(ovaltree, xccdf_to_cce_id_mapping)
+
         ovaltree = translator.translate(ovaltree, store_defname=True)
         newovalfile = ovalfile.replace("unlinked", idname)
         ET.ElementTree(ovaltree).write(newovalfile)
 
-    # rename all IDs in the ocil file
+    # Rename all IDs in the ocil file
     if ocilfile:
         ociltree = parse_xml_file(ocilfile)
         ociltree = translator.translate(ociltree)
         newocilfile = ocilfile.replace("unlinked", idname)
         ET.ElementTree(ociltree).write(newocilfile)
 
-    # rename all IDs and file refs in the xccdf file
+    # Rename all IDs and file refs in the xccdf file
     for check in checks:
         checkcontentref = check.find("./{%s}check-content-ref" % xccdf_ns)
 


### PR DESCRIPTION
This changeset is performing the following:
* patch https://github.com/OpenSCAP/scap-security-guide/commit/93bb6a54418aa4b0bc5f57fad765caefe22683f6 is fixing majority of the problems reported in issue #1092 

  The SCAP NIST content validation test suite is requiring for each XCCDF rule having CCE <ident> tag and referencing OVAL definition, that OVAL definition to contain a ```<metadata>``` element in the form of ```<reference source="CCE" ref_id="concrete CCE ID for that rule from XCCDF" />```.

This patch is modifying the ```shared/transforms/relabelids.py``` helper script to propagate the CCE id information from XCCDF into corresponding OVAL definition,

Fixes (majority of issues from): https://github.com/OpenSCAP/scap-security-guide/issues/1092

* patch https://github.com/OpenSCAP/scap-security-guide/commit/7dff49f1a1d32ebc1cd38150bae6295cca776cec is performing the following:
  * adding a verification check if all local OVAL definitions referenced in XCCDF document are truly defined in the corresponding ```ssg-$(PROD)-oval.xml``` document,
  * in the case they aren't (case of the ```rsyslog_files_permissions``` rule when building RHEL-6 content with openscap-1.0.x) it also drops the ```<check-content>``` element from XCCDF for such a locally referenced OVAL.

Fixes (rest of issues from): https://github.com/OpenSCAP/scap-security-guide/issues/1092
Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1095
Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1098

Please review.

Thank you, Jan.