### PR TITLE
[BugFix] [Fedora] Add missing CPE for Rawhide

### DIFF
--- a/Fedora/input/guide.xml
+++ b/Fedora/input/guide.xml
@@ -35,6 +35,7 @@ quality, reliability, or any other characteristic.</notice>
 trademarks or trademarks of Red Hat, Inc. in the United States and other
 countries. All other names are registered trademarks or trademarks of their
 respective companies.</rear-matter>
+<platform idref="cpe:/o:fedoraproject:fedora:25" />
 <platform idref="cpe:/o:fedoraproject:fedora:24" />
 <platform idref="cpe:/o:fedoraproject:fedora:23" />
 <platform idref="cpe:/o:fedoraproject:fedora:22" />

--- a/shared/oval/installed_OS_is_fedora.xml
+++ b/shared/oval/installed_OS_is_fedora.xml
@@ -7,6 +7,8 @@
       </affected>
       <reference ref_id="cpe:/o:fedoraproject:fedora:22" source="CPE" />
       <reference ref_id="cpe:/o:fedoraproject:fedora:23" source="CPE" />
+      <reference ref_id="cpe:/o:fedoraproject:fedora:24" source="CPE" />
+      <reference ref_id="cpe:/o:fedoraproject:fedora:25" source="CPE" />
       <description>The operating system installed on the system is Fedora</description>
       <reference source="JL" ref_id="RHEL6_20150624" ref_url="test_attestation" />
       <reference source="JL" ref_id="RHEL7_20150522" ref_url="test_attestation" />


### PR DESCRIPTION
Fix downstream bug:
&nbsp; &nbsp;  https://bugzilla.redhat.com/show_bug.cgi?id=1147275
re-appeared again (since Rawhide already diverged from Fedora 24 branch). Fix it

Changes:
* Add Fedora 25 CPE to Fedora benchmark,
* Add Fedora 24 and Fedora 25 as supported platforms for
  'installed_OS_is_fedora.xml' OVAL check

Please review

Thank you, Jan