### PR TITLE
[BugFix] [RHEL/6] Fix for issue #1319

### DIFF
--- a/RHEL/6/input/profiles/stig-rhel6-server-gui-upstream.xml
+++ b/RHEL/6/input/profiles/stig-rhel6-server-gui-upstream.xml
@@ -1,5 +1,5 @@
 <Profile id="stig-rhel6-server-gui-upstream" extends="stig-rhel6-server-upstream">
-<title override="true">Upstream STIG for Red Hat Enterprise Linux 6 Server</title>
+<title override="true">Upstream STIG for Red Hat Enterprise Linux 6 Server Running GUIs</title>
 <description override="true">This profile is developed under the DoD consensus model and DISA FSO Vendor STIG process,
 serving as the upstream development environment for the Red Hat Enterprise Linux 6 Server STIG.
 


### PR DESCRIPTION

Make the title of the RHEL-6 ```stig-rhel6-server-gui-upstream profile``` consistent with its RHEL-7 equivalent

Fixes #1319