### PR TITLE
[BugFix] [RHEL/7] Modify RHEL-7 OVAL for 'install_PAE_kernel_on_x86-32' rule not to fail on 64-bit (any not 32-bit system)

### DIFF
--- a/RHEL/7/input/oval/install_PAE_kernel_on_x86-32.xml
+++ b/RHEL/7/input/oval/install_PAE_kernel_on_x86-32.xml
@@ -1,26 +1,37 @@
 <def-group>
-  <definition class="compliance" id="install_PAE_kernel_on_x86-32"
-  version="1">
+  <definition class="compliance" id="install_PAE_kernel_on_x86-32" version="2">
     <metadata>
       <title>Package kernel-PAE Installed</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
       </affected>
-      <description>The RPM package kernel-PAE should be installed on 32-bit systems.</description>
-      <reference source="galford" ref_id="20150923" ref_url="test_attestation"/>
+      <description>The RPM package kernel-PAE should be installed on 32-bit
+      systems.</description>
+      <reference source="JL" ref_id="RHEL7_20160621" ref_url="test_attestation"/>
     </metadata>
-    <criteria>
-      <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
-      <criterion comment="package kernel-PAE is installed"
-      test_ref="test_package_kernel-PAE_installed" />
+    <criteria operator="OR">
+      <!-- System is either not 32-bit one. In that case there's
+           nothing more to check -->
+      <extend_definition comment="Not a 32-bit system"
+      definition_ref="system_info_architecture_x86" negate="true" />
+      <!-- Or system is 32-bit one. Then check if kernel-PAE rpm
+           is installed the test to succeed -->
+      <criteria operator="AND">
+        <extend_definition comment="A 32-bit system"
+        definition_ref="system_info_architecture_x86" />
+        <criterion comment="Package kernel-PAE is installed"
+        test_ref="test_package_kernel-PAE_installed" />
+      </criteria>
     </criteria>
   </definition>
+
   <linux:rpminfo_test check="all" check_existence="all_exist"
   id="test_package_kernel-PAE_installed" version="1"
-  comment="package kernel-PAE is installed">
+  comment="Package kernel-PAE is installed">
     <linux:object object_ref="obj_package_kernel-PAE_installed" />
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_package_kernel-PAE_installed" version="1">
     <linux:name>kernel-PAE</linux:name>
   </linux:rpminfo_object>
+
 </def-group>


### PR DESCRIPTION
As detailed in [corresponding downstream bug](https://bugzilla.redhat.com/show_bug.cgi?id=1291518)
the ```install_PAE_kernel_on_x86-32``` currently fails when 64-bit system is scanned.

But the XCCDF prose requires kernel-PAE rpm to be installed only on 32-bit systems. It doesn't make sense to perform the check if kernel-PAE rpm is installed (and possibly fail) if the system is not a 32-bit one.

Fixes (part of downstream): https://bugzilla.redhat.com/show_bug.cgi?id=1291518

Please review.

Thank you, Jan