### PR TITLE
[Bugfix] Add warning note for ctrl-alt-delete key sequence

### DIFF
--- a/RHEL/6/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/6/input/xccdf/system/accounts/physical.xml
@@ -171,6 +171,12 @@ Linux 6 system, custom changes to <tt>/etc/init/control-alt-delete.conf</tt>
 may be overwritten. Refer to <b>https://access.redhat.com/site/solutions/70464</b>
 for additional information.
 </rationale>
+<warning category="general">Disabling the <tt>Ctrl-Alt-Del</tt> key sequence
+in <tt>/etc/init/control-alt-delete.conf</tt> DOES NOT disable the <tt>Ctrl-Alt-Del</tt>
+key sequence if running in <tt>runlevel 6</tt> (e.g. in GNOME, KDE, etc.)! The
+<tt>Ctrl-Alt-Del</tt> key sequence will only be disabled if running in
+the non-graphical <tt>runlevel 3</tt>.
+</warning>
 <oval id="disable_ctrlaltdel_reboot" />
 <ident cce="27567-7" stig="RHEL-06-000286" />
 </Rule>

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -212,6 +212,12 @@ can reboot the system. If accidentally pressed, as could happen in
 the case of mixed OS environment, this can create the risk of short-term
 loss of availability of systems due to unintentional reboot.
 </rationale>
+<warning category="general">Disabling the <tt>Ctrl-Alt-Del</tt> key sequence
+with <tt>SystemD</tt> DOES NOT disable the <tt>Ctrl-Alt-Del</tt> key sequence
+if running in <tt>graphical.target</tt> mode (e.g. in GNOME, KDE, etc.)! The
+<tt>Ctrl-Alt-Del</tt> key sequence will only be disabled if running in
+the non-graphical <tt>multi-user.target</tt> mode.
+</warning>
 <oval id="disable_ctrlaltdel_reboot" />
 <ident cce="27511-5" />
 <ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="020220" />


### PR DESCRIPTION
- Add a warning for disabling the ctrl-alt-delete key sequence. If disabling
  the ctrl-alt-delete key sequence in /etc/init/control-alt-delete.conf in el6,
  the ctrl-alt-delete key sequence is only disabled in runlevel 3 and has no
  effect in runlevel 5 or GNOME, KDE, etc. If disabling the ctrl-alt-delete key
  sequence using SystemD in el7 or higher, the same thing applies. A different
  XCCDF Rule/OVAL check/remediation is used when running in graphical environments.