### PR TITLE
[BugFix] [RHEL/7] Fix for issue #1227

### DIFF
--- a/RHEL/6/input/oval/platform/rhel6-cpe-dictionary.xml
+++ b/RHEL/6/input/oval/platform/rhel6-cpe-dictionary.xml
@@ -13,7 +13,7 @@
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel6</check>
       </cpe-item>
       <cpe-item name="cpe:/o:redhat:enterprise_linux:6::computenode">
-            <title xml:lang="en-us">Red Hat Enterprise Linux ComputeNode</title>
+            <title xml:lang="en-us">Red Hat Enterprise Linux 6 ComputeNode</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel6</check>
       </cpe-item>

--- a/RHEL/7/input/oval/platform/rhel7-cpe-dictionary.xml
+++ b/RHEL/7/input/oval/platform/rhel7-cpe-dictionary.xml
@@ -7,6 +7,16 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel7</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:redhat:enterprise_linux:7::client">
+            <title xml:lang="en-us">Red Hat Enterprise Linux 7 Client</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel7</check>
+      </cpe-item>
+      <cpe-item name="cpe:/o:redhat:enterprise_linux:7::computenode">
+            <title xml:lang="en-us">Red Hat Enterprise Linux 7 ComputeNode</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel7</check>
+      </cpe-item>
       <cpe-item name="cpe:/o:centos:centos:7">
             <title xml:lang="en-us">CentOS 7</title>
             <!-- the check references an OVAL file that contains an inventory definition -->


### PR DESCRIPTION
<br/>
Add ```cpe:/o:redhat:enterprise_linux:7::client``` and ```cpe:/o:redhat:enterprise_linux:7::computenode``` into ```RHEL/7```'s CPE dictionary to fix [Requirement #15 of SCAP Version 1.2 Requirements
Matrix](http://people.redhat.com/swells/nist-scap-validation/scap-val-requirements-1.2.html):
```
Every <xccdf:platform> or <cpe2:fact-ref> MUST match as EQUAL or SUPERSET to
a CPE in a CPE dictionary component of this data stream. 
```

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1227

Besides that fix RHEL 6 ComputeNode name in RHEL-6 CPE dictionary (add "6" to the name).

Please review.

Thank you, Jan