### PR TITLE
[Blocker] [BugFix] [Infrastructure] [RHEL/7] use_kerberos_security_all_exports OVAL

### DIFF
--- a/RHEL/7/input/oval/use_kerberos_security_all_exports.xml
+++ b/RHEL/7/input/oval/use_kerberos_security_all_exports.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="use_kerberos_security_all_exports" version="1">
+  <definition class="compliance" id="use_kerberos_security_all_exports" version="2">
     <metadata>
       <title>Use Kerberos Security on All Exports</title>
       <affected family="unix">
@@ -7,10 +7,9 @@
       </affected>
       <description>Using Kerberos Security allows to cryptography authenticate a
       valid user to an NFS share.</description>
-      <reference source="galford" ref_id="20160405" ref_url="test_attestation" />
+      <reference source="JL" ref_id="20160411" ref_url="test_attestation" />
     </metadata>
-    <criteria operator="OR">
-      <extend_definition comment="nfs-utils removed" definition_ref="package_nfs-utils_removed" />
+    <criteria>
       <criterion comment="Check for Kerberos settings in /etc/exports"
       test_ref="test_use_kerberos_security_all_exports" />
     </criteria>


### PR DESCRIPTION

Drop useless dependency on ```package_nfs-utils_removed``` OVAL check

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1196

My (only assumption) being the dependency on ```package_nfs-utils_removed``` OVAL
check has been added to ensure ```/etc/exports``` file is installed on the underlying system.

But ```/etc/exports``` isn't owned by ```nfs-utils``` package, but rather by ```setup``` package
(see below for details):
```
# rpm -qf /etc/exports 
setup-2.8.14-20.el6_4.1.noarch
# rpm -ql setup | grep exports
/etc/exports
```
And since the ```setup``` package is one of the core components (attempt to remove it leads to situation where lot of system critical packages would be uninstalled, basically leading to unusable system), it's not necessary to check verify if ```/etc/exports``` is present on the system.

Because in the case it isn't, there is something truly very wrong with such a system.

Besides making the ```use_kerberos_security_all_exports``` more clean, the fix for this has the nice side effect of fixing https://github.com/OpenSCAP/scap-security-guide/issues/1196 issue too.

Please review.

Thank you, Jan.