### PR TITLE
[Enhancement][RHEL/7] Create a STIG for GUI-enabled systems

### DIFF
--- a/RHEL/7/input/guide.xslt
+++ b/RHEL/7/input/guide.xslt
@@ -18,6 +18,8 @@
 		<xsl:apply-templates select="document('profiles/C2S.xml')" />
 		<xsl:apply-templates select="document('profiles/rht-ccp.xml')" />
 		<xsl:apply-templates select="document('profiles/common.xml')" />
+		<xsl:apply-templates select="document('profiles/stig-rhel7-workstation-upstream.xml')" />
+		<xsl:apply-templates select="document('profiles/stig-rhel7-server-gui-upstream.xml')" />
 		<xsl:apply-templates select="document('profiles/stig-rhel7-server-upstream.xml')" />
 		<xsl:apply-templates select="document('profiles/ospp-rhel7-server.xml')" />
 

--- a/RHEL/7/input/profiles/stig-rhel7-server-gui-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-gui-upstream.xml
@@ -1,0 +1,34 @@
+<Profile id="stig-rhel7-server-gui-upstream" extends="stig-rhel7-server-upstream">
+<title override="true">STIG for Red Hat Enterprise Linux 7 Server Running GUIs</title>
+<description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
+
+<!-- DISA FSO REFINEMENT VALUES
+     The following refine-values tailor the NIAP OSPP profile
+     to DoD-specific settings, as deemed approriate by DISA FSO (RE71) -->
+<refine-value idref="login_banner_text" selector="dod_default" />
+<!-- END DISA FSO REFINEMENT VALUES -->
+
+<!-- NIAP/OSPP EXCLUDED RULES
+          The following rules are established within the NIAP Operating System Protection Profile,
+     however specifically excluded by DISA FSO (RE71) for use U.S. Department of Defense baselines -->
+
+<!-- END NIAP/OSPP EXCLUDED RULES -->
+
+<!-- DISA FSO (RE71) RULE ADDITIONS -->
+<!-- The following rules reflect DISA FSO (RE71) extensions to the NIAP Operating System
+          Protection Profile (NIAP OSPP). -->
+
+<!-- GDM Settings -->
+<select idref="dconf_gnome_banner_enabled" selected ="true" />
+<select idref="dconf_gnome_login_banner_text" selected="true" />
+<select idref="dconf_gnome_screensaver_lock_enabled" selected="true"/>
+<select idref="dconf_gnome_screensaver_idle_activation_enabled" selected="true"/>
+<select idref="dconf_gnome_screensaver_idle_delay" selected="true"/>
+
+<!-- X Window System Settings -->
+<select idref="xwindows_runlevel_setting" selected="false" />
+<select idref="package_xorg-x11-server-common_removed" selected="false" />
+
+<!-- Currently uncategorized -->
+
+</Profile>

--- a/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
@@ -48,11 +48,6 @@
 <select idref="banner_etc_issue" selected="true" />
 <select idref="sshd_enable_warning_banner" selected="true" />
 <select idref="ftp_present_banner" selected="true" />
-<select idref="dconf_gnome_banner_enabled" selected ="true" />
-<select idref="dconf_gnome_login_banner_text" selected="true" />
-<select idref="dconf_gnome_screensaver_lock_enabled" selected="true"/>
-<select idref="dconf_gnome_screensaver_idle_activation_enabled" selected="true"/>
-<select idref="dconf_gnome_screensaver_idle_delay" selected="true"/>
 
 <!-- Software/Patch Requirements -->
 <select idref="ensure_redhat_gpgkey_installed" selected="true" />

--- a/RHEL/7/input/profiles/stig-rhel7-workstation-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-workstation-upstream.xml
@@ -1,0 +1,26 @@
+<Profile id="stig-rhel7-workstation-upstream" extends="stig-rhel7-server-gui-upstream">
+<title override="true">STIG for Red Hat Enterprise Linux 7 Workstation</title>
+<description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
+
+<!-- DISA FSO REFINEMENT VALUES
+     The following refine-values tailor the NIAP OSPP profile
+     to DoD-specific settings, as deemed approriate by DISA FSO (RE71) -->
+<!-- END DISA FSO REFINEMENT VALUES -->
+
+<!-- NIAP/OSPP EXCLUDED RULES
+          The following rules are established within the NIAP Operating System Protection Profile,
+     however specifically excluded by DISA FSO (RE71) for use U.S. Department of Defense baselines -->
+
+<!-- END NIAP/OSPP EXCLUDED RULES -->
+
+<!-- DISA FSO (RE71) RULE ADDITIONS -->
+<!-- The following rules reflect DISA FSO (RE71) extensions to the NIAP Operating System
+          Protection Profile (NIAP OSPP). -->
+
+<!-- GDM Settings -->
+
+<!-- X Window System Settings -->
+
+<!-- Currently uncategorized -->
+
+</Profile>


### PR DESCRIPTION
- Create a RHEL7 GUI STIG
- Create a RHEL7 Workstation STIG for future use
- Remove DConf checks from the stig-rhel7-server-upstream profile and add
  to the new stig-rhel7-server-gui-upstream profile
- See #1242
- Fixes #481