### PR TITLE
[BugFix] [Infrastructure] Introduce $(SHARED)/$(OUT) directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ docs/html/en-US/SCAP_Security_Guide
 shared/*.ini
 shared/modules/*.ini
 shared/oval/*.ini
+
+# Ignore intermediary output XML files in the shared directory
+shared/output/*.xml

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,7 @@ git-tag:
 
 clean:
 	rm -rf $(RPMBUILD)
+	rm -rf shared/output
 	cd RHEL/5 && $(MAKE) clean
 	cd RHEL/6 && $(MAKE) clean
 	cd RHEL/7 && $(MAKE) clean

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -52,9 +52,14 @@ $(OUT)/shorthand.xml: $(OUT)/guide.xml $(IN)/guide.xslt $(guide_xslt_deps)
 	xsltproc --param withtest "$(INCLUDE_TEST_PROFILE)" --stringparam SHARED_RP "$(realpath $(SHARED))" -o $@ $(IN)/guide.xslt $(OUT)/guide.xml
 	xmllint --format --output $@ $@
 
-# Benchmark metadata prerequisite - derive $(OUT)/contributors.xml from the content of Contributors.md
-$(OUT)/contributors.xml:
-	# Create $(OUT)/contributors.xml file:
+# Create temporary $(SHARED)/$(OUT) folder to hold information like list of contributors or list of
+# available remediation functions used by all SSG benchmarks
+$(SHARED)/$(OUT):
+	mkdir $@
+
+# Benchmark metadata prerequisite - derive $(SHARED)/$(OUT)/contributors.xml from the content of Contributors.md
+$(SHARED)/$(OUT)/contributors.xml: $(SHARED)/$(OUT)
+	# Create $(SHARED)/$(OUT)/contributors.xml file:
 	# * holding <text> like root element and
 	# * names of the individual SSG contributor(s) within <contributor> element(s)
 	echo "<text>" > $@
@@ -62,7 +67,7 @@ $(OUT)/contributors.xml:
 	echo "</text>" >> $@
 
 # Common build targets - convert shorthand format to an XCCDF stub
-$(OUT)/xccdf-unlinked-unresolved.xml: $(OUT)/shorthand.xml $(OUT)/contributors.xml $(TRANS)/shorthand2xccdf.xslt $(TRANS)/constants.xslt $(SHARED)/$(TRANS)/shared_constants.xslt
+$(OUT)/xccdf-unlinked-unresolved.xml: $(OUT)/shorthand.xml $(SHARED)/$(OUT)/contributors.xml $(TRANS)/shorthand2xccdf.xslt $(TRANS)/constants.xslt $(SHARED)/$(TRANS)/shared_constants.xslt
 	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $@ $(TRANS)/shorthand2xccdf.xslt $<
 
 # Common build targets - improve the XCCDF stub - first resolve


### PR DESCRIPTION
To hold intermediary XML files (like ```contributors.xml``` [current state] or ```remediation_functions.xml``` [future state]) that are used by all SSG benchmarks to produce the final XCCDF / DataStream files

Fixes (rest of issues from): https://github.com/OpenSCAP/scap-security-guide/issues/1288
A prerequisite for: https://github.com/OpenSCAP/scap-security-guide/issues/1291

Additional information:
Instead of generating ```$(OUT)/contributors.xml``` for each benchmark during the SSG build create just one ```$(SHARED)/$(OUT/contributors.xml``` file (since the ```<metadata>``` information is the same for each of the benchmarks). This will make the build process a bit more effective.

Also, introduction of ```$(SHARED)/$(OUT)/``` folder will create a place / location where dynamically generated ```remediation_functions.xml``` file (derived from shell version of ```remediation_functions``` could be placed temporarily). This again makes sense, because various remediation functions are shared / the same across different benchmarks, and we need to generate ```remediation_functions.xml``` only once for the whole buildsystem.

The side effect of this change is it will fix the rest of the issue https://github.com/OpenSCAP/scap-security-guide/issues/1288 (namely the failure to include the ```<metadata>``` / ```contributors.xml``` file into RHEL-6 and RHEL-7 benchmarks currently). It's also prerequisite for intended https://github.com/OpenSCAP/scap-security-guide/issues/1291 change.

Testing report:
Have tested locally on RHEL-6 and RHEL-7 guests, and the proposal seem to be working correctly (```<metadata>``` element is back to the bechmarks).

Please review.

Thank you, Jan