### PR TITLE
[BugFix] [Infrastructure] Fix for issue #1075

### DIFF
--- a/shared/remediations/bash/selinux_policytype.sh
+++ b/shared/remediations/bash/selinux_policytype.sh
@@ -1,8 +1,7 @@
 # platform = multi_platform_rhel
-. /usr/share/scap-security-guide/remediation_functions
-populate var_selinux_policy_name
-
+#
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
+populate var_selinux_policy_name
 
 replace_or_append '/etc/sysconfig/selinux' '^SELINUXTYPE=' $var_selinux_policy_name 'CCENUM' '%s=%s'

--- a/shared/remediations/bash/selinux_state.sh
+++ b/shared/remediations/bash/selinux_state.sh
@@ -1,8 +1,7 @@
 # platform = multi_platform_rhel
-. /usr/share/scap-security-guide/remediation_functions
-populate var_selinux_state
-
+#
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
+populate var_selinux_state
 
 replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' $var_selinux_state 'CCENUM' '%s=%s'


### PR DESCRIPTION
* First patch is doing the following:

   [BugFix] [Infrastructure] When populating shell variable into corresponding
   <xccdf:Value> in remediation scripts don't remove the inclusion of the
   remediation_functions library (because in the case there's also some other
   remediation function called besides populate() the resulting remediation
   script won't be functional)
    
   Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1075
   Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1075#issue-141217491
   Fixes: https://github.com/OpenSCAP/scap-security-guide/pull/1207#issuecomment-210481325

   The failure to include remediation fixes in the form they would work correctly can be reproduced on the current master e.g. with the following rules:
  * ```RHEL/7``` benchmark: ```Set SSH Idle Timeout Interval``` rule,
  * ```Firefox``` benchmark: ```Enable Downloading and Opening File Confirmation``` rule,
  * ```Firefox``` benchmark: ```Default Firefox Home Page Configured```

  When remediation for some of these rules is attempted, the attempt to remediate returns 'error' (state of the system isn't corrected). This is because the path for the remediation functions library is ```eaten``` in the moment the ```populate()``` remediation function is called to export some shell variable to corresponding ```<xccdf:Value>```. Since these fixes also call another remediation functions from the library, shell can't locate definition of the function, and fails to execute it (=> state isn't corrected).

  This patch modifies the corresponding code when creating modified remediation script (when exporting shell variable into it's ```<xccdf:Value>``` counterpart) ```not to eat``` inclusion of the remediation functions library exactly for this case. Therefore shell can still find the definition of the remediation function, executes it, and remediation succeeds.

* Second patch is just cosmetic change, performing the following:

    [BugFix] Drop the duplicate inclusion of the remediation_functions library
    from the following remediation scripts:
    * selinux_policytype.sh
    * selinux_state.sh
    
    since to include the functions library two times is not necessary
    (one time is enough)

Right now there exist two ```shared/``` remediation functions, including remediation functions library two times. But with the previous patch in place, this is not necessary any more the functions to work properly. Thus drop the second inclusion of the library.

Testing report:
--

The change has been tested with aforementioned rules on RHEL-7 and Firefox benchmarks. And to my knowledge, the proposed change is working fine (attempt to remediate prior the patch returns ```error```, while after the commits it returns proper ```fixed``` state).

Please review.

Thank you, Jan