### PR TITLE
STIG update for RHEL7 SSH key permissions

### DIFF
--- a/RHEL/7/input/oval/file_permissions_sshd_private_key.xml
+++ b/RHEL/7/input/oval/file_permissions_sshd_private_key.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="compliance" id="file_permissions_sshd_private_key" version="1">
+    <metadata>
+      <title>SSH Server Private Key Permissions</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>File permissions for the SSH Server's private keys should be
+set to 0600 (or stronger). By default, these files are located at /etc/ssh.</description>
+      <reference source="galford" ref_id="20160401" ref_url="test_attestation"/>
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_file_permissions_sshd_private_key" />
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing file permissions" id="test_file_permissions_sshd_private_key" version="1">
+    <unix:object object_ref="object_file_permissions_sshd_private_key" />
+    <unix:state state_ref="state_file_permissions_sshd_private_key" />
+  </unix:file_test>
+
+  <unix:file_object comment="/etc/ssh" id="object_file_permissions_sshd_private_key" version="1">
+    <unix:path>/etc/ssh/</unix:path>
+    <unix:filename operation="pattern match">^.*key$</unix:filename>
+  </unix:file_object>
+
+  <unix:file_state id="state_file_permissions_sshd_private_key" version="1">
+    <unix:uexec datatype="boolean">false</unix:uexec>
+    <unix:gread datatype="boolean">false</unix:gread>
+    <unix:gwrite datatype="boolean">false</unix:gwrite>
+    <unix:gexec datatype="boolean">false</unix:gexec>
+    <unix:oread datatype="boolean">false</unix:oread>
+    <unix:owrite datatype="boolean">false</unix:owrite>
+    <unix:oexec datatype="boolean">false</unix:oexec>
+  </unix:file_state>
+</def-group>

--- a/RHEL/7/input/oval/file_permissions_sshd_pub_key.xml
+++ b/RHEL/7/input/oval/file_permissions_sshd_pub_key.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="file_permissions_sshd_pub_key" version="1">
+    <metadata>
+      <title>SSHD Service Public Key Permissions</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>File permissions for the SSH Server's public keys should be
+set to 0644 (or stronger). By default, these files are located at /etc/ssh.</description>
+      <reference source="galford" ref_id="20160401" ref_url="test_attestation"/>
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_file_permissions_sshd_pub_key" />
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing file permissions" id="test_file_permissions_sshd_pub_key" version="1">
+    <unix:object object_ref="object_file_permissions_sshd_pub_key" />
+    <unix:state state_ref="state_file_permissions_sshd_pub_key" />
+  </unix:file_test>
+
+  <unix:file_object comment="/etc/ssh" id="object_file_permissions_sshd_pub_key" version="1">
+    <unix:path>/etc/ssh/</unix:path>
+    <unix:filename operation="pattern match">^.*key.pub$</unix:filename>
+  </unix:file_object>
+
+  <unix:file_state id="state_file_permissions_sshd_pub_key" version="1">
+    <unix:uexec datatype="boolean">false</unix:uexec>
+    <unix:gwrite datatype="boolean">false</unix:gwrite>
+    <unix:gexec datatype="boolean">false</unix:gexec>
+    <unix:owrite datatype="boolean">false</unix:owrite>
+    <unix:oexec datatype="boolean">false</unix:oexec>
+  </unix:file_state>
+</def-group>

--- a/RHEL/7/input/xccdf/services/ssh.xml
+++ b/RHEL/7/input/xccdf/services/ssh.xml
@@ -34,6 +34,36 @@ remote access.
 <tested by="DS" on="20121024"/>
 </Rule>
 
+<Rule id="file_permissions_sshd_pub_key">
+<title>Verify Permissions on SSH Server Public <tt>*.pub</tt> Key Files</title>
+<description><fileperms-desc-macro file="/etc/ssh/*.pub" perms="0644"/></description>
+</description>
+<ocil><fileperms-check-macro file="/etc/ssh/*.pub" perms="-rw-r--r--"/></ocil>
+<rationale>
+If a public host key file is modified by an unauthorized user, the SSH service
+may be compromised.
+</rationale>
+<ident cce="RHEL7-CCE-TBD" />
+<ref nist="AC-6" disa="366"
+ossrg="SRG-OS-000480-GPOS-00227" stigid="040640"/>
+<oval id="file_permissions_sshd_pub_key" />
+</Rule>
+
+<Rule id="file_permissions_sshd_private_key">
+<title>Verify Permissions on SSH Server Private <tt>*_key</tt> Key Files</title>
+<description><fileperms-desc-macro file="/etc/ssh/*_key" perms="0600"/></description>
+</description>
+<ocil><fileperms-check-macro file="/etc/ssh/*.pub" perms="-rw-------"/></ocil>
+<rationale>
+If an unauthorized user obtains the private SSH host key file, the host could be
+impersonated.
+</rationale>
+<ident cce="RHEL7-CCE-TBD" />
+<ref nist="AC-6" disa="366"
+ossrg="SRG-OS-000480-GPOS-00227" stigid="040650"/>
+<oval id="file_permissions_sshd_private_key" />
+</Rule>
+
 <Rule id="firewalld_sshd_disabled">
 <title>Remove SSH Server <tt>firewalld</tt> Firewall exception (Unusual)</title>
 <description>By default, inbound connections to SSH's port are allowed. If 

--- a/RHEL/7/input/xccdf/services/ssh.xml
+++ b/RHEL/7/input/xccdf/services/ssh.xml
@@ -37,7 +37,6 @@ remote access.
 <Rule id="file_permissions_sshd_pub_key" severity="medium">
 <title>Verify Permissions on SSH Server Public <tt>*.pub</tt> Key Files</title>
 <description><fileperms-desc-macro file="/etc/ssh/*.pub" perms="0644"/></description>
-</description>
 <ocil><fileperms-check-macro file="/etc/ssh/*.pub" perms="-rw-r--r--"/></ocil>
 <rationale>
 If a public host key file is modified by an unauthorized user, the SSH service
@@ -52,7 +51,6 @@ ossrg="SRG-OS-000480-GPOS-00227" stigid="040640"/>
 <Rule id="file_permissions_sshd_private_key" severity="medium">
 <title>Verify Permissions on SSH Server Private <tt>*_key</tt> Key Files</title>
 <description><fileperms-desc-macro file="/etc/ssh/*_key" perms="0600"/></description>
-</description>
 <ocil><fileperms-check-macro file="/etc/ssh/*.pub" perms="-rw-------"/></ocil>
 <rationale>
 If an unauthorized user obtains the private SSH host key file, the host could be

--- a/RHEL/7/input/xccdf/services/ssh.xml
+++ b/RHEL/7/input/xccdf/services/ssh.xml
@@ -34,7 +34,7 @@ remote access.
 <tested by="DS" on="20121024"/>
 </Rule>
 
-<Rule id="file_permissions_sshd_pub_key">
+<Rule id="file_permissions_sshd_pub_key" severity="medium">
 <title>Verify Permissions on SSH Server Public <tt>*.pub</tt> Key Files</title>
 <description><fileperms-desc-macro file="/etc/ssh/*.pub" perms="0644"/></description>
 </description>
@@ -49,7 +49,7 @@ ossrg="SRG-OS-000480-GPOS-00227" stigid="040640"/>
 <oval id="file_permissions_sshd_pub_key" />
 </Rule>
 
-<Rule id="file_permissions_sshd_private_key">
+<Rule id="file_permissions_sshd_private_key" severity="medium">
 <title>Verify Permissions on SSH Server Private <tt>*_key</tt> Key Files</title>
 <description><fileperms-desc-macro file="/etc/ssh/*_key" perms="0600"/></description>
 </description>


### PR DESCRIPTION
- Add XCCDF and OVAL for SSH Server private and public key permissions