### PR TITLE
[BugFix] [RHEL/6] [RHEL/7] [Fedora] Modify 'standard' profiles to comment out the rules currently returning 'notapplicable' result

### DIFF
--- a/Fedora/input/profiles/standard.xml
+++ b/Fedora/input/profiles/standard.xml
@@ -8,16 +8,18 @@ Regardless of your system's workload all of these checks should pass.</descripti
 <select idref="rpm_verify_hashes" selected="true" />
 
 <select idref="no_empty_passwords" selected="true"/>
-<select idref="accounts_password_all_shadowed" selected="true"/>
 
-<select idref="root_path_no_dot" selected="true"/>
 <select idref="accounts_root_path_dirs_no_write" selected="true"/>
 <select idref="file_permissions_library_dirs" selected="true"/>
 <select idref="file_ownership_library_dirs" selected="true"/>
 <select idref="file_permissions_binary_dirs" selected="true"/>
 <select idref="file_ownership_binary_dirs" selected="true"/>
 
-<select idref="mount_option_dev_shm_nodev" selected="true" />
-<select idref="mount_option_dev_shm_nosuid" selected="true" />
+<!-- The following rules currently returns 'notapplicable' on Fedora container -->
+<!-- Investigate why, fix the issues, and re-enable back once fixed -->
+<!-- <select idref="accounts_password_all_shadowed" selected="true"/> -->
+<!-- <select idref="root_path_no_dot" selected="true"/> -->
+<!-- <select idref="mount_option_dev_shm_nodev" selected="true" /> -->
+<!-- <select idref="mount_option_dev_shm_nosuid" selected="true" /> -->
 
 </Profile>

--- a/RHEL/6/input/profiles/standard.xml
+++ b/RHEL/6/input/profiles/standard.xml
@@ -7,19 +7,18 @@ Regardless of your system's workload all of these checks should pass.</descripti
 <select idref="ensure_gpgcheck_globally_activated" selected="true" />
 <select idref="rpm_verify_permissions" selected="true" />
 <select idref="rpm_verify_hashes" selected="true" />
-
-<select idref="security_patches_up_to_date" selected="true"/>
 <select idref="no_empty_passwords" selected="true"/>
-<select idref="accounts_password_all_shadowed" selected="true"/>
-
 <select idref="file_permissions_unauthorized_sgid" selected="true"/>
 <select idref="file_permissions_unauthorized_suid" selected="true"/>
 <select idref="file_permissions_unauthorized_world_writable" selected="true"/>
-<select idref="root_path_no_dot" selected="true"/>
 <select idref="accounts_root_path_dirs_no_write" selected="true"/>
 <select idref="dir_perms_world_writable_sticky_bits" selected="true" />
 
-<select idref="mount_option_dev_shm_nodev" selected="true" />
-<select idref="mount_option_dev_shm_nosuid" selected="true" />
+<!-- The following rules currently returns 'notapplicable' on RHEL-6 container -->
+<!-- Investigate why, fix the issues, and re-enable back once fixed -->
+<!-- <select idref="accounts_password_all_shadowed" selected="true"/> -->
+<!-- <select idref="root_path_no_dot" selected="true"/> -->
+<!-- <select idref="mount_option_dev_shm_nodev" selected="true" /> -->
+<!-- <select idref="mount_option_dev_shm_nosuid" selected="true" /> -->
 
 </Profile>

--- a/RHEL/7/input/profiles/standard.xml
+++ b/RHEL/7/input/profiles/standard.xml
@@ -7,19 +7,18 @@ Regardless of your system's workload all of these checks should pass.</descripti
 <select idref="ensure_gpgcheck_globally_activated" selected="true" />
 <select idref="rpm_verify_permissions" selected="true" />
 <select idref="rpm_verify_hashes" selected="true" />
-
-<select idref="security_patches_up_to_date" selected="true"/>
 <select idref="no_empty_passwords" selected="true"/>
-<select idref="accounts_password_all_shadowed" selected="true"/>
-
 <select idref="file_permissions_unauthorized_sgid" selected="true"/>
 <select idref="file_permissions_unauthorized_suid" selected="true"/>
 <select idref="file_permissions_unauthorized_world_writable" selected="true"/>
-<select idref="root_path_no_dot" selected="true"/>
 <select idref="accounts_root_path_dirs_no_write" selected="true"/>
 <select idref="dir_perms_world_writable_sticky_bits" selected="true" />
 
-<select idref="mount_option_dev_shm_nodev" selected="true" />
-<select idref="mount_option_dev_shm_nosuid" selected="true" />
+<!-- The following rules currently returns 'notapplicable' on RHEL-7 container -->
+<!-- Investigate why, fix the issues, and re-enable back once fixed -->
+<!-- <select idref="accounts_password_all_shadowed" selected="true"/> -->
+<!-- <select idref="root_path_no_dot" selected="true"/> -->
+<!-- <select idref="mount_option_dev_shm_nodev" selected="true" /> -->
+<!-- <select idref="mount_option_dev_shm_nosuid" selected="true" /> -->
 
 </Profile>


### PR DESCRIPTION
(needs investigation of reasons why it's behaving so, and fixing the
issues prior re-enabling them back)

Also drop 'security_patches_up2date' rules (since for containers
we would want to perform oscap-docker {image,container}-cve scan
instead)