### PR TITLE
[BugFix] [Infrastructure] FIx for issues #1189 and #1190

### DIFF
--- a/shared/transforms/xccdf-ocilcheck2ref.xslt
+++ b/shared/transforms/xccdf-ocilcheck2ref.xslt
@@ -22,6 +22,12 @@
        Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1190 -->
   <xsl:template match="xccdf:check-export[@value-id='conditional_clause']"/>
 
+  <!-- Remove the "conditional_clause" <xccdf:Value> since it was required only to expand OCIL macros
+       to insert proper questions when creating OCIL content. At this stage the OCIL content was built
+       alreaady, thus "conditional_clause" is not needed anymore in the final XCCDF benchmark (and only
+       causing confusion e.g. in SCAP Workbench tool -->
+  <xsl:template match="xccdf:Value[@id='conditional_clause']"/>
+
   <!-- Remove check-content nodes and replace them with a check-content-ref node, using the Rule id
        to create a reference name -->
   <xsl:template match="xccdf:check-content">

--- a/shared/transforms/xccdf-ocilcheck2ref.xslt
+++ b/shared/transforms/xccdf-ocilcheck2ref.xslt
@@ -6,7 +6,7 @@
 <!-- This transform replaces check-content with a check-content-ref, using the enclosing Rule id to create
      an id for the check (by appending "_ocil") -->
 
-  <!-- replace check system attribute with the real OCIL one -->
+  <!-- Replace check system attribute with the real OCIL one -->
   <xsl:template match="xccdf:check[@system='ocil-transitional']">
     <xsl:copy>
 		<xsl:apply-templates select="@*" />
@@ -15,7 +15,14 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- remove check-content nodes and replace them with a check-content-ref node, using the Rule id
+  <!-- Remove OCIL <check-export> nodes since they were used only to append the appropriate question
+       to OCIL <check-content> nodes by previous run of $(SHARED)/$(TRANS)/xccdf-create-ocil.xslt.
+       But at this state of building the content this has been already finished.
+       Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1189
+       Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1190 -->
+  <xsl:template match="xccdf:check-export[@value-id='conditional_clause']"/>
+
+  <!-- Remove check-content nodes and replace them with a check-content-ref node, using the Rule id
        to create a reference name -->
   <xsl:template match="xccdf:check-content">
 	<xsl:element name="check-content-ref" namespace="http://checklists.nist.gov/xccdf/1.1">
@@ -25,7 +32,7 @@
   </xsl:template>
 
 
-  <!-- copy everything else through to final output -->
+  <!-- Copy everything else through to final output -->
   <xsl:template match="@*|node()">
     <xsl:copy>
       <xsl:apply-templates select="@*|node()" />


### PR DESCRIPTION
Update xccdf-ocilcheck2ref.xslt transformation to also remove <xccdf:check-export> OCIL elements
of the form e.g.:
```
  <xccdf:check-export export-name="no line is returned" value-id="conditional_clause"/>
```
since these were used only in the previous stage of the build to append
the correct question to the particular OCIL <check-content> element.

But when kept in the final XCCDF they are causing issues like in:
* https://github.com/OpenSCAP/scap-security-guide/issues/1190
* https://github.com/OpenSCAP/scap-security-guide/issues/1189

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1189
Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1190

Please review.

Thank you, Jan.

