### PR TITLE
Add service_kdump_disabled to RHEL7 STIG profile

### DIFF
--- a/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
@@ -93,6 +93,7 @@
 <!-- Miscellaneous Services -->
 <select idref="service_zebra_disabled" selected="true" />
 <select idref="snmpd_not_default_password" selected="true" />
+<select idref="service_kdump_disabled" selected="true" />
 
 <!-- Currently uncategorized -->
 <select idref="disable_ctrlaltdel_reboot" selected="true" />


### PR DESCRIPTION
Now that service_kdump_disabled has DISA language, adding to STIG profile

ref https://github.com/OpenSCAP/scap-security-guide/pull/1184/