### PR TITLE
[BugFix] [Infrastructure] Fix currently failing 'make content' for RHEL/6 content due to undefined 'cisuri' variable

### DIFF
--- a/Debian/8/transforms/constants.xslt
+++ b/Debian/8/transforms/constants.xslt
@@ -2,6 +2,7 @@
 
 <xsl:include href="../../../shared/transforms/shared_constants.xslt"/>
 
+<!-- Define URI of official Center for Internet Security Benchmark for Debian Linux v1.0 -->
 <xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 <xsl:variable name="os-stigid-concat" />

--- a/Fedora/transforms/constants.xslt
+++ b/Fedora/transforms/constants.xslt
@@ -2,7 +2,7 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
-<xsl:variable name="cisuri"></xsl:variable>
+<xsl:variable name="cisuri">empty</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 <xsl:variable name="os-stigid-concat" />
 

--- a/Firefox/transforms/constants.xslt
+++ b/Firefox/transforms/constants.xslt
@@ -2,6 +2,7 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="cisuri">empty</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-browers-uri"/>
 <xsl:variable name="os-stigid-concat" />
 

--- a/JBoss/Fuse/6/transforms/constants.xslt
+++ b/JBoss/Fuse/6/transforms/constants.xslt
@@ -2,6 +2,7 @@
 
 <xsl:include href="../../../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="cisuri">empty</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appserver-uri"/>
 <xsl:variable name="os-stigid-concat" />
 

--- a/JRE/transforms/constants.xslt
+++ b/JRE/transforms/constants.xslt
@@ -2,6 +2,7 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="cisuri">empty</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appsecurity-dev-uri"/>
 <xsl:variable name="os-stigid-concat" />
 

--- a/OpenStack/RHEL-OSP/7/transforms/constants.xslt
+++ b/OpenStack/RHEL-OSP/7/transforms/constants.xslt
@@ -2,6 +2,7 @@
 
 <xsl:include href="../../../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="cisuri">empty</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 <xsl:variable name="os-stigid-concat" />
 

--- a/RHEL/5/transforms/constants.xslt
+++ b/RHEL/5/transforms/constants.xslt
@@ -2,6 +2,7 @@
 
 <xsl:include href="../../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="cisuri">empty</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 <xsl:variable name="os-stigid-concat" />
 

--- a/RHEL/6/transforms/constants.xslt
+++ b/RHEL/6/transforms/constants.xslt
@@ -2,6 +2,7 @@
 
 <xsl:include href="../../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="cisuri">empty</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 <xsl:variable name="os-stigid-concat">DISA FSO </xsl:variable>
 

--- a/RHEL/7/transforms/constants.xslt
+++ b/RHEL/7/transforms/constants.xslt
@@ -2,6 +2,7 @@
 
 <xsl:include href="../../../shared/transforms/shared_constants.xslt"/>
 
+<!-- Define URI of official CIS Red Hat Enterprise Linux 7 Benchmark -->
 <xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Red_Hat_Enterprise_Linux_7_Benchmark_v1.1.0.pdf</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 <xsl:variable name="os-stigid-concat">RHEL-07-</xsl:variable>

--- a/RHEVM3/transforms/constants.xslt
+++ b/RHEVM3/transforms/constants.xslt
@@ -2,6 +2,7 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="cisuri">empty</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appserver-uri"/>
 <xsl:variable name="os-stigid-concat" />
 

--- a/Webmin/transforms/constants.xslt
+++ b/Webmin/transforms/constants.xslt
@@ -2,6 +2,7 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
+<xsl:variable name="cisuri">empty</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-apps-appserver-uri"/>
 <xsl:variable name="os-stigid-concat" />
 

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -193,7 +193,11 @@
             <xsl:value-of select="$anssiuri" />
           </xsl:if>
           <xsl:if test="$refsource = 'cis'">
-            <xsl:value-of select="$cisuri" />
+            <!-- Precaution for repeated occurrence of issue:
+                 https://github.com/OpenSCAP/scap-security-guide/issues/1288 -->
+            <xsl:if test="$cisuri != 'empty'">
+              <xsl:value-of select="$cisuri" />
+            </xsl:if>
           </xsl:if>
           <xsl:if test="$refsource = 'stigid'">
             <xsl:value-of select="$disa-stigs-uri" />


### PR DESCRIPTION

Part of: https://github.com/OpenSCAP/scap-security-guide/issues/1288