### PR TITLE
[RHEL/7] Use replace_or_append function for sshd_config remediations

### DIFF
--- a/RHEL/7/input/remediations/bash/sshd_disable_empty_passwords.sh
+++ b/RHEL/7/input/remediations/bash/sshd_disable_empty_passwords.sh
@@ -1,6 +1,6 @@
 # platform = Red Hat Enterprise Linux 7
-grep -qi ^PermitEmptyPasswords /etc/ssh/sshd_config && \
-  sed -i "s/PermitEmptyPasswords.*/PermitEmptyPasswords no/gI" /etc/ssh/sshd_config
-if ! [ $? -eq 0 ]; then
-    echo "PermitEmptyPasswords no" >> /etc/ssh/sshd_config
-fi
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '/etc/ssh/sshd_config' '^PermitEmptyPasswords' 'no' 'CCENUM' '%s %s'

--- a/RHEL/7/input/remediations/bash/sshd_do_not_permit_user_env.sh
+++ b/RHEL/7/input/remediations/bash/sshd_do_not_permit_user_env.sh
@@ -1,6 +1,6 @@
 # platform = Red Hat Enterprise Linux 7
-grep -qi ^PermitUserEnvironment /etc/ssh/sshd_config && \
-  sed -i "s/PermitUserEnvironment.*/PermitUserEnvironment no/gI" /etc/ssh/sshd_config
-if ! [ $? -eq 0 ]; then
-    echo "PermitUserEnvironment no" >> /etc/ssh/sshd_config
-fi
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '/etc/ssh/sshd_config' '^PermitUserEnvironment' 'no' 'CCENUM' '%s %s'

--- a/RHEL/7/input/remediations/bash/sshd_enable_warning_banner.sh
+++ b/RHEL/7/input/remediations/bash/sshd_enable_warning_banner.sh
@@ -1,7 +1,6 @@
 # platform = Red Hat Enterprise Linux 7
-grep -qi ^Banner /etc/ssh/sshd_config && \
-  sed -i "s/Banner.*/Banner \/etc\/issue/gI" /etc/ssh/sshd_config
-if ! [ $? -eq 0 ]; then
-    echo "" >> /etc/ssh/sshd_config
-    echo "Banner /etc/issue" >> /etc/ssh/sshd_config
-fi
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '/etc/ssh/sshd_config' '^Banner' '/etc/issue' 'CCENUM' '%s %s'

--- a/RHEL/7/input/remediations/bash/sshd_set_idle_timeout.sh
+++ b/RHEL/7/input/remediations/bash/sshd_set_idle_timeout.sh
@@ -2,8 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate sshd_idle_timeout_value
 
-grep -qi ^ClientAliveInterval /etc/ssh/sshd_config && \
-  sed -i "s/ClientAliveInterval.*/ClientAliveInterval $sshd_idle_timeout_value/gI" /etc/ssh/sshd_config
-if ! [ $? -eq 0 ]; then
-    echo "ClientAliveInterval $sshd_idle_timeout_value" >> /etc/ssh/sshd_config
-fi
+replace_or_append '/etc/ssh/sshd_config' '^ClientAliveInterval' $sshd_idle_timeout_value 'CCENUM' '%s %s'

--- a/RHEL/7/input/remediations/bash/sshd_set_keepalive.sh
+++ b/RHEL/7/input/remediations/bash/sshd_set_keepalive.sh
@@ -1,6 +1,6 @@
 # platform = Red Hat Enterprise Linux 7
-grep -qi ^ClientAliveCountMax /etc/ssh/sshd_config && \
-  sed -i "s/ClientAliveCountMax.*/ClientAliveCountMax 0/gI" /etc/ssh/sshd_config
-if ! [ $? -eq 0 ]; then
-    echo "ClientAliveCountMax 0" >> /etc/ssh/sshd_config
-fi
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '/etc/ssh/sshd_config' '^ClientAliveCountMax' '0' 'CCENUM' '%s %s'

--- a/RHEL/7/input/remediations/bash/sshd_use_approved_ciphers.sh
+++ b/RHEL/7/input/remediations/bash/sshd_use_approved_ciphers.sh
@@ -1,6 +1,6 @@
 # platform = Red Hat Enterprise Linux 7
-grep -qi ^Ciphers /etc/ssh/sshd_config && \
-  sed -i "s/Ciphers.*/Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc/gI" /etc/ssh/sshd_config
-if ! [ $? -eq 0 ]; then
-    echo "Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc" >> /etc/ssh/sshd_config
-fi
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '/etc/ssh/sshd_config' '^Ciphers' 'aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc' 'CCENUM' '%s %s'

--- a/shared/remediations/bash/templates/remediation_functions
+++ b/shared/remediations/bash/templates/remediation_functions
@@ -778,7 +778,7 @@ function replace_or_append {
 
   # If there is no print format specified in the last arg, use the default format.
   if ! [ "x$format" = x ] ; then
-    printf -v formatted_output $format $stripped_key $value
+    printf -v formatted_output "$format" $stripped_key $value
   else
     formatted_output="$stripped_key = $value"
   fi


### PR DESCRIPTION
Also fixes the `replace_or_append` function to allow spaces in the custom format (which is required to edit sshd_config)