### PR TITLE
[BugFix] [Infrastructure] Fix parallel make

### DIFF
--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -55,7 +55,7 @@ $(OUT)/shorthand.xml: $(OUT)/guide.xml $(IN)/guide.xslt $(guide_xslt_deps)
 # Create temporary $(SHARED)/$(OUT) folder to hold information like list of contributors or list of
 # available remediation functions used by all SSG benchmarks
 $(SHARED)/$(OUT):
-	mkdir $@
+	mkdir -p $@
 
 # Benchmark metadata prerequisite - derive $(SHARED)/$(OUT)/contributors.xml from the content of Contributors.md
 $(SHARED)/$(OUT)/contributors.xml: $(SHARED)/$(OUT)


### PR DESCRIPTION
As visible e.g. in:
  https://kojipkgs.fedoraproject.org//work/tasks/1659/14671659/build.log

currently attempt to build current SSG master in parallel:
```
  cd scap-security-guide-0.1.30
  make -j4 dist
  ..
```
fails with:
```
  ..
  mkdir ../shared/output
  mkdir ../shared/output
  xsltproc -o output/guide.xml ../shared/transforms/includelogo.xslt input/guide.xml
  mkdir: cannot create directory '../shared/output': File exists
  ..
```

Fix that (so ```make -j4 dist``` will work again)

Please review.

Thank you, Jan