### PR TITLE
[BugFix] [Infrastructure] Fix for issue #1096

### DIFF
--- a/Chromium/transforms/shorthand2xccdf.xslt
+++ b/Chromium/transforms/shorthand2xccdf.xslt
@@ -40,7 +40,7 @@
 
   <!-- insert SSG version -->
   <xsl:template match="Benchmark/version">
-    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+    <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/Fedora/transforms/shorthand2xccdf.xslt
+++ b/Fedora/transforms/shorthand2xccdf.xslt
@@ -40,7 +40,7 @@
 
   <!-- insert SSG version -->
   <xsl:template match="Benchmark/version">
-    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+    <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/Firefox/transforms/shorthand2xccdf.xslt
+++ b/Firefox/transforms/shorthand2xccdf.xslt
@@ -40,7 +40,7 @@
 
   <!-- insert SSG version -->
   <xsl:template match="Benchmark/version">
-    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+    <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/JRE/transforms/shorthand2xccdf.xslt
+++ b/JRE/transforms/shorthand2xccdf.xslt
@@ -40,7 +40,7 @@
 
   <!-- insert SSG version -->
   <xsl:template match="Benchmark/version">
-    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+    <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/OpenStack/RHEL-OSP/7/transforms/shorthand2xccdf.xslt
+++ b/OpenStack/RHEL-OSP/7/transforms/shorthand2xccdf.xslt
@@ -40,7 +40,7 @@
 
   <!-- insert SSG version -->
   <xsl:template match="Benchmark/version">
-    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+    <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/RHEL/5/transforms/shorthand2xccdf.xslt
+++ b/RHEL/5/transforms/shorthand2xccdf.xslt
@@ -40,7 +40,7 @@
 
   <!-- insert SSG version -->
   <xsl:template match="Benchmark/version">
-    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+    <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/RHEL/6/transforms/shorthand2xccdf.xslt
+++ b/RHEL/6/transforms/shorthand2xccdf.xslt
@@ -40,7 +40,7 @@
 
   <!-- insert SSG version -->
   <xsl:template match="Benchmark/version">
-    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+    <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/RHEL/7/transforms/shorthand2xccdf.xslt
+++ b/RHEL/7/transforms/shorthand2xccdf.xslt
@@ -40,7 +40,7 @@
 
   <!-- insert SSG version -->
   <xsl:template match="Benchmark/version">
-    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+    <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/RHEVM3/transforms/shorthand2xccdf.xslt
+++ b/RHEVM3/transforms/shorthand2xccdf.xslt
@@ -40,7 +40,7 @@
 
   <!-- insert SSG version -->
   <xsl:template match="Benchmark/version">
-    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+    <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/Webmin/transforms/shorthand2xccdf.xslt
+++ b/Webmin/transforms/shorthand2xccdf.xslt
@@ -40,7 +40,7 @@
 
   <!-- insert SSG version -->
   <xsl:template match="Benchmark/version">
-    <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
+    <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->

--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -17,6 +17,7 @@
 <xsl:variable name="pcidssuri">https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-1.pdf</xsl:variable>
 <xsl:variable name="anssiuri">http://www.ssi.gouv.fr/administration/bonnes-pratiques/</xsl:variable>
 <xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
+<xsl:variable name="ssg-benchmark-latest-uri">https://github.com/OpenSCAP/scap-security-guide/releases/latest</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 


### PR DESCRIPTION
<br/>
Add fix for issue #1096
<br/>
Fixes:  https://github.com/OpenSCAP/scap-security-guide/issues/1096
<br/>
Note: This will (fully) work only with ```1.0.11``` / ```1.2.9``` since it requires oscap fix for:
          https://github.com/OpenSCAP/openscap/issues/366
<br/>
I was originally thinking about making an SSG workaround till this is fixed in oscap (calling custom ```sed``` command). But playing with it, I am considering it ugly workaround (and worthless to introduce the additional complexity) for that short period of time till ```1.0.11``` / ```1.2.9``` are released. Thus adding just change which will insert @update attribute to SSG version during the build (pointing to latest SSG release).

Please review.

Thank you, Jan.