### PR TITLE
[Enhancement][Infrastructure] Add vendor variable

### DIFF
--- a/Chromium/Makefile
+++ b/Chromium/Makefile
@@ -7,6 +7,7 @@ export SHARED = ../shared
 include $(SHARED)/product-make.include
 
 PROD = chromium
+VENDOR = ssgproject
 
 checks:
 	xmlwf $(IN)/oval/*.xml
@@ -65,7 +66,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 #	Update @style attribute of <xccdf:Benchmark> to "SCAP_1.2". Fixes #1059

--- a/Debian/8/Makefile
+++ b/Debian/8/Makefile
@@ -8,6 +8,7 @@ include $(SHARED)/product-make.include
 
 PROD = debian8
 PROD_OVAL = $(BUILD)/$(PROD)_oval
+VENDOR = ssgproject
 
 checks:
 	# Make intermediate $(PROD_OVAL) directory to hold final list of OVAL checks for $(PROD)
@@ -82,7 +83,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 #	Update @style attribute of <xccdf:Benchmark> to "SCAP_1.2". Fixes #1059

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -8,6 +8,7 @@ include $(SHARED)/product-make.include
 
 PROD = fedora
 PROD_OVAL = $(BUILD)/$(PROD)_oval
+VENDOR = ssgproject
 
 SHELLCHECK_AVAIL := $(shell which shellcheck >& /dev/null; echo $$?)
 
@@ -41,7 +42,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 #	Update @style attribute of <xccdf:Benchmark> to "SCAP_1.2". Fixes #1059

--- a/Firefox/Makefile
+++ b/Firefox/Makefile
@@ -7,6 +7,7 @@ export SHARED = ../shared
 include $(SHARED)/product-make.include
 
 PROD = firefox
+VENDOR = ssgproject
 
 #stats:
 #	$(SHARED)/$(TRANS)/stats.sh
@@ -68,7 +69,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 #	Update @style attribute of <xccdf:Benchmark> to "SCAP_1.2". Fixes #1059

--- a/JBoss/EAP/5/Makefile
+++ b/JBoss/EAP/5/Makefile
@@ -7,6 +7,7 @@ export SHARED = ../../../shared
 include $(SHARED)/product-make.include
 
 PROD = eap5
+VENDOR = ssgproject
 
 #stats:
 #	$(SHARED)/$(TRANS)/stats.sh
@@ -68,7 +69,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	oscap ds sds-compose $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml $(OUT)/$(ID)-$(PROD)-ds.xml

--- a/JBoss/Fuse/6/Makefile
+++ b/JBoss/Fuse/6/Makefile
@@ -8,6 +8,7 @@ include $(SHARED)/product-make.include
 
 PROD = fuse6
 PROD_OVAL = $(BUILD)/$(PROD)_oval
+VENDOR = ssgproject
 
 checks:
 	# Make intermediate $(PROD_OVAL) directory to hold final list of OVAL checks for $(PROD)
@@ -81,7 +82,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 #	Update @style attribute of <xccdf:Benchmark> to "SCAP_1.2". Fixes #1059

--- a/JRE/Makefile
+++ b/JRE/Makefile
@@ -7,6 +7,7 @@ export SHARED = ../shared
 include $(SHARED)/product-make.include
 
 PROD = jre
+VENDOR = ssgproject
 
 #stats:
 #	$(SHARED)/$(TRANS)/stats.sh
@@ -68,7 +69,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 #	Update @style attribute of <xccdf:Benchmark> to "SCAP_1.2". Fixes #1059

--- a/OpenStack/RHEL-OSP/7/Makefile
+++ b/OpenStack/RHEL-OSP/7/Makefile
@@ -8,6 +8,7 @@ include $(SHARED)/product-make.include
 
 PROD = rhel-osp7
 PROD_OVAL = $(BUILD)/$(PROD)_oval
+VENDOR = ssgproject
 
 checks:
 	# Make intermediate $(PROD_OVAL) directory to hold final list of OVAL checks for $(PROD)
@@ -86,7 +87,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 #	Update @style attribute of <xccdf:Benchmark> to "SCAP_1.2". Fixes #1059

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -8,6 +8,7 @@ include $(SHARED)/product-make.include
 
 PROD = rhel5
 PROD_OVAL = $(BUILD)/$(PROD)_oval
+VENDOR = ssgproject
 
 all: tables guide content dist
 
@@ -73,7 +74,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 #	Update @style attribute of <xccdf:Benchmark> to "SCAP_1.2". Fixes #1059

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -8,6 +8,7 @@ include $(SHARED)/product-make.include
 
 PROD = rhel6
 PROD_OVAL = $(BUILD)/$(PROD)_oval
+VENDOR = ssgproject
 
 # Don't include the 'test' profile into benchmark by default. Only upon request (e.g. in 'eval-test' target)
 # Value '0' means 'test' will be included. Any other value means 'test' will NOT be included.
@@ -87,7 +88,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 #	Update @style attribute of <xccdf:Benchmark> to "SCAP_1.2". Fixes #1059

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -8,6 +8,7 @@ include $(SHARED)/product-make.include
 
 PROD = rhel7
 PROD_OVAL = $(BUILD)/$(PROD)_oval
+VENDOR = ssgproject
 
 # Don't include the 'test' profile into benchmark by default. Only upon request (e.g. in 'eval-test' target)
 # Value '0' means 'test' will be included. Any other value means 'test' will NOT be included.
@@ -91,7 +92,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 #	Update @style attribute of <xccdf:Benchmark> to "SCAP_1.2". Fixes #1059

--- a/RHEVM3/Makefile
+++ b/RHEVM3/Makefile
@@ -10,6 +10,7 @@ include $(SHARED)/product-make.include
 REFS = references
 
 PROD = rhevm3
+VENDOR = ssgproject
 
 checks:
 	xmlwf $(IN)/oval/*.xml

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -7,6 +7,7 @@ export SHARED = ../shared
 include $(SHARED)/product-make.include
 
 PROD = webmin
+VENDOR = ssgproject
 
 # will uncomment after PR 452 gets merged
 # also put stats into the all: target
@@ -70,7 +71,7 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 #	Once things are relabelled, create a datastream
 	xsltproc /usr/share/openscap/xsl/xccdf_1.1_remove_dangling_sub.xsl $(OUT)/$(ID)-$(PROD)-xccdf.xml \
 		> $(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml
-	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
+	xsltproc --stringparam reverse_DNS org.$(VENDOR).content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 #	Update @style attribute of <xccdf:Benchmark> to "SCAP_1.2". Fixes #1059

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -19,6 +19,7 @@ import subprocess
 
 import threading
 import Queue
+import re
 
 OSCAP_PATH = "oscap"
 
@@ -28,7 +29,7 @@ XCCDF12_NS = "http://checklists.nist.gov/xccdf/1.2"
 # if a profile ID ends with a string listed here we skip it
 PROFILE_ID_BLACKLIST = ["test", "index", "default"]
 # filler XCCDF 1.2 prefix which we will strip to avoid very long filenames
-PROFILE_ID_PREFIX = "xccdf_org.ssgproject.content_profile_"
+PROFILE_ID_PREFIX = ("^xccdf_org.*content_profile_")
 
 
 def get_benchmark_ids_titles_for_input(input_tree):
@@ -113,8 +114,8 @@ def get_profile_short_id(long_id):
     """If given profile ID is the XCCDF 1.2 long ID this function shortens it
     """
 
-    if long_id.startswith(PROFILE_ID_PREFIX):
-        return long_id[len(PROFILE_ID_PREFIX):]
+    if re.search(PROFILE_ID_PREFIX, long_id):
+        return long_id[re.search(PROFILE_ID_PREFIX, long_id).end():]
 
     return long_id
 


### PR DESCRIPTION
- Add Vendor variable to Makefiles for datastream generation. This is for downstream vendors to reflect their own organization instead of ssgproject.