### PR TITLE
[BugFix] [RHEL/6] [RHEL/7] [Fedora] Rewrite OVAL and XCCDF for no_shelllogin_for_systemaccounts rule (fixes downstream RH BZ#1302061)

### DIFF
--- a/Fedora/input/xccdf/system/accounts/restrictions/root_logins.xml
+++ b/Fedora/input/xccdf/system/accounts/restrictions/root_logins.xml
@@ -125,35 +125,34 @@ administration should be documented in site-defined policy.
 <Rule id="no_shelllogin_for_systemaccounts" severity="medium">
 <title>System Accounts Do Not Run a Shell Upon Login</title>
 <description>
-Some accounts are not associated with a human
-user of the system, and exist to perform some administrative
-function. Should an attacker be able to log into these accounts,
-they should not be granted access to a shell.
+Some accounts are not associated with a human user of the system, and exist to
+perform some administrative function. Should an attacker be able to log into
+these accounts, they should not be granted access to a shell.
 <br /><br />
 The login shell for each local account is stored in the last field of each line
-in <tt>/etc/passwd</tt>. System accounts are those user accounts with a user ID less than
-500. The user ID is stored in the third field.
-If any system account <i>SYSACCT</i> (other than root) has a login shell,
-disable it with the command:
-<pre># usermod -s /sbin/nologin <i>SYSACCT</i></pre>
+in <tt>/etc/passwd</tt>. System accounts are those user accounts with a user ID
+less than UID_MIN, where value of the UID_MIN directive is set in
+/etc/login.defs configuration file. In the default configuration UID_MIN is set
+to 1000, thus system accounts are those user accounts with a user ID less than
+1000. The user ID is stored in the third field. If any system account
+<i>SYSACCT</i> (other than root) has a login shell, disable it with the
+command: <pre># usermod -s /sbin/nologin <i>SYSACCT</i></pre>
 </description>
 <ocil clause="any system account (other than root) has a login shell">
-To obtain a listing of all users,
-their UIDs, and their shells, run the command:
-<pre>$ awk -F: '{print $1 ":" $3 ":" $7}' /etc/passwd</pre>
-Identify the system accounts from this listing. These will
-primarily be the accounts with UID numbers less than 500, other
-than root.
+To obtain a listing of all users, their UIDs, and their shells, run the
+command: <pre>$ awk -F: '{print $1 ":" $3 ":" $7}' /etc/passwd</pre> Identify
+the system accounts from this listing. These will primarily be the accounts
+with UID numbers less than UID_MIN, other than root. Value of the UID_MIN
+directive is set in /etc/login.defs configuration file. In the default
+configuration UID_MIN is set to 1000.
 </ocil>
 <rationale>
-Ensuring shells are not given to system accounts upon login
-makes it more difficult for attackers to make use of
-system accounts.
+Ensuring shells are not given to system accounts upon login makes it more
+difficult for attackers to make use of system accounts.
 </rationale>
 <warning category="functionality">
-Do not perform the steps in this
-section on the root account. Doing so might cause the system to
-become inaccessible.
+Do not perform the steps in this section on the root account. Doing so might
+cause the system to become inaccessible.
 </warning>
 <oval id="no_shelllogin_for_systemaccounts" />
 <ref nist="AC-2,CM-6(b)" disa="178" />

--- a/RHEL/6/input/xccdf/system/accounts/restrictions/root_logins.xml
+++ b/RHEL/6/input/xccdf/system/accounts/restrictions/root_logins.xml
@@ -131,35 +131,34 @@ administration should be documented in site-defined policy.
 <Rule id="no_shelllogin_for_systemaccounts" severity="medium">
 <title>Ensure that System Accounts Do Not Run a Shell Upon Login</title>
 <description>
-Some accounts are not associated with a human
-user of the system, and exist to perform some administrative
-function. Should an attacker be able to log into these accounts,
-they should not be granted access to a shell.
+Some accounts are not associated with a human user of the system, and exist to
+perform some administrative function. Should an attacker be able to log into
+these accounts, they should not be granted access to a shell.
 <br /><br />
 The login shell for each local account is stored in the last field of each line
-in <tt>/etc/passwd</tt>. System accounts are those user accounts with a user ID less than
-500. The user ID is stored in the third field.
-If any system account <i>SYSACCT</i> (other than root) has a login shell,
-disable it with the command:
-<pre>$ sudo usermod -s /sbin/nologin <i>SYSACCT</i></pre>
+in <tt>/etc/passwd</tt>. System accounts are those user accounts with a user ID
+less than UID_MIN, where value of the UID_MIN directive is set in
+/etc/login.defs configuration file. In the default configuration UID_MIN is set
+to 500, thus system accounts are those user accounts with a user ID less than
+500. The user ID is stored in the third field. If any system account
+<i>SYSACCT</i> (other than root) has a login shell, disable it with the
+command: <pre>$ sudo usermod -s /sbin/nologin <i>SYSACCT</i></pre>
 </description>
 <ocil clause="any system account (other than root) has a login shell">
-To obtain a listing of all users,
-their UIDs, and their shells, run the command:
-<pre>$ awk -F: '{print $1 ":" $3 ":" $7}' /etc/passwd</pre>
-Identify the system accounts from this listing. These will
-primarily be the accounts with UID numbers less than 500, other
-than root.
+To obtain a listing of all users, their UIDs, and their shells, run the
+command: <pre>$ awk -F: '{print $1 ":" $3 ":" $7}' /etc/passwd</pre> Identify
+the system accounts from this listing. These will primarily be the accounts
+with UID numbers less than UID_MIN, other than root. Value of the UID_MIN
+directive is set in /etc/login.defs configuration file. In the default
+configuration UID_MIN is set to 500.
 </ocil>
 <rationale>
-Ensuring shells are not given to system accounts upon login
-makes it more difficult for attackers to make use of
-system accounts.
+Ensuring shells are not given to system accounts upon login makes it more
+difficult for attackers to make use of system accounts.
 </rationale>
 <warning category="functionality">
-Do not perform the steps in this
-section on the root account. Doing so might cause the system to
-become inaccessible.
+Do not perform the steps in this section on the root account. Doing so might
+cause the system to become inaccessible.
 </warning>
 <ident cce="26966-2" />
 <oval id="no_shelllogin_for_systemaccounts" />

--- a/RHEL/7/input/xccdf/system/accounts/restrictions/root_logins.xml
+++ b/RHEL/7/input/xccdf/system/accounts/restrictions/root_logins.xml
@@ -131,35 +131,34 @@ administration should be documented in site-defined policy.
 <Rule id="no_shelllogin_for_systemaccounts" severity="medium">
 <title>Ensure that System Accounts Do Not Run a Shell Upon Login</title>
 <description>
-Some accounts are not associated with a human
-user of the system, and exist to perform some administrative
-function. Should an attacker be able to log into these accounts,
-they should not be granted access to a shell.
+Some accounts are not associated with a human user of the system, and exist to
+perform some administrative function. Should an attacker be able to log into
+these accounts, they should not be granted access to a shell.
 <br /><br />
 The login shell for each local account is stored in the last field of each line
-in <tt>/etc/passwd</tt>. System accounts are those user accounts with a user ID less than
-1000. The user ID is stored in the third field.
-If any system account <i>SYSACCT</i> (other than root) has a login shell,
-disable it with the command:
-<pre>$ sudo usermod -s /sbin/nologin <i>SYSACCT</i></pre>
+in <tt>/etc/passwd</tt>. System accounts are those user accounts with a user ID
+less than UID_MIN, where value of UID_MIN directive is set in
+/etc/login.defs configuration file. In the default configuration UID_MIN is set
+to 1000, thus system accounts are those user accounts with a user ID less than
+1000. The user ID is stored in the third field. If any system account
+<i>SYSACCT</i> (other than root) has a login shell, disable it with the
+command: <pre>$ sudo usermod -s /sbin/nologin <i>SYSACCT</i></pre>
 </description>
 <ocil clause="any system account (other than root) has a login shell">
-To obtain a listing of all users,
-their UIDs, and their shells, run the command:
-<pre>$ awk -F: '{print $1 ":" $3 ":" $7}' /etc/passwd</pre>
-Identify the system accounts from this listing. These will
-primarily be the accounts with UID numbers less than 1000, other
-than root.
+To obtain a listing of all users, their UIDs, and their shells, run the
+command: <pre>$ awk -F: '{print $1 ":" $3 ":" $7}' /etc/passwd</pre> Identify
+the system accounts from this listing. These will primarily be the accounts
+with UID numbers less than UID_MIN, other than root. Value of the UID_MIN
+directive is set in /etc/login.defs configuration file. In the default
+configuration UID_MIN is set to 1000.
 </ocil>
 <rationale>
-Ensuring shells are not given to system accounts upon login
-makes it more difficult for attackers to make use of
-system accounts.
+Ensuring shells are not given to system accounts upon login makes it more
+difficult for attackers to make use of system accounts.
 </rationale>
 <warning category="functionality">
-Do not perform the steps in this
-section on the root account. Doing so might cause the system to
-become inaccessible.
+Do not perform the steps in this section on the root account. Doing so might
+cause the system to become inaccessible.
 </warning>
 <ident cce="26448-1" />
 <oval id="no_shelllogin_for_systemaccounts" />

--- a/shared/oval/no_shelllogin_for_systemaccounts.xml
+++ b/shared/oval/no_shelllogin_for_systemaccounts.xml
@@ -1,23 +1,325 @@
 <def-group>
-  <definition class="compliance" id="no_shelllogin_for_systemaccounts" version="1">
+  <definition class="compliance" id="no_shelllogin_for_systemaccounts" version="2">
     <metadata>
       <title>System Accounts Do Not Run a Shell</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The root account is the only system account that should have a login shell.</description>
-      <reference source="swells" ref_id="20130918" ref_url="test_attestation" />
+      <description>The root account is the only system account that should have
+      a login shell.</description>
+      <reference source="JL" ref_id="RHEL6_20160621" ref_url="test_attestation"/>
+      <reference source="JL" ref_id="RHEL7_20160621" ref_url="test_attestation"/>
+      <reference source="JL" ref_id="FEDORA23_20160621" ref_url="test_attestation"/>
     </metadata>
-    <criteria>
-      <criterion comment="tests for the presence of login shells (not /sbin/nologin) for system accounts in /etc/passwd file" test_ref="test_no_shelllogin_for_systemaccounts" />
+    <criteria operator="OR">
+      <!-- If SYS_UID_MIN and SYS_UID_MAX is not defined in /etc/login.defs
+           perform the check that all /etc/passwd entries having shell defined
+           have UIDs outside the default <0, UID_MIN -1> range.
+           If at least one UID with shell defined exists within that range,
+           the requirement isn't met -->
+      <criteria operator="AND">
+        <criterion comment="Test SYS_UID_MIN not defined in /etc/login.defs"
+        test_ref="test_sys_uid_min_not_defined" />
+        <criterion comment="Test SYS_UID_MAX not defined in /etc/login.defs"
+        test_ref="test_sys_uid_max_not_defined" />
+        <criterion comment="Test shell defined for UID from &lt;0, UID_MIN -1&gt;"
+        test_ref="test_shell_defined_default_uid_range" />
+      </criteria>
+      <!-- If both SYS_UID_MIN and SYS_UID_MAX are defined in /etc/login.defs
+           perform both checks:
+           * That all /etc/passwd entries having shell defined have UIDs outside
+           the range for reserved system accounts <0, SYS_UID_MIN> range,
+           * That all /etc/passwd entries having shell defined have UIDs outside
+           the range for dynamically allocated system accounts <SYS_UID_MIN, SYS_UID_MAX>
+           If at least one UID with shell defined exists within some of the two
+           ranges, the requirement isn't met -->
+      <criteria operator="AND">
+        <criterion comment="Test SYS_UID_MIN defined in /etc/login.defs"
+        test_ref="test_sys_uid_min_not_defined" negate="true" />
+        <criterion comment="Test SYS_UID_MAX defined in /etc/login.defs"
+        test_ref="test_sys_uid_max_not_defined" negate="true" />
+        <criterion comment="Test shell defined for reserved system UIDs"
+        test_ref="test_shell_defined_reserved_uid_range" />
+        <criterion comment="Test shell defined for dynamically allocated system UIDs"
+        test_ref="test_shell_defined_dynalloc_uid_range" />
+      </criteria>
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="tests for the presence of login shells (not /sbin/nologin) for system accounts in /etc/passwd file" id="test_no_shelllogin_for_systemaccounts" version="1">
-    <ind:object object_ref="object_no_shelllogin_for_systemaccounts" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_no_shelllogin_for_systemaccounts" version="1">
-    <ind:filepath>/etc/passwd</ind:filepath>
-    <ind:pattern operation="pattern match">^(?!root).*:x:0*([0-9]{1,2}|[1-4][0-9]{2}):[\d]*:[^:]*:[^:]*:(?!\/sbin\/nologin|\/bin\/sync|\/sbin\/shutdown|\/sbin\/halt).*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+
+  <!-- First define OVAL entities used by both criteria above -->
+
+  <!-- Get last occurrence of UID_MIN from /etc/login.defs as OVAL object -->
+  <ind:textfilecontent54_object id="object_last_uid_min_from_etc_login_defs"
+  version="1">
+    <ind:behaviors singleline="true" />
+    <ind:filepath>/etc/login.defs</ind:filepath>
+    <!-- Last (uncommented) instance od UID_MIN directive -->
+    <ind:pattern operation="pattern match">.*\n(?!#|SYS_)(UID_MIN[\s]+[\d]+)\s*\n</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <!-- Get last occurrence of SYS_UID_MIN from /etc/login.defs as OVAL object -->
+  <ind:textfilecontent54_object id="object_last_sys_uid_min_from_etc_login_defs"
+  version="1">
+    <ind:behaviors singleline="true" />
+    <ind:filepath>/etc/login.defs</ind:filepath>
+    <!-- Last (uncommented) instance of SYS_UID_MIN directive -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(SYS_UID_MIN[\s]+[\d]+)\s*\n</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Get last occurrence of SYS_UID_MAX from /etc/login.defs as OVAL object -->
+  <ind:textfilecontent54_object id="object_last_sys_uid_max_from_etc_login_defs" version="1">
+    <ind:behaviors singleline="true" />
+    <ind:filepath>/etc/login.defs</ind:filepath>
+    <!-- Last (uncommented) instance of SYS_UID_MAX directive -->
+    <ind:pattern operation="pattern match">.*\n[^#]*(SYS_UID_MAX[\s]+[\d]+)\s*\n</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Get all /etc/passwd entries having shell defined as OVAL object -->
+  <ind:textfilecontent54_object id="object_etc_passwd_entries" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^(?!root).*:x:([\d]+):[\d]+:[^:]*:[^:]*:(?!\/sbin\/nologin|\/bin\/sync|\/sbin\/shutdown|\/sbin\/halt).*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Extract UIDs from /etc/passwd entries into OVAL variable -->
+  <local_variable id="variable_sys_uids_etc_passwd" datatype="int"
+  comment="UIDs retrieved from /etc/passwd" version="1">
+    <object_component item_field="subexpression"
+    object_ref="object_etc_passwd_entries" />
+  </local_variable>
+
+  <!-- FIRST CRITERION -->
+  <!-- If both SYS_UID_MIN and SYS_UID_MAX aren't defined in /etc/login.defs
+       perform the check that all /etc/passwd entries having shell defined have
+       UIDs outside the <0, UID_MIN - 1> range -->
+
+  <!-- Actual /etc/login.defs UID_MIN value as OVAL variable -->
+  <local_variable id="variable_uid_min_value" datatype="int"
+  comment="Value of last UID_MIN from /etc/login.defs" version="1">
+    <regex_capture pattern="UID_MIN[\s]+(\d+)">
+      <object_component item_field="subexpression"
+      object_ref="object_last_uid_min_from_etc_login_defs" />
+    </regex_capture>
+  </local_variable>
+
+  <!-- OVAL entities below are workaround for the OpenSCAP bug:
+       https://github.com/OpenSCAP/openscap/issues/428
+
+       Within the test below we will check if all /etc/passwd entries
+       having shell defined have UIDs outside of <0, UID_MIN - 1> range.
+       If at least one UID is within the range, test will fail.
+
+       Observation: Number "x" is outside of <a, b> range if the following
+       inequality is met (x - a) * (x - b) > 0
+  -->
+
+  <!-- OVAL variable to hold (x - 0) * (x - (UID_MIN -1)) range -->
+  <local_variable id="variable_default_range_quad_expr" datatype="int"
+  comment="Construct (x - 0) * (x - (UID_MIN - 1)) expression"
+  version="1">
+    <!-- Construct the final multiplication -->
+    <arithmetic arithmetic_operation="multiply">
+      <!-- Get "x", thus retrieved /etc/passwd UIDs as int -->
+      <!-- (x - 0) = x => use just "x" value -->
+      <variable_component var_ref="variable_sys_uids_etc_passwd" />
+      <!-- Get (x - (UID_MIN -1)) result -->
+      <arithmetic arithmetic_operation="add">
+        <variable_component var_ref="variable_sys_uids_etc_passwd" />
+        <!-- Get -1 * (UID_MIN - 1) result -->
+        <arithmetic arithmetic_operation="multiply">
+          <literal_component datatype="int">-1</literal_component>
+          <!-- Get (UID_MIN -1) result -->
+          <arithmetic arithmetic_operation="add">
+            <!-- Get "x", thus retrieved /etc/passwd UIDs as int -->
+            <variable_component var_ref="variable_uid_min_value" />
+            <literal_component datatype="int">-1</literal_component>
+          </arithmetic>
+        </arithmetic>
+      </arithmetic>
+    </arithmetic>
+  </local_variable>
+
+  <!-- Foreach previously collected UID store the expression into
+       corresponding OVAL object -->
+  <ind:variable_object id="object_shell_defined_default_uid_range" version="1">
+    <ind:var_ref>variable_default_range_quad_expr</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Finally verify that (x - a) * (x - b) > 0 -->
+  <ind:variable_state id="state_shell_defined_default_uid_range" version="1">
+    <ind:value datatype="int" operation="greater than">0</ind:value>
+  </ind:variable_state>
+
+  <!-- Perform the default <0, UID_MIN - 1> UID range test itself -->
+  <!-- Thus check that all /etc/passwd entries having shell defined
+       have UID outside of <0, UID_MIN -1> range -->
+  <ind:variable_test id="test_shell_defined_default_uid_range" check="all"
+  check_existence="all_exist" comment="&lt;0, UID_MIN - 1&gt; system UIDs having shell set"
+  version="1">
+    <ind:object object_ref="object_shell_defined_default_uid_range" />
+    <ind:state state_ref="state_shell_defined_default_uid_range" />
+  </ind:variable_test>
+
+  <!-- Test if SYS_UID_MIN not defined in /etc/login.defs -->
+  <ind:textfilecontent54_test id="test_sys_uid_min_not_defined"
+  comment="SYS_UID_MIN not defined in /etc/login.defs" check="all"
+  check_existence="none_exist" version="1">
+    <ind:object object_ref="object_last_sys_uid_min_from_etc_login_defs" />
+  </ind:textfilecontent54_test>
+
+  <!-- Test if SYS_UID_MAX not defined in /etc/login.defs -->
+  <ind:textfilecontent54_test id="test_sys_uid_max_not_defined"
+  comment="SYS_UID_MAX not defined in /etc/login.defs" check="all"
+  check_existence="none_exist" version="1">
+    <ind:object object_ref="object_last_sys_uid_max_from_etc_login_defs" />
+  </ind:textfilecontent54_test>
+
+  <!-- SECOND CRITERION -->
+  <!-- If both SYS_UID_MIN and SYS_UID_MAX are defined in /etc/login.defs,
+       perform more advanced test:
+       * Check that all /etc/passwd entries having shell defined have UIDs
+       outside the range of reserved system UIDs, thus <0, SYS_UID_MIN>,
+       * Also check that all /etc/passwd entries having shell defined have
+       UIDs outside the range of dynamically allocated system UIDs, thus
+       <SYS_UID_MIN, SYS_UID_MAX>
+  -->
+
+  <!-- Actual /etc/login.defs SYS_UID_MIN value as OVAL variable -->
+  <local_variable id="variable_sys_uid_min_value" datatype="int"
+  comment="Value of last SYS_UID_MIN from /etc/login.defs" version="1">
+    <regex_capture pattern="SYS_UID_MIN[\s]+(\d+)">
+      <object_component item_field="subexpression"
+      object_ref="object_last_sys_uid_min_from_etc_login_defs" />
+    </regex_capture>
+  </local_variable>
+
+  <!-- Actual /etc/login.defs SYS_UID_MAX value as OVAL variable -->
+  <local_variable id="variable_sys_uid_max_value" datatype="int"
+  comment="Value of last SYS_UID_MAX from /etc/login.defs" version="1">
+    <regex_capture pattern="SYS_UID_MAX[\s]+(\d+)">
+      <object_component item_field="subexpression"
+      object_ref="object_last_sys_uid_max_from_etc_login_defs" />
+    </regex_capture>
+  </local_variable>
+
+  <!-- OVAL entities below are workaround for the OpenSCAP bug:
+       https://github.com/OpenSCAP/openscap/issues/428
+
+       Within the test below we will check if all /etc/passwd entries
+       having shell defined have UIDs outside of <0, SYS_UID_MIN> range.
+       If at least one UID is within the range, test will fail.
+
+       Observation: Number "x" is outside of <a, b> range if the following
+       inequality is met (x - a) * (x - b) > 0
+  -->
+
+  <!-- OVAL variable to hold UIDs for reserved system accounts, thus
+       UIDs from the range <0, SYS_UID_MIN> -->
+  <local_variable id="variable_reserved_range_quad_expr" datatype="int"
+  comment="Construct (x - 0) * (x - SYS_UID_MIN) expression"
+  version="1">
+    <!-- Construct the final multiplication -->
+    <arithmetic arithmetic_operation="multiply">
+      <!-- Get "x", thus retrieved /etc/passwd UIDs as int -->
+      <!-- (x - 0) = x => use just "x" value -->
+      <variable_component var_ref="variable_sys_uids_etc_passwd" />
+      <!-- Construct (x - SYS_UID_MIN) expression -->
+      <arithmetic arithmetic_operation="add">
+        <!-- Get "x", thus retrieved /etc/passwd UIDs as int -->
+        <variable_component var_ref="variable_sys_uids_etc_passwd" />
+        <!-- Get negative value of SYS_UID_MIN -->
+        <arithmetic arithmetic_operation="multiply">
+          <literal_component datatype="int">-1</literal_component>
+          <variable_component var_ref="variable_sys_uid_min_value" />
+        </arithmetic>
+      </arithmetic>
+    </arithmetic>
+  </local_variable>
+
+  <!-- Foreach previously collected UID store the expression into
+       corresponding OVAL object -->
+  <ind:variable_object id="object_shell_defined_reserved_uid_range" version="1">
+    <ind:var_ref>variable_reserved_range_quad_expr</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Finally verify that (x - a) * (x - b) > 0 -->
+  <ind:variable_state id="state_shell_defined_reserved_uid_range" version="1">
+    <ind:value datatype="int" operation="greater than">0</ind:value>
+  </ind:variable_state>
+
+  <!-- Perform the reserved UID range <0, SYS_UID_MIN> test itself -->
+  <!-- Thus check that all /etc/passwd entries having shell defined
+       have UID outside of <0, SYS_UID_MIN> range -->
+  <ind:variable_test id="test_shell_defined_reserved_uid_range" check="all"
+  check_existence="all_exist" comment="&lt;0, SYS_UID_MIN&gt; system UIDs having shell set"
+  version="1">
+    <ind:object object_ref="object_shell_defined_reserved_uid_range" />
+    <ind:state state_ref="state_shell_defined_reserved_uid_range" />
+  </ind:variable_test>
+
+  <!-- OVAL entities below are workaround for the OpenSCAP bug:
+       https://github.com/OpenSCAP/openscap/issues/428
+
+       Within the test below we will check if all /etc/passwd entries
+       having shell defined have UIDs outside of <SYS_UID_MIN, SYS_UID_MAX> range.
+       If at least one UID is within the range, test will fail.
+
+       Observation: Number "x" is outside of <a, b> range if the following
+       inequality is met (x - a) * (x - b) > 0
+  -->
+
+  <!-- OVAL variable to hold UIDs for dynamically allocated system accounts,
+       thus UIDs from the range <SYS_UID_MIN, SYS_UID_MAX> -->
+  <local_variable id="variable_dynalloc_range_quad_expr" datatype="int"
+  comment="Construct (x - SYS_UID_MIN) * (x - SYS_UID_MAX) expression"
+  version="1">
+    <!-- Construct the final multiplication -->
+    <arithmetic arithmetic_operation="multiply">
+      <!-- Construct (x - SYS_UID_MIN) expression -->
+      <arithmetic arithmetic_operation="add">
+        <!-- Get "x", thus retrieved /etc/passwd UIDs as int -->
+        <variable_component var_ref="variable_sys_uids_etc_passwd" />
+        <!-- Get negative value of SYS_UID_MIN -->
+        <arithmetic arithmetic_operation="multiply">
+          <literal_component datatype="int">-1</literal_component>
+          <variable_component var_ref="variable_sys_uid_min_value" />
+        </arithmetic>
+      </arithmetic>
+      <!-- Construct (x - SYS_UID_MAX) expression -->
+      <arithmetic arithmetic_operation="add">
+        <!-- Get "x", thus retrieved /etc/passwd UIDs as int -->
+        <variable_component var_ref="variable_sys_uids_etc_passwd" />
+        <!-- Get negative value of SYS_UID_MAX -->
+        <arithmetic arithmetic_operation="multiply">
+          <literal_component datatype="int">-1</literal_component>
+          <variable_component var_ref="variable_sys_uid_max_value" />
+        </arithmetic>
+      </arithmetic>
+    </arithmetic>
+  </local_variable>
+
+  <!-- Foreach previously collected UID store the expression into
+       corresponding OVAL object -->
+  <ind:variable_object id="object_shell_defined_dynalloc_uid_range" version="1">
+    <ind:var_ref>variable_dynalloc_range_quad_expr</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Finally verify that (x - a) * (x - b) > 0 -->
+  <ind:variable_state id="state_shell_defined_dynalloc_uid_range" version="1">
+    <ind:value datatype="int" operation="greater than">0</ind:value>
+  </ind:variable_state>
+
+  <!-- Perform the dynamically allocated UID range <SYS_UID_MIN, SYS_UID_MAX> test itself -->
+  <!-- Thus check that all /etc/passwd entries having shell defined
+       have UID outside of <SYS_UID_MIN, SYS_UID_MAX> range -->
+  <ind:variable_test id="test_shell_defined_dynalloc_uid_range" check="all"
+  check_existence="all_exist" comment="&lt;SYS_UID_MIN, SYS_UID_MAX&gt; system UIDS having shell set"
+  version="1">
+    <ind:object object_ref="object_shell_defined_dynalloc_uid_range" />
+    <ind:state state_ref="state_shell_defined_dynalloc_uid_range" />
+  </ind:variable_test>
+
 </def-group>


### PR DESCRIPTION
* Patch https://github.com/OpenSCAP/scap-security-guide/commit/bedbf593e7e251a32e22fc9c1a0cbbd2e2c37eef is doing the following:

    [BugFix] [shared] Rewrite OVAL for 'no_shelllogin_for_systemaccounts'
    rule so it wouldn't always perform the check on hardcoded <0, 499> UID
    range
    
    The existing check has been enhanced to perform the following checks:
    * If both SYS_UID_MIN and SYS_UID_MAX aren't defined in /etc/login.defs
      file (default RHEL-6 case), the check will scan the <0, UID_MIN - 1>
      UID range,
    * If both SYS_UID_MIN and SYS_UID_MAX are defined in /etc/login.defs
      file (default RHEL-7+ case), the check will scan both of the following
      UID ranges:
      * <0, SYS_UID_MIN> to check case of reserved system accounts,
      * <SYS_UID_MIN, SYS_UID_MAX> to check case of dynamically allocated
      system accounts
    
    The new implementation will obtain the actual values / settings
    of UID_MIN, SYS_UID_MIN, and SYS_UID_MAX directives from the /etc/login.defs
    file of the corresponding host system to be scanned (ToV)
    
    Fixes downstream: https://bugzilla.redhat.com/show_bug.cgi?id=1302061

* Patch https://github.com/OpenSCAP/scap-security-guide/commit/f15874c39b1db1ea7a6991bacd3cd81367a34a5b removes hardcode (500, 1000) UID values from RHEL-6, RHEL-7, and Fedora XCCDF prose for ```no_shelllogin_for_systemaccounts``` rule and replaces it with ```UID_MIN``` value (and default values of this variable on RHEL-6, RHEL-7, and Fedora systems)

This is a rewrite (version 2) of https://github.com/OpenSCAP/scap-security-guide/pull/1285
Fixes (downstream issue): https://bugzilla.redhat.com/show_bug.cgi?id=1302061
Workarounds: https://github.com/OpenSCAP/openscap/issues/428

Note: In comparison to the previous version, the corresponding checks logic has been inverted (thus instead of checking there doesn't exist an UID having shell defined within particular UID range, this version requires all /etc/passwd entries having shell defined will have UIDs outside of the allowed ranges:
* outside of <0, UID_MIN - 1> for the default case (no SYS_UID_MIN, SYS_UID_MAX defined),
* outside of <0, SYS_UID_MIN> for the reserved system accounts case, and
* outside of <SYS_UID_MIN, SYS_UID_MAX> range for the dynamically allocated system accounts case)

This allowed the tests to be simplified and required the corresponding inequality operations to be inverted too (thus this version used ```(x -a ) * (x - b) > 0``` form instead of the former one).

Testing report:

--
Have tested the changes on all of RHEL-6, RHEL-7, and Fedora systems and AFAICT from testing, works fine.

Please review.

Thank you, Jan