### PR TITLE
[Enhancement] Create a STIG GUI profile and non-gui profile

### DIFF
--- a/RHEL/7/input/guide.xslt
+++ b/RHEL/7/input/guide.xslt
@@ -18,7 +18,9 @@
 		<xsl:apply-templates select="document('profiles/C2S.xml')" />
 		<xsl:apply-templates select="document('profiles/rht-ccp.xml')" />
 		<xsl:apply-templates select="document('profiles/common.xml')" />
-		<xsl:apply-templates select="document('profiles/stig-rhel7-server-upstream.xml')" />
+		<xsl:apply-templates select="document('profiles/stig-rhel7-server-gui-upstream.xml')" />
+		<xsl:apply-templates select="document('profiles/stig-rhel7-server-nogui-upstream.xml')" />
+		<xsl:apply-templates select="document('profiles/stig-rhel7-base-upstream.xml')" />
 		<xsl:apply-templates select="document('profiles/ospp-rhel7-server.xml')" />
 
        <Value id="conditional_clause" type="string" operator="equals">

--- a/RHEL/7/input/profiles/stig-rhel7-base-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-base-upstream.xml
@@ -1,0 +1,92 @@
+<Profile id="stig-rhel7-base-upstream" extends="ospp-rhel7-server">
+<title override="true">Base STIG for Red Hat Enterprise Linux 7</title>
+<description override="true">This is a *draft* profile for STIG. This profile is being developed
+under the DoD consensus model to become a STIG in coordination with DISA FSO.
+<br/><br/>
+This profile is the base STIG profile for Red Hat Enterprise Linux 7 STIGs.
+It contains checks that should be in all Red Hat Enterprise Linux 7 STIGs profiles.</description>
+
+<!-- DISA FSO REFINEMENT VALUES
+     The following refine-values tailor the NIAP OSPP profile
+     to DoD-specific settings, as deemed approriate by DISA FSO (RE71) -->
+<refine-value idref="sshd_idle_timeout_value" selector="15_minutes" />
+<refine-value idref="var_password_pam_unix_remember" selector="5" />
+<refine-value idref="var_password_pam_difok" selector="8" />
+<refine-value idref="login_banner_text" selector="dod_default" />
+<refine-value idref="var_password_pam_minclass" selector="4" />
+<refine-value idref="var_password_pam_maxrepeat" selector="2" />
+<refine-value idref="var_password_pam_maxclassrepeat" selector="2" />
+<refine-value idref="inactivity_timeout_value" selector="900" />
+<refine-value idref="var_account_disable_post_pw_expiration" selector="0" />
+<!-- END DISA FSO REFINEMENT VALUES -->
+
+<!-- NIAP/OSPP EXCLUDED RULES
+     The following rules are established within the NIAP Operating System Protection Profile,
+     however specifically excluded by DISA FSO (RE71) for use U.S. Department of Defense baselines -->
+
+<!-- END NIAP/OSPP EXCLUDED RULES -->
+
+<!-- DISA FSO (RE71) RULE ADDITIONS -->
+<!-- The following rules reflect DISA FSO (RE71) extensions to the NIAP Operating System
+     Protection Profile (NIAP OSPP). -->
+
+<!-- Disk/Partition Requirements -->
+<select idref="partition_for_tmp" selected="true" />
+<select idref="partition_for_var_log_audit" selected="true" />
+<select idref="partition_for_var" selected="true" />
+<select idref="partition_for_home" selected="true" />
+
+<!-- Password Requirements -->
+<select idref="accounts_password_pam_minclass" selected="true" />
+<select idref="accounts_password_pam_unix_remember" selected="true" />
+<select idref="accounts_password_pam_minlen" selected="true" />
+<select idref="accounts_password_pam_difok" selected="true" />
+<select idref="accounts_password_pam_maxrepeat" selected="true" />
+<select idref="accounts_password_pam_maxclassrepeat" selected="true" />
+<select idref="account_disable_post_pw_expiration" selected="true" />
+
+<!-- Account Management Requirements -->
+<select idref="account_temp_expire_date" selected="true" />
+
+<!-- User Management -->
+<select idref="banner_etc_issue" selected="true" />
+<select idref="sshd_enable_warning_banner" selected="true" />
+<select idref="ftp_present_banner" selected="true" />
+
+<!-- Software/Patch Requirements -->
+<select idref="ensure_redhat_gpgkey_installed" selected="true" />
+<select idref="ensure_gpgcheck_never_disabled" selected="true" />
+<select idref="security_patches_up_to_date" selected="true" />
+
+<!-- System Audit Requirements -->
+
+<!-- Kernel/Network Settings -->
+<select idref="sysctl_net_ipv6_conf_all_accept_source_route" selected="true" />
+<select idref="libreswan_approved_tunnels" selected="true" />
+
+<!-- System Logging Requirements -->
+<select idref="rsyslog_remote_loghost" selected="true" />
+
+<!-- Remote Access Requirements -->
+<select idref="sshd_disable_compression" selected="true" />
+<select idref="sshd_disable_gssapi_auth" selected="true" />
+<select idref="sshd_disable_kerb_auth" selected="true" />
+<select idref="sshd_enable_strictmodes" selected="true" />
+<select idref="sshd_use_priv_separation" selected="true" />
+
+<!-- File Server/Client Settings -->
+<select idref="mount_option_krb_sec_remote_filesystems.xml" selected="true" />
+<select idref="use_kerberos_security_all_exports.xml" selected="true" />
+
+<!-- Obsolete Services -->
+<select idref="package_tftp-server_removed" selected="true" />
+
+<!-- Miscellaneous Services -->
+<select idref="service_zebra_disabled" selected="true" />
+<select idref="snmpd_not_default_password" selected="true" />
+<select idref="service_kdump_disabled" selected="true" />
+
+<!-- Currently uncategorized -->
+<select idref="disable_ctrlaltdel_reboot" selected="true" />
+
+</Profile>

--- a/RHEL/7/input/profiles/stig-rhel7-server-gui-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-gui-upstream.xml
@@ -1,0 +1,32 @@
+<Profile id="stig-rhel7-server-gui-upstream" extends="stig-rhel7-base-upstream">
+<title override="true">STIG for Red Hat Enterprise Linux 7 Server</title>
+<description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
+
+<!-- DISA FSO REFINEMENT VALUES
+     The following refine-values tailor the NIAP OSPP profile
+     to DoD-specific settings, as deemed approriate by DISA FSO (RE71) -->
+<refine-value idref="login_banner_text" selector="dod_default" />
+<!-- END DISA FSO REFINEMENT VALUES -->
+
+<!-- NIAP/OSPP EXCLUDED RULES
+          The following rules are established within the NIAP Operating System Protection Profile,
+     however specifically excluded by DISA FSO (RE71) for use U.S. Department of Defense baselines -->
+
+<!-- END NIAP/OSPP EXCLUDED RULES -->
+
+<!-- DISA FSO (RE71) RULE ADDITIONS -->
+<!-- The following rules reflect DISA FSO (RE71) extensions to the NIAP Operating System
+          Protection Profile (NIAP OSPP). -->
+
+<!-- GDM Settings -->
+<select idref="dconf_gnome_banner_enabled" selected ="true" />
+<select idref="dconf_gnome_login_banner_text" selected="true" />
+<select idref="dconf_gnome_screensaver_lock_enabled" selected="true"/>
+<select idref="dconf_gnome_screensaver_idle_activation_enabled" selected="true"/>
+<select idref="dconf_gnome_screensaver_idle_delay" selected="true"/>
+
+<!-- X Window System Settings -->
+
+<!-- Currently uncategorized -->
+
+</Profile>

--- a/RHEL/7/input/profiles/stig-rhel7-server-nogui-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-nogui-upstream.xml
@@ -1,0 +1,27 @@
+<Profile id="stig-rhel7-server-nogui-upstream" extends="stig-rhel7-base-upstream">
+<title override="true">STIG for Red Hat Enterprise Linux 7 Server</title>
+<description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
+
+<!-- DISA FSO REFINEMENT VALUES
+     The following refine-values tailor the NIAP OSPP profile
+     to DoD-specific settings, as deemed approriate by DISA FSO (RE71) -->
+<!-- END DISA FSO REFINEMENT VALUES -->
+
+<!-- NIAP/OSPP EXCLUDED RULES
+     The following rules are established within the NIAP Operating System Protection Profile,
+     however specifically excluded by DISA FSO (RE71) for use U.S. Department of Defense baselines -->
+
+<!-- END NIAP/OSPP EXCLUDED RULES -->
+
+<!-- DISA FSO (RE71) RULE ADDITIONS -->
+<!-- The following rules reflect DISA FSO (RE71) extensions to the NIAP Operating System
+     Protection Profile (NIAP OSPP). -->
+
+<!-- X Window System Settings -->
+<select idref="xwindows_runlevel_setting" selected="true" />
+<select idref="package_xorg-x11-server-common_removed" selected="true" />
+<select idref="enable_x11_forwarding" selected="true" />
+
+<!-- Currently uncategorized -->
+
+</Profile>


### PR DESCRIPTION
This PR allows us to separate between a GUI and non-GUI STIG profile. It uses a base STIG profile for STIG checks that apply to all types of systems then has a GUI STIG profile and a non-GUI STIG profile for associated GUI vs. non-GUI checks. So, all GUI associated checks such as dconf go in the GUI profile, and all non-GUI checks including removing X/running in runlevel 3 go in the non-GUI profile.

- Fixes #481