### PR TITLE
[BugFix] [Various benchmarks] Fixes for issue #1225 and #1226

### DIFF
--- a/Chromium/input/guide.xml
+++ b/Chromium/input/guide.xml
@@ -38,4 +38,5 @@ countries. All other names are registered trademarks or trademarks of their
 respective companies.</rear-matter>
 <platform idref="cpe:/a:google:chromium-browser" />
 <version>0.9</version>
+<metadata/>
 </Benchmark>

--- a/Chromium/transforms/shorthand2xccdf.xslt
+++ b/Chromium/transforms/shorthand2xccdf.xslt
@@ -43,6 +43,23 @@
     <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+              publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/Debian/8/input/guide.xml
+++ b/Debian/8/input/guide.xml
@@ -34,4 +34,5 @@ quality, reliability, or any other characteristic.</notice>
 <rear-matter><i>SCAP security guide for Debian - release 1</i></rear-matter>
 <platform idref="cpe:/o:debianproject:debian:8" />
 <version>0.0.1</version>
+<metadata/>
 </Benchmark>

--- a/Debian/8/transforms/shorthand2xccdf.xslt
+++ b/Debian/8/transforms/shorthand2xccdf.xslt
@@ -36,6 +36,23 @@
     </xsl:attribute>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+       publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/Fedora/input/guide.xml
+++ b/Fedora/input/guide.xml
@@ -40,4 +40,5 @@ respective companies.</rear-matter>
 <platform idref="cpe:/o:fedoraproject:fedora:23" />
 <platform idref="cpe:/o:fedoraproject:fedora:22" />
 <version>0.0.4</version>
+<metadata/>
 </Benchmark>

--- a/Fedora/transforms/shorthand2xccdf.xslt
+++ b/Fedora/transforms/shorthand2xccdf.xslt
@@ -43,6 +43,23 @@
     <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+              publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/Firefox/input/guide.xml
+++ b/Firefox/input/guide.xml
@@ -38,4 +38,5 @@ countries. All other names are registered trademarks or trademarks of their
 respective companies.</rear-matter>
 <platform idref="cpe:/a:mozilla:firefox" />
 <version>0.9</version>
+<metadata/>
 </Benchmark>

--- a/Firefox/transforms/shorthand2xccdf.xslt
+++ b/Firefox/transforms/shorthand2xccdf.xslt
@@ -43,6 +43,23 @@
     <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+              publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/JBoss/Fuse/6/input/guide.xml
+++ b/JBoss/Fuse/6/input/guide.xml
@@ -40,4 +40,5 @@ respective companies.</rear-matter>
 <platform idref="cpe:/a:redhat:jboss_fuse:6.1.0" />
 <platform idref="cpe:/a:redhat:jboss_fuse_service_works:6.0" />
 <version>0.9</version>
+<metadata/>
 </Benchmark>

--- a/JBoss/Fuse/6/transforms/shorthand2xccdf.xslt
+++ b/JBoss/Fuse/6/transforms/shorthand2xccdf.xslt
@@ -43,6 +43,23 @@
     <xccdf:version><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+              publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/JRE/input/guide.xml
+++ b/JRE/input/guide.xml
@@ -41,4 +41,5 @@ respective companies.</rear-matter>
 <platform idref="cpe:/a:redhat:openjdk:" />
 <platform idref="cpe:/a:ibm:jre:" />
 <version>1.0</version>
+<metadata/>
 </Benchmark>

--- a/JRE/transforms/shorthand2xccdf.xslt
+++ b/JRE/transforms/shorthand2xccdf.xslt
@@ -43,6 +43,23 @@
     <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+              publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/OpenStack/RHEL-OSP/7/input/guide.xml
+++ b/OpenStack/RHEL-OSP/7/input/guide.xml
@@ -39,4 +39,5 @@ respective companies.</rear-matter>
 <platform idref="cpe:/o:redhat:enterprise_linux:7" />
 <platform idref="cpe:/o:redhat:enterprise_linux:7::client" />
 <version>0.9</version>
+<metadata/>
 </Benchmark>

--- a/OpenStack/RHEL-OSP/7/transforms/shorthand2xccdf.xslt
+++ b/OpenStack/RHEL-OSP/7/transforms/shorthand2xccdf.xslt
@@ -43,6 +43,23 @@
     <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+              publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/RHEL/5/input/guide.xml
+++ b/RHEL/5/input/guide.xml
@@ -39,4 +39,5 @@ respective companies.</rear-matter>
 <platform idref="cpe:/o:redhat:enterprise_linux:4" />
 <platform idref="cpe:/o:redhat:enterprise_linux:5" />
 <version>0.9</version>
+<metadata/>
 </Benchmark>

--- a/RHEL/5/transforms/shorthand2xccdf.xslt
+++ b/RHEL/5/transforms/shorthand2xccdf.xslt
@@ -43,6 +43,23 @@
     <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+              publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/RHEL/6/input/guide.xml
+++ b/RHEL/6/input/guide.xml
@@ -44,51 +44,5 @@ respective companies.</rear-matter>
 <platform idref="cpe:/o:redhat:enterprise_linux:6::client" />
 <platform idref="cpe:/o:redhat:enterprise_linux:6::computenode" />
 <version>0.9</version>
-<metadata>
-	<dc:publisher>SCAP Security Guide Project</dc:publisher>
-	<dc:creator>SCAP Security Guide Project</dc:creator>
-	<dc:contributor>Gabe Alford</dc:contributor>
-	<dc:contributor>Christopher Anderson</dc:contributor>
-	<dc:contributor>Jeff Blank</dc:contributor>
-	<dc:contributor>Blake Burkhart</dc:contributor>
-	<dc:contributor>Frank Caviggia</dc:contributor>
-	<dc:contributor>Eric Christensen</dc:contributor>
-	<dc:contributor>Caleb Cooper</dc:contributor>
-	<dc:contributor>Nick Crawford</dc:contributor>
-	<dc:contributor>Maura Dailey</dc:contributor>
-	<dc:contributor>Greg Elin</dc:contributor>
-	<dc:contributor>Andrew Gilmore</dc:contributor>
-	<dc:contributor>Jeremiah Jahn</dc:contributor>
-	<dc:contributor>Luke Kordell</dc:contributor>
-	<dc:contributor>Ján Lieskovský</dc:contributor>
-	<dc:contributor>Šimon Lukašík</dc:contributor>
-	<dc:contributor>Michael McConachie</dc:contributor>
-	<dc:contributor>Rodney Mercer</dc:contributor>
-	<dc:contributor>Brian Millett</dc:contributor>
-	<dc:contributor>Michael Moseley</dc:contributor>
-	<dc:contributor>Joe Nall</dc:contributor>
-	<dc:contributor>Michele Newman</dc:contributor>
-	<dc:contributor>Michael Palmiotto</dc:contributor>
-	<dc:contributor>Kenneth Peeples</dc:contributor>
-	<dc:contributor>Martin Preisler</dc:contributor>
-	<dc:contributor>Rick Renshaw</dc:contributor>
-	<dc:contributor>Willy Santos</dc:contributor>
-	<dc:contributor>Satoru Satoh</dc:contributor>
-	<dc:contributor>Ray Shaw</dc:contributor>
-	<dc:contributor>Spencer Shimko</dc:contributor>
-	<dc:contributor>Francisco Slavin</dc:contributor>
-	<dc:contributor>Dave Smith</dc:contributor>
-	<dc:contributor>Kevin Spargur</dc:contributor>
-	<dc:contributor>Kenneth Stailey</dc:contributor>
-	<dc:contributor>Leland Steinke</dc:contributor>
-	<dc:contributor>Paul Tittle</dc:contributor>
-	<dc:contributor>Jeb Trayer</dc:contributor>
-	<dc:contributor>Shawn Wells</dc:contributor>
-	<dc:contributor>Jan Černý</dc:contributor>
-	<dc:contributor>Zbyněk Moravec</dc:contributor>
-	<dc:contributor>Michal Šrubař</dc:contributor>
-	<dc:contributor>Jean-Baptiste Donnette</dc:contributor>
-	<dc:contributor>Philippe Thierry</dc:contributor>
-	<dc:source>https://github.com/OpenSCAP/scap-security-guide/releases/latest</dc:source>
-</metadata>
+<metadata/>
 </Benchmark>

--- a/RHEL/6/transforms/shorthand2xccdf.xslt
+++ b/RHEL/6/transforms/shorthand2xccdf.xslt
@@ -43,6 +43,23 @@
     <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+              publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/RHEL/7/input/guide.xml
+++ b/RHEL/7/input/guide.xml
@@ -40,4 +40,5 @@ respective companies.</rear-matter>
 <platform idref="cpe:/o:redhat:enterprise_linux:7::client" />
 <platform idref="cpe:/o:redhat:enterprise_linux:7::computenode" />
 <version>0.9</version>
+<metadata/>
 </Benchmark>

--- a/RHEL/7/transforms/shorthand2xccdf.xslt
+++ b/RHEL/7/transforms/shorthand2xccdf.xslt
@@ -43,6 +43,23 @@
     <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+       publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/RHEVM3/input/guide.xml
+++ b/RHEVM3/input/guide.xml
@@ -10,4 +10,5 @@
   <reference href="TODO::INSERT"></reference>
   <platform idref="cpe:/o:redhat:enterprise_linux:6" />
   <version>0.1</version>
+  <metadata/>
 </Benchmark>

--- a/RHEVM3/transforms/shorthand2xccdf.xslt
+++ b/RHEVM3/transforms/shorthand2xccdf.xslt
@@ -43,6 +43,23 @@
     <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+              publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/Webmin/input/guide.xml
+++ b/Webmin/input/guide.xml
@@ -38,4 +38,5 @@ countries. All other names are registered trademarks or trademarks of their
 respective companies.</rear-matter>
 <!-- <platform idref="cpe:/a:gentoo:webmin" /> -->
 <version>1.0</version>
+<metadata/>
 </Benchmark>

--- a/Webmin/transforms/shorthand2xccdf.xslt
+++ b/Webmin/transforms/shorthand2xccdf.xslt
@@ -43,6 +43,23 @@
     <xccdf:version update="{$ssg-benchmark-latest-uri}"><xsl:value-of select="$ssg_version"/></xccdf:version>
   </xsl:template>
 
+  <!-- Expand <metadata> element with required information about benchmark's
+              publisher, creator, contributor(s), and source -->
+  <xsl:template match="Benchmark/metadata">
+    <xccdf:metadata>
+      <!-- Insert benchmark publisher -->
+      <dc:publisher><xsl:value-of select="$ssg-project-name"/></dc:publisher>
+      <!-- Insert benchmark creator -->
+      <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
+      <!-- Insert list of individual contributors for benchmark -->
+      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+        <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
+      </xsl:for-each>
+      <!-- Insert benchmark source -->
+      <dc:source><xsl:value-of select="$ssg-benchmark-latest-uri"/></dc:source>
+    </xccdf:metadata>
+  </xsl:template>
+
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
   <xsl:template match="Rule">
     <Rule selected="false">

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -52,8 +52,17 @@ $(OUT)/shorthand.xml: $(OUT)/guide.xml $(IN)/guide.xslt $(guide_xslt_deps)
 	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" -o $@ $(IN)/guide.xslt $(OUT)/guide.xml
 	xmllint --format --output $@ $@
 
+# Benchmark metadata prerequisite - derive $(OUT)/contributors.xml from the content of Contributors.md
+$(OUT)/contributors.xml:
+	# Create $(OUT)/contributors.xml file:
+	# * holding <text> like root element and
+	# * names of the individual SSG contributor(s) within <contributor> element(s)
+	echo "<text>" > $@
+	sed -n -e 's/\* \(.*\)/<contributor>\1<\/contributor>/p' $(SHARED)/../Contributors.md >> $@
+	echo "</text>" >> $@
+
 # Common build targets - convert shorthand format to an XCCDF stub
-$(OUT)/xccdf-unlinked-unresolved.xml: $(OUT)/shorthand.xml $(TRANS)/shorthand2xccdf.xslt $(TRANS)/constants.xslt $(SHARED)/$(TRANS)/shared_constants.xslt
+$(OUT)/xccdf-unlinked-unresolved.xml: $(OUT)/shorthand.xml $(OUT)/contributors.xml $(TRANS)/shorthand2xccdf.xslt $(TRANS)/constants.xslt $(SHARED)/$(TRANS)/shared_constants.xslt
 	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $@ $(TRANS)/shorthand2xccdf.xslt $<
 
 # Common build targets - improve the XCCDF stub - first resolve

--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -17,6 +17,7 @@
 <xsl:variable name="pcidssuri">https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-1.pdf</xsl:variable>
 <xsl:variable name="anssiuri">http://www.ssi.gouv.fr/administration/bonnes-pratiques/</xsl:variable>
 <xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
+<xsl:variable name="ssg-project-name">SCAP Security Guide Project</xsl:variable>
 <xsl:variable name="ssg-benchmark-latest-uri">https://github.com/OpenSCAP/scap-security-guide/releases/latest</xsl:variable>
 
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>


### PR DESCRIPTION
Start generating the content of the ```<xccdf:metadata>``` benchmark element in various benchmark dynamically:
* obtain the ```<dc:publisher>``` and ```<dc:creator>``` values from the newly introduced ```ssg-project-name``` shared ```<xsl:variable```,
* obtain ```<dc:contributor>``` element values from the content of the currently present ```Contributors.md``` file,
* finally obtain ```<dc:source>``` value from the value of the ```ssg-benchmark-latest-uri``` shared ```<xsl:variable```

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1226
Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1225

For the count of the commits within this PR - the changes are basically always the same, but in different benchmark (have split them into separate commits for [hopefully] better readability).

Please review.

Thank you, Jan