### PR TITLE
String-->Number validation errors

### DIFF
--- a/RHEL/5/input/xccdf/system/network/kernel.xml
+++ b/RHEL/5/input/xccdf/system/network/kernel.xml
@@ -62,7 +62,7 @@ created outside and has been redirected.</description>
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv4_conf_all_accept_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_accept_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.accept_redirects</title>
 <description>Disable ICMP Redirect Acceptance</description>

--- a/RHEL/5/input/xccdf/system/network/kernel.xml
+++ b/RHEL/5/input/xccdf/system/network/kernel.xml
@@ -71,7 +71,7 @@ operator="equals" interactive="0">
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv4_conf_all_secure_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_secure_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.secure_redirects</title>
 <description>Enable to prevent hijacking of routing path by only
@@ -82,7 +82,7 @@ table.</description>
 <value selector="disabled">0</value>
 </Value>
 
-<Value id="sysctl_net_ipv4_conf_all_log_martians_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_log_martians_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.log_martians</title>
 <description>Disable so you don't Log Spoofed Packets, Source
@@ -93,7 +93,7 @@ Routed Packets, Redirect Packets</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_default_accept_source_route_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_accept_source_route_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.accept_source_route</title>
 <description>Disable IP source routing?</description>
@@ -102,8 +102,7 @@ operator="equals" interactive="0">
 <value selector="disabled">0</value>
 </Value>
 
-
-<Value id="sysctl_net_ipv4_conf_default_accept_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_accept_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.accept_redirects</title>
 <description>Disable ICMP Redirect Acceptance?</description>
@@ -112,8 +111,7 @@ operator="equals" interactive="0">
 <value selector="disabled">0</value>
 </Value>
 
-
-<Value id="sysctl_net_ipv4_conf_default_secure_redirects_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_secure_redirects_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.secure_redirects</title>
 <description>Log packets with impossible addresses to kernel
@@ -123,8 +121,7 @@ log?</description>
 <value selector="disabled">0</value>
 </Value>
 
-
-<Value id="sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" type="string"
+<Value id="sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.icmp_echo_ignore_broadcasts</title>
 <description>Ignore all ICMP ECHO and TIMESTAMP requests sent to it
@@ -135,7 +132,7 @@ via broadcast/multicast</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value" type="string"
+<Value id="sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.icmp_ignore_bogus_error_responses</title>
 <description>Enable to prevent unnecessary logging</description>
@@ -145,7 +142,7 @@ operator="equals" interactive="0">
 </Value>
 
 
-<Value id="sysctl_net_ipv4_tcp_syncookies_value" type="string"
+<Value id="sysctl_net_ipv4_tcp_syncookies_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.tcp_syncookies</title>
 <description>Enable to turn on TCP SYN Cookie
@@ -166,8 +163,7 @@ Protection</description>
 <value selector="disabled">0</value>
 </Value>
 
-
-<Value id="sysctl_net_ipv4_conf_all_rp_filter_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_rp_filter_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.rp_filter</title>
 <description>Enable to enforce sanity checking, also called ingress
@@ -181,7 +177,7 @@ it arrived.</description>
 </Value>
 
 
-<Value id="sysctl_net_ipv4_conf_default_rp_filter_value" type="string"
+<Value id="sysctl_net_ipv4_conf_default_rp_filter_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.default.rp_filter</title>
 <description>Enables source route verification</description>

--- a/RHEL/5/input/xccdf/system/network/kernel.xml
+++ b/RHEL/5/input/xccdf/system/network/kernel.xml
@@ -51,7 +51,7 @@ only appropriate for systems acting as routers.</rationale>
 acting as either hosts or routers to improve the system's ability defend
 against certain types of IPv4 protocol attacks.</description>
 
-<Value id="sysctl_net_ipv4_conf_all_accept_source_route_value" type="string"
+<Value id="sysctl_net_ipv4_conf_all_accept_source_route_value" type="number"
 operator="equals" interactive="0">
 <title>net.ipv4.conf.all.accept_source_route</title>
 <description>Trackers could be using source-routed packets to


### PR DESCRIPTION
Many warnings in the Jenkins build about string mismatches, e.g.:

`````

Warning: XCCDF 'type' of "sysctl_net_ipv4_conf_all_accept_redirects_value" value does not meet the XCCDF value 'type' to OVAL variable 'datatype'
export matching constraint! Got: "string", Expected: "number". Resetting it! Set 'type' of "sysctl_net_ipv4_conf_all_accept_redirects_value"
<xccdf:value> to 'number' directly in the XCCDF content to dismiss this warning!

`````

Updated associated strings to numbers to clean up the build.