### PR TITLE
[DO NOT MERGE] [BugFix] [shared] Fix downstream RH BZ#1302061

### DIFF
--- a/shared/oval/no_shelllogin_for_systemaccounts.xml
+++ b/shared/oval/no_shelllogin_for_systemaccounts.xml
@@ -1,23 +1,186 @@
 <def-group>
-  <definition class="compliance" id="no_shelllogin_for_systemaccounts" version="1">
+  <definition class="compliance" id="no_shelllogin_for_systemaccounts" version="2">
     <metadata>
       <title>System Accounts Do Not Run a Shell</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The root account is the only system account that should have a login shell.</description>
-      <reference source="swells" ref_id="20130918" ref_url="test_attestation" />
+      <description>The root account is the only system account that should have
+      a login shell.</description>
+      <reference source="JL" ref_id="RHEL6_20160614" ref_url="test_attestation"/>
+      <reference source="JL" ref_id="RHEL7_20160614" ref_url="test_attestation"/>
+      <reference source="JL" ref_id="FEDORA23_20160614" ref_url="test_attestation"/>
     </metadata>
-    <criteria>
-      <criterion comment="tests for the presence of login shells (not /sbin/nologin) for system accounts in /etc/passwd file" test_ref="test_no_shelllogin_for_systemaccounts" />
+    <criteria operator="OR">
+      <!-- If SYS_UID_MIN and SYS_UID_MAX is not defined in /etc/login.defs
+           perform the check against UIDs from default <0, 499> range -->
+      <criteria operator="AND">
+        <criterion comment="Test SYS_UID_MIN not defined in /etc/login.defs"
+        test_ref="test_sys_uid_min_not_defined" />
+        <criterion comment="Test SYS_UID_MAX not defined in /etc/login.defs"
+        test_ref="test_sys_uid_max_not_defined" />
+        <criterion comment="Test shell defined for UID from &lt;0, 499&gt;"
+        test_ref="test_shell_defined_basic_uid_range" />
+      </criteria>
+      <!-- If both SYS_UID_MIN and SYS_UID_MAX are defined in /etc/login.defs
+           perform the check against UIDs from <SYS_UID_MIN, SYS_UID_MAX>
+           range. If at least one such UID exists, requirement isn't met -->
+      <criteria operator="AND">
+        <criterion comment="Test SYS_UID_MIN defined in /etc/login.defs"
+        test_ref="test_sys_uid_min_not_defined" negate="true" />
+        <criterion comment="Test SYS_UID_MAX defined in /etc/login.defs"
+        test_ref="test_sys_uid_max_not_defined" negate="true" />
+        <criterion comment="Test if at least one system account has shell defined"
+        test_ref="test_shell_defined_custom_uid_range" negate="true" />
+      </criteria>
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="tests for the presence of login shells (not /sbin/nologin) for system accounts in /etc/passwd file" id="test_no_shelllogin_for_systemaccounts" version="1">
-    <ind:object object_ref="object_no_shelllogin_for_systemaccounts" />
+
+  <!-- First define objects used by both criterions above -->
+
+  <!-- Get last occurrence of SYS_UID_MIN from /etc/login.defs as OVAL object -->
+  <ind:textfilecontent54_object id="object_last_sys_uid_min_from_etc_login_defs"
+  version="1">
+    <ind:behaviors singleline="true" />
+    <ind:filepath>/etc/login.defs</ind:filepath>
+    <!-- Last (uncommented) instance of SYS_UID_MIN directive -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(SYS_UID_MIN[\s]+[\d]+)\s*\n</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Get last occurrence of SYS_UID_MAX from /etc/login.defs as OVAL object -->
+  <ind:textfilecontent54_object id="object_last_sys_uid_max_from_etc_login_defs" version="1">
+    <ind:behaviors singleline="true" />
+    <ind:filepath>/etc/login.defs</ind:filepath>
+    <!-- Last (uncommented) instance of SYS_UID_MAX directive -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(SYS_UID_MAX[\s]+[\d]+)\s*\n</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- FIRST CRITERION -->
+  <!-- If both SYS_UID_MIN and SYS_UID_MAX aren't defined in /etc/login.defs
+       perform the original test - checking if shell is set for UIDS from
+       /etc/passwd, where UID is in the range <0, 499> -->
+
+  <!-- Test if no UID from range <0, 499> has shell defined -->
+  <ind:textfilecontent54_test id="test_shell_defined_basic_uid_range"
+  comment="Shell defined for system account" check="all"
+  check_existence="none_exist" version="1">
+    <ind:object object_ref="object_shell_defined_basic_uid_range" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_no_shelllogin_for_systemaccounts" version="1">
+
+  <ind:textfilecontent54_object id="object_shell_defined_basic_uid_range"
+  version="1">
     <ind:filepath>/etc/passwd</ind:filepath>
     <ind:pattern operation="pattern match">^(?!root).*:x:0*([0-9]{1,2}|[1-4][0-9]{2}):[\d]*:[^:]*:[^:]*:(?!\/sbin\/nologin|\/bin\/sync|\/sbin\/shutdown|\/sbin\/halt).*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <!-- Test if SYS_UID_MIN is defined in /etc/login.defs -->
+  <ind:textfilecontent54_test id="test_sys_uid_min_not_defined"
+  comment="SYS_UID_MIN not defined in /etc/login.defs" check="all"
+  check_existence="none_exist" version="1">
+    <ind:object object_ref="object_last_sys_uid_min_from_etc_login_defs" />
+  </ind:textfilecontent54_test>
+
+  <!-- Test if SYS_UID_MAX is defined in /etc/login.defs -->
+  <ind:textfilecontent54_test id="test_sys_uid_max_not_defined"
+  comment="SYS_UID_MAX not defined in /etc/login.defs" check="all"
+  check_existence="none_exist" version="1">
+    <ind:object object_ref="object_last_sys_uid_max_from_etc_login_defs" />
+  </ind:textfilecontent54_test>
+
+  <!-- SECOND CRITERION -->
+  <!-- If both SYS_UID_MIN and SYS_UID_MAX are defined in /etc/login.defs
+       perform enhanced test - check if shell is set only for UIDs from
+       /etc/passwd, where UID is in the range <SYS_UID_MIN, SYS_UID_MAX> -->
+
+  <!-- Actual /etc/login.defs SYS_UID_MIN value as OVAL variable -->
+  <local_variable id="variable_sys_uid_min_value" datatype="int"
+  comment="Value of last SYS_UID_MIN from /etc/login.defs" version="1">
+    <regex_capture pattern="SYS_UID_MIN[\s]+(\d+)">
+      <object_component item_field="subexpression"
+      object_ref="object_last_sys_uid_min_from_etc_login_defs" />
+    </regex_capture>
+  </local_variable>
+
+  <!-- Actual /etc/login.defs SYS_UID_MAX value as OVAL variable -->
+  <local_variable id="variable_sys_uid_max_value" datatype="int"
+  comment="Value of last SYS_UID_MAX from /etc/login.defs" version="1">
+    <regex_capture pattern="SYS_UID_MAX[\s]+(\d+)">
+      <object_component item_field="subexpression"
+      object_ref="object_last_sys_uid_max_from_etc_login_defs" />
+    </regex_capture>
+  </local_variable>
+
+  <!-- /etc/passwd entries having shell defined as OVAL object -->
+  <ind:textfilecontent54_object id="object_etc_passwd_entries" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^(?!root).*:x:([\d]+):[\d]+:[^:]*:[^:]*:(?!\/sbin\/nologin|\/bin\/sync|\/sbin\/shutdown|\/sbin\/halt).*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Extract UIDs from /etc/passwd entries into OVAL variable -->
+  <local_variable id="variable_sys_uids_etc_passwd" datatype="int"
+  comment="UIDs retrieved from /etc/passwd" version="1">
+    <object_component item_field="subexpression"
+    object_ref="object_etc_passwd_entries" />
+  </local_variable>
+
+  <!-- Due to https://github.com/OpenSCAP/openscap/issues/428 OpenSCAP bug
+       we can't currently use "state_operator=\"AND\"" construct.
+
+       Therefore we use the following observation to obtain UIDs from
+       <SYS_UID_MIN, SYS_UID_MAX> range: Number "x" belongs to range
+       <a,b> if and only if the following statement holds:
+           (x - a) * (x - b) < 0
+  -->
+
+  <local_variable id="variable_quadratic_expression" datatype="int"
+  comment="Construct (x - SYS_UID_MIN) * (x - SYS_UID_MAX) expression"
+  version="1">
+    <!-- Construct the final multiplication -->
+    <arithmetic arithmetic_operation="multiply">
+      <!-- Construct (x - SYS_UID_MIN) expression -->
+      <arithmetic arithmetic_operation="add">
+        <!-- Get "x", thus retrieved /etc/passwd UIDs as int -->
+        <variable_component var_ref="variable_sys_uids_etc_passwd" />
+        <!-- Get negative value of SYS_UID_MIN -->
+        <arithmetic arithmetic_operation="multiply">
+          <literal_component datatype="int">-1</literal_component>
+          <variable_component var_ref="variable_sys_uid_min_value" />
+        </arithmetic>
+      </arithmetic>
+      <!-- Construct (x - SYS_UID_MAX) expression -->
+      <arithmetic arithmetic_operation="add">
+        <!-- Get "x", thus retrieved /etc/passwd UIDs as int -->
+        <variable_component var_ref="variable_sys_uids_etc_passwd" />
+        <!-- Get negative value of SYS_UID_MAX -->
+        <arithmetic arithmetic_operation="multiply">
+          <literal_component datatype="int">-1</literal_component>
+          <variable_component var_ref="variable_sys_uid_max_value" />
+        </arithmetic>
+      </arithmetic>
+    </arithmetic>
+  </local_variable>
+
+  <!-- Foreach previously collected UID store the expression into
+       corresponding OVAL object -->
+  <ind:variable_object id="object_shell_defined_custom_uid_range" version="1">
+    <ind:var_ref>variable_quadratic_expression</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Finally verify that (x - a) * (x - b) < 0 -->
+  <ind:variable_state id="state_shell_defined_custom_uid_range" version="1">
+    <ind:value datatype="int" operation="less than">0</ind:value>
+  </ind:variable_state>
+
+  <!-- Perform the test itself -->
+  <ind:variable_test id="test_shell_defined_custom_uid_range" check="all"
+  check_existence="at_least_one_exists" comment="System UIDS having shell set"
+  version="1">
+    <ind:object object_ref="object_shell_defined_custom_uid_range" />
+    <ind:state state_ref="state_shell_defined_custom_uid_range" />
+  </ind:variable_test>
+
 </def-group>


### PR DESCRIPTION

<b> DO NOT MERGE YET (requires v2) </b>

Enhance the OVAL for ```no_shelllogin_for_systemaccounts```` rule to check system accounts within <SYS_UID_MIN, SYS_UID_MAX> UID range if defined in /etc/login.defs

The current implementation of [shared] OVAL for ```no_shelllogin_for_systemaccounts``` rule always considers system accounts to be within <0, 499> UID range. [But since /etc/login.defs can contain SYS_UID_MIN and SYS_UID_MAX definitions to specify the desired system accounts range](https://bugzilla.redhat.com/show_bug.cgi?id=1302061) the particular regex should be adaptable to search / consider system user accounts only those, where UID is in the <SYS_UID_MIN, SYS_UID_MAX> range. This change enables the functionality (if both SYS_UID_MIN and SYS_UID_MAX are undefined, current OVAL version is used. But if they are defined, custom UID range is checked).

Since right now [due to the OpenSCAP bug](https://github.com/OpenSCAP/openscap/issues/428) it's not possible to use ```state_operator``` to express the logical condition / relation the multiple OVAL states should follow (from the collected ```/etc/passwd``` entries we need to select only those rows having UID record > ```SYS_UID_MIN``` and simultaneously < ```SYS_UID_MAX```), we use the following workaround to decide if the particular UID (retrieved from ```/etc/passwd```) belongs to <SYS_UID_MIN, SYS_UID_MAX> interval / range:

The number ```x``` belongs to range <a, b> if and only if the following is met:
   ```(x - a) * (x - b) < 0```

Testing report:
The change has been tested on the following systems:
* RHEL-6 (without SYS_UID_MIN, and SYS_UID_MAX defined in /etc/login.defs), and also at
* RHEL-7 (with SYS_UID_MIN, and SYS_UID_MAX defined in /etc/login.defs == <201, 999>)

and AFAICT from testing seems to be working on both systems as expected.

Fixes (downstream): https://bugzilla.redhat.com/show_bug.cgi?id=1302061

Please review.

Thank you, Jan
