### PR TITLE
STIG updates to RPM verify

### DIFF
--- a/RHEL/7/input/xccdf/system/software/integrity.xml
+++ b/RHEL/7/input/xccdf/system/software/integrity.xml
@@ -124,14 +124,24 @@ modification of important files. To list which files on the system differ from w
 See the man page for <tt>rpm</tt> to see a complete explanation of each column.
 </description>
 
-<Rule id="rpm_verify_permissions">
+<Rule id="rpm_verify_permissions" severity="high">
 <title>Verify and Correct File Permissions with RPM</title>
 <description>
-The RPM package management system can check file access
-permissions of installed software packages, including many that are
-important to system security. 
-After locating a file with incorrect permissions, run the following command to determine which package owns it:
+Discretionary access control is weakened if a user or group has access
+permissions to system files and directories greater than the default.
+
+The RPM package management system can check file access permissions 
+of installed software packages, including many that are important 
+to system security. 
+
+Verify that the file permissions, ownership, and gruop membership of system files
+and commands match vendor values. Check the file permissions, ownership, and group
+membership with the following command:
+<pre>$ sudo rpm -Va | grep '^.M'</pre>
+
+Output indicates files that do not match vendor defaults. After locating a file with incorrect permissions, run the following command to determine which package owns it:
 <pre>$ rpm -qf <i>FILENAME</i></pre>
+
 Next, run the following command to reset its permissions to 
 the correct values:
 <pre>$ sudo rpm --setperms <i>PACKAGENAME</i></pre>
@@ -154,7 +164,7 @@ Bugzilla #1275532.
 </warning>
 <ident cce="27209-6" />
 <oval id="rpm_verify_permissions" />
-<ref nist="AC-6,CM-6(d),CM-6(3)" disa="1493,1494,1495" pcidss="Req-11.5" cis="1.2.6,6.1.3,6.1.4,6.1.5,6.1.6,6.1.7,6.1.8,6.1.9,6.2.3" />
+<ref nist="AC-6,CM-6(d),CM-6(3)" disa="1493,1494,1495" pcidss="Req-11.5" cis="1.2.6,6.1.3,6.1.4,6.1.5,6.1.6,6.1.7,6.1.8,6.1.9,6.2.3" stigid="010010" />
 </Rule>
 
 <Rule id="rpm_verify_hashes">


### PR DESCRIPTION
- Added DISA-provided RHEL7 STIG ID
- Updated to CAT I to match DISA rating
- Updated XCCDF description to align with DISA requested text