### PR TITLE
[Bugfix] [Infrastructure] Remediation sanity checks

### DIFF
--- a/shared/transforms/combineremediations.py
+++ b/shared/transforms/combineremediations.py
@@ -234,6 +234,27 @@ def expand_xccdf_subs(fix, remediation_functions):
                             if re.search('.*\n$', previouselem.tail) is None:
                                 previouselem.tail += '\n'
 
+    # Perform a sanity check if all known remediation function calls have been
+    # properly XCCDF substituted. Exit with failure if some wasn't
+
+    # First concat output form of modified fix text (including text appended
+    # to all children of the fix)
+    modfixtext = fix.text
+    for child in fix.getchildren():
+        if child is not None and child.text is not None:
+            modfixtext += child.text
+    for f in remediation_functions:
+        # Then efine expected XCCDF sub element form for this function
+        funcxccdfsub = "<sub idref=\"function_%s\"" % f
+        # Finally perform the sanity check -- if function was properly XCCDF
+        # substituted both the original function call and XCCDF <sub> element
+        # for that function need to be present in the modified text of the fix
+        # Otherwise something went wrong, thus exit with failure
+        if f in modfixtext and funcxccdfsub not in modfixtext:
+            print("Error performing XCCDF <sub> substitution for function")
+            print("%s in %s fix.\nExiting..." % (f, fix.get("rule")))
+            sys.exit(1)
+
 
 def main():
     if len(sys.argv) < 2:

--- a/shared/transforms/combineremediations.py
+++ b/shared/transforms/combineremediations.py
@@ -136,7 +136,7 @@ def expand_xccdf_subs(fix, remediation_functions):
     # Expand shell variables and remediation functions calls with <xccdf:sub>
     # elements
     else:
-        pattern = '\n(\s*(?:' + '|'.join(remediation_functions) + ')[^\n]+)\n'
+        pattern = '\n+(\s*(?:' + '|'.join(remediation_functions) + ')[^\n]*)\n'
         patcomp = re.compile(pattern, re.DOTALL)
         fixparts = re.split(patcomp, fix.text)
         if fixparts[0] is not None:
@@ -201,7 +201,8 @@ def expand_xccdf_subs(fix, remediation_functions):
                     # This chunk contains call of other remediation function
                     else:
                         # Extract remediation function name
-                        funcname = re.search('\n\s*(\S+) .*\n', fixparts[idx],
+                        funcname = re.search('\n\s*(\S+)(| .*)\n',
+                                             fixparts[idx],
                                              re.DOTALL).group(1)
                         # Define new XCCDF <sub> element for the function
                         xccdffuncsub = etree.SubElement(fix, "sub",

--- a/shared/xccdf/remediation_functions.xml
+++ b/shared/xccdf/remediation_functions.xml
@@ -674,6 +674,174 @@ audit system calls on Red Hat Enterprise Linux 6</title>
 <description>Perform the remediation for the 'adjtimex', 'settimeofday', and 'stime' audit
 # system calls on Red Hat Enterprise Linux 6 OS</description>
 <value selector="">
+function fix_audit_syscall_rule {
+
+# Load function arguments into local variables
+local tool="$1"
+local pattern="$2"
+local group="$3"
+local arch="$4"
+local full_rule="$5"
+
+# Check sanity of the input
+if [ $# -ne "5" ]
+then
+        echo "Usage: fix_audit_syscall_rule 'tool' 'pattern' 'group' 'arch' 'full rule'"
+        echo "Aborting."
+        exit 1
+fi
+
+# Create a list of audit *.rules files that should be inspected for presence and correctness
+# of a particular audit rule. The scheme is as follows:
+# 
+# -----------------------------------------------------------------------------------------
+#  Tool used to load audit rules | Rule already defined  |  Audit rules file to inspect    |
+# -----------------------------------------------------------------------------------------
+#        auditctl                |     Doesn't matter    |  /etc/audit/audit.rules         |
+# -----------------------------------------------------------------------------------------
+#        augenrules              |          Yes          |  /etc/audit/rules.d/*.rules     |
+#        augenrules              |          No           |  /etc/audit/rules.d/$key.rules  |
+# -----------------------------------------------------------------------------------------
+#
+declare -a files_to_inspect
+
+# First check sanity of the specified audit tool
+if [ "$tool" != 'auditctl' ] &amp;&amp; [ "$tool" != 'augenrules' ]
+then
+        echo "Unknown audit rules loading tool: $1. Aborting."
+        echo "Use either 'auditctl' or 'augenrules'!"
+        exit 1
+# If audit tool is 'auditctl', then add '/etc/audit/audit.rules'
+# file to the list of files to be inspected
+elif [ "$tool" == 'auditctl' ]
+then
+        files_to_inspect=("${files_to_inspect[@]}" '/etc/audit/audit.rules' )
+# If audit tool is 'augenrules', then check if the audit rule is defined
+# If rule is defined, add '/etc/audit/rules.d/*.rules' to the list for inspection
+# If rule isn't defined yet, add '/etc/audit/rules.d/$key.rules' to the list for inspection
+elif [ "$tool" == 'augenrules' ]
+then
+        # Extract audit $key from audit rule so we can use it later
+        key=$(expr "$full_rule" : '.*-k[[:space:]]\([^[:space:]]\+\)')
+        # Check if particular audit rule is already defined
+        IFS=$'\n' matches=($(sed -s -n -e "/${pattern}/!d" -e "/${arch}/!d" -e "/${group}/!d;F" /etc/audit/rules.d/*.rules))
+        # Reset IFS back to default
+        unset $IFS
+        for match in "${matches[@]}"
+        do
+                files_to_inspect=("${files_to_inspect[@]}" "${match}")
+        done
+        # Case when particular rule isn't defined in /etc/audit/rules.d/*.rules yet
+        if [ ${#files_to_inspect[@]} -eq "0" ]
+        then
+                files_to_inspect="/etc/audit/rules.d/$key.rules"
+                if [ ! -e "$files_to_inspect" ]
+                then
+                        touch "$files_to_inspect"
+                        chmod 0640 "$files_to_inspect"
+                fi
+        fi
+fi
+
+#
+# Indicator that we want to append $full_rule into $audit_file by default
+local append_expected_rule=0
+
+for audit_file in "${files_to_inspect[@]}"
+do
+
+        # Filter existing $audit_file rules' definitions to select those that:
+        # * follow the rule pattern, and
+        # * meet the hardware architecture requirement, and
+        # * are current syscall group specific
+        IFS=$'\n' existing_rules=($(sed -e "/${pattern}/!d" -e "/${arch}/!d" -e "/${group}/!d"  "$audit_file"))
+        # Reset IFS back to default
+        unset $IFS
+
+        # Process rules found case-by-case
+        for rule in "${existing_rules[@]}"
+        do
+                # Found rule is for same arch &amp; key, but differs (e.g. in count of -S arguments)
+                if [ "${rule}" != "${full_rule}" ]
+                then
+                        # If so, isolate just '(-S \w)+' substring of that rule
+                        rule_syscalls=$(echo $rule | grep -o -P '(-S \w+ )+')
+                        # Check if list of '-S syscall' arguments of that rule is subset
+                        # of '-S syscall' list of expected $full_rule
+                        if grep -q -- "$rule_syscalls" &lt;&lt;&lt; "$full_rule"
+                        then
+                                # Rule is covered (i.e. the list of -S syscalls for this rule is
+                                # subset of -S syscalls of $full_rule => existing rule can be deleted
+                                # Thus delete the rule from audit.rules &amp; our array
+                                sed -i -e "/$rule/d" "$audit_file"
+                                existing_rules=("${existing_rules[@]//$rule/}")
+                        else
+                                # Rule isn't covered by $full_rule - it besides -S syscall arguments
+                                # for this group contains also -S syscall arguments for other syscall
+                                # group. Example: '-S lchown -S fchmod -S fchownat' => group='chown'
+                                # since 'lchown' &amp; 'fchownat' share 'chown' substring
+                                # Therefore:
+                                # * 1) delete the original rule from audit.rules
+                                # (original '-S lchown -S fchmod -S fchownat' rule would be deleted)
+                                # * 2) delete the -S syscall arguments for this syscall group, but
+                                # keep those not belonging to this syscall group
+                                # (original '-S lchown -S fchmod -S fchownat' would become '-S fchmod'
+                                # * 3) append the modified (filtered) rule again into audit.rules
+                                # if the same rule not already present
+                                #
+                                # 1) Delete the original rule
+                                sed -i -e "/$rule/d" "$audit_file"
+                                # 2) Delete syscalls for this group, but keep those from other groups
+                                # Convert current rule syscall's string into array splitting by '-S' delimiter
+                                IFS=$'-S' read -a rule_syscalls_as_array &lt;&lt;&lt; "$rule_syscalls"
+                                # Reset IFS back to default
+                                unset $IFS
+                                # Declare new empty string to hold '-S syscall' arguments from other groups
+                                new_syscalls_for_rule=''
+                                # Walk through existing '-S syscall' arguments
+                                for syscall_arg in "${rule_syscalls_as_array[@]}"
+                                do
+                                        # Skip empty $syscall_arg values
+                                        if [ "$syscall_arg" == '' ]
+                                        then
+                                                continue
+                                        fi
+                                        # If the '-S syscall' doesn't belong to current group add it to the new list
+                                        # (together with adding '-S' delimiter back for each of such item found)
+                                        if grep -q -v -- "$group" &lt;&lt;&lt; "$syscall_arg"
+                                        then
+                                                new_syscalls_for_rule="$new_syscalls_for_rule -S $syscall_arg"
+                                        fi
+                                done
+                                # Replace original '-S syscall' list with the new one for this rule
+                                updated_rule=${rule//$rule_syscalls/$new_syscalls_for_rule}
+                                # Squeeze repeated whitespace characters in rule definition (if any) into one
+                                updated_rule=$(echo "$updated_rule" | tr -s '[:space:]')
+                                # 3) Append the modified / filtered rule again into audit.rules
+                                #    (but only in case it's not present yet to prevent duplicate definitions)
+                                if ! grep -q -- "$updated_rule" "$audit_file"
+                                then
+                                        echo "$updated_rule" >> "$audit_file"
+                                fi
+                        fi
+                else
+                        # $audit_file already contains the expected rule form for this
+                        # architecture &amp; key => don't insert it second time
+                        append_expected_rule=1
+                fi
+        done
+
+        # We deleted all rules that were subset of the expected one for this arch &amp; key.
+        # Also isolated rules containing system calls not from this system calls group.
+        # Now append the expected rule if it's not present in $audit_file yet
+        if [[ ${append_expected_rule} -eq "0" ]]
+        then
+                echo "$full_rule" >> "$audit_file"
+        fi
+done
+
+}
+
 function rhel6_perform_audit_adjtimex_settimeofday_stime_remediation {
 
 # Perform the remediation for the 'adjtimex', 'settimeofday', and 'stime' audit
@@ -714,6 +882,174 @@ audit system calls on Red Hat Enterprise Linux 7 or Fedora</title>
 <description>Perform the remediation for the 'adjtimex', 'settimeofday', and
 'stime' audit system calls on Red Hat Enterprise Linux 7 or Fedora OSes</description>
 <value selector="">
+function fix_audit_syscall_rule {
+
+# Load function arguments into local variables
+local tool="$1"
+local pattern="$2"
+local group="$3"
+local arch="$4"
+local full_rule="$5"
+
+# Check sanity of the input
+if [ $# -ne "5" ]
+then
+        echo "Usage: fix_audit_syscall_rule 'tool' 'pattern' 'group' 'arch' 'full rule'"
+        echo "Aborting."
+        exit 1
+fi
+
+# Create a list of audit *.rules files that should be inspected for presence and correctness
+# of a particular audit rule. The scheme is as follows:
+# 
+# -----------------------------------------------------------------------------------------
+#  Tool used to load audit rules | Rule already defined  |  Audit rules file to inspect    |
+# -----------------------------------------------------------------------------------------
+#        auditctl                |     Doesn't matter    |  /etc/audit/audit.rules         |
+# -----------------------------------------------------------------------------------------
+#        augenrules              |          Yes          |  /etc/audit/rules.d/*.rules     |
+#        augenrules              |          No           |  /etc/audit/rules.d/$key.rules  |
+# -----------------------------------------------------------------------------------------
+#
+declare -a files_to_inspect
+
+# First check sanity of the specified audit tool
+if [ "$tool" != 'auditctl' ] &amp;&amp; [ "$tool" != 'augenrules' ]
+then
+        echo "Unknown audit rules loading tool: $1. Aborting."
+        echo "Use either 'auditctl' or 'augenrules'!"
+        exit 1
+# If audit tool is 'auditctl', then add '/etc/audit/audit.rules'
+# file to the list of files to be inspected
+elif [ "$tool" == 'auditctl' ]
+then
+        files_to_inspect=("${files_to_inspect[@]}" '/etc/audit/audit.rules' )
+# If audit tool is 'augenrules', then check if the audit rule is defined
+# If rule is defined, add '/etc/audit/rules.d/*.rules' to the list for inspection
+# If rule isn't defined yet, add '/etc/audit/rules.d/$key.rules' to the list for inspection
+elif [ "$tool" == 'augenrules' ]
+then
+        # Extract audit $key from audit rule so we can use it later
+        key=$(expr "$full_rule" : '.*-k[[:space:]]\([^[:space:]]\+\)')
+        # Check if particular audit rule is already defined
+        IFS=$'\n' matches=($(sed -s -n -e "/${pattern}/!d" -e "/${arch}/!d" -e "/${group}/!d;F" /etc/audit/rules.d/*.rules))
+        # Reset IFS back to default
+        unset $IFS
+        for match in "${matches[@]}"
+        do
+                files_to_inspect=("${files_to_inspect[@]}" "${match}")
+        done
+        # Case when particular rule isn't defined in /etc/audit/rules.d/*.rules yet
+        if [ ${#files_to_inspect[@]} -eq "0" ]
+        then
+                files_to_inspect="/etc/audit/rules.d/$key.rules"
+                if [ ! -e "$files_to_inspect" ]
+                then
+                        touch "$files_to_inspect"
+                        chmod 0640 "$files_to_inspect"
+                fi
+        fi
+fi
+
+#
+# Indicator that we want to append $full_rule into $audit_file by default
+local append_expected_rule=0
+
+for audit_file in "${files_to_inspect[@]}"
+do
+
+        # Filter existing $audit_file rules' definitions to select those that:
+        # * follow the rule pattern, and
+        # * meet the hardware architecture requirement, and
+        # * are current syscall group specific
+        IFS=$'\n' existing_rules=($(sed -e "/${pattern}/!d" -e "/${arch}/!d" -e "/${group}/!d"  "$audit_file"))
+        # Reset IFS back to default
+        unset $IFS
+
+        # Process rules found case-by-case
+        for rule in "${existing_rules[@]}"
+        do
+                # Found rule is for same arch &amp; key, but differs (e.g. in count of -S arguments)
+                if [ "${rule}" != "${full_rule}" ]
+                then
+                        # If so, isolate just '(-S \w)+' substring of that rule
+                        rule_syscalls=$(echo $rule | grep -o -P '(-S \w+ )+')
+                        # Check if list of '-S syscall' arguments of that rule is subset
+                        # of '-S syscall' list of expected $full_rule
+                        if grep -q -- "$rule_syscalls" &lt;&lt;&lt; "$full_rule"
+                        then
+                                # Rule is covered (i.e. the list of -S syscalls for this rule is
+                                # subset of -S syscalls of $full_rule => existing rule can be deleted
+                                # Thus delete the rule from audit.rules &amp; our array
+                                sed -i -e "/$rule/d" "$audit_file"
+                                existing_rules=("${existing_rules[@]//$rule/}")
+                        else
+                                # Rule isn't covered by $full_rule - it besides -S syscall arguments
+                                # for this group contains also -S syscall arguments for other syscall
+                                # group. Example: '-S lchown -S fchmod -S fchownat' => group='chown'
+                                # since 'lchown' &amp; 'fchownat' share 'chown' substring
+                                # Therefore:
+                                # * 1) delete the original rule from audit.rules
+                                # (original '-S lchown -S fchmod -S fchownat' rule would be deleted)
+                                # * 2) delete the -S syscall arguments for this syscall group, but
+                                # keep those not belonging to this syscall group
+                                # (original '-S lchown -S fchmod -S fchownat' would become '-S fchmod'
+                                # * 3) append the modified (filtered) rule again into audit.rules
+                                # if the same rule not already present
+                                #
+                                # 1) Delete the original rule
+                                sed -i -e "/$rule/d" "$audit_file"
+                                # 2) Delete syscalls for this group, but keep those from other groups
+                                # Convert current rule syscall's string into array splitting by '-S' delimiter
+                                IFS=$'-S' read -a rule_syscalls_as_array &lt;&lt;&lt; "$rule_syscalls"
+                                # Reset IFS back to default
+                                unset $IFS
+                                # Declare new empty string to hold '-S syscall' arguments from other groups
+                                new_syscalls_for_rule=''
+                                # Walk through existing '-S syscall' arguments
+                                for syscall_arg in "${rule_syscalls_as_array[@]}"
+                                do
+                                        # Skip empty $syscall_arg values
+                                        if [ "$syscall_arg" == '' ]
+                                        then
+                                                continue
+                                        fi
+                                        # If the '-S syscall' doesn't belong to current group add it to the new list
+                                        # (together with adding '-S' delimiter back for each of such item found)
+                                        if grep -q -v -- "$group" &lt;&lt;&lt; "$syscall_arg"
+                                        then
+                                                new_syscalls_for_rule="$new_syscalls_for_rule -S $syscall_arg"
+                                        fi
+                                done
+                                # Replace original '-S syscall' list with the new one for this rule
+                                updated_rule=${rule//$rule_syscalls/$new_syscalls_for_rule}
+                                # Squeeze repeated whitespace characters in rule definition (if any) into one
+                                updated_rule=$(echo "$updated_rule" | tr -s '[:space:]')
+                                # 3) Append the modified / filtered rule again into audit.rules
+                                #    (but only in case it's not present yet to prevent duplicate definitions)
+                                if ! grep -q -- "$updated_rule" "$audit_file"
+                                then
+                                        echo "$updated_rule" >> "$audit_file"
+                                fi
+                        fi
+                else
+                        # $audit_file already contains the expected rule form for this
+                        # architecture &amp; key => don't insert it second time
+                        append_expected_rule=1
+                fi
+        done
+
+        # We deleted all rules that were subset of the expected one for this arch &amp; key.
+        # Also isolated rules containing system calls not from this system calls group.
+        # Now append the expected rule if it's not present in $audit_file yet
+        if [[ ${append_expected_rule} -eq "0" ]]
+        then
+                echo "$full_rule" >> "$audit_file"
+        fi
+done
+
+}
+
 function rhel7_fedora_perform_audit_adjtimex_settimeofday_stime_remediation {
 
 # Perform the remediation for the 'adjtimex', 'settimeofday', and 'stime' audit


### PR DESCRIPTION
* Patch https://github.com/OpenSCAP/scap-security-guide/commit/07f3520c85d5df8322afaa2147426bc5fda35fe9 is adding a sanity check to ```combineremediations.py``` helper to check if XCCDF ```<sub idref="..">``` substitution of the particular remediation function succeed. Will report a failure and exit with error if not (if both original function call and new ```<sub idref>``` element for that function call are not present in the modified version of the fix text),

* Patch https://github.com/OpenSCAP/scap-security-guide/commit/96d730cf0eb36ff54badbc3a27e8ab873c368e11 is correcting the XCCDF ```<sub>``` expansion script (```combineremediations.py``` helper) to count also with possibility of functions not requiring arguments in the function call. There are two such functions in ```shared/xccdf/remediation_functions.xml``` file currently,

* Finally patch https://github.com/OpenSCAP/scap-security-guide/commit/95ff8d2e39fcb5a27269392115dbc5ff0759230b deals with the situation when some remediation function recursively calls another remediation function. Since now we are using XCCDF ```<sub>``` mechanism, the recursively called remediation function needs to be defined in that remediation script too in order the remediation to succeed. Both of those remediation functions not requiring an argument call ```fix_audit_syscall_rule``` function within their body. Thus equipped them with definition of this function too.

The last changes makes [RHEL/6] [RHEL/7] remediation scripts for audit ```stime```, ```adjtimex```, and ```settimeofday``` system calls to start working again.

Testing report:

--
Tested locally on both RHEL-6 && RHEL-7 systems, and AFAICT from testing the changes seem to be working fine.

Please review.

Thank you, Jan