### PR TITLE
[BugFix] [Debian/8] When extending ANSSI profiles don't inherit the title and description from the parent profile

### DIFF
--- a/Debian/8/input/profiles/anssi_np_nt28_average.xml
+++ b/Debian/8/input/profiles/anssi_np_nt28_average.xml
@@ -1,6 +1,6 @@
 <Profile id="anssi_np_nt28_average" extends="anssi_np_nt28_minimal">
-<title>Profile for ANSSI DAT-NT28 Average (Intermediate) Level</title>
-<description>This profile contains items for GNU/Linux installations already protected by multiple higher level security stacks.</description>
+<title override="true">Profile for ANSSI DAT-NT28 Average (Intermediate) Level</title>
+<description override="true">This profile contains items for GNU/Linux installations already protected by multiple higher level security stacks.</description>
 
 <!-- partitioning -->
 <select idref="partition_for_tmp" selected="true"/>

--- a/Debian/8/input/profiles/anssi_np_nt28_high.xml
+++ b/Debian/8/input/profiles/anssi_np_nt28_high.xml
@@ -1,6 +1,6 @@
 <Profile id="anssi_np_nt28_high" extends="anssi_np_nt28_restrictive">
-<title>Profile for ANSSI DAT-NT28 High (Enforced) Level</title>
-<description>This profile contains items for GNU/Linux installations storing sensitive informations that can be accessible from unauthenticated or uncontroled networks.</description>
+<title override="true">Profile for ANSSI DAT-NT28 High (Enforced) Level</title>
+<description override="true">This profile contains items for GNU/Linux installations storing sensitive informations that can be accessible from unauthenticated or uncontroled networks.</description>
 
 <!-- partitioning -->
 <!-- services -->

--- a/Debian/8/input/profiles/anssi_np_nt28_restrictive.xml
+++ b/Debian/8/input/profiles/anssi_np_nt28_restrictive.xml
@@ -1,6 +1,6 @@
 <Profile id="anssi_np_nt28_restrictive" extends="anssi_np_nt28_average">
-<title>Profile for ANSSI DAT-NT28 Restrictive Level</title>
-<description>This profile contains items for GNU/Linux installations exposed to unauthenticated flows or multiple sources.</description>
+<title override="true">Profile for ANSSI DAT-NT28 Restrictive Level</title>
+<description override="true">This profile contains items for GNU/Linux installations exposed to unauthenticated flows or multiple sources.</description>
 
 <!-- partitioning -->
 <select idref="partition_for_tmp" selected="true"/>


### PR DESCRIPTION
As can be seen in:
* http://static.open-scap.org/ssg-guides/ssg-debian8-guide-anssi_np_nt28_average.html
* http://static.open-scap.org/ssg-guides/ssg-debian8-guide-anssi_np_nt28_restrictive.html , and
* http://static.open-scap.org/ssg-guides/ssg-debian8-guide-anssi_np_nt28_high.html

in the current form the various ANSSI NP NT28 child profiles for Debian/8 product when extending ANSSI minimal profile, the derived profiles inherit title and description from the parent / extended profile (IOW the profile title is concatenation of multiple profile titles. Same case for the description element).

This doesn't look nice and probably wasn't an intention (since the titles and descriptions in the derived / child profiles have meaningful and mainly different values than the parent one).

Therefore fix the titles and descriptions so just the intended values would be displayed for the average, high, and restrictive profiles.

Please review.

Thank you, Jan