### PR TITLE
[Enhancement] [Infrastructure] Don't rely on absolute path of the remediation functions library to be able to perform remediations

### DIFF
--- a/Chromium/Makefile
+++ b/Chromium/Makefile
@@ -1,6 +1,9 @@
 all: tables guide content dist
 
-SHARED = ../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../shared
 include $(SHARED)/product-make.include
 
 PROD = chromium

--- a/Chromium/input/guide.xslt
+++ b/Chromium/input/guide.xslt
@@ -1,16 +1,39 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
+
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
-       <!-- adding profiles here -->
-		<xsl:apply-templates select="document('profiles/stig-chromium-upstream.xml')" />
-       <Value id="conditional_clause" type="string" operator="equals">
-                 <title>A conditional clause for check statements.</title>
-                 <description>A conditional clause for check statements.</description>
-                 <value>This is a placeholder.</value>
-       </Value>
+
+      <!-- Adding profiles here -->
+      <xsl:apply-templates select="document('profiles/stig-chromium-upstream.xml')" />
+
+      <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
+      <Value id="conditional_clause" type="string" operator="equals">
+        <title>A conditional clause for check statements.</title>
+        <description>A conditional clause for check statements.</description>
+        <value>This is a placeholder.</value>
+      </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
 
       <xsl:apply-templates select="document('intro/intro.xml')" /> 
       <xsl:apply-templates select="document('application/chromium.xml')" />

--- a/Debian/8/Makefile
+++ b/Debian/8/Makefile
@@ -1,6 +1,9 @@
 all: tables guide content dist
 
-SHARED = ../../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../../shared
 include $(SHARED)/product-make.include
 
 PROD = debian8

--- a/Debian/8/input/guide.xslt
+++ b/Debian/8/input/guide.xslt
@@ -1,25 +1,45 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
-<!-- This transform assembles all fragments into one "shorthand" XCCDF document -->
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
+
 
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
 
-      <!-- adding profiles here -->
-          <!---
+      <!-- Adding profiles here -->
+        <!---
           <xsl:if test=" number($withtest) = number(0) ">
 	       <xsl:apply-templates select="document('profiles/test.xml')" />
           </xsl:if>
-          -->
-          <xsl:apply-templates select="document('profiles/common.xml')" />
+        -->
+      <xsl:apply-templates select="document('profiles/common.xml')" />
 
+      <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
       <Value id="conditional_clause" type="string" operator="equals">
-                <title>A conditional clause for check statements.</title>
-                <description>A conditional clause for check statements.</description>
-                <value>This is a placeholder.</value>
+        <title>A conditional clause for check statements.</title>
+        <description>A conditional clause for check statements.</description>
+        <value>This is a placeholder.</value>
       </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
       
       <xsl:apply-templates select="document('intro/intro.xml')" />
       <xsl:apply-templates select="document('xccdf/system/system.xml')" />

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -1,6 +1,9 @@
 all: guide content dist
 
-SHARED = ../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../shared
 include $(SHARED)/product-make.include
 
 PROD = fedora

--- a/Fedora/input/guide.xslt
+++ b/Fedora/input/guide.xslt
@@ -1,21 +1,41 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
-<!-- This transform assembles all fragments into one "shorthand" XCCDF document -->
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
 
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
 
-      <!-- adding profiles here -->
+      <!-- Adding profiles here -->
       <xsl:apply-templates select="document('profiles/standard.xml')" />
       <xsl:apply-templates select="document('profiles/common.xml')" />
 
+      <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
       <Value id="conditional_clause" type="string" operator="equals">
-                <title>A conditional clause for check statements.</title>
-                <description>A conditional clause for check statements.</description>
-                <value>This is a placeholder.</value>
+        <title>A conditional clause for check statements.</title>
+        <description>A conditional clause for check statements.</description>
+        <value>This is a placeholder.</value>
       </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
+
       <xsl:apply-templates select="document('intro/intro.xml')" />
       <xsl:apply-templates select="document('xccdf/system/system.xml')" />
       <xsl:apply-templates select="document('xccdf/services/services.xml')" />

--- a/Firefox/Makefile
+++ b/Firefox/Makefile
@@ -1,6 +1,9 @@
 all: tables guide content dist
 
-SHARED = ../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../shared
 include $(SHARED)/product-make.include
 
 PROD = firefox

--- a/Firefox/input/guide.xslt
+++ b/Firefox/input/guide.xslt
@@ -1,16 +1,39 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
+
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
-       <!-- adding profiles here -->
-		<xsl:apply-templates select="document('profiles/stig-firefox-upstream.xml')" />
+
+       <!-- Adding profiles here -->
+       <xsl:apply-templates select="document('profiles/stig-firefox-upstream.xml')" />
+
+       <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
        <Value id="conditional_clause" type="string" operator="equals">
-                 <title>A conditional clause for check statements.</title>
-                 <description>A conditional clause for check statements.</description>
-                 <value>This is a placeholder.</value>
+         <title>A conditional clause for check statements.</title>
+         <description>A conditional clause for check statements.</description>
+         <value>This is a placeholder.</value>
        </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
 
       <xsl:apply-templates select="document('intro/intro.xml')" /> 
       <xsl:apply-templates select="document('xccdf/application/firefox.xml')" />

--- a/JBoss/EAP/5/Makefile
+++ b/JBoss/EAP/5/Makefile
@@ -1,6 +1,9 @@
 all: tables guide content dist
 
-SHARED = ../../../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../../../shared
 include $(SHARED)/product-make.include
 
 PROD = eap5

--- a/JBoss/EAP/5/input/guide.xslt
+++ b/JBoss/EAP/5/input/guide.xslt
@@ -1,16 +1,39 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
+
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
-       <!-- adding profiles here -->
-		<xsl:apply-templates select="document('profiles/stig-eap5-upstream.xml')" />
+
+       <!-- Adding profiles here -->
+       <xsl:apply-templates select="document('profiles/stig-eap5-upstream.xml')" />
+
+       <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
        <Value id="conditional_clause" type="string" operator="equals">
-                 <title>A conditional clause for check statements.</title>
-                 <description>A conditional clause for check statements.</description>
-                 <value>This is a placeholder.</value>
+         <title>A conditional clause for check statements.</title>
+         <description>A conditional clause for check statements.</description>
+         <value>This is a placeholder.</value>
        </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
 
       <xsl:apply-templates select="document('intro/intro.xml')" /> 
       <xsl:apply-templates select="document('xccdf/application/eap5.xml')" />

--- a/JBoss/Fuse/6/Makefile
+++ b/JBoss/Fuse/6/Makefile
@@ -1,6 +1,9 @@
 all: tables guide content dist
 
-SHARED = ../../../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../../../shared
 include $(SHARED)/product-make.include
 
 PROD = fuse6

--- a/JBoss/Fuse/6/input/guide.xslt
+++ b/JBoss/Fuse/6/input/guide.xslt
@@ -1,18 +1,41 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
+
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
-       <!-- adding profiles here -->
-                <xsl:apply-templates select="document('profiles/common.xml')" />
-                <xsl:apply-templates select="document('profiles/stig-amq-upstream.xml')" />
-		<xsl:apply-templates select="document('profiles/stig-fuse6-upstream.xml')" />
+
+       <!-- Adding profiles here -->
+       <xsl:apply-templates select="document('profiles/common.xml')" />
+       <xsl:apply-templates select="document('profiles/stig-amq-upstream.xml')" />
+       <xsl:apply-templates select="document('profiles/stig-fuse6-upstream.xml')" />
+
+       <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
        <Value id="conditional_clause" type="string" operator="equals">
-                 <title>A conditional clause for check statements.</title>
-                 <description>A conditional clause for check statements.</description>
-                 <value>This is a placeholder.</value>
+         <title>A conditional clause for check statements.</title>
+         <description>A conditional clause for check statements.</description>
+         <value>This is a placeholder.</value>
        </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
 
       <xsl:apply-templates select="document('intro/intro.xml')" /> 
       <xsl:apply-templates select="document('xccdf/application/fuse6.xml')" />

--- a/JRE/Makefile
+++ b/JRE/Makefile
@@ -1,6 +1,9 @@
 all: tables guide content dist
 
-SHARED = ../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../shared
 include $(SHARED)/product-make.include
 
 PROD = jre

--- a/JRE/input/guide.xslt
+++ b/JRE/input/guide.xslt
@@ -1,16 +1,39 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
+
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
-       <!-- adding profiles here -->
-		<xsl:apply-templates select="document('profiles/stig-java-upstream.xml')" />
+
+       <!-- Adding profiles here -->
+       <xsl:apply-templates select="document('profiles/stig-java-upstream.xml')" />
+
+       <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
        <Value id="conditional_clause" type="string" operator="equals">
-                 <title>A conditional clause for check statements.</title>
-                 <description>A conditional clause for check statements.</description>
-                 <value>This is a placeholder.</value>
+         <title>A conditional clause for check statements.</title>
+         <description>A conditional clause for check statements.</description>
+         <value>This is a placeholder.</value>
        </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
 
       <xsl:apply-templates select="document('intro/intro.xml')" />
       <xsl:apply-templates select="document('application/java.xml')" />

--- a/OpenStack/RHEL-OSP/7/Makefile
+++ b/OpenStack/RHEL-OSP/7/Makefile
@@ -1,6 +1,9 @@
 all: tables guide content dist
 
-SHARED = ../../../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../../../shared
 include $(SHARED)/product-make.include
 
 PROD = rhel-osp7

--- a/OpenStack/RHEL-OSP/7/input/guide.xslt
+++ b/OpenStack/RHEL-OSP/7/input/guide.xslt
@@ -1,26 +1,45 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
-<!-- This transform assembles all fragments into one "shorthand" XCCDF document -->
-<!-- It expects a numeric parameter "withtest" specifying if the 'test' profile should
-     be included ("withtest=0") into the benchmark or not ("withtest=1"). -->
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
+
 
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
 
-       <!-- adding profiles here -->
+       <!-- Adding profiles here -->
 		<!-- old testing code 
 		<xsl:if test=" number($withtest) = number(0) ">
 			<xsl:apply-templates select="document('profiles/test.xml')" />
 		</xsl:if> -->
-		<xsl:apply-templates select="document('profiles/stig-openstack.xml')" />
+       <xsl:apply-templates select="document('profiles/stig-openstack.xml')" />
 
+       <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
        <Value id="conditional_clause" type="string" operator="equals">
-                 <title>A conditional clause for check statements.</title>
-                 <description>A conditional clause for check statements.</description>
-                 <value>This is a placeholder.</value>
+         <title>A conditional clause for check statements.</title>
+         <description>A conditional clause for check statements.</description>
+         <value>This is a placeholder.</value>
        </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
+
       <xsl:apply-templates select="document('intro/intro.xml')" />
       <xsl:apply-templates select="document('xccdf/services/services.xml')" />
       <!-- the auxiliary Groups here will be removed prior to some outputs -->

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -1,6 +1,9 @@
 all: tables guide content dist
 
-SHARED = ../../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../../shared
 include $(SHARED)/product-make.include
 
 PROD = rhel5

--- a/RHEL/5/input/guide.xslt
+++ b/RHEL/5/input/guide.xslt
@@ -1,20 +1,40 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
-<!-- This transform assembles all fragments into one "shorthand" XCCDF document -->
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
 
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
 
-       <!-- adding profiles here -->
-		<xsl:apply-templates select="document('profiles/stig-rhel5-server-upstream.xml')" />
+       <!-- Adding profiles here -->
+       <xsl:apply-templates select="document('profiles/stig-rhel5-server-upstream.xml')" />
 
+       <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
        <Value id="conditional_clause" type="string" operator="equals">
-                 <title>A conditional clause for check statements.</title>
-                 <description>A conditional clause for check statements.</description>
-                 <value>This is a placeholder.</value>
+         <title>A conditional clause for check statements.</title>
+         <description>A conditional clause for check statements.</description>
+         <value>This is a placeholder.</value>
        </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
+
       <xsl:apply-templates select="document('intro/intro.xml')" />
       <xsl:apply-templates select="document('xccdf/system/system.xml')" />
       <xsl:apply-templates select="document('xccdf/services/services.xml')" />

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -1,6 +1,9 @@
 all: tables guide content dist
 
-SHARED = ../../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../../shared
 include $(SHARED)/product-make.include
 
 PROD = rhel6

--- a/RHEL/6/input/guide.xslt
+++ b/RHEL/6/input/guide.xslt
@@ -1,39 +1,57 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
-<!-- This transform assembles all fragments into one "shorthand" XCCDF document -->
-<!-- An optional parameter "withtest 0" specifies whether the 'test' profile should
-     be included into the benchmark. -->
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
 
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
 
-       <!-- adding profiles here -->
-		<xsl:if test=" number($withtest) = number(0) ">
-			<xsl:apply-templates select="document('profiles/test.xml')" />
-		</xsl:if>
-		<xsl:apply-templates select="document('profiles/standard.xml')" />
-		<xsl:apply-templates select="document('profiles/CS2.xml')" />
-		<xsl:apply-templates select="document('profiles/common.xml')" />
-		<!-- <xsl:apply-templates select="document('profiles/desktop.xml')" /> -->
-		<xsl:apply-templates select="document('profiles/server.xml')" />
-		<!-- <xsl:apply-templates select="document('profiles/ftp.xml')" /> -->
-		<xsl:apply-templates select="document('profiles/stig-rhel6-workstation-upstream.xml')" />
-		<xsl:apply-templates select="document('profiles/stig-rhel6-server-gui-upstream.xml')" />
-		<xsl:apply-templates select="document('profiles/stig-rhel6-server-upstream.xml')" />
-		<xsl:apply-templates select="document('profiles/usgcb-rhel6-server.xml')" />
-		<xsl:apply-templates select="document('profiles/rht-ccp.xml')" />
-		<xsl:apply-templates select="document('profiles/CSCF-RHEL6-MLS.xml')" />
-		<xsl:apply-templates select="document('profiles/C2S.xml')" />
-		<xsl:apply-templates select="document('profiles/pci-dss.xml')" />
-		<xsl:apply-templates select="document('profiles/nist-CL-IL-AL.xml')" />
+       <!-- Adding profiles here -->
+       <xsl:if test=" number($withtest) = number(0) ">
+         <xsl:apply-templates select="document('profiles/test.xml')" />
+       </xsl:if>
+       <xsl:apply-templates select="document('profiles/standard.xml')" />
+       <xsl:apply-templates select="document('profiles/CS2.xml')" />
+       <xsl:apply-templates select="document('profiles/common.xml')" />
+       <!-- <xsl:apply-templates select="document('profiles/desktop.xml')" /> -->
+       <xsl:apply-templates select="document('profiles/server.xml')" />
+       <!-- <xsl:apply-templates select="document('profiles/ftp.xml')" /> -->
+       <xsl:apply-templates select="document('profiles/stig-rhel6-workstation-upstream.xml')" />
+       <xsl:apply-templates select="document('profiles/stig-rhel6-server-gui-upstream.xml')" />
+       <xsl:apply-templates select="document('profiles/stig-rhel6-server-upstream.xml')" />
+       <xsl:apply-templates select="document('profiles/usgcb-rhel6-server.xml')" />
+       <xsl:apply-templates select="document('profiles/rht-ccp.xml')" />
+       <xsl:apply-templates select="document('profiles/CSCF-RHEL6-MLS.xml')" />
+       <xsl:apply-templates select="document('profiles/C2S.xml')" />
+       <xsl:apply-templates select="document('profiles/pci-dss.xml')" />
+       <xsl:apply-templates select="document('profiles/nist-CL-IL-AL.xml')" />
 
+       <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
        <Value id="conditional_clause" type="string" operator="equals">
-                 <title>A conditional clause for check statements.</title>
-                 <description>A conditional clause for check statements.</description>
-                 <value>This is a placeholder.</value>
+         <title>A conditional clause for check statements.</title>
+         <description>A conditional clause for check statements.</description>
+         <value>This is a placeholder.</value>
        </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
+
       <xsl:apply-templates select="document('intro/intro.xml')" />
       <xsl:apply-templates select="document('xccdf/system/system.xml')" />
       <xsl:apply-templates select="document('xccdf/services/services.xml')" />

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -1,6 +1,9 @@
 all: tables guide content dist
 
-SHARED = ../../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../../shared
 include $(SHARED)/product-make.include
 
 PROD = rhel7

--- a/RHEL/7/input/guide.xslt
+++ b/RHEL/7/input/guide.xslt
@@ -1,34 +1,52 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
-<!-- This transform assembles all fragments into one "shorthand" XCCDF document -->
-<!-- An optional parameter "withtest 0" specifies whether the 'test' profile should
-     be included into the benchmark. -->
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
 
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
 
-       <!-- adding profiles here -->
-		<xsl:if test=" number($withtest) = number(0) ">
-			<xsl:apply-templates select="document('profiles/test.xml')" />
-		</xsl:if>
-		<xsl:apply-templates select="document('profiles/standard.xml')" />
-		<xsl:apply-templates select="document('profiles/pci-dss.xml')" />
-		<xsl:apply-templates select="document('profiles/C2S.xml')" />
-		<xsl:apply-templates select="document('profiles/rht-ccp.xml')" />
-		<xsl:apply-templates select="document('profiles/common.xml')" />
-		<xsl:apply-templates select="document('profiles/stig-rhel7-workstation-upstream.xml')" />
-		<xsl:apply-templates select="document('profiles/stig-rhel7-server-gui-upstream.xml')" />
-		<xsl:apply-templates select="document('profiles/stig-rhel7-server-upstream.xml')" />
-		<xsl:apply-templates select="document('profiles/ospp-rhel7-server.xml')" />
-		<xsl:apply-templates select="document('profiles/nist-CL-IL-AL.xml')" />
+        <!-- Adding profiles here -->
+	<xsl:if test=" number($withtest) = number(0) ">
+          <xsl:apply-templates select="document('profiles/test.xml')" />
+	</xsl:if>
+        <xsl:apply-templates select="document('profiles/standard.xml')" />
+        <xsl:apply-templates select="document('profiles/pci-dss.xml')" />
+        <xsl:apply-templates select="document('profiles/C2S.xml')" />
+        <xsl:apply-templates select="document('profiles/rht-ccp.xml')" />
+        <xsl:apply-templates select="document('profiles/common.xml')" />
+        <xsl:apply-templates select="document('profiles/stig-rhel7-workstation-upstream.xml')" />
+        <xsl:apply-templates select="document('profiles/stig-rhel7-server-gui-upstream.xml')" />
+        <xsl:apply-templates select="document('profiles/stig-rhel7-server-upstream.xml')" />
+        <xsl:apply-templates select="document('profiles/ospp-rhel7-server.xml')" />
+        <xsl:apply-templates select="document('profiles/nist-CL-IL-AL.xml')" />
 
-       <Value id="conditional_clause" type="string" operator="equals">
-                 <title>A conditional clause for check statements.</title>
-                 <description>A conditional clause for check statements.</description>
-                 <value>This is a placeholder.</value>
-       </Value>
+        <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
+        <Value id="conditional_clause" type="string" operator="equals">
+          <title>A conditional clause for check statements.</title>
+          <description>A conditional clause for check statements.</description>
+          <value>This is a placeholder.</value>
+        </Value>
+
+        <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+             location here -->
+        <xsl:if test=" string($SHARED_RP) != 'undef' ">
+          <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+        </xsl:if>
+
       <xsl:apply-templates select="document('intro/intro.xml')" />
       <xsl:apply-templates select="document('xccdf/system/system.xml')" />
       <xsl:apply-templates select="document('xccdf/services/services.xml')" />

--- a/RHEL/7/input/guide.xslt
+++ b/RHEL/7/input/guide.xslt
@@ -19,33 +19,33 @@
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
 
-        <!-- Adding profiles here -->
-	<xsl:if test=" number($withtest) = number(0) ">
-          <xsl:apply-templates select="document('profiles/test.xml')" />
-	</xsl:if>
-        <xsl:apply-templates select="document('profiles/standard.xml')" />
-        <xsl:apply-templates select="document('profiles/pci-dss.xml')" />
-        <xsl:apply-templates select="document('profiles/C2S.xml')" />
-        <xsl:apply-templates select="document('profiles/rht-ccp.xml')" />
-        <xsl:apply-templates select="document('profiles/common.xml')" />
-        <xsl:apply-templates select="document('profiles/stig-rhel7-workstation-upstream.xml')" />
-        <xsl:apply-templates select="document('profiles/stig-rhel7-server-gui-upstream.xml')" />
-        <xsl:apply-templates select="document('profiles/stig-rhel7-server-upstream.xml')" />
-        <xsl:apply-templates select="document('profiles/ospp-rhel7-server.xml')" />
-        <xsl:apply-templates select="document('profiles/nist-CL-IL-AL.xml')" />
+      <!-- Adding profiles here -->
+      <xsl:if test=" number($withtest) = number(0) ">
+        <xsl:apply-templates select="document('profiles/test.xml')" />
+      </xsl:if>
+      <xsl:apply-templates select="document('profiles/standard.xml')" />
+      <xsl:apply-templates select="document('profiles/pci-dss.xml')" />
+      <xsl:apply-templates select="document('profiles/C2S.xml')" />
+      <xsl:apply-templates select="document('profiles/rht-ccp.xml')" />
+      <xsl:apply-templates select="document('profiles/common.xml')" />
+      <xsl:apply-templates select="document('profiles/stig-rhel7-workstation-upstream.xml')" />
+      <xsl:apply-templates select="document('profiles/stig-rhel7-server-gui-upstream.xml')" />
+      <xsl:apply-templates select="document('profiles/stig-rhel7-server-upstream.xml')" />
+      <xsl:apply-templates select="document('profiles/ospp-rhel7-server.xml')" />
+      <xsl:apply-templates select="document('profiles/nist-CL-IL-AL.xml')" />
 
-        <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
-        <Value id="conditional_clause" type="string" operator="equals">
-          <title>A conditional clause for check statements.</title>
-          <description>A conditional clause for check statements.</description>
-          <value>This is a placeholder.</value>
-        </Value>
+      <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
+      <Value id="conditional_clause" type="string" operator="equals">
+        <title>A conditional clause for check statements.</title>
+        <description>A conditional clause for check statements.</description>
+        <value>This is a placeholder.</value>
+      </Value>
 
-        <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
-             location here -->
-        <xsl:if test=" string($SHARED_RP) != 'undef' ">
-          <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
-        </xsl:if>
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
 
       <xsl:apply-templates select="document('intro/intro.xml')" />
       <xsl:apply-templates select="document('xccdf/system/system.xml')" />

--- a/RHEVM3/Makefile
+++ b/RHEVM3/Makefile
@@ -1,6 +1,9 @@
 all: tables guide checks content dist
 
-SHARED = ../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../shared
 include $(SHARED)/product-make.include
 
 # todo: remove this local override of REFS variable

--- a/RHEVM3/input/guide.xslt
+++ b/RHEVM3/input/guide.xslt
@@ -1,17 +1,39 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
+
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
 
-       <xsl:apply-templates select="document('profiles/stig-rhevm3.xml')" />
+      <!-- Adding profiles here --> 
+      <xsl:apply-templates select="document('profiles/stig-rhevm3.xml')" />
 
-       <Value id="conditional_clause" type="string" operator="equals">
-                 <title>A conditional clause for check statements.</title>
-                 <description>A conditional clause for check statements.</description>
-                 <value>This is a placeholder.</value>
-       </Value>
+      <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
+      <Value id="conditional_clause" type="string" operator="equals">
+        <title>A conditional clause for check statements.</title>
+        <description>A conditional clause for check statements.</description>
+        <value>This is a placeholder.</value>
+      </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
 
       <xsl:apply-templates select="document('intro/intro.xml')" />
       <xsl:apply-templates select="document('xccdf/services/sample.xml')" />

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -1,6 +1,9 @@
 all: tables guide content dist
 
-SHARED = ../shared
+# Do not remove exporting of SHARED variable!!! (since
+# shared/transforms/combineremediations.py helper
+# requires its value to be available)
+export SHARED = ../shared
 include $(SHARED)/product-make.include
 
 PROD = webmin

--- a/Webmin/input/guide.xslt
+++ b/Webmin/input/guide.xslt
@@ -1,16 +1,39 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
 
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP	(required)	Holds the resolved ABSOLUTE path
+					to the SSG's "shared/" directory.
+
+     * withtest		(optional)	If having value set to "0" specifies
+					the 'test' profile should be included
+					into the benchmark.
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
+
   <xsl:template match="Benchmark">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
-       <!-- adding profiles here -->
-		<xsl:apply-templates select="document('profiles/common.xml')" />
+
+       <!-- Adding profiles here -->
+       <xsl:apply-templates select="document('profiles/common.xml')" />
+
+       <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
        <Value id="conditional_clause" type="string" operator="equals">
-                 <title>A conditional clause for check statements.</title>
-                 <description>A conditional clause for check statements.</description>
-                 <value>This is a placeholder.</value>
+         <title>A conditional clause for check statements.</title>
+         <description>A conditional clause for check statements.</description>
+         <value>This is a placeholder.</value>
        </Value>
+
+      <!-- Adding remediation functions from concat($SHARED_RP, '/xccdf/remediation_functions.xml')
+           location here -->
+      <xsl:if test=" string($SHARED_RP) != 'undef' ">
+        <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
+      </xsl:if>
 
       <xsl:apply-templates select="document('intro/intro.xml')" />
       <xsl:apply-templates select="document('xccdf/system/accounts.xml')" />

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -49,7 +49,7 @@ endif
 # Common build targets - compose single shorthand XCCDF guide from all the sources
 guide_xslt_deps= $(wildcard $(IN)/auxiliary/*.xml) $(wildcard $(IN)/profiles/*.xml) $(wildcard $(IN)/xccdf/**/*.xml)
 $(OUT)/shorthand.xml: $(OUT)/guide.xml $(IN)/guide.xslt $(guide_xslt_deps)
-	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" -o $@ $(IN)/guide.xslt $(OUT)/guide.xml
+	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" --stringparam SHARED_RP "$(realpath $(SHARED))" -o $@ $(IN)/guide.xslt $(OUT)/guide.xml
 	xmllint --format --output $@ $@
 
 # Benchmark metadata prerequisite - derive $(OUT)/contributors.xml from the content of Contributors.md

--- a/shared/transforms/combineremediations.py
+++ b/shared/transforms/combineremediations.py
@@ -77,28 +77,143 @@ def fix_is_applicable_for_product(platform, product):
     # for this product => return False to indicate that
     return False
 
-def substitute_vars(fix):
-    # Brittle and troubling code to assign environment vars to XCCDF values
-    lib = "(\s*\. \/usr\/share\/scap-security-guide\/remediation_functions\s*\S*)"
-    regex = lib + "\n+(\s*declare\s+\S+\n+)?(\s*populate\s+)(\S+)\n(.*)"
-    env_var = re.match(regex, fix.text, re.DOTALL)
 
-    if not env_var:
-        # No need to alter fix.text
+def get_available_remediation_functions():
+    """Parse the content of "$(SHARED)/xccdf/remediation_functions.xml" XML
+    file to obtain the list of currently known SCAP Security Guide internal
+    remediation functions"""
+
+    remediation_functions = []
+    # Determine the relative path to the "/shared" directory
+    shared_dir = os.getenv("SHARED")
+    # Default location of XML file with definitions of remediation functions
+    xmlfilepath = ''
+    # If location of /shared directory is known
+    if shared_dir is not None:
+        # Construct the final path of XML file with remediation functions
+        xmlfilepath = shared_dir + '/xccdf/remediation_functions.xml'
+    if xmlfilepath == '':
+        print("Error determinining location of XML file with definitions of remediation functions")
+        sys.exit(1)
+
+    with open(xmlfilepath) as xmlfile:
+        filestring = xmlfile.read()
+        remediation_functions = re.findall('(?:^|\n)<Value id=\"function_(\S+)\"', filestring, re.DOTALL)
+
+    return remediation_functions
+
+
+def expand_xccdf_subs(fix, remediation_functions):
+    """For those remediation scripts utilizing some of the internal SCAP
+    Security Guide remediation functions expand the selected shell variables
+    and remediation functions calls with <xccdf:sub> element
+
+    This routine translates any instance of the 'populate' function call in
+    the form of:
+
+            populate variable_name
+
+    into
+
+            variable_name="<sub idref="variable_name"/>"
+
+    Also transforms any instance of some other known remediation function (e.g.
+    'replace_or_append' etc.) from the form of:
+
+            function_name "arg1" "arg2" ... "argN"
+
+    into:
+
+            <sub idref="function_function_name"/>
+            function_name "arg1" "arg2" ... "argN"
+    """
+
+    # This remediation script doesn't utilize internal remediation functions
+    # Skip it without any further processing
+    if 'remediation_functions' not in fix.text:
         return
-    # Otherwise, create node to populate environment variable
-    varname = env_var.group(4)
-    mainscript = env_var.group(5)
-    # Keep the source of the remediation_functions library still included in
-    # the updated remediation script. This ensures the script will work
-    # properly also in the case there's yet another of the remediation
-    # functions called later in the script body
-    # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1075
-    fix.text = "\n" + env_var.group(1) + "\n" + varname + "=" + '"'
-    # New <sub> element to reference XCCDF variable
-    xccdf_sub = etree.SubElement(fix, "sub", idref=varname)
-    xccdf_sub.tail = '"' + mainscript
-    fix.append(xccdf_sub)
+    # This remediation script utilizes some of internal remediation functions
+    # Expand shell variables and remediation functions calls with <xccdf:sub>
+    # elements
+    else:
+        pattern = '\n(\s*(?:' + '|'.join(remediation_functions) + ')[^\n]+)\n'
+        fixparts = re.split(pattern, fix.text, re.DOTALL)
+        if fixparts[0] is not None:
+            # Split the portion of fix.text from fix start to first call of
+            # remediation function into two parts:
+            # * head        to hold inclusion of the remediation functions
+            # * tail        to hold part of the fix.text after inclusion,
+            #               but before first call of remediation function
+            _, head, tail, _ = re.split('(.*remediation_functions)(.*)', fixparts[0], 2, re.DOTALL)
+            # If the 'tail' is not empty, make it new fix.text. Otherwise use ''
+            fix.text = tail if tail is not None else ''
+            # Drop the first element of 'fixparts' since it has been processed
+            fixparts.pop(0)
+            # Perform sanity check on new 'fixparts' list content (to continue
+            # successfully 'fixparts' has to contain even count of elements)
+            if len(fixparts) % 2 != 0:
+                print("Error performing XCCDF expansion on remediation script: %s" % fix.get('rule'))
+                print("Invalid count of elements. Exiting")
+                sys.exit(1)
+            # Process remaining 'fixparts' elements in pairs
+            # First pair element is remediation function to be XCCDF expanded
+            # Second pair element (if not empty) is the portion of the original
+            # fix text to be used in newly added sublement's tail
+            for idx in range(0, len(fixparts), 2):
+                # We previously removed enclosing newlines when creating
+                # fixparts list. Add them back and reuse the above 'pattern'
+                fixparts[idx] = "\n%s\n" % fixparts[idx]
+                # Sanity check (verify the first field truly contains call of
+                # some of the remediation functions)
+                if re.match(pattern, fixparts[idx], re.DOTALL) is not None:
+                    # This chunk contains call of 'populate' function
+                    if 'populate' in fixparts[idx]:
+                        # Extract variable name
+                        varname = re.search('\npopulate (\S+)\n', fixparts[idx], re.DOTALL).group(1)
+                        # Define fix text part to contribute to main fix text
+                        fixtextcontribution = '\n%s="' % varname
+                        # Append the contribution
+                        fix.text += fixtextcontribution
+                        # Define new XCCDF <sub> element for the variable
+                        xccdfvarsub = etree.SubElement(fix, "sub", idref=varname)
+                        # If second pair element is not empty, append it as
+                        # tail for the subelement (prefixed with closing '"')
+                        if fixparts[idx + 1] is not None:
+                            xccdfvarsub.tail = '"' + '\n' + fixparts[idx + 1]
+                        # Otherwise append just enclosing '"'
+                        else:
+                           xccdfvarsub.tail = '"' + '\n'
+                        # Append the new subelement to the fix element
+                        fix.append(xccdfvarsub)
+                    # This chunk contains call of other remediation function
+                    else:
+                        # Extract remediation function name
+                        funcname = re.search('\n\s*(\S+) .*\n', fixparts[idx], re.DOTALL).group(1)
+                        # Define new XCCDF <sub> element for the function
+                        xccdffuncsub = etree.SubElement(fix, "sub", idref='function_%s' % funcname)
+                        # Append original function call into tail of the subelement
+                        xccdffuncsub.tail = fixparts[idx]
+                        # If the second element of the pair is not empty,
+                        # append it to the tail of the subelement too
+                        if fixparts[idx + 1] is not None:
+                            xccdffuncsub.tail += fixparts[idx + 1]
+                        # Append the new subelement to the fix element
+                        fix.append(xccdffuncsub)
+                        # Ensure the newly added <xccdf:sub> element for the function
+                        # will be always inserted at newline
+                        # If xccdffuncsub is the first <xccdf:sub> element being
+                        # added as child of <fix> and fix.text doesn't end up with
+                        # newline character, append the newline to the fix.text
+                        if fix.index(xccdffuncsub) == 0:
+                            if re.search('.*\n$', fix.text) is None:
+                                fix.text += '\n'
+                        # If xccdffuncsub isn't the first child (first <xccdf:sub>
+                        # being added), and tail of previous child doesn't end up with
+                        # newline, append the newline to the tail of previous child
+                        else:
+                            previouselem = xccdffuncsub.getprevious()
+                            if re.search('.*\n$', previouselem.tail) is None:
+                                previouselem.tail += '\n'
 
 
 def main():
@@ -116,15 +231,17 @@ def main():
                                 system="urn:xccdf:fix:script:sh",
                                 xmlns="http://checklists.nist.gov/xccdf/1.1")
 
+    remediation_functions = get_available_remediation_functions()
+
     platform = {}
     included_fixes_count = 0
     for filename in os.listdir(fixdir):
         if filename.endswith(".sh"):
-            # create and populate new fix element based on shell file
+            # Create and populate new fix element based on shell file
             fixname = os.path.splitext(filename)[0]
 
             with open(fixdir + "/" + filename, 'r') as fix_file:
-                # assignment automatically escapes shell characters for XML
+                # Assignment automatically escapes shell characters for XML
                 script_platform = fix_file.readline().strip('#').strip().split('=')
                 if len(script_platform) > 1:
                     platform[script_platform[0].strip()] = script_platform[1].strip()
@@ -134,9 +251,9 @@ def main():
                         fix.text = fix_file.read()
                         included_fixes_count += 1
 
-                        # replace instance of bash function "populate" with XCCDF
-                        # variable substitution
-                        substitute_vars(fix)
+                        # Expand shell variables and remediation functions into
+                        # corresponding XCCDF <sub> elements
+                        expand_xccdf_subs(fix, remediation_functions)
                 else:
                     print("\nNotification: Removed the '%s' remediation script from merging as " \
                           "the platform identifier in the script is missing!" % filename)

--- a/shared/xccdf/remediation_functions.xml
+++ b/shared/xccdf/remediation_functions.xml
@@ -1,0 +1,980 @@
+<Group id="remediation_functions">
+<title>Remediation functions used by the SCAP Security Guide Project</title>
+<description>XCCDF form of the various remediation functions as used by
+remediation scripts from the SCAP Security Guide Project</description>
+
+
+<Value id="function_fix_audit_syscall_rule" type="string" operator="equals" interactive="0">
+<title>Remediation function to fix syscall audit rule for given system call</title>
+<description>Function to fix syscall audit rule for given system call. It is
+based on example audit syscall rule definitions as outlined in
+/usr/share/doc/audit-2.3.7/stig.rules file provided with the audit package. It
+will combine multiple system calls belonging to the same syscall group into one
+audit rule (rather than to create audit rule per different system call) to
+avoid audit infrastructure performance penalty in the case of
+'one-audit-rule-definition-per-one-system-call'. See:
+
+	https://www.redhat.com/archives/linux-audit/2014-November/msg00009.html
+
+for further details.
+
+Expects five arguments (each of them is required) in the form of:
+  * audit tool                          tool used to load audit rules,
+                                        either 'auditctl', or 'augenrules
+  * audit rules' pattern                audit rule skeleton for same syscall
+  * syscall group                       greatest common string this rule shares
+                                        with other rules from the same group
+  * architecture                        architecture this rule is intended for
+  * full form of new rule to add        expected full form of audit rule as to
+                                        be added into audit.rules file
+
+Note: The 2-th up to 4-th arguments are used to determine how many existing
+audit rules will be inspected for resemblance with the new audit rule
+(5-th argument) the function is going to add. The rule's similarity check
+is performed to optimize audit.rules definition (merge syscalls of the same
+group into one rule) to avoid the "single-syscall-per-audit-rule" performance
+penalty.
+
+Example call:
+
+  PATTERN="-a always,exit -F arch=$ARCH -S .* -F auid>=500 -F auid!=4294967295 -k delete"
+  # Use escaped BRE regex to specify rule group
+  GROUP="\(rmdir\|unlink\|rename\)"
+  FULL_RULE="-a always,exit -F arch=$ARCH -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete"
+  fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+</description>
+<value selector="">
+function fix_audit_syscall_rule {
+
+# Load function arguments into local variables
+local tool="$1"
+local pattern="$2"
+local group="$3"
+local arch="$4"
+local full_rule="$5"
+
+# Check sanity of the input
+if [ $# -ne "5" ]
+then
+        echo "Usage: fix_audit_syscall_rule 'tool' 'pattern' 'group' 'arch' 'full rule'"
+        echo "Aborting."
+        exit 1
+fi
+
+# Create a list of audit *.rules files that should be inspected for presence and correctness
+# of a particular audit rule. The scheme is as follows:
+#
+# -----------------------------------------------------------------------------------------
+#  Tool used to load audit rules | Rule already defined  |  Audit rules file to inspect    |
+# -----------------------------------------------------------------------------------------
+#        auditctl                |     Doesn't matter    |  /etc/audit/audit.rules         |
+# -----------------------------------------------------------------------------------------
+#        augenrules              |          Yes          |  /etc/audit/rules.d/*.rules     |
+#        augenrules              |          No           |  /etc/audit/rules.d/$key.rules  |
+# -----------------------------------------------------------------------------------------
+#
+declare -a files_to_inspect
+
+# First check sanity of the specified audit tool
+if [ "$tool" != 'auditctl' ] &amp;&amp; [ "$tool" != 'augenrules' ]
+then
+        echo "Unknown audit rules loading tool: $1. Aborting."
+        echo "Use either 'auditctl' or 'augenrules'!"
+        exit 1
+# If audit tool is 'auditctl', then add '/etc/audit/audit.rules'
+# file to the list of files to be inspected
+elif [ "$tool" == 'auditctl' ]
+then
+        files_to_inspect=("${files_to_inspect[@]}" '/etc/audit/audit.rules' )
+# If audit tool is 'augenrules', then check if the audit rule is defined
+# If rule is defined, add '/etc/audit/rules.d/*.rules' to the list for inspection
+# If rule isn't defined yet, add '/etc/audit/rules.d/$key.rules' to the list for inspection
+elif [ "$tool" == 'augenrules' ]
+then
+        # Extract audit $key from audit rule so we can use it later
+        key=$(expr "$full_rule" : '.*-k[[:space:]]\([^[:space:]]\+\)')
+        # Check if particular audit rule is already defined
+        IFS=$'\n' matches=($(sed -s -n -e "/${pattern}/!d" -e "/${arch}/!d" -e "/${group}/!d;F" /etc/audit/rules.d/*.rules))
+        # Reset IFS back to default
+        unset $IFS
+        for match in "${matches[@]}"
+        do
+                files_to_inspect=("${files_to_inspect[@]}" "${match}")
+        done
+        # Case when particular rule isn't defined in /etc/audit/rules.d/*.rules yet
+        if [ ${#files_to_inspect[@]} -eq "0" ]
+        then
+                files_to_inspect="/etc/audit/rules.d/$key.rules"
+                if [ ! -e "$files_to_inspect" ]
+                then
+                        touch "$files_to_inspect"
+                        chmod 0640 "$files_to_inspect"
+                fi
+        fi
+fi
+
+#
+# Indicator that we want to append $full_rule into $audit_file by default
+local append_expected_rule=0
+
+for audit_file in "${files_to_inspect[@]}"
+do
+
+        # Filter existing $audit_file rules' definitions to select those that:
+        # * follow the rule pattern, and
+        # * meet the hardware architecture requirement, and
+        # * are current syscall group specific
+        IFS=$'\n' existing_rules=($(sed -e "/${pattern}/!d" -e "/${arch}/!d" -e "/${group}/!d"  "$audit_file"))
+        # Reset IFS back to default
+        unset $IFS
+
+        # Process rules found case-by-case
+        for rule in "${existing_rules[@]}"
+        do
+                # Found rule is for same arch &amp; key, but differs (e.g. in count of -S arguments)
+                if [ "${rule}" != "${full_rule}" ]
+                then
+                        # If so, isolate just '(-S \w)+' substring of that rule
+                        rule_syscalls=$(echo $rule | grep -o -P '(-S \w+ )+')
+                        # Check if list of '-S syscall' arguments of that rule is subset
+                        # of '-S syscall' list of expected $full_rule
+                        if grep -q -- "$rule_syscalls" &lt;&lt;&lt; "$full_rule"
+                        then
+                                # Rule is covered (i.e. the list of -S syscalls for this rule is
+                                # subset of -S syscalls of $full_rule => existing rule can be deleted
+                                # Thus delete the rule from audit.rules &amp; our array
+                                sed -i -e "/$rule/d" "$audit_file"
+                                existing_rules=("${existing_rules[@]//$rule/}")
+                        else
+                                # Rule isn't covered by $full_rule - it besides -S syscall arguments
+                                # for this group contains also -S syscall arguments for other syscall
+                                # group. Example: '-S lchown -S fchmod -S fchownat' => group='chown'
+                                # since 'lchown' &amp; 'fchownat' share 'chown' substring
+                                # Therefore:
+                                # * 1) delete the original rule from audit.rules
+                                # (original '-S lchown -S fchmod -S fchownat' rule would be deleted)
+                                # * 2) delete the -S syscall arguments for this syscall group, but
+                                # keep those not belonging to this syscall group
+                                # (original '-S lchown -S fchmod -S fchownat' would become '-S fchmod'
+                                # * 3) append the modified (filtered) rule again into audit.rules
+                                # if the same rule not already present
+                                #
+                                # 1) Delete the original rule
+                                sed -i -e "/$rule/d" "$audit_file"
+                                # 2) Delete syscalls for this group, but keep those from other groups
+                                # Convert current rule syscall's string into array splitting by '-S' delimiter
+                                IFS=$'-S' read -a rule_syscalls_as_array &lt;&lt;&lt; "$rule_syscalls"
+                                # Reset IFS back to default
+                                unset $IFS
+                                # Declare new empty string to hold '-S syscall' arguments from other groups
+                                new_syscalls_for_rule=''
+                                # Walk through existing '-S syscall' arguments
+                                for syscall_arg in "${rule_syscalls_as_array[@]}"
+                                do
+                                        # Skip empty $syscall_arg values
+                                        if [ "$syscall_arg" == '' ]
+                                        then
+                                                continue
+                                        fi
+                                        # If the '-S syscall' doesn't belong to current group add it to the new list
+                                        # (together with adding '-S' delimiter back for each of such item found)
+                                        if grep -q -v -- "$group" &lt;&lt;&lt; "$syscall_arg"
+                                        then
+                                                new_syscalls_for_rule="$new_syscalls_for_rule -S $syscall_arg"
+                                        fi
+                                done
+                                # Replace original '-S syscall' list with the new one for this rule
+                                updated_rule=${rule//$rule_syscalls/$new_syscalls_for_rule}
+                                # Squeeze repeated whitespace characters in rule definition (if any) into one
+                                updated_rule=$(echo "$updated_rule" | tr -s '[:space:]')
+                                # 3) Append the modified / filtered rule again into audit.rules
+                                #    (but only in case it's not present yet to prevent duplicate definitions)
+                                if ! grep -q -- "$updated_rule" "$audit_file"
+                                then
+                                        echo "$updated_rule" >> "$audit_file"
+                                fi
+                        fi
+                else
+                        # $audit_file already contains the expected rule form for this
+                        # architecture &amp; key => don't insert it second time
+                        append_expected_rule=1
+                fi
+        done
+
+        # We deleted all rules that were subset of the expected one for this arch &amp; key.
+        # Also isolated rules containing system calls not from this system calls group.
+        # Now append the expected rule if it's not present in $audit_file yet
+        if [[ ${append_expected_rule} -eq "0" ]]
+        then
+                echo "$full_rule" >> "$audit_file"
+        fi
+done
+
+}
+</value>
+</Value>
+
+
+<Value id="function_fix_audit_watch_rule" type="string" operator="equals" interactive="0">
+<title>Remediation function to fix audit file system object watch rule for given path</title>
+<description>Function to fix audit file system object watch rule for given path:
+  * if rule exists, also verifies the -w bits match the requirements
+  * if rule doesn't exist yet, appends expected rule form to $files_to_inspect
+    audit rules file, depending on the tool which was used to load audit rules
+
+Expects four arguments (each of them is required) in the form of:
+  * audit tool                          tool used to load audit rules,
+                                        either 'auditctl', or 'augenrules'
+  * path                                value of -w audit rule's argument
+  * required access bits                value of -p audit rule's argument
+  * key                                 value of -k audit rule's argument
+
+Example call:
+
+  fix_audit_watch_rule "auditctl" "/etc/localtime" "wa" "audit_time_rules"
+</description>
+<value selector="">
+function fix_audit_watch_rule {
+
+# Load function arguments into local variables
+local tool="$1"
+local path="$2"
+local required_access_bits="$3"
+local key="$4"
+
+# Check sanity of the input
+if [ $# -ne "4" ]
+then
+        echo "Usage: fix_audit_watch_rule 'tool' 'path' 'bits' 'key'"
+        echo "Aborting."
+        exit 1
+fi
+
+# Create a list of audit *.rules files that should be inspected for presence and correctness
+# of a particular audit rule. The scheme is as follows:
+#
+# -----------------------------------------------------------------------------------------
+# Tool used to load audit rules | Rule already defined  |  Audit rules file to inspect    |
+# -----------------------------------------------------------------------------------------
+#       auditctl                |     Doesn't matter    |  /etc/audit/audit.rules         |
+# -----------------------------------------------------------------------------------------
+#       augenrules              |          Yes          |  /etc/audit/rules.d/*.rules     |
+#       augenrules              |          No           |  /etc/audit/rules.d/$key.rules  |
+# -----------------------------------------------------------------------------------------
+declare -a files_to_inspect
+
+# Check sanity of the specified audit tool
+if [ "$tool" != 'auditctl' ] &amp;&amp; [ "$tool" != 'augenrules' ]
+then
+        echo "Unknown audit rules loading tool: $1. Aborting."
+        echo "Use either 'auditctl' or 'augenrules'!"
+        exit 1
+# If the audit tool is 'auditctl', then add '/etc/audit/audit.rules'
+# into the list of files to be inspected
+elif [ "$tool" == 'auditctl' ]
+then
+        files_to_inspect=("${files_to_inspect[@]}" '/etc/audit/audit.rules')
+# If the audit is 'augenrules', then check if rule is already defined
+# If rule is defined, add '/etc/audit/rules.d/*.rules' to list of files for inspection.
+# If rule isn't defined, add '/etc/audit/rules.d/$key.rules' to list of files for inspection.
+elif [ "$tool" == 'augenrules' ]
+then
+        # Case when particular audit rule is already defined in some of /etc/audit/rules.d/*.rules file
+        # Get pair -- filepath : matching_row into @matches array
+        IFS=$'\n' matches=($(grep -P "[\s]*-w[\s]+$path" /etc/audit/rules.d/*.rules))
+        # Reset IFS back to default
+        unset $IFS
+        # For each of the matched entries
+        for match in "${matches[@]}"
+        do
+                # Extract filepath from the match
+                rulesd_audit_file=$(echo $match | cut -f1 -d ':')
+                # Append that path into list of files for inspection
+                files_to_inspect=("${files_to_inspect[@]}" "$rulesd_audit_file")
+        done
+        # Case when particular audit rule isn't defined yet
+        if [ ${#files_to_inspect[@]} -eq "0" ]
+        then
+                # Append '/etc/audit/rules.d/$key.rules' into list of files for inspection
+                files_to_inspect="/etc/audit/rules.d/$key.rules"
+                # If the $key.rules file doesn't exist yet, create it with correct permissions
+                if [ ! -e "$files_to_inspect" ]
+                then
+                        touch "$files_to_inspect"
+                        chmod 0640 "$files_to_inspect"
+                fi
+        fi
+fi
+
+# Finally perform the inspection and possible subsequent audit rule
+# correction for each of the files previously identified for inspection
+for audit_rules_file in "${files_to_inspect[@]}"
+do
+
+        # Check if audit watch file system object rule for given path already present
+        if grep -q -P -- "[\s]*-w[\s]+$path" "$audit_rules_file"
+        then
+                # Rule is found => verify yet if existing rule definition contains
+                # all of the required access type bits
+
+                # Escape slashes in path for use in sed pattern below
+                local esc_path=${path//$'/'/$'\/'}
+                # Define BRE whitespace class shortcut
+                local sp="[[:space:]]"
+                # Extract current permission access types (e.g. -p [r|w|x|a] values) from audit rule
+                current_access_bits=$(sed -ne "s/$sp*-w$sp\+$esc_path$sp\+-p$sp\+\([rxwa]\{1,4\}\).*/\1/p" "$audit_rules_file")
+                # Split required access bits string into characters array
+                # (to check bit's presence for one bit at a time)
+                for access_bit in $(echo "$required_access_bits" | grep -o .)
+                do
+                        # For each from the required access bits (e.g. 'w', 'a') check
+                        # if they are already present in current access bits for rule.
+                        # If not, append that bit at the end
+                        if ! grep -q "$access_bit" &lt;&lt;&lt; "$current_access_bits"
+                        then
+                                # Concatenate the existing mask with the missing bit
+                                current_access_bits="$current_access_bits$access_bit"
+                        fi
+                done
+                # Propagate the updated rule's access bits (original + the required
+                # ones) back into the /etc/audit/audit.rules file for that rule
+                sed -i "s/\($sp*-w$sp\+$esc_path$sp\+-p$sp\+\)\([rxwa]\{1,4\}\)\(.*\)/\1$current_access_bits\3/" "$audit_rules_file"
+        else
+                # Rule isn't present yet. Append it at the end of $audit_rules_file file
+                # with proper key
+
+                echo "-w $path -p $required_access_bits -k $key" >> "$audit_rules_file"
+        fi
+done
+}
+</value>
+</Value>
+
+
+<Value id="function_package_command" type="string" operator="equals" interactive="0">
+<title>Remediation function to to install or uninstall packages on RHEL and Fedora systems</title>
+<description>Function to install or uninstall packages on RHEL and Fedora systems.
+
+Example Call(s):
+
+  package_command install aide
+  package_command remove telnet-server
+</description>
+<value selector="">
+function package_command {
+
+# Load function arguments into local variables
+local package_operation=$1
+local package=$2
+
+# Check sanity of the input
+if [ $# -ne "2" ]
+then
+  echo "Usage: package_command 'install/uninstall' 'rpm_package_name"
+  echo "Aborting."
+  exit 1
+fi
+
+# If dnf is installed, use dnf; otherwise, use yum
+if [ -f "/usr/bin/dnf" ] ; then
+  install_util="/usr/bin/dnf"
+else
+  install_util="/usr/bin/yum"
+fi
+
+if [ "$package_operation" != 'remove' ] ; then
+  # If the rpm is not installed, install the rpm
+  if ! /bin/rpm -q --quiet $package; then
+    $install_util -y $package_operation $package
+  fi
+else
+  # If the rpm is installed, uninstall the rpm
+  if /bin/rpm -q --quiet $package; then
+    $install_util -y $package_operation $package
+  fi
+fi
+
+}
+</value>
+</Value>
+
+
+<Value id="function_service_command" type="string" operator="equals" interactive="0">
+<title>Remediation function to enable/disable and start/stop services on RHEL
+and Fedora systems</title>
+<description>Function to enable/disable and start/stop services on RHEL and
+Fedora systems.
+
+Example Call(s):
+
+  service_command enable bluetooth
+  service_command disable bluetooth.service
+
+  Using xinetd:
+  service_command disable rsh.socket xinetd=rsh
+</description>
+<value selector="">
+function service_command {
+
+# Load function arguments into local variables
+local service_state=$1
+local service=$2
+local xinetd=$(echo $3 | cut -d'=' -f2)
+
+# Check sanity of the input
+if [ $# -lt "2" ]
+then
+  echo "Usage: service_command 'enable/disable' 'service_name.service'"
+  echo
+  echo "To enable or disable xinetd services add \'xinetd=service_name\'"
+  echo "as the last argument"
+  echo "Aborting."
+  exit 1
+fi
+
+# If systemctl is installed, use systemctl command; otherwise, use the service/chkconfig commands
+if [ -f "/usr/bin/systemctl" ] ; then
+  service_util="/usr/bin/systemctl"
+else
+  service_util="/sbin/service"
+  chkconfig_util="/sbin/chkconfig"
+fi
+
+# If disable is not specified in arg1, set variables to enable services.
+# Otherwise, variables are to be set to disable services.
+if [ "$service_state" != 'disable' ] ; then
+  service_state="enable"
+  service_operation="start"
+  chkconfig_state="on"
+else
+  service_state="disable"
+  service_operation="stop"
+  chkconfig_state="off"
+fi
+
+# If chkconfig_util is not empty, use chkconfig/service commands.
+if ! [ "x$chkconfig_util" = x ] ; then
+  $service_util $service $service_operation
+  $chkconfig_util --level 0123456 $service $chkconfig_state
+else
+  $service_util $service_operation $service
+  $service_util $service_state $service
+fi
+
+# Test if local variable xinetd is empty using non-bashism.
+# If empty, then xinetd is not being used.
+if ! [ "x$xinetd" = x ] ; then
+  grep -qi disable /etc/xinetd.d/$xinetd &amp;&amp; \
+
+  if ! [ "$service_operation" != 'disable' ] ; then
+    sed -i "s/disable.*/disable         = no/gI" /etc/xinetd.d/$xinetd
+  else
+    sed -i "s/disable.*/disable         = yes/gI" /etc/xinetd.d/$xinetd
+  fi
+fi
+
+}
+</value>
+</Value>
+
+
+<Value id="function_perform_audit_rules_privileged_commands_remediation" type="string" operator="equals" interactive="0">
+<title>Remediation function to perform remediation for 'audit_rules_privileged_commands' rule</title>
+<description>Function to perform remediation for 'audit_rules_privileged_commands' rule
+
+Expects two arguments:
+
+  audit_tool            tool used to load audit rules
+                        One of 'auditctl' or 'augenrules'
+
+  min_auid              Minimum original ID the user logged in with
+                        '500' for RHEL-6 and before, '1000' for RHEL-7 and after.
+
+Example Call(s):
+
+  perform_audit_rules_privileged_commands_remediation "auditctl" "500"
+  perform_audit_rules_privileged_commands_remediation "augenrules" "1000"
+</description>
+<value selector="">
+function perform_audit_rules_privileged_commands_remediation {
+#
+# Load function arguments into local variables
+local tool="$1"
+local min_auid="$2"
+
+# Check sanity of the input
+if [ $# -ne "2" ]
+then
+        echo "Usage: perform_audit_rules_privileged_commands_remediation 'auditctl | augenrules' '500 | 1000'"
+        echo "Aborting."
+        exit 1
+fi
+
+declare -a files_to_inspect=()
+
+# Check sanity of the specified audit tool
+if [ "$tool" != 'auditctl' ] &amp;&amp; [ "$tool" != 'augenrules' ]
+then
+        echo "Unknown audit rules loading tool: $1. Aborting."
+        echo "Use either 'auditctl' or 'augenrules'!"
+        exit 1
+# If the audit tool is 'auditctl', then:
+# * add '/etc/audit/audit.rules'to the list of files to be inspected,
+# * specify '/etc/audit/audit.rules' as the output audit file, where
+#   missing rules should be inserted
+elif [ "$tool" == 'auditctl' ]
+then
+        files_to_inspect=("/etc/audit/audit.rules")
+        output_audit_file="/etc/audit/audit.rules"
+#
+# If the audit tool is 'augenrules', then:
+# * add '/etc/audit/rules.d/*.rules' to the list of files to be inspected
+#   (split by newline),
+# * specify /etc/audit/rules.d/privileged.rules' as the output file, where
+#   missing rules should be inserted
+elif [ "$tool" == 'augenrules' ]
+then
+        IFS=$'\n' files_to_inspect=($(find /etc/audit/rules.d -maxdepth 1 -type f -name *.rules -print))
+        output_audit_file="/etc/audit/rules.d/privileged.rules"
+fi
+
+# Obtain the list of SUID/SGID binaries on the particular system (split by newline)
+# into privileged_binaries array
+IFS=$'\n' privileged_binaries=($(find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null))
+
+# Keep list of SUID/SGID binaries that have been already handled within some previous iteration
+declare -a sbinaries_to_skip=()
+
+# For each found sbinary in privileged_binaries list
+for sbinary in "${privileged_binaries[@]}"
+do
+
+        # Replace possible slash '/' character in sbinary definition so we could use it in sed expressions below
+        sbinary_esc=${sbinary//$'/'/$'\/'}
+        # Check if this sbinary wasn't already handled in some of the previous iterations
+        # Return match only if whole sbinary definition matched (not in the case just prefix matched!!!)
+        if [[ $(sed -ne "/${sbinary_esc}$/p" &lt;&lt;&lt; ${sbinaries_to_skip[@]}) ]]
+        then
+                # If so, don't process it second time &amp; go to process next sbinary
+                continue
+        fi
+
+        # Reset the counter of inspected files when starting to check
+        # presence of existing audit rule for new sbinary
+        local count_of_inspected_files=0
+
+        # For each audit rules file from the list of files to be inspected
+        for afile in "${files_to_inspect[@]}"
+        do
+
+                # Search current audit rules file's content for match. Match criteria:
+                # * existing rule is for the same SUID/SGID binary we are currently processing (but
+                #   can contain multiple -F path= elements covering multiple SUID/SGID binaries)
+                # * existing rule contains all arguments from expected rule form (though can contain
+                #   them in arbitrary order)
+
+                base_search=$(sed -e "/-a always,exit/!d" -e "/-F path=${sbinary_esc}$/!d"   \
+                                  -e "/-F path=[^[:space:]]\+/!d" -e "/-F perm=.*/!d"       \
+                                  -e "/-F auid>=${min_auid}/!d" -e "/-F auid!=4294967295/!d"  \
+                                  -e "/-k privileged/!d" $afile)
+
+                # Increase the count of inspected files for this sbinary
+                count_of_inspected_files=$((count_of_inspected_files + 1))
+
+                # Define expected rule form for this binary
+                expected_rule="-a always,exit -F path=${sbinary} -F perm=x -F auid>=${min_auid} -F auid!=4294967295 -k privileged"
+
+                # Require execute access type to be set for existing audit rule
+                exec_access='x'
+
+                # Search current audit rules file's content for presence of rule pattern for this sbinary
+                if [[ $base_search ]]
+                then
+
+                        # Current audit rules file already contains rule for this binary =>
+                        # Store the exact form of found rule for this binary for further processing
+                        concrete_rule=$base_search
+
+                        # Select all other SUID/SGID binaries possibly also present in the found rule
+                        IFS=$'\n' handled_sbinaries=($(grep -o -e "-F path=[^[:space:]]\+" &lt;&lt;&lt; $concrete_rule))
+                        IFS=$' ' handled_sbinaries=(${handled_sbinaries[@]//-F path=/})
+
+                        # Merge the list of such SUID/SGID binaries found in this iteration with global list ignoring duplicates
+                        sbinaries_to_skip=($(for i in "${sbinaries_to_skip[@]}" "${handled_sbinaries[@]}"; do echo $i; done | sort -du))
+
+                        # Separate concrete_rule into three sections using hash '#'
+                        # sign as a delimiter around rule's permission section borders
+                        concrete_rule=$(echo $concrete_rule | sed -n "s/\(.*\)\+\(-F perm=[rwax]\+\)\+/\1#\2#/p")
+
+                        # Split concrete_rule into head, perm, and tail sections using hash '#' delimiter
+                        IFS=$'#' read rule_head rule_perm rule_tail &lt;&lt;&lt;  "$concrete_rule"
+
+                        # Extract already present exact access type [r|w|x|a] from rule's permission section
+                        access_type=${rule_perm//-F perm=/}
+
+                        # Verify current permission access type(s) for rule contain 'x' (execute) permission
+                        if ! grep -q "$exec_access" &lt;&lt;&lt; "$access_type"
+                        then
+
+                                # If not, append the 'x' (execute) permission to the existing access type bits
+                                access_type="$access_type$exec_access"
+                                # Reconstruct the permissions section for the rule
+                                new_rule_perm="-F perm=$access_type"
+                                # Update existing rule in current audit rules file with the new permission section
+                                sed -i "s#${rule_head}\(.*\)${rule_tail}#${rule_head}${new_rule_perm}${rule_tail}#" $afile
+
+                        fi
+
+                # If the required audit rule for particular sbinary wasn't found yet, insert it under following conditions:
+                #
+                # * in the "auditctl" mode of operation insert particular rule each time
+                #   (because in this mode there's only one file -- /etc/audit/audit.rules to be inspected for presence of this rule),
+                #
+                # * in the "augenrules" mode of operation insert particular rule only once and only in case we have already
+                #   searched all of the files from /etc/audit/rules.d/*.rules location (since that audit rule can be defined
+                #   in any of those files and if not, we want it to be inserted only once into /etc/audit/rules.d/privileged.rules file)
+                #
+                elif [ "$tool" == "auditctl" ] || [[ "$tool" == "augenrules" &amp;&amp; $count_of_inspected_files -eq "${#files_to_inspect[@]}" ]]
+                then
+
+                        # Current audit rules file's content doesn't contain expected rule for this
+                        # SUID/SGID binary yet => append it
+                        echo $expected_rule >> $output_audit_file
+                fi
+
+        done
+
+done
+
+}
+</value>
+</Value>
+
+
+<Value id="function_populate" type="string" operator="equals" interactive="0">
+<title>Remediation function to populate environment variables needed for unit testing</title>
+<description>The populate function isn't directly used by SSG at the moment but it can
+ba used for testing purposes (to verify proper work of the remediation script directly
+from the shell).</description>
+<value selector="">
+function populate {
+# Code to populate environment variables needed (for unit testing)
+if [ -z "${!1}" ]; then
+	echo "$1 is not defined. Exiting."
+	exit
+fi
+}
+</value>
+</Value>
+
+
+<Value id="function_rhel6_perform_audit_adjtimex_settimeofday_stime_remediation" type="string" operator="equals" interactive="0">
+<title>Remediation function for the 'adjtimex', 'settimeofday', and 'stime'
+audit system calls on Red Hat Enterprise Linux 6</title>
+<description>Perform the remediation for the 'adjtimex', 'settimeofday', and 'stime' audit
+# system calls on Red Hat Enterprise Linux 6 OS</description>
+<value selector="">
+function rhel6_perform_audit_adjtimex_settimeofday_stime_remediation {
+
+# Perform the remediation for the 'adjtimex', 'settimeofday', and 'stime' audit
+# system calls on Red Hat Enterprise Linux 6 OS
+#
+# Retrieve hardware architecture of the underlying system
+[ $(getconf LONG_BIT) = "32" ] &amp;&amp; RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
+
+for ARCH in "${RULE_ARCHS[@]}"
+do
+        PATTERN="-a always,exit -F arch=${ARCH} -S .* -k *"
+        # Create expected audit group and audit rule form for particular system call &amp; architecture
+        if [ ${ARCH} = "b32" ]
+        then
+                # stime system call is known at 32-bit arch (see e.g "$ ausyscall i386 stime" 's output)
+                # so append it to the list of time group system calls to be audited
+                GROUP="\(adjtimex\|settimeofday\|stime\)"
+                FULL_RULE="-a always,exit -F arch=${ARCH} -S adjtimex -S settimeofday -S stime -k audit_time_rules"
+        elif [ ${ARCH} = "b64" ]
+        then
+                # stime system call isn't known at 64-bit arch (see "$ ausyscall x86_64 stime" 's output)
+                # therefore don't add it to the list of time group system calls to be audited
+                GROUP="\(adjtimex\|settimeofday\)"
+                FULL_RULE="-a always,exit -F arch=${ARCH} -S adjtimex -S settimeofday -k audit_time_rules"
+        fi
+        # Perform the remediation itself
+        fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+done
+
+}
+</value>
+</Value>
+
+
+<Value id="function_rhel7_fedora_perform_audit_adjtimex_settimeofday_stime_remediation" type="string" operator="equals" interactive="0">
+<title>Remediation function for the 'adjtimex', 'settimeofday', and 'stime'
+audit system calls on Red Hat Enterprise Linux 7 or Fedora</title>
+<description>Perform the remediation for the 'adjtimex', 'settimeofday', and
+'stime' audit system calls on Red Hat Enterprise Linux 7 or Fedora OSes</description>
+<value selector="">
+function rhel7_fedora_perform_audit_adjtimex_settimeofday_stime_remediation {
+
+# Perform the remediation for the 'adjtimex', 'settimeofday', and 'stime' audit
+# system calls on Red Hat Enterprise Linux 7 or Fedora OSes
+#
+# Retrieve hardware architecture of the underlying system
+[ $(getconf LONG_BIT) = "32" ] &amp;&amp; RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
+
+for ARCH in "${RULE_ARCHS[@]}"
+do
+
+        PATTERN="-a always,exit -F arch=${ARCH} -S .* -k *"
+        # Create expected audit group and audit rule form for particular system call &amp; architecture
+        if [ ${ARCH} = "b32" ]
+        then
+                # stime system call is known at 32-bit arch (see e.g "$ ausyscall i386 stime" 's output)
+                # so append it to the list of time group system calls to be audited
+                GROUP="\(adjtimex\|settimeofday\|stime\)"
+                FULL_RULE="-a always,exit -F arch=${ARCH} -S adjtimex -S settimeofday -S stime -k audit_time_rules"
+        elif [ ${ARCH} = "b64" ]
+        then
+                # stime system call isn't known at 64-bit arch (see "$ ausyscall x86_64 stime" 's output)
+                # therefore don't add it to the list of time group system calls to be audited
+                GROUP="\(adjtimex\|settimeofday\)"
+                FULL_RULE="-a always,exit -F arch=${ARCH} -S adjtimex -S settimeofday -k audit_time_rules"
+        fi
+        # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+        fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+        fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+done
+
+}
+</value>
+</Value>
+
+
+<Value id="function_replace_or_append" type="string" operator="equals" interactive="0">
+<title>Remediation function to replace configuration setting in config file or
+add the configuration setting if it does not exist yet</title>
+<description>Function to replace configuration setting in config file or add
+the configuration setting if it does not exist.
+
+Expects four arguments:
+
+  config_file:		Configuration file that will be modified
+  key:			Configuration option to change
+  value:		Value of the configuration option to change
+  cce:			The CCE identifier or 'CCENUM' if no CCE identifier exists
+
+Optional arguments:
+
+  format:		Optional argument to specify the format of how key/value should be
+			modified/appended in the configuration file. The default is key = value.
+
+Example Call(s):
+
+  With default format of 'key = value':
+  replace_or_append '/etc/sysctl.conf' '^kernel.randomize_va_space' '2' 'CCENUM'
+
+  With custom key/value format:
+  replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' 'disabled' 'CCENUM' '%s=%s'
+
+  With a variable:
+  replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' $var_selinux_state 'CCENUM' '%s=%s'
+</description>
+<value selector="">
+function replace_or_append {
+  local config_file=$1
+  local key=$2
+  local value=$3
+  local cce=$4
+  local format=$5
+
+  # Check sanity of the input
+  if [ $# -lt "3" ]
+  then
+        echo "Usage: replace_or_append 'config_file_location' 'key_to_search' 'new_value'"
+        echo
+        echo "If symlinks need to be taken into account, add yes/no to the last argument"
+        echo "to allow to 'follow_symlinks'."
+        echo "Aborting."
+        exit 1
+  fi
+
+  # Test if the config_file is a symbolic link. If so, use &#45;&#45;follow-symlinks with sed.
+  # Otherwise, regular sed command will do.
+  if test -L $config_file; then
+    sed_command="sed -i &#45;&#45;follow-symlinks"
+  else
+    sed_command="sed -i"
+  fi
+
+  # Test that the cce arg is not empty or does not equal CCENUM.
+  # If CCENUM exists, it means that there is no CCE assigned.
+  if ! [ "x$cce" = x ] &amp;&amp; [ "$cce" != 'CCENUM' ]; then
+    cce="CCE-${cce}"
+  else
+    cce="CCE"
+  fi
+
+  # Strip any search characters in the key arg so that the key can be replaced without
+  # adding any search characters to the config file.
+  stripped_key=${key//[!a-zA-Z]/}
+
+  # If there is no print format specified in the last arg, use the default format.
+  if ! [ "x$format" = x ] ; then
+    printf -v formatted_output "$format" $stripped_key $value
+  else
+    formatted_output="$stripped_key = $value"
+  fi
+
+  # If the key exists, change it. Otherwise, add it to the config_file.
+  if `grep -qi $key $config_file` ; then
+    $sed_command "s/$key.*/$formatted_output/g" $config_file
+  else
+    echo -ne "\n# Per $cce: Set $formatted_output in $config_file" >> $config_file
+    echo -ne "\n$formatted_output" >> $config_file
+  fi
+
+}
+</value>
+</Value>
+
+
+<Value id="function_firefox_js_setting" type="string" operator="equals" interactive="0">
+<title>Remediation function to replace configuration setting(s) in the Firefox
+preferences JavaScript file or add the preference if it does not exist yet</title>
+<description>Function to replace configuration setting(s) in the Firefox
+preferences JavaScript file or add the preference if it does not exist.
+
+Expects three arguments:
+
+  config_file:          Configuration file that will be modified
+  key:                  Configuration option to change
+  value:                Value of the configuration option to change
+
+
+Example Call(s):
+
+  Without string or variable:
+  firefox_js_setting "stig_settings.js" "general.config.obscure_value" "0"
+
+  With string:
+  firefox_js_setting "stig_settings.js" "general.config.filename" "\"stig.cfg\""
+
+  With a string variable:
+  firefox_js_setting "stig_settings.js" "general.config.filename" "\"$var_config_file_name\""
+</description>
+<value selector="">
+function firefox_js_setting {
+  local firefox_js=$1
+  local key=$2
+  local value=$3
+  local firefox_dirs="/usr/lib/firefox /usr/lib64/firefox /usr/local/lib/firefox /usr/local/lib64/firefox"
+  local firefox_pref="/defaults/pref"
+  local firefox_preferences="/defaults/preferences"
+
+  # Check sanity of input
+  if [ $# -lt "3" ]
+  then
+        echo "Usage: firefox_js_setting 'config_javascript_file' 'key_to_search' 'new_value'"
+        echo
+        echo "Aborting."
+        exit 1
+  fi
+
+  # Check the possible Firefox install directories
+  for firefox_dir in ${firefox_dirs}; do
+    # If the Firefox directory exists, then Firefox is installed
+    if [ -d "${firefox_dir}" ]; then
+      # Different versions of Firefox have different preferences directories, check for them and set the right one
+      if [ -d "${firefox_dir}/${firefox_pref}" ] ; then
+        local firefox_pref_dir="${firefox_dir}/${firefox_pref}"
+      elif [ -d "${firefox_dir}/${firefox_preferences}" ] ; then
+        local firefox_pref_dir="${firefox_dir}/${firefox_preferences}"
+      else
+        mkdir -m 755 -p "${firefox_dir}/${firefox_preferences}"
+        local firefox_pref_dir="${firefox_dir}/${firefox_preferences}"
+      fi
+
+      # Make sure the Firefox .js file exists and has the appropriate permissions
+      if ! [ -f "${firefox_pref_dir}/${firefox_js}" ] ; then
+        touch "${firefox_pref_dir}/${firefox_js}"
+        chmod 644 "${firefox_pref_dir}/${firefox_js}"
+      fi
+
+      # If the key exists, change it. Otherwise, add it to the config_file.
+      if `grep -q "^pref(\"${key}\", " "${firefox_pref_dir}/${firefox_js}"` ; then
+        sed -i "s/pref(\"${key}\".*/pref(\"${key}\", ${value});/g" "${firefox_pref_dir}/${firefox_js}"
+      else
+        echo "pref(\"${key}\", ${value});" >> "${firefox_pref_dir}/${firefox_js}"
+      fi
+    fi
+  done
+
+}
+</value>
+</Value>
+
+
+<Value id="function_firefox_cfg_setting" type="string" operator="equals" interactive="0">
+<title>Remediation function to replace configuration setting(s) in the Firefox
+preferences configuration (.cfg) file or add the preference if it does not exist yet</title>
+<description>Function to replace configuration setting(s) in the Firefox
+preferences configuration (.cfg) file or add the preference if it does not exist.
+
+Expects three arguments:
+
+  config_file:          Configuration file that will be modified
+  key:                  Configuration option to change
+  value:                Value of the configuration option to change
+
+
+Example Call(s):
+
+  Without string or variable:
+  firefox_cfg_setting "stig.cfg" "extensions.update.enabled" "false"
+
+  With string:
+  firefox_cfg_setting "stig.cfg" "security.default_personal_cert" "\"Ask Every Time\""
+
+  With a string variable:
+  firefox_cfg_setting "stig.cfg" "browser.startup.homepage\" "\"${var_default_home_page}\""
+</description>
+<value selector="">
+function firefox_cfg_setting {
+  local firefox_cfg=$1
+  local key=$2
+  local value=$3
+  local firefox_dirs="/usr/lib/firefox /usr/lib64/firefox /usr/local/lib/firefox /usr/local/lib64/firefox"
+
+  # Check sanity of input
+  if [ $# -lt "3" ]
+  then
+        echo "Usage: firefox_cfg_setting 'config_cfg_file' 'key_to_search' 'new_value'"
+        echo
+        echo "Aborting."
+        exit 1
+  fi
+
+  # Check the possible Firefox install directories
+  for firefox_dir in ${firefox_dirs}; do
+    # If the Firefox directory exists, then Firefox is installed
+    if [ -d "${firefox_dir}" ]; then
+      # Make sure the Firefox .cfg file exists and has the appropriate permissions
+      if ! [ -f "${firefox_dir}/${firefox_cfg}" ] ; then
+        touch "${firefox_dir}/${firefox_cfg}"
+        chmod 644 "${firefox_dir}/${firefox_cfg}"
+      fi
+
+      # If the key exists, change it. Otherwise, add it to the config_file.
+      if `grep -q "^lockPref(\"${key}\", " "${firefox_dir}/${firefox_cfg}"` ; then
+        sed -i "s/lockPref(\"${key}\".*/lockPref(\"${key}\", ${value});/g" "${firefox_dir}/${firefox_cfg}"
+      else
+        echo "lockPref(\"${key}\", ${value});" >> "${firefox_dir}/${firefox_cfg}"
+      fi
+    fi
+  done
+}
+</value>
+</Value>
+
+
+</Group>


### PR DESCRIPTION
Replace the necessity of ```/usr/share/scap-security-guide/remediation-functions``` remediation functions library to be installed in order to be able to perform remediations with use of ```<xccdf:sub>``` elements for each general remediation functions used in the specific remediation script

Fixes (upstream): https://github.com/OpenSCAP/scap-security-guide/issues/590
Fixes (upstream): https://github.com/OpenSCAP/scap-security-guide/issues/1055
Fixes (downstream): https://bugzilla.redhat.com/show_bug.cgi?id=1313491

Overview of the changes performed by specific patches (present within this PR):
* patch https://github.com/OpenSCAP/scap-security-guide/commit/a2c069238c6d56861260b9f085fc9555ceb9020c modifies the ```combineremediations.py``` helper to substitute every occurrence / instance of remediation function call with corresponding ```<xccdf:sub>``` element,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/e0ee706f787c6216e6d9cdbb220e4d43ca255f48 applies the new functionality against ```RHEL/7``` benchmark,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/8b9be626ee491e1ad42a990e3604eb31fcbc4206 applies the new functionality to the remaining benchmarks:
  *  ```Webmin```
  * ```RHEVM3```
  * ```RHEL/6```
  * ```RHEL/5```
  * ```OpenStack/RHEL-OSP/7```
  * ```JRE```
  * ```JBoss/Fuse/6```
  * ```JBoss/EAP/5```
  * ```Firefox```
  * ```Fedora```
  * ```Debian/8``` and
  * ```Chromium```
* patch https://github.com/OpenSCAP/scap-security-guide/commit/79817066a4d2322cd90e937e6cbeffa461ff808d fixes multiple (by testing identified) issues in newly added ```expand_xccdf_subs()``` routine, and finally
* patch https://github.com/OpenSCAP/scap-security-guide/commit/a0e046940825ec31ea2767e12a05914703201186 approaches the problem of absenting support for ```flags``` parameter in Python's ```re.split()``` routine in Python < 2.7 (thus RHEL-6 and older) in more official way (instead of using custom ugly workaround uses more official ```re.compile()``` method).

Testing report:
This PR has been tested on the following systems:
* ```RHEL-6```, and
* ```RHEL-7```
in the following testing scope:
* ```make jenkins``` target was performed on both of them as was identified as passing,
* the new approach how to implemented execution of remediations (having remediations present directly in the benchmark rather than rely on existence of external ```/usr/share/scap-security-guide/remediation-functions``` shell library with their definition) has been tested (on both systems) on the following three different rules (categories of rules):
  * ```Ensure SELinux State is Enforcing``` (using ```replace_or_append``` function)
  * ```Ensure auditd Collects Information on the Use of Privileged Commands``` (using ```perform_audit_rules_privileged_commands_remediation``` function), and
  * ```Ensure auditd Collects File Deletion Events by User``` (using ```fix_audit_syscall_rule``` remediation function).

Testing of these tree different routines / categories confirmed on both (RHEL/6 and RHEL/7) systems the remediations are still working properly.

Known limitations of the PR (to be corrected in the future):
* If remediation function is called multiple times in the ```fix.text```, a new ```<xccdf:sub>``` element will be created for each such a call (this will be optimized to add ```<xccdf:sub>``` only first time not yet substituted remediation function is called),
* The newly added ```shared/xccdf/remediation_functions.xml``` location (containing definition of ```<xccdf:Values``` the ```<xccdf:sub>``` elements to point to) has been generated manually for now. In future PR, I will add a routine generating content of ```shared/xccdf/remediation_functions.xml``` file from the content of ```shared/remediations/bash/templates/remediation_functions``` automatically (to handle also the case new remediation function is added into the library).

Please review.

Thank you, Jan.