### PR TITLE
[BugFix] [Enhancement] [Infrastructure] Fix for issue #1222

### DIFF
--- a/Chromium/Makefile
+++ b/Chromium/Makefile
@@ -120,6 +120,7 @@ dist: tables guide content
 	mkdir -p $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/Debian/8/Makefile
+++ b/Debian/8/Makefile
@@ -133,6 +133,7 @@ dist: guide content
 	cp $(OUT)/*-guide-*.html $(DIST)/guide
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -89,6 +89,7 @@ dist: guide content
 	mkdir -p $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
 	mkdir -p $(DIST)/guide
 	cp $(OUT)/*-guide-*.html $(DIST)/guide

--- a/Firefox/Makefile
+++ b/Firefox/Makefile
@@ -123,6 +123,7 @@ dist: tables guide content
 	mkdir -p $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/JBoss/EAP/5/Makefile
+++ b/JBoss/EAP/5/Makefile
@@ -115,6 +115,7 @@ dist: tables guide content
 	mkdir -p $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/JBoss/Fuse/6/Makefile
+++ b/JBoss/Fuse/6/Makefile
@@ -116,6 +116,7 @@ dist: tables guide content
 	mkdir -p $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/JRE/Makefile
+++ b/JRE/Makefile
@@ -123,6 +123,7 @@ dist: tables guide content
 	mkdir -p $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/OpenStack/RHEL-OSP/7/Makefile
+++ b/OpenStack/RHEL-OSP/7/Makefile
@@ -158,6 +158,7 @@ dist: tables guide content
 	mkdir -p $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -143,6 +143,7 @@ dist: tables guide content
 	mkdir -p $(DIST)/content $(DIST)/guide
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -173,6 +173,7 @@ dist: tables guide content
 	mkdir -p $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -176,6 +176,7 @@ dist: tables guide content
 	mkdir -p $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/RHEVM3/Makefile
+++ b/RHEVM3/Makefile
@@ -115,6 +115,7 @@ dist: tables guide content
 	cp $(OUT)/*-guide-*.html $(DIST)/guide
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/table-$(PROD)-* $(DIST)/policytables

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -125,7 +125,6 @@ dist: tables guide content
 	mkdir -p $(DIST)/content $(DIST)/guide
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
-	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -125,6 +125,7 @@ dist: tables guide content
 	mkdir -p $(DIST)/content $(DIST)/guide
 	cp $(OUT)/$(ID)-$(PROD)-xccdf.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-oval.xml $(DIST)/content
+	cp $(OUT)/$(ID)-$(PROD)-ocil.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-cpe-oval.xml $(DIST)/content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -71,11 +71,11 @@ $(OUT)/xccdf-unlinked-resolved.xml: $(OUT)/xccdf-unlinked-empty-groups-unselecte
 # Common build targets - create OCIL questionnaire stub for further processing
 $(OUT)/ocil-unlinked.xml: $(OUT)/xccdf-unlinked-resolved.xml $(SHARED)/$(TRANS)/xccdf-create-ocil.xslt
 	xsltproc -o $@ $(SHARED)/$(TRANS)/xccdf-create-ocil.xslt $<
-	xmllint --format --output $@ $@
+	xmllint --format --output $(OUT)/unlinked-$(PROD)-ocil.xml $@
 
 # Common build targets - an XCCDF witch OCIL checks in the form of official OCIL-2.0 syntax
 $(OUT)/xccdf-unlinked-ocilrefs.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/ocil-unlinked.xml $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $(SHARED)/$(TRANS)/shared_constants.xslt
-	xsltproc -o $@ $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $<
+	xsltproc -stringparam product "$(PROD)" -o $@ $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $<
 
 # Common build targets - a catalogue of XCCDF remediations
 bash_remediations_deps= $(wildcard $(IN)/remediations/bash/*.sh) $(wildcard $(SHARED_REMEDIATIONS)/*.sh)

--- a/shared/transforms/datastream_move_ocil_to_ds_checks.py
+++ b/shared/transforms/datastream_move_ocil_to_ds_checks.py
@@ -160,7 +160,7 @@ def main():
     extendedcomps = datastreamtree.find(".//{%s}extended-components" % datastream_ns)
     if extendedcomps is not None:
         # Locate OCIL component within <ds:extended-components>
-        ocilcomps = extendedcomps.xpath(".//ds:component-ref[contains(@id,'_ocil')]",
+        ocilcomps = extendedcomps.xpath(".//ds:component-ref[contains(@id,'-ocil')]",
                                         namespaces={"ds" : datastream_ns})
         # SSG produces datastream with exactly one OCIL component
         if len(ocilcomps) != 1:

--- a/shared/transforms/xccdf-ocilcheck2ref.xslt
+++ b/shared/transforms/xccdf-ocilcheck2ref.xslt
@@ -3,8 +3,13 @@
 
 <xsl:include href="shared_constants.xslt"/>
 
-<!-- This transform replaces check-content with a check-content-ref, using the enclosing Rule id to create
-     an id for the check (by appending "_ocil") -->
+<!-- This transform expects a stringparam "product" specifying a SSG product
+     for which it will produce the resulting "ssg-$(PROD)-ocil.xml" OCIL file.
+     It replaces check-content with a check-content-ref, using the enclosing
+     Rule id to create an id for the check (by appending "_ocil") -->
+
+<xsl:param name="product">undef</xsl:param>
+
 
   <!-- Replace check system attribute with the real OCIL one -->
   <xsl:template match="xccdf:check[@system='ocil-transitional']">
@@ -32,7 +37,9 @@
        to create a reference name -->
   <xsl:template match="xccdf:check-content">
 	<xsl:element name="check-content-ref" namespace="http://checklists.nist.gov/xccdf/1.1">
-		<xsl:attribute name="href">ocil-unlinked.xml</xsl:attribute>
+		<xsl:if test="$product != 'undef'" >
+			<xsl:attribute name="href">unlinked-<xsl:value-of select="$product"/>-ocil.xml</xsl:attribute>
+		</xsl:if>
 		<xsl:attribute name="name"><xsl:value-of select="../../@id"/>_ocil</xsl:attribute>
 	</xsl:element>
   </xsl:template>


### PR DESCRIPTION
This changeset is performing the following:
* first patch is modifying the OCIL content build process to start producing resulting OCIL file with the filename "ssg-$(PROD)-ocil.xml" [e.g. "ssg-rhel7-ocil.xml" ] rather than with "ocil-ssg.xml" like it's produced currently (since "ssg-$(PROD)-ocil.xml" scheme better aligns with the form we already use to name produced XCCDF, OVAL, and DataStream files),

* the second patch is instructing the ```make dist``` targets of different products to start shipping the produced "ssg-$(PROD)-ocil.xml" file together with OVAL, XCCDF, and DataStream files. Though OpenSCAP doesn't support OCIL standard currently, the support might be added in the future. Also there might be other scanners already supporting the OCIL standard. Moreover, the OCIL content is already included in the produced DataStream file "ssg-$(PROD)-ds.xml" so this change prevents the CLI / GUI scanners from issuing a ```No such file or directory``` warning message when loading the datastream.

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1222

Please review.

Thank you, Jan