### PR TITLE
[BugFix] Fix for downstream RH BZ#1344581

### DIFF
--- a/RHEL/7/input/oval/accounts_passwords_pam_faillock_deny_root.xml
+++ b/RHEL/7/input/oval/accounts_passwords_pam_faillock_deny_root.xml
@@ -34,7 +34,7 @@
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so preauth silent in auth section is listed before
          pam_unix.so module in auth section -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*even_deny_root[\s]*[^\n]*[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*even_deny_root[\s]*(?s).*[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -51,7 +51,7 @@
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so in auth section is listed right after pam_unix.so auth row -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]+[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*even_deny_root[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]+(?s).*[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*even_deny_root[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -69,7 +69,7 @@
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so preauth silent in auth section is listed before
          pam_unix.so module in auth section -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*even_deny_root[\s]*[^\n]*[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*even_deny_root[\s]*(?s).*[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -86,7 +86,7 @@
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so in auth section is listed right after pam_unix.so auth row -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]+[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*even_deny_root[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]+(?s).*[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*even_deny_root[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/oval/accounts_passwords_pam_faillock_deny.xml
+++ b/shared/oval/accounts_passwords_pam_faillock_deny.xml
@@ -51,7 +51,7 @@
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so preauth silent in auth section is listed before
          pam_unix.so module in auth section -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*deny=([0-9]+)[\s]*[^\n]*[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*deny=([0-9]+)[\s]*(?s).*[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -69,7 +69,7 @@
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so in auth section is listed right after pam_unix.so auth row -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]+[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*deny=([0-9]+)[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]+(?s).*[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*deny=([0-9]+)[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -106,7 +106,7 @@
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so preauth silent in auth section is listed before
          pam_unix.so module in auth section -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*deny=([0-9]+)[\s]*[^\n]*[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*deny=([0-9]+)[\s]*(?s).*[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -124,7 +124,7 @@
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so in auth section is listed right after pam_unix.so auth row -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+sufficient[\s]+pam_unix\.so[^\n]+[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*deny=([0-9]+)[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]+(?s).*[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*deny=([0-9]+)[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>


### PR DESCRIPTION
As has been reported downstream in https://bugzilla.redhat.com/show_bug.cgi?id=1344581
the current implementation of OVAL checks for:

* ```accounts_passwords_pam_faillock_deny_root ``` and
* ```accounts_passwords_pam_faillock_deny```

rules does not work properly in the case when sssd package is installed and sssd daemon is running
(since ```/etc/pam.d/system-auth``` and ```/etc/pam.d/password-auth``` will have slightly different form in that case).

Therefore enhance the OVAL checks to work properly also in these cases.

Testing report:
Verified the modified OVALs work fine in both of the following scenarios:
* sssd package is not installed (pam.d config files have form like expected by current OVAL implementation),
* sssd package is installed (pam.d configs differ slightly)

Fixes downstream: https://bugzilla.redhat.com/show_bug.cgi?id=1344581

Please review.

Thank you, Jan