### PR TITLE
[BugFix] [Infrastructure] Fix XCCDF to OVAL data export warnings

### DIFF
--- a/RHEL/5/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/5/input/xccdf/system/accounts/physical.xml
@@ -269,7 +269,7 @@ enforcing preferences in the GNOME environment using the GConf
 configuration system, see http://projects.gnome.org/gconf and
 the man page <tt>gconftool-2(1)</tt>.</description>
 
-<Value id="inactivity_timeout_value" type="string" operator="equals">
+<Value id="inactivity_timeout_value" type="number" operator="equals">
 <title>Inactivity timeout</title>
 <description>Choose allowed duration of inactive SSH connections, shells, and X sessions</description>
 <value>15</value>

--- a/RHEL/6/input/xccdf/system/accounts/session.xml
+++ b/RHEL/6/input/xccdf/system/accounts/session.xml
@@ -24,7 +24,7 @@ operator="equals" interactive="0">
 <value selector="20">20</value>
 </Value>
 
-<Value id="var_accounts_tmout" type="number" operator="equals" interactive="0">
+<Value id="var_accounts_tmout" type="string" operator="equals" interactive="0">
 <title>Account Inactivity Timeout (minutes)</title>
 <description>In an interactive shell, the value is interpreted as the
 number of seconds to wait for input after issueing the primary prompt.

--- a/RHEL/6/input/xccdf/system/accounts/session.xml
+++ b/RHEL/6/input/xccdf/system/accounts/session.xml
@@ -24,7 +24,7 @@ operator="equals" interactive="0">
 <value selector="20">20</value>
 </Value>
 
-<Value id="var_accounts_tmout" type="string" operator="equals" interactive="0">
+<Value id="var_accounts_tmout" type="number" operator="equals" interactive="0">
 <title>Account Inactivity Timeout (minutes)</title>
 <description>In an interactive shell, the value is interpreted as the
 number of seconds to wait for input after issueing the primary prompt.

--- a/RHEL/6/input/xccdf/system/network/ipv6.xml
+++ b/RHEL/6/input/xccdf/system/network/ipv6.xml
@@ -104,7 +104,7 @@ forwarding is disabled)</description>
 <value selector="disabled">no</value>
 </Value>
 
-<Value id="sysctl_net_ipv6_conf_default_accept_ra_value" type="string"
+<Value id="sysctl_net_ipv6_conf_default_accept_ra_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv6.conf.default.accept_ra</title>
 <description>Accept default router advertisements?</description>
@@ -113,7 +113,7 @@ operator="equals" interactive="0">
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv6_conf_default_accept_redirects_value" type="string"
+<Value id="sysctl_net_ipv6_conf_default_accept_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv6.conf.default.accept_redirects</title>
 <description>Toggle ICMP Redirect Acceptance</description>

--- a/RHEL/6/input/xccdf/system/network/kernel.xml
+++ b/RHEL/6/input/xccdf/system/network/kernel.xml
@@ -70,7 +70,7 @@ only appropriate for systems acting as routers.</rationale>
 acting as either hosts or routers to improve the system's ability defend
 against certain types of IPv4 protocol attacks.</description>
 
-<Value id="sysctl_net_ipv4_conf_all_accept_source_route_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_accept_source_route_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.accept_source_route</title>
 <description>Trackers could be using source-routed packets to
@@ -81,7 +81,7 @@ created outside and has been redirected.</description>
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv4_conf_all_accept_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_accept_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.accept_redirects</title>
 <description>Disable ICMP Redirect Acceptance</description>
@@ -90,7 +90,7 @@ operator="equals" interactive="0">
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv4_conf_all_secure_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_secure_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.secure_redirects</title>
 <description>Enable to prevent hijacking of routing path by only
@@ -101,7 +101,7 @@ table.</description>
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv4_conf_all_log_martians_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_log_martians_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.log_martians</title>
 <description>Disable so you don't Log Spoofed Packets, Source
@@ -112,7 +112,7 @@ Routed Packets, Redirect Packets</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_default_accept_source_route_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_accept_source_route_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.accept_source_route</title>
 <description>Disable IP source routing?</description>
@@ -122,7 +122,7 @@ operator="equals" interactive="0">
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_default_accept_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_accept_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.accept_redirects</title>
 <description>Disable ICMP Redirect Acceptance?</description>
@@ -132,7 +132,7 @@ operator="equals" interactive="0">
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_default_secure_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_secure_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.secure_redirects</title>
 <description>Log packets with impossible addresses to kernel
@@ -143,7 +143,7 @@ log?</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" type="string"
+<Value id="sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.icmp_echo_ignore_broadcasts</title>
 <description>Ignore all ICMP ECHO and TIMESTAMP requests sent to it
@@ -154,7 +154,7 @@ via broadcast/multicast</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value" type="string"
+<Value id="sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.icmp_ignore_bogus_error_responses</title>
 <description>Enable to prevent unnecessary logging</description>
@@ -164,7 +164,7 @@ operator="equals" interactive="0">
 </Value>
 
 
-<Value id="sysctl_net_ipv4_tcp_syncookies_value" type="string"
+<Value id="sysctl_net_ipv4_tcp_syncookies_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.tcp_syncookies</title>
 <description>Enable to turn on TCP SYN Cookie
@@ -175,7 +175,7 @@ Protection</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_all_rp_filter_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_rp_filter_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.rp_filter</title>
 <description>Enable to enforce sanity checking, also called ingress
@@ -189,7 +189,7 @@ it arrived.</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_default_rp_filter_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_rp_filter_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.rp_filter</title>
 <description>Enables source route verification</description>

--- a/RHEL/7/input/xccdf/system/network/ipv6.xml
+++ b/RHEL/7/input/xccdf/system/network/ipv6.xml
@@ -103,7 +103,7 @@ forwarding is disabled)</description>
 <value selector="disabled">no</value>
 </Value>
 
-<Value id="sysctl_net_ipv6_conf_all_accept_source_route_value" type="string"
+<Value id="sysctl_net_ipv6_conf_all_accept_source_route_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv6.conf.all.accept_source_route</title>
 <description>Trackers could be using source-routed packets to
@@ -114,7 +114,7 @@ created outside and has been redirected.</description>
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv6_conf_default_accept_ra_value" type="string"
+<Value id="sysctl_net_ipv6_conf_default_accept_ra_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv6.conf.default.accept_ra</title>
 <description>Accept default router advertisements by default?</description>
@@ -123,7 +123,7 @@ operator="equals" interactive="0">
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv6_conf_all_accept_ra_value" type="string"
+<Value id="sysctl_net_ipv6_conf_all_accept_ra_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv6.conf.all.accept_ra</title>
 <description>Accept all router advertisements?</description>
@@ -132,7 +132,7 @@ operator="equals" interactive="0">
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv6_conf_default_accept_redirects_value" type="string"
+<Value id="sysctl_net_ipv6_conf_default_accept_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv6.conf.default.accept_redirects</title>
 <description>Toggle ICMP Redirect Acceptance By Default</description>
@@ -141,7 +141,7 @@ operator="equals" interactive="0">
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv6_conf_all_accept_redirects_value" type="string"
+<Value id="sysctl_net_ipv6_conf_all_accept_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv6.conf.all.accept_redirects</title>
 <description>Toggle ICMP Redirect Acceptance</description>

--- a/RHEL/7/input/xccdf/system/network/kernel.xml
+++ b/RHEL/7/input/xccdf/system/network/kernel.xml
@@ -70,7 +70,7 @@ only appropriate for systems acting as routers.</rationale>
 acting as either hosts or routers to improve the system's ability defend
 against certain types of IPv4 protocol attacks.</description>
 
-<Value id="sysctl_net_ipv4_conf_all_accept_source_route_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_accept_source_route_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.accept_source_route</title>
 <description>Trackers could be using source-routed packets to
@@ -81,7 +81,7 @@ created outside and has been redirected.</description>
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv4_conf_all_accept_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_accept_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.accept_redirects</title>
 <description>Disable ICMP Redirect Acceptance</description>
@@ -90,7 +90,7 @@ operator="equals" interactive="0">
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv4_conf_all_secure_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_secure_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.secure_redirects</title>
 <description>Enable to prevent hijacking of routing path by only
@@ -101,7 +101,7 @@ table.</description>
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv4_conf_default_log_martians_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_log_martians_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.log_martians</title>
 <description>Disable so you don't Log Spoofed Packets, Source
@@ -111,7 +111,7 @@ Routed Packets, Redirect Packets</description>
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv4_conf_all_log_martians_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_log_martians_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.log_martians</title>
 <description>Disable so you don't Log Spoofed Packets, Source
@@ -122,7 +122,7 @@ Routed Packets, Redirect Packets</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_default_accept_source_route_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_accept_source_route_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.accept_source_route</title>
 <description>Disable IP source routing?</description>
@@ -132,7 +132,7 @@ operator="equals" interactive="0">
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_default_accept_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_accept_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.accept_redirects</title>
 <description>Disable ICMP Redirect Acceptance?</description>
@@ -142,7 +142,7 @@ operator="equals" interactive="0">
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_default_secure_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_secure_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.secure_redirects</title>
 <description>Log packets with impossible addresses to kernel
@@ -153,7 +153,7 @@ log?</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" type="string"
+<Value id="sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.icmp_echo_ignore_broadcasts</title>
 <description>Ignore all ICMP ECHO and TIMESTAMP requests sent to it
@@ -164,7 +164,7 @@ via broadcast/multicast</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value" type="string"
+<Value id="sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.icmp_ignore_bogus_error_responses</title>
 <description>Enable to prevent unnecessary logging</description>
@@ -174,7 +174,7 @@ operator="equals" interactive="0">
 </Value>
 
 
-<Value id="sysctl_net_ipv4_tcp_syncookies_value" type="string"
+<Value id="sysctl_net_ipv4_tcp_syncookies_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.tcp_syncookies</title>
 <description>Enable to turn on TCP SYN Cookie
@@ -185,7 +185,7 @@ Protection</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_all_rp_filter_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_rp_filter_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.rp_filter</title>
 <description>Enable to enforce sanity checking, also called ingress
@@ -199,7 +199,7 @@ it arrived.</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_default_rp_filter_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_rp_filter_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.rp_filter</title>
 <description>Enables source route verification</description>

--- a/shared/oval/accounts_tmout.xml
+++ b/shared/oval/accounts_tmout.xml
@@ -1,7 +1,7 @@
 <def-group>
-  <definition class="compliance" id="accounts_tmout" version="1">
+  <definition class="compliance" id="accounts_tmout" version="2">
     <metadata>
-      <title>SELinux Enforcing</title>
+      <title>Set Interactive Session Timeout</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
       </affected>
@@ -25,7 +25,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_etc_profile_tmout" version="1">
-    <ind:subexpression datatype="string" operation="greater than or equal" var_check="all" var_ref="var_accounts_tmout" />
+    <ind:subexpression datatype="int" operation="greater than or equal" var_check="all" var_ref="var_accounts_tmout" />
   </ind:textfilecontent54_state>
 
   <external_variable comment="external variable for TMOUT" datatype="int" id="var_accounts_tmout" version="1" />

--- a/shared/oval/accounts_tmout.xml
+++ b/shared/oval/accounts_tmout.xml
@@ -28,5 +28,5 @@
     <ind:subexpression datatype="string" operation="greater than or equal" var_check="all" var_ref="var_accounts_tmout" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="external variable for TMOUT" datatype="string" id="var_accounts_tmout" version="1" />
+  <external_variable comment="external variable for TMOUT" datatype="int" id="var_accounts_tmout" version="1" />
 </def-group>

--- a/shared/oval/dconf_gnome_screensaver_idle_delay.xml
+++ b/shared/oval/dconf_gnome_screensaver_idle_delay.xml
@@ -67,7 +67,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_screensaver_idle_delay_setting" version="1">
-    <ind:subexpression operation="equals" var_check="all" var_ref="inactivity_timeout_value" />
+    <ind:subexpression datatype="int" operation="equals" var_check="all" var_ref="inactivity_timeout_value" />
   </ind:textfilecontent54_state>
 
   <external_variable comment="inactivity timeout variable" datatype="int"

--- a/shared/oval/dconf_gnome_screensaver_idle_delay.xml
+++ b/shared/oval/dconf_gnome_screensaver_idle_delay.xml
@@ -70,6 +70,6 @@
     <ind:subexpression operation="equals" var_check="all" var_ref="inactivity_timeout_value" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="inactivity timeout variable" datatype="string"
+  <external_variable comment="inactivity timeout variable" datatype="int"
   id="inactivity_timeout_value" version="1" />
 </def-group>


### PR DESCRIPTION
Use proper (matching) datatypes in XCCDF and OVAL when exporting XCCDF Values to OVAL.

This fixes numerous warnings displayed during the SSG build due to content currently breaking data export constraints.

Please review.

Thank you, Jan.