### PR TITLE
disable unused checking file digest differs by rpm

### DIFF
--- a/shared/remediations/bash/rpm_verify_permissions.sh
+++ b/shared/remediations/bash/rpm_verify_permissions.sh
@@ -5,7 +5,7 @@ declare -a SETPERMS_RPM_LIST
 
 # Create a list of files on the system having permissions different from what
 # is expected by the RPM database
-FILES_WITH_INCORRECT_PERMS=($(rpm -Va | grep '^.M'))
+FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep '^.M'))
 
 # For each file path from that list:
 # * Determine the RPM package the file path is shipped by,


### PR DESCRIPTION
Checking file digest differs causes full-file scan, but in this case we are just interesting in mode differs.