### PR TITLE
[BugFix] [RHEL/7] [Fedora] Fix for issue #851

### DIFF
--- a/Fedora/input/xccdf/system/accounts/physical.xml
+++ b/Fedora/input/xccdf/system/accounts/physical.xml
@@ -207,27 +207,38 @@ loss of availability of systems due to unintentional reboot.
 </Rule>
 
 <Rule id="disable_interactive_boot" severity="medium">
-<title>Disable Interactive Boot</title>
+<title>Verify that Interactive Boot is Disabled</title>
 <description>
-To disable the ability for users to perform interactive startups,
-edit the file <tt>/etc/sysconfig/init</tt>.
-Add or correct the line:
-<pre>PROMPT=no</pre>
-The <tt>PROMPT</tt> option allows the console user to perform an
-interactive system startup, in which it is possible to select the
-set of services which are started on boot.
+Fedora systems support an "interactive boot" option that can be used to prevent
+services from being started. On a Fedora system, interactive boot can be
+enabled by providing a <tt>1</tt>, <tt>yes</tt>, <tt>true</tt>, or
+<tt>on</tt> value to the <tt>systemd.confirm_spawn</tt> kernel argument in
+<tt>/etc/default/grub</tt>. Remove any instance of
+<pre>systemd.confirm_spawn=(1|yes|true|on)</pre> from the kernel arguments in
+that file to disable interactive boot.
 </description>
-<ocil clause="it does not">
-To check whether interactive boot is disabled, run the following command:
-<pre>$ grep PROMPT /etc/sysconfig/init</pre>
-If interactive boot is disabled, the output will show:
-<pre>PROMPT=no</pre>
+<ocil clause="Interactive boot is enabled at boot time">
+Inspect <tt>/etc/default/grub</tt> for any instances of
+<tt>systemd.confirm_spawn=(1|yes|true|on)</tt> in the kernel boot arguments.
+Presence of a <tt>systemd.confirm_spawn=(1|yes|true|on)</tt> indicates
+that interactive boot is enabled at boot time.
 </ocil>
 <rationale>
-Using interactive boot,
-the console user could disable auditing, firewalls, or other
-services, weakening system security.
+Using interactive boot, the console user could disable auditing, firewalls,
+or other services, weakening system security.
 </rationale>
+<warning category="general">The GRUB 2 configuration file, <tt>grub.cfg</tt>,
+is automatically updated each time a new kernel is installed. Note that any
+changes to <tt>/etc/default/grub</tt> require rebuilding the <tt>grub.cfg</tt>
+file. To update the GRUB 2 configuration file manually, use the
+<pre>grub2-mkconfig -o</pre> command as follows:
+<ul>
+<li>On BIOS-based machines, issue the following command as <tt>root</tt>:
+<pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
+<li>On UEFI-based machines, issue the following command as <tt>root</tt>:
+<pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
+</ul>
+</warning>
 <oval id="disable_interactive_boot" />
 <ref nist="SC-2,AC-3" disa="213"/>
 </Rule>

--- a/RHEL/7/input/remediations/bash/disable_interactive_boot.sh
+++ b/RHEL/7/input/remediations/bash/disable_interactive_boot.sh
@@ -1,6 +1,0 @@
-# platform = Red Hat Enterprise Linux 7
-grep -q ^PROMPT /etc/sysconfig/init && \
-  sed -i "s/PROMPT.*/PROMPT=no/g" /etc/sysconfig/init
-if ! [ $? -eq 0 ]; then
-    echo "PROMPT=no" >> /etc/sysconfig/init
-fi

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -224,27 +224,38 @@ the non-graphical <tt>multi-user.target</tt> mode.
 </Rule>
 
 <Rule id="disable_interactive_boot" severity="medium">
-<title>Disable Interactive Boot</title>
+<title>Verify that Interactive Boot is Disabled</title>
 <description>
-To disable the ability for users to perform interactive startups,
-edit the file <tt>/etc/sysconfig/init</tt>.
-Add or correct the line:
-<pre>PROMPT=no</pre>
-The <tt>PROMPT</tt> option allows the console user to perform an
-interactive system startup, in which it is possible to select the
-set of services which are started on boot.
+Red Hat Enterprise Linux systems support an "interactive boot" option that can
+be used to prevent services from being started. On a Red Hat Enterprise Linux 7
+system, interactive boot can be enabled by providing a <tt>1</tt>,
+<tt>yes</tt>, <tt>true</tt>, or <tt>on</tt> value to the
+<tt>systemd.confirm_spawn</tt> kernel argument in <tt>/etc/default/grub</tt>.
+Remove any instance of <pre>systemd.confirm_spawn=(1|yes|true|on)</pre> from
+the kernel arguments in that file to disable interactive boot.
 </description>
-<ocil clause="it does not">
-To check whether interactive boot is disabled, run the following command:
-<pre>$ grep PROMPT /etc/sysconfig/init</pre>
-If interactive boot is disabled, the output will show:
-<pre>PROMPT=no</pre>
+<ocil clause="Interactive boot is enabled at boot time">
+Inspect <tt>/etc/default/grub</tt> for any instances of
+<tt>systemd.confirm_spawn=(1|yes|true|on)</tt> in the kernel boot arguments.
+Presence of a <tt>systemd.confirm_spawn=(1|yes|true|on)</tt> indicates
+that interactive boot is enabled at boot time.
 </ocil>
 <rationale>
-Using interactive boot,
-the console user could disable auditing, firewalls, or other
-services, weakening system security.
+Using interactive boot, the console user could disable auditing, firewalls,
+or other services, weakening system security.
 </rationale>
+<warning category="general">The GRUB 2 configuration file, <tt>grub.cfg</tt>,
+is automatically updated each time a new kernel is installed. Note that any
+changes to <tt>/etc/default/grub</tt> require rebuilding the <tt>grub.cfg</tt>
+file. To update the GRUB 2 configuration file manually, use the
+<pre>grub2-mkconfig -o</pre> command as follows:
+<ul>
+<li>On BIOS-based machines, issue the following command as <tt>root</tt>:
+<pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
+<li>On UEFI-based machines, issue the following command as <tt>root</tt>:
+<pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
+</ul>
+</warning>
 <ident cce="27335-9" />
 <oval id="disable_interactive_boot" />
 <ref nist="SC-2,AC-3" disa="213"/>

--- a/shared/oval/disable_interactive_boot.xml
+++ b/shared/oval/disable_interactive_boot.xml
@@ -1,34 +1,74 @@
 <def-group>
-  <definition class="compliance" id="disable_interactive_boot" version="2">
+  <definition class="compliance" id="disable_interactive_boot" version="3">
     <metadata>
-      <title>Disable Interactive Boot</title>
+      <title>Verify that Interactive Boot is Disabled</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>The ability for users to perform interactive startups should
       be disabled.</description>
-      <reference source="JL" ref_id="20140407" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20160613" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA23_20160613" ref_url="test_attestation" />
     </metadata>
-    <criteria>
-      <criterion test_ref="test_disable_interactive_boot" />
-      <!-- This needs to be enhanced yet to properly cover case of 'systemd.confirm_spawn=1'
-           use case on RHEL-7 and Fedora per:
-             https://rhsummit.files.wordpress.com/2014/04/summit_demystifying_systemd1.pdf Page #20
-           SSG Upstream ticket to come yet -->
+    <criteria operator="AND">
+      <criterion test_ref="test_disable_interactive_boot_grub_cmdline_linux"
+      comment="Check systemd.confirm_spawn=(1|yes|true|on) not in GRUB_CMDLINE_LINUX" />
+      <criteria operator="AND">
+        <criterion test_ref="test_disable_interactive_boot_grub_cmdline_linux_default"
+        comment="Check systemd.confirm_spawn=(1|yes|true|on) not in GRUB_CMDLINE_LINUX_DEFAULT" />
+        <criterion test_ref="test_bootloader_recovery_disabled"
+        comment="Check GRUB_DISABLE_RECOVERY=true in /etc/default/grub" />
+      </criteria>
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist"
-  comment="Tests that PROMPT=no in /etc/sysconfig/init"
-  id="test_disable_interactive_boot" version="1">
-    <ind:object object_ref="object_disable_interactive_boot" />
+  <!-- Verify systemd.confirm_spawn=(1|yes|true|on) not present in GRUB_CMDLINE_LINUX
+       of /etc/default/grub -->
+  <ind:textfilecontent54_test id="test_disable_interactive_boot_grub_cmdline_linux"
+  comment="Check systemd.confirm_spawn=(1|true|yes|on) not in GRUB_CMDLINE_LINUX"
+  check="all" check_existence="none_exist" version="1">
+    <ind:object object_ref="object_disable_interactive_boot_grub_cmdline_linux" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_disable_interactive_boot"
-  version="2">
-    <ind:filepath>/etc/sysconfig/init</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*PROMPT=no[\s]+</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+  <ind:textfilecontent54_object id="object_disable_interactive_boot_grub_cmdline_linux"
+  version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX=".*systemd.confirm_spawn=(?:1|yes|true|on).*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <!-- Or verify systemd.confirm_spawn=(1|yes|true|on) not present in GRUB_CMDLINE_LINUX_DEFAULT
+       of /etc/default/grub and GRUB_DISABLE_RECOVERY set to "true" -->
+  <ind:textfilecontent54_test id="test_disable_interactive_boot_grub_cmdline_linux_default"
+  comment="Check systemd.confirm_spawn=(1|true|yes|on) not in GRUB_CMDLINE_LINUX_DEFAULT"
+  check="all" check_existence="none_exist" version="1">
+    <ind:object object_ref="object_disable_interactive_boot_grub_cmdline_linux_default" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_disable_interactive_boot_grub_cmdline_linux_default"
+  version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT=".*systemd.confirm_spawn=(?:1|yes|true|on).*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Verify GRUB_DISABLE_RECOVERY set to "true" in /etc/default/grub -->
+  <ind:textfilecontent54_test id="test_bootloader_recovery_disabled"
+  comment="Check for GRUB_DISABLE_RECOVERY=true in /etc/default/grub"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_bootloader_disable_recovery_argument" />
+    <ind:state state_ref="state_bootloader_disable_recovery_argument" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_bootloader_disable_recovery_argument" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_DISABLE_RECOVERY=(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_bootloader_disable_recovery_argument" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^true|"true"$</ind:subexpression>
+  </ind:textfilecontent54_state>
 
 </def-group>

--- a/shared/remediations/bash/disable_interactive_boot.sh
+++ b/shared/remediations/bash/disable_interactive_boot.sh
@@ -1,0 +1,22 @@
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+
+# Systemd confirm_spawn regex to search for and delete if found
+CONFIRM_SPAWN_REGEX="systemd.confirm_spawn=\(1\|yes\|true\|on\)"
+
+# Modify both the GRUB_CMDLINE_LINUX and GRUB_CMDLINE_LINUX_DEFAULT directives
+for grubcmdline in "GRUB_CMDLINE_LINUX" "GRUB_CMDLINE_LINUX_DEFAULT"
+do
+  # Remove 'systemd.confirm_spawn' argument from /etc/default/grub if found
+  if grep -q "^${grubcmdline}=\".*${CONFIRM_SPAWN_REGEX}.*\"" /etc/default/grub
+  then
+    # Remove all three possible occurrences of CONFIRM_SPAWN_REGEX:
+    # At the start
+    sed -i "s/\"${CONFIRM_SPAWN_REGEX} /\"/" /etc/default/grub
+    # At the end
+    sed -i "s/ ${CONFIRM_SPAWN_REGEX}\"$/\"/" /etc/default/grub
+    # In the middle
+    sed -i "s/ ${CONFIRM_SPAWN_REGEX}//" /etc/default/grub
+  fi
+done
+# Remove 'systemd.confirm_spawn' kernel argument also from runtime settings
+/sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"


### PR DESCRIPTION
Update the form of ```disable_interactive_boot``` rule for Systemd (RHEL/7, Fedora) based systems

Update:
* rule title (since on RHEL/7, Fedora systems interactive boot is disabled by default),
* XCCDF prose to mention updating ```systemd.confirm_spawn=(1|yes|true|on)``` kernel argument in ```/etc/default/grub``` (rather than setting ```PROMPT=no``` in ```/etc/sysconfig/init```),
* OVAL checks for RHEL/7 and Fedora (to check ```systemd.confirm_spawn``` in ```/etc/default/grub```),
* Finally also update remediation script for this rule for RHEL/7 and  Fedora

Additional information:
* See https://access.redhat.com/solutions/2112701 for further details

Fixes:
* https://github.com/OpenSCAP/scap-security-guide/issues/851

Please review.

Thank you, Jan