### PR TITLE
[BugFix] [RHEL/7] Fixes for majority of the rules from issue #1085

### DIFF
--- a/RHEL/7/input/remediations/bash/accounts_password_pam_dcredit.sh
+++ b/RHEL/7/input/remediations/bash/accounts_password_pam_dcredit.sh
@@ -2,8 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_dcredit
 
-if egrep -q ^dcredit[[:space:]]*=[[:space:]]*[-]?[[:digit:]]+ /etc/security/pwquality.conf; then
-	sed -i "s/^\(dcredit *= *\).*/\1$var_password_pam_dcredit/" /etc/security/pwquality.conf
-else
-	sed -i "/\(dcredit *= *\).*/a dcredit = $var_password_pam_dcredit" /etc/security/pwquality.conf
-fi
+replace_or_append '/etc/security/pwquality.conf' '^dcredit' $var_password_pam_dcredit 'CCE-27214-6' '%s = %s'

--- a/RHEL/7/input/remediations/bash/accounts_password_pam_difok.sh
+++ b/RHEL/7/input/remediations/bash/accounts_password_pam_difok.sh
@@ -2,8 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_difok
 
-if egrep -q ^difok[[:space:]]*=[[:space:]]*[-]?[[:digit:]]+ /etc/security/pwquality.conf; then
-	sed -i "s/^\(difok *= *\).*/\1$var_password_pam_difok/" /etc/security/pwquality.conf
-else
-	sed -i "/\(difok *= *\).*/a difok = $var_password_pam_difok" /etc/security/pwquality.conf
-fi
+replace_or_append '/etc/security/pwquality.conf' '^difok' $var_password_pam_difok 'CCE-26631-2' '%s = %s'

--- a/RHEL/7/input/remediations/bash/accounts_password_pam_lcredit.sh
+++ b/RHEL/7/input/remediations/bash/accounts_password_pam_lcredit.sh
@@ -2,8 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_lcredit
 
-if egrep -q ^lcredit[[:space:]]*=[[:space:]]*[-]?[[:digit:]]+ /etc/security/pwquality.conf; then
-	sed -i "s/^\(lcredit *= *\).*/\1$var_password_pam_lcredit/" /etc/security/pwquality.conf
-else
-	sed -i "/\(lcredit *= *\).*/a lcredit = $var_password_pam_lcredit" /etc/security/pwquality.conf
-fi
+replace_or_append '/etc/security/pwquality.conf' '^lcredit' $var_password_pam_lcredit 'CCE-27345-8' '%s = %s'

--- a/RHEL/7/input/remediations/bash/accounts_password_pam_maxrepeat.sh
+++ b/RHEL/7/input/remediations/bash/accounts_password_pam_maxrepeat.sh
@@ -2,8 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_maxrepeat
 
-if egrep -q ^maxrepeat[[:space:]]*=[[:space:]]*[[:digit:]]+ /etc/security/pwquality.conf; then
-	sed -i "s/^\(maxrepeat *= *\).*/\1$var_password_pam_maxrepeat/" /etc/security/pwquality.conf
-else
-	sed -i "/\(maxrepeat *= *\).*/a maxrepeat = $var_password_pam_maxrepeat" /etc/security/pwquality.conf
-fi
+replace_or_append '/etc/security/pwquality.conf' '^maxrepeat' $var_password_pam_maxrepeat 'CCE-27333-4' '%s = %s'

--- a/RHEL/7/input/remediations/bash/accounts_password_pam_minclass.sh
+++ b/RHEL/7/input/remediations/bash/accounts_password_pam_minclass.sh
@@ -2,8 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_minclass
 
-if egrep -q ^minclass[[:space:]]*=[[:space:]]*[[:digit:]]+ /etc/security/pwquality.conf; then
-	sed -i "s/^\(minclass *= *\).*/\1$var_password_pam_minclass/" /etc/security/pwquality.conf
-else
-	sed -i "/\(minclass *= *\).*/a minclass = $var_password_pam_minclass" /etc/security/pwquality.conf
-fi
+replace_or_append '/etc/security/pwquality.conf' '^minclass' $var_password_pam_minclass 'CCE-27115-5' '%s = %s'

--- a/RHEL/7/input/remediations/bash/accounts_password_pam_minlen.sh
+++ b/RHEL/7/input/remediations/bash/accounts_password_pam_minlen.sh
@@ -2,8 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_minlen
 
-if egrep -q ^minlen[[:space:]]*=[[:space:]]*[[:digit:]]+ /etc/security/pwquality.conf; then
-	sed -i "s/^\(minlen *= *\).*/\1$var_password_pam_minlen/" /etc/security/pwquality.conf
-else
-	sed -i "/\(minlen *= *\).*/a minlen = $var_password_pam_minlen" /etc/security/pwquality.conf
-fi
+replace_or_append '/etc/security/pwquality.conf' '^minlen' $var_password_pam_minlen 'CCE-27293-0' '%s = %s'

--- a/RHEL/7/input/remediations/bash/accounts_password_pam_ocredit.sh
+++ b/RHEL/7/input/remediations/bash/accounts_password_pam_ocredit.sh
@@ -2,8 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_ocredit
 
-if egrep -q ^ocredit[[:space:]]*=[[:space:]]*[-]?[[:digit:]]+ /etc/security/pwquality.conf; then
-	sed -i "s/^\(ocredit *= *\).*/\1$var_password_pam_ocredit/" /etc/security/pwquality.conf
-else
-	sed -i "/\(ocredit *= *\).*/a ocredit = $var_password_pam_ocredit" /etc/security/pwquality.conf
-fi
+replace_or_append '/etc/security/pwquality.conf' '^ocredit' $var_password_pam_ocredit 'CCE-27360-7' '%s = %s'

--- a/RHEL/7/input/remediations/bash/accounts_password_pam_ucredit.sh
+++ b/RHEL/7/input/remediations/bash/accounts_password_pam_ucredit.sh
@@ -2,8 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_ucredit
 
-if egrep -q ^ucredit[[:space:]]*=[[:space:]]*[-]?[[:digit:]]+ /etc/security/pwquality.conf; then
-	sed -i "s/^\(ucredit *= *\).*/\1$var_password_pam_ucredit/" /etc/security/pwquality.conf
-else
-	sed -i "/\(ucredit *= *\).*/a ucredit = $var_password_pam_ucredit" /etc/security/pwquality.conf
-fi
+replace_or_append '/etc/security/pwquality.conf' '^ucredit' $var_password_pam_ucredit 'CCE-27200-5' '%s = %s'


### PR DESCRIPTION
[BugFix] [RHEL/7] Replace buggy implementation of accounts_passwords_pam_*.sh 
remediation scripts with use of SSG internal ```replace_or_append``` remediation
function 

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1085
       (all the rules except "accounts_password_pam_retry" which needs slightly
        more testing => part of future PR)

Fixes (downstream): https://bugzilla.redhat.com/show_bug.cgi?id=1309037

Motivation behind this change in more detail:
As reported in downstream https://bugzilla.redhat.com/show_bug.cgi?id=1309037 bug report the current implementation of various ```accounts_passwords_pam_*.sh``` remediation scripts doesn't work properly in the following scenario:

```
$ cp /etc/security/pwquality.conf /etc/security/pwquality.conf.backup
$ touch /etc/security/pwquality.conf
```
(in other words create completely empty ```/etc/security/pwquality.conf``` file). Then attempt the remediation for various PAM password categories touching ```/etc/security/pwquality.conf``` (```minlen, minclass, difok, lcredit etc.```)

Current result:
The currently present ```[RHEL/7] accounts_passwords_*``` remediation scripts won't fix the state of the system.

Expected result:
The corresponding ```[RHEL/7] accounts_passwords_*``` remediation scripts work also in this scenario properly.

The fix:
Replace the existing scripts with the use of SSG internal ```replace_or_append``` remediation function called with proper arguments (for each of the cases) to prevent this scenario (bug) from happening again.

Testing report:
The proposed change has been tested on RHEL-7 system and AFAICT from testing seems to be working fine (for both cases, when we update improperly set values to the expected / required ones, and also in the case when we operate on completely blank ```/etc/security/pwquality.conf``` file [IOW when the option in question we are searching for isn't present in ```/etc/security/pwquality.conf``` file yet).

Please review.

Thank you, Jan

P.S.: This change assumes the following PR: https://github.com/OpenSCAP/scap-security-guide/pull/1218 is reviewed && merged first (without it it won't operate properly, since ```replace_or_append``` function wouldn't be executed properly).

