### PR TITLE
[Enhancement][Fedora][RHEL/7] Add UEFI XCCDF/OVAL content

### DIFF
--- a/Fedora/input/xccdf/system/accounts/physical.xml
+++ b/Fedora/input/xccdf/system/accounts/physical.xml
@@ -122,6 +122,51 @@ the grub2 superuser account and password, please refer to
 <ref nist="IA-2(1),IA-5(e),AC-3" disa="213" cis="1.5.3" />
 </Rule>
 
+<Rule id="bootloader_uefi_password" severity="medium">
+<title>Set the UEFI Boot Loader Password</title>
+<description>The UEFI grub2 boot loader should have a superuser account and password
+protection enabled to protect boot-time settings.
+<br /><br />
+To do so, select a superuser account and password and add them into the
+appropriate grub2 configuration file(s) under <tt>/etc/grub.d</tt>.
+Since plaintext passwords are a security risk, generate a hash for the pasword
+by running the following command:
+<pre>$ grub2-mkpasswd-pbkdf2</pre>
+When prompted, enter the password that was selected and insert the returned
+password hash into the appropriate grub2 configuration file(s) under
+<tt>/etc/grub.d</tt> immediately after the superuser account.
+(Use the output from <tt>grub2-mkpasswd-pbkdf2</tt> as the value of
+<b>password-hash</b>):
+<pre>password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+NOTE: It is recommended not to use common administrator account names like root,
+admin, or administrator for the grub2 superuser account.
+<br />
+To meet FISMA Moderate, the bootloader superuser account and password MUST
+differ from the root account and password.
+Once the superuser account and password have been added, update the
+<tt>grub.cfg</tt> file by running:
+<pre>grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre>
+NOTE: Do NOT manually add the superuser account and password to the
+<tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
+</description>
+<ocil clause="it does not">
+To verify the boot loader superuser account and superuser account password have
+been set, and the password encrypted, run the following command:
+<pre>sudo grep -A1 "superusers\|password" /etc/grub2-efi.cfg</pre>
+The output should show the following:
+<pre>set superusers="<b>superusers-account</b>"
+password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+</ocil>
+<rationale>
+Password protection on the boot loader configuration ensures
+users with physical access cannot trivially alter
+important bootloader settings. These include which kernel to use,
+and whether to enter single-user mode.
+</rationale>
+<oval id="bootloader_uefi_password" />
+<ref nist="AC-3" disa="213" />
+</Rule>
+
 </Group>
 
 <Rule id="require_singleuser_auth" severity="medium">

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -129,6 +129,56 @@ the grub2 superuser account and password, please refer to
 <tested by="DS" on="20121026"/>
 </Rule>
 
+<Rule id="bootloader_uefi_password" severity="medium">
+<title>Set the UEFI Boot Loader Password</title>
+<description>The UEFI grub2 boot loader should have a superuser account and password
+protection enabled to protect boot-time settings.
+<br /><br />
+To do so, select a superuser account and password and add them into the
+appropriate grub2 configuration file(s) under <tt>/etc/grub.d</tt>.
+Since plaintext passwords are a security risk, generate a hash for the pasword
+by running the following command:
+<pre>$ grub2-mkpasswd-pbkdf2</pre>
+When prompted, enter the password that was selected and insert the returned
+password hash into the appropriate grub2 configuration file(s) under
+<tt>/etc/grub.d</tt> immediately after the superuser account.
+(Use the output from <tt>grub2-mkpasswd-pbkdf2</tt> as the value of
+<b>password-hash</b>):
+<pre>password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+NOTE: It is recommended not to use common administrator account names like root,
+admin, or administrator for the grub2 superuser account.
+<br />
+To meet FISMA Moderate, the bootloader superuser account and password MUST
+differ from the root account and password.
+Once the superuser account and password have been added, update the
+<tt>grub.cfg</tt> file by running:
+<pre>grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre>
+NOTE: Do NOT manually add the superuser account and password to the
+<tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
+</description>
+<ocil clause="it does not">
+To verify the boot loader superuser account and superuser account password have
+been set, and the password encrypted, run the following command:
+<pre>sudo grep -A1 "superusers\|password" /etc/grub2-efi.cfg</pre>
+The output should show the following:
+<pre>set superusers="<b>superusers-account</b>"
+password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+</ocil>
+<rationale>
+Password protection on the boot loader configuration ensures
+users with physical access cannot trivially alter
+important bootloader settings. These include which kernel to use,
+and whether to enter single-user mode. For more information on how to configure
+the grub2 superuser account and password, please refer to
+<ul>
+<li>https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-GRUB_2_Password_Protection.html</li>.
+</ul>
+</rationale>
+<ident cce="RHEL7-CCE-TBD" />
+<oval id="bootloader_uefi_password" />
+<ref nist="AC-3" disa="213" ossrg="SRG-OS-000080-GPOS-00048" stigid="010470" />
+</Rule>
+
 </Group>
 
 <Rule id="require_singleuser_auth" severity="medium">

--- a/shared/oval/bootloader_password.xml
+++ b/shared/oval/bootloader_password.xml
@@ -9,17 +9,27 @@
       <description>The grub2 boot loader should have password protection enabled.</description>
       <reference source="galford" ref_id="20140909" ref_url="test_attestation" />
     </metadata>
-    <criteria operator="AND">
-      <criterion comment="make sure a password is defined in /etc/grub2.cfg" test_ref="test_bootloader_password" />
-      <criterion comment="make sure a superuser is defined in /etc/grub2.cfg" test_ref="test_bootloader_superuser"/>
+    <criteria operator="OR">
+      <criterion comment="Pass if /boot/grub2/grub.cfg does not exist" test_ref="test_bootloader_grub_cfg" />
+      <criteria operator="AND">
+        <criterion comment="make sure a password is defined in /etc/grub2.cfg" test_ref="test_bootloader_password" />
+        <criterion comment="make sure a superuser is defined in /etc/grub2.cfg" test_ref="test_bootloader_superuser"/>
+      </criteria>
     </criteria>
   </definition>
+
+   <unix:file_test check="all" check_existence="none_exist" comment="/boot/grub2/grub.cfg does not exist" id="test_bootloader_grub_cfg" version="1">
+    <unix:object object_ref="object_bootloader_grub_cfg" />
+  </unix:file_test>
+  <unix:file_object id="object_bootloader_grub_cfg" version="1">
+    <unix:filepath>/boot/grub2/grub.cfg</unix:filepath>
+  </unix:file_object>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in /etc/grub2.cfg files. Superuser is not root, admin, or administrator" id="test_bootloader_superuser" version="1">
     <ind:object object_ref="object_bootloader_superuser" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_superuser" version="1">
-    <ind:filepath>/etc/grub2.cfg</ind:filepath>
+    <ind:filepath>/boot/grub2/grub2.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=\"(?i)(?!root|admin|administrator)(?-i).*\"$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -28,7 +38,7 @@
     <ind:object object_ref="object_bootloader_password" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_password" version="1">
-    <ind:filepath>/etc/grub2.cfg</ind:filepath>
+    <ind:filepath>/boot/grub2/grub2.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/oval/bootloader_uefi_password.xml
+++ b/shared/oval/bootloader_uefi_password.xml
@@ -1,0 +1,46 @@
+<def-group>
+  <definition class="compliance" id="bootloader_eufi_password" version="1">
+    <metadata>
+      <title>Set the UEFI Boot Loader Password</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>The UEFI grub2 boot loader should have password protection enabled.</description>
+      <reference source="galford" ref_id="20160609" ref_url="test_attestation" />
+    </metadata>
+
+    <criteria operator="OR">
+      <criterion comment="Pass if /boot/efi/EFI/redhat/grub.cfg does not exist" test_ref="test_bootloader_eufi_grub_cfg" />
+      <criteria operator="AND">
+        <criterion comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_eufi_password" />
+        <criterion comment="make sure a superuser is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_eufi_superuser"/>
+      </criteria>
+    </criteria>
+  </definition>
+
+   <unix:file_test check="all" check_existence="none_exist" comment="/boot/efi/EFI/redhat/grub.cfg does not exist" id="test_bootloader_eufi_grub_cfg" version="1">
+    <unix:object object_ref="object_bootloader_eufi_grub_cfg" />
+  </unix:file_test>
+  <unix:file_object id="object_bootloader_eufi_grub_cfg" version="1">
+    <unix:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/grub.cfg</unix:filepath>
+  </unix:file_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in /boot/efi/EFI/redhat/grub.cfg. Superuser is not root, admin, or administrator" id="test_bootloader_eufi_superuser" version="1">
+    <ind:object object_ref="object_bootloader_eufi_superuser" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_bootloader_eufi_superuser" version="1">
+    <ind:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/grub.cfg</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=\"(?i)(?!root|admin|administrator)(?-i).*\"$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" id="test_bootloader_eufi_password" version="1">
+    <ind:object object_ref="object_bootloader_eufi_password" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_bootloader_eufi_password" version="1">
+    <ind:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/grub.cfg</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/shared/oval/bootloader_uefi_password.xml
+++ b/shared/oval/bootloader_uefi_password.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="bootloader_eufi_password" version="1">
+  <definition class="compliance" id="bootloader_uefi_password" version="1">
     <metadata>
       <title>Set the UEFI Boot Loader Password</title>
       <affected family="unix">
@@ -11,34 +11,34 @@
     </metadata>
 
     <criteria operator="OR">
-      <criterion comment="Pass if /boot/efi/EFI/redhat/grub.cfg does not exist" test_ref="test_bootloader_eufi_grub_cfg" />
+      <criterion comment="Pass if /boot/efi/EFI/redhat/grub.cfg does not exist" test_ref="test_bootloader_uefi_grub_cfg" />
       <criteria operator="AND">
-        <criterion comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_eufi_password" />
-        <criterion comment="make sure a superuser is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_eufi_superuser"/>
+        <criterion comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_uefi_password" />
+        <criterion comment="make sure a superuser is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_uefi_superuser"/>
       </criteria>
     </criteria>
   </definition>
 
-   <unix:file_test check="all" check_existence="none_exist" comment="/boot/efi/EFI/redhat/grub.cfg does not exist" id="test_bootloader_eufi_grub_cfg" version="1">
-    <unix:object object_ref="object_bootloader_eufi_grub_cfg" />
+   <unix:file_test check="all" check_existence="none_exist" comment="/boot/efi/EFI/redhat/grub.cfg does not exist" id="test_bootloader_uefi_grub_cfg" version="1">
+    <unix:object object_ref="object_bootloader_uefi_grub_cfg" />
   </unix:file_test>
-  <unix:file_object id="object_bootloader_eufi_grub_cfg" version="1">
+  <unix:file_object id="object_bootloader_uefi_grub_cfg" version="1">
     <unix:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/grub.cfg</unix:filepath>
   </unix:file_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in /boot/efi/EFI/redhat/grub.cfg. Superuser is not root, admin, or administrator" id="test_bootloader_eufi_superuser" version="1">
-    <ind:object object_ref="object_bootloader_eufi_superuser" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in /boot/efi/EFI/redhat/grub.cfg. Superuser is not root, admin, or administrator" id="test_bootloader_uefi_superuser" version="1">
+    <ind:object object_ref="object_bootloader_uefi_superuser" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_bootloader_eufi_superuser" version="1">
+  <ind:textfilecontent54_object id="object_bootloader_uefi_superuser" version="1">
     <ind:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=\"(?i)(?!root|admin|administrator)(?-i).*\"$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" id="test_bootloader_eufi_password" version="1">
-    <ind:object object_ref="object_bootloader_eufi_password" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" id="test_bootloader_uefi_password" version="1">
+    <ind:object object_ref="object_bootloader_uefi_password" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_bootloader_eufi_password" version="1">
+  <ind:textfilecontent54_object id="object_bootloader_uefi_password" version="1">
     <ind:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>


### PR DESCRIPTION
- Add new UEFI XCCDF/OVAL content
- Make sure that if /boot/grub2.cfg or /boot/efi/EFI/<product>/grub.cfg does not exist
  to not fail the check.
- Fixes #1162