### PR TITLE
[Enhancement][Bugfix][Infrastructure] Update constants XSLT

### DIFF
--- a/Chromium/transforms/constants.xslt
+++ b/Chromium/transforms/constants.xslt
@@ -2,4 +2,6 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-browers-uri"/>
+
 </xsl:stylesheet>

--- a/Chromium/transforms/constants.xslt
+++ b/Chromium/transforms/constants.xslt
@@ -3,5 +3,6 @@
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-browers-uri"/>
+<xsl:variable name="os-stigid-concat" />
 
 </xsl:stylesheet>

--- a/Debian/8/transforms/constants.xslt
+++ b/Debian/8/transforms/constants.xslt
@@ -1,6 +1,8 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-<xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Red_Hat_Enterprise_Linux_7_Benchmark_v1.1.0.pdf</xsl:variable>
 <xsl:include href="../../../shared/transforms/shared_constants.xslt"/>
+
+<xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf</xsl:variable>
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 
 </xsl:stylesheet>

--- a/Debian/8/transforms/constants.xslt
+++ b/Debian/8/transforms/constants.xslt
@@ -4,5 +4,6 @@
 
 <xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
+<xsl:variable name="os-stigid-concat" />
 
 </xsl:stylesheet>

--- a/Fedora/transforms/constants.xslt
+++ b/Fedora/transforms/constants.xslt
@@ -3,5 +3,6 @@
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
+<xsl:variable name="os-stigid-concat" />
 
 </xsl:stylesheet>

--- a/Fedora/transforms/constants.xslt
+++ b/Fedora/transforms/constants.xslt
@@ -2,4 +2,6 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
+
 </xsl:stylesheet>

--- a/Firefox/transforms/constants.xslt
+++ b/Firefox/transforms/constants.xslt
@@ -2,4 +2,6 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-browers-uri"/>
+
 </xsl:stylesheet>

--- a/Firefox/transforms/constants.xslt
+++ b/Firefox/transforms/constants.xslt
@@ -3,5 +3,6 @@
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-browers-uri"/>
+<xsl:variable name="os-stigid-concat" />
 
 </xsl:stylesheet>

--- a/JBoss/Fuse/6/transforms/constants.xslt
+++ b/JBoss/Fuse/6/transforms/constants.xslt
@@ -3,5 +3,6 @@
 <xsl:include href="../../../../shared/transforms/shared_constants.xslt"/>
 
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appserver-uri"/>
+<xsl:variable name="os-stigid-concat" />
 
 </xsl:stylesheet>

--- a/JBoss/Fuse/6/transforms/constants.xslt
+++ b/JBoss/Fuse/6/transforms/constants.xslt
@@ -2,4 +2,6 @@
 
 <xsl:include href="../../../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appserver-uri"/>
+
 </xsl:stylesheet>

--- a/JRE/transforms/constants.xslt
+++ b/JRE/transforms/constants.xslt
@@ -2,4 +2,6 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appsecurity-dev-uri"/>
+
 </xsl:stylesheet>

--- a/JRE/transforms/constants.xslt
+++ b/JRE/transforms/constants.xslt
@@ -3,5 +3,6 @@
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appsecurity-dev-uri"/>
+<xsl:variable name="os-stigid-concat" />
 
 </xsl:stylesheet>

--- a/OpenStack/RHEL-OSP/7/transforms/constants.xslt
+++ b/OpenStack/RHEL-OSP/7/transforms/constants.xslt
@@ -3,5 +3,6 @@
 <xsl:include href="../../../../shared/transforms/shared_constants.xslt"/>
 
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
+<xsl:variable name="os-stigid-concat" />
 
 </xsl:stylesheet>

--- a/OpenStack/RHEL-OSP/7/transforms/constants.xslt
+++ b/OpenStack/RHEL-OSP/7/transforms/constants.xslt
@@ -2,4 +2,6 @@
 
 <xsl:include href="../../../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
+
 </xsl:stylesheet>

--- a/RHEL/5/transforms/constants.xslt
+++ b/RHEL/5/transforms/constants.xslt
@@ -3,5 +3,6 @@
 <xsl:include href="../../../shared/transforms/shared_constants.xslt"/>
 
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
+<xsl:variable name="os-stigid-concat" />
 
 </xsl:stylesheet>

--- a/RHEL/5/transforms/constants.xslt
+++ b/RHEL/5/transforms/constants.xslt
@@ -2,4 +2,6 @@
 
 <xsl:include href="../../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
+
 </xsl:stylesheet>

--- a/RHEL/6/transforms/constants.xslt
+++ b/RHEL/6/transforms/constants.xslt
@@ -2,4 +2,7 @@
 
 <xsl:include href="../../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
+<xsl:variable name="os-stigid-concat">DISA FSO </xsl:variable>
+
 </xsl:stylesheet>

--- a/RHEL/7/transforms/constants.xslt
+++ b/RHEL/7/transforms/constants.xslt
@@ -3,5 +3,7 @@
 <xsl:include href="../../../shared/transforms/shared_constants.xslt"/>
 
 <xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Red_Hat_Enterprise_Linux_7_Benchmark_v1.1.0.pdf</xsl:variable>
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
+<xsl:variable name="os-stigid-concat">RHEL-07-</xsl:variable>
 
 </xsl:stylesheet>

--- a/RHEVM3/transforms/constants.xslt
+++ b/RHEVM3/transforms/constants.xslt
@@ -2,4 +2,6 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appserver-uri"/>
+
 </xsl:stylesheet>

--- a/RHEVM3/transforms/constants.xslt
+++ b/RHEVM3/transforms/constants.xslt
@@ -3,5 +3,6 @@
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appserver-uri"/>
+<xsl:variable name="os-stigid-concat" />
 
 </xsl:stylesheet>

--- a/Webmin/transforms/constants.xslt
+++ b/Webmin/transforms/constants.xslt
@@ -2,4 +2,6 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appserver-uri"/>
+
 </xsl:stylesheet>

--- a/Webmin/transforms/constants.xslt
+++ b/Webmin/transforms/constants.xslt
@@ -3,5 +3,6 @@
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appserver-uri"/>
+<xsl:variable name="os-stigid-concat" />
 
 </xsl:stylesheet>

--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -4,7 +4,7 @@
 <!-- Constants are called variables in XSLT.  At this point this is not a surprise. -->
 
 <!-- abbreviated as idents in the XCCDF-->
-<xsl:variable name="cceuri">http://cce.mitre.org</xsl:variable>
+<xsl:variable name="cceuri">https://nvd.nist.gov/cce/index.cfm</xsl:variable>
 
 <!-- abbreviated as references in the XCCDF-->
 <xsl:variable name="nist800-53uri">http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf</xsl:variable>
@@ -14,6 +14,10 @@
 <xsl:variable name="disa-srguri">http://iase.disa.mil/stigs/srgs/Pages/index.aspx</xsl:variable>
 <!-- Fix for issue https://github.com/OpenSCAP/scap-security-guide/issues/1035 -->
 <xsl:variable name="disa-stigs-os-unix-linux-uri">http://iase.disa.mil/stigs/os/unix-linux/Pages/index.aspx</xsl:variable>
+<xsl:variable name="disa-stigs-apps-browers-uri">http://iase.disa.mil/stigs/app-security/browser-guidance/Pages/index.aspx</xsl:variable>
+<xsl:variable name="disa-stigs-apps-appserver-uri">http://iase.disa.mil/stigs/app-security/app-servers/Pages/index.aspx</xsl:variable>
+<xsl:variable name="disa-stigs-apps-appsecurity-dev-uri">http://iase.disa.mil/stigs/app-security/app-security/Pages/index.aspx</xsl:variable>
+<xsl:variable name="disa-stigs-apps-web-server-uri">http://iase.disa.mil/stigs/app-security/web-servers/Pages/index.aspx</xsl:variable>
 <xsl:variable name="pcidssuri">https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-1.pdf</xsl:variable>
 <xsl:variable name="anssiuri">http://www.ssi.gouv.fr/administration/bonnes-pratiques/</xsl:variable>
 <xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>


### PR DESCRIPTION
- Add local 'disa-stigs-uri' variable to modify STIG URI based off of
  the local content which will be utilized by a new shared shorthand2xccdf.xslt
- Add local 'os-stigid-concat' variable to concatenate stigids based off of
  local content which will be utilized by a new shared shorthand2xccdf.xslt
- Update CCEURI constant to new uri
- Add new DISA STIG uris