### PR TITLE
[bugfix] Add installed_OS_is_certified OVAL for RHEL systems

### DIFF
--- a/shared/oval/installed_OS_is_certified.xml
+++ b/shared/oval/installed_OS_is_certified.xml
@@ -1,0 +1,20 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_certified" version="1">
+    <metadata>
+      <title>Vendor Certified Operating System</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>The operating system installed on the system is
+      a certified vendor operating system and meets government
+      requirements/certifications such as FIPS, NIAP, etc.</description>
+      <reference source="galford" ref_id="20160707" ref_url="test_attestation" />
+    </metadata>
+    <criteria comment="Installed operating system is a certified operating system" operator="OR">
+      <extend_definition comment="Installed OS is RHEL6" definition_ref="installed_OS_is_rhel6" />
+      <extend_definition comment="Installed OS is RHEL7" definition_ref="installed_OS_is_rhel7" />
+    </criteria>
+  </definition>
+
+</def-group>

--- a/shared/oval/installed_OS_is_rhel6.xml
+++ b/shared/oval/installed_OS_is_rhel6.xml
@@ -4,8 +4,7 @@
     <metadata>
       <title>Red Hat Enterprise Linux 6</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <reference ref_id="cpe:/o:redhat:enterprise_linux:6"
       source="CPE" />

--- a/shared/oval/package_dracut-fips_installed.xml
+++ b/shared/oval/package_dracut-fips_installed.xml
@@ -11,6 +11,7 @@
       <reference source="galford" ref_id="20160608" ref_url="test_attestation"/>
     </metadata>
     <criteria>
+      <extend_definition comment="Installed OS is certified" definition_ref="installed_OS_is_certified" />
       <criterion comment="package dracut-fips is installed"
       test_ref="test_package_dracut-fips_installed" />
     </criteria>

--- a/shared/oval/sshd_use_approved_ciphers.xml
+++ b/shared/oval/sshd_use_approved_ciphers.xml
@@ -15,7 +15,7 @@
       operator="OR">
         <extend_definition comment="sshd service is disabled"
         definition_ref="service_sshd_disabled" />
-        <criterion comment="Check ClientAliveInterval in /etc/ssh/sshd_config"
+        <criterion comment="Check the Cipers list in /etc/ssh/sshd_config"
         test_ref="test_sshd_use_approved_ciphers" />
       </criteria>
     </criteria>

--- a/shared/oval/sshd_use_approved_ciphers.xml
+++ b/shared/oval/sshd_use_approved_ciphers.xml
@@ -9,12 +9,15 @@
       use ciphers in counter (CTR) mode.</description>
       <reference source="JL" ref_id="20140414" ref_url="test_attestation" />
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
-    operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check ClientAliveInterval in /etc/ssh/sshd_config"
-      test_ref="test_sshd_use_approved_ciphers" />
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is certified" definition_ref="installed_OS_is_certified" />
+      <criteria comment="SSH is not being used or conditions are met"
+      operator="OR">
+        <extend_definition comment="sshd service is disabled"
+        definition_ref="service_sshd_disabled" />
+        <criterion comment="Check ClientAliveInterval in /etc/ssh/sshd_config"
+        test_ref="test_sshd_use_approved_ciphers" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/shared/oval/sshd_use_approved_macs.xml
+++ b/shared/oval/sshd_use_approved_macs.xml
@@ -8,12 +8,15 @@
       <description>Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.</description>
       <reference source="PCA" ref_id="20150718" ref_url="test_attestation" />
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
-    operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check MACs in /etc/ssh/sshd_config"
-      test_ref="test_sshd_use_approved_macs" />
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is certified" definition_ref="installed_OS_is_certified" />
+      <criteria comment="SSH is not being used or conditions are met"
+      operator="OR">
+        <extend_definition comment="sshd service is disabled"
+        definition_ref="service_sshd_disabled" />
+        <criterion comment="Check MACs in /etc/ssh/sshd_config"
+        test_ref="test_sshd_use_approved_macs" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"


### PR DESCRIPTION
- Add installed_OS_is_certified OVAL for RHEL systems
- Update OVAL that requires FIPS to fail if installed_OS_is_certified is not valid