### PR TITLE
STIG update for rhel7/sysctl_net_ipv4_tcp_syncookies

### DIFF
--- a/RHEL/7/input/xccdf/system/network/kernel.xml
+++ b/RHEL/7/input/xccdf/system/network/kernel.xml
@@ -393,7 +393,7 @@ enables the system to continue servicing valid connection requests.
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="sysctl_net_ipv4_tcp_syncookies" value="sysctl_net_ipv4_tcp_syncookies_value" />
-<ref nist="AC-4,SC-5(2),SC-5(3)" disa="1092, 1095" cis="4.2.8" />
+<ref nist="AC-4,SC-5(1)(2),SC-5(2),SC-5(3)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="040430" cis="4.2.8" />
 <tested by="DS" on="20121024"/>
 </Rule>
 


### PR DESCRIPTION
- update references

![image](https://cloud.githubusercontent.com/assets/5713754/14038075/1c02671a-f222-11e5-82d2-648067943a85.png)
