### PR TITLE
[BugFix] [Infrastructure] Get rid of duplicate definition of selected OVAL entities (fix for part of #50)

### DIFF
--- a/Chromium/input/oval/installed_OS_is_part_of_Unix_family.xml
+++ b/Chromium/input/oval/installed_OS_is_part_of_Unix_family.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="inventory" id="installed_OS_is_part_of_Unix_family" version="1">
+    <metadata>
+      <title>Installed operating system is part of the Unix family</title>
+      <affected family="unix">
+        <product>Google Chromium Browser</product>
+      </affected>
+      <description>The operating system installed on the system is part of the Unix OS family</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_unix_family" />
+    </criteria>
+  </definition>
+
+  <ind:family_test id="test_unix_family" check="all" check_existence="at_least_one_exists"
+  comment="Test installed OS is part of the unix family" version="1">
+    <ind:object object_ref="object_unix_family" />
+    <ind:state state_ref="state_unix_family" />
+  </ind:family_test>
+
+  <ind:family_object id="object_unix_family" version="1" />
+
+  <ind:family_state id="state_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+
+</def-group>

--- a/Chromium/input/oval/installed_app_is_chromium.xml
+++ b/Chromium/input/oval/installed_app_is_chromium.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_app_is_chromium" version="1">
+  id="installed_app_is_chromium" version="2">
     <metadata>
       <title>Google Chromium Browser</title>
       <affected family="unix">
@@ -10,9 +10,9 @@
       source="CPE" />
       <description>The application installed on the system is the Google Chromium Browser</description>
        </metadata>
-    <criteria>
-      <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_unix_family" />
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
       <criteria operator="OR">
         <criterion comment="Chromium is installed"
         test_ref="test_chromium-browser_installed" />
@@ -21,15 +21,6 @@
       </criteria>
     </criteria>
   </definition>
-
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
-    <ind:object object_ref="obj_unix_family" />
-    <ind:state state_ref="state_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_unix_family" version="1" />
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="Chromium is installed" id="test_chromium-browser_installed" version="1">
     <linux:object object_ref="obj_chromium-browser_installed" />
@@ -44,4 +35,5 @@
   <linux:rpminfo_object id="obj_chromium_installed" version="1">
     <linux:name>chromium</linux:name>
   </linux:rpminfo_object>
+
 </def-group>

--- a/Debian/8/input/oval/installed_OS_is_debian8.xml
+++ b/Debian/8/input/oval/installed_OS_is_debian8.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="inventory" id="installed_OS_is_debian8" version="2">
+  <definition class="inventory" id="installed_OS_is_debian8" version="3">
     <metadata>
       <title>Debian 8</title>
       <affected family="unix">
@@ -10,20 +10,11 @@
       <reference source="JL" ref_id="DEBIAN8_20151210" ref_url="test_attestation" />
     </metadata>
     <criteria comment="current Debian version is Debian jessie" operator="AND">
-      <criterion comment="Installed operating system is part of the unix family" test_ref="test_unix_family" />
+      <extend_definition comment="Installed OS is part of the Unix family" definition_ref="installed_OS_is_part_of_Unix_family" />
       <criterion comment="Debian is installed" test_ref="test_debian" />
       <criterion comment="Debian8 is installed" test_ref="test_debian_8" />
     </criteria>
   </definition>
-
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
-    <ind:object object_ref="obj_unix_family" />
-    <ind:state state_ref="state_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_unix_family" version="1" />
 
   <unix:file_test check="all" check_existence="all_exist" comment="/etc/debian_version exists" id="test_debian" version="1">
     <unix:object object_ref="obj_debian" />

--- a/Firefox/input/oval/installed_OS_is_part_of_Unix_family.xml
+++ b/Firefox/input/oval/installed_OS_is_part_of_Unix_family.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="inventory" id="installed_OS_is_part_of_Unix_family" version="1">
+    <metadata>
+      <title>Installed operating system is part of the Unix family</title>
+      <affected family="unix">
+        <product>Mozilla Firefox</product>
+      </affected>
+      <description>The operating system installed on the system is part of the Unix OS family</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_unix_family" />
+    </criteria>
+  </definition>
+
+  <ind:family_test id="test_unix_family" check="all" check_existence="at_least_one_exists"
+  comment="Test installed OS is part of the unix family" version="1">
+    <ind:object object_ref="object_unix_family" />
+    <ind:state state_ref="state_unix_family" />
+  </ind:family_test>
+
+  <ind:family_object id="object_unix_family" version="1" />
+
+  <ind:family_state id="state_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+
+</def-group>

--- a/Firefox/input/oval/installed_app_is_firefox.xml
+++ b/Firefox/input/oval/installed_app_is_firefox.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_app_is_firefox" version="1">
+  id="installed_app_is_firefox" version="2">
     <metadata>
       <title>Mozilla Firefox</title>
       <affected family="unix">
@@ -10,22 +10,13 @@
       source="CPE" />
       <description>The application installed on the system is firefox.</description>
        </metadata>
-    <criteria>
-      <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_unix_family" />
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
       <criterion comment="Firefox is installed"
       test_ref="test_firefox" />
     </criteria>
   </definition>
-
-<ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
-    <ind:object object_ref="obj_unix_family" />
-    <ind:state state_ref="state_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_unix_family" version="1" />
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="Firefox is installed" id="test_firefox" version="1">
     <linux:object object_ref="obj_firefox" />

--- a/Webmin/input/oval/installed_OS_is_part_of_Unix_family.xml
+++ b/Webmin/input/oval/installed_OS_is_part_of_Unix_family.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="inventory" id="installed_OS_is_part_of_Unix_family" version="1">
+    <metadata>
+      <title>Installed operating system is part of the Unix family</title>
+      <affected family="unix">
+        <product>Webmin</product>
+      </affected>
+      <description>The operating system installed on the system is part of the Unix OS family</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_unix_family" />
+    </criteria>
+  </definition>
+
+  <ind:family_test id="test_unix_family" check="all" check_existence="at_least_one_exists"
+  comment="Test installed OS is part of the unix family" version="1">
+    <ind:object object_ref="object_unix_family" />
+    <ind:state state_ref="state_unix_family" />
+  </ind:family_test>
+
+  <ind:family_object id="object_unix_family" version="1" />
+
+  <ind:family_state id="state_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+
+</def-group>

--- a/Webmin/input/oval/installed_app_is_webmin.xml
+++ b/Webmin/input/oval/installed_app_is_webmin.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_app_is_webmin" version="1">
+  id="installed_app_is_webmin" version="2">
     <metadata>
       <title>Webmin</title>
       <affected family="unix">
@@ -11,22 +11,13 @@
       <description>The application installed on the system is
       webmin</description>
     </metadata>
-    <criteria>
-      <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_unix_family" />
-	  <criterion comment="Webmin is installed"
-	  test_ref="test_webmin" />
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
+      <criterion comment="Webmin is installed"
+      test_ref="test_webmin" />
     </criteria>
   </definition>
-
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
-    <ind:object object_ref="obj_unix_family" />
-    <ind:state state_ref="state_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_unix_family" version="1" />
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="Webmin is installed" id="test_webmin" version="1">
     <linux:object object_ref="obj_webmin" />

--- a/shared/oval/ensure_redhat_gpgkey_installed.xml
+++ b/shared/oval/ensure_redhat_gpgkey_installed.xml
@@ -1,12 +1,13 @@
 <def-group>
-  <definition class="compliance" id="ensure_redhat_gpgkey_installed" version="1">
+  <definition class="compliance" id="ensure_redhat_gpgkey_installed" version="2">
     <metadata>
       <title>Red Hat Release and Auxiliary gpg-pubkey Packages Installed</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
       </affected>
       <description>The Red Hat release and auxiliary key packages are required to be installed.</description>
-      <reference source="galford" ref_id="20151006" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL6_20160719" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20160719" ref_url="test_attestation" />
     </metadata>
     <criteria comment="Vendor GPG keys" operator="OR">
       <criteria comment="Red Hat Vendor Keys" operator="AND">
@@ -32,56 +33,62 @@
     </criteria>
   </definition>
 
+  <!-- First define global "object_package_gpg-pubkey" to be shared (reused) across multiple tests -->
+  <linux:rpminfo_object id="object_package_gpg-pubkey" version="1">
+    <linux:name>gpg-pubkey</linux:name>
+  </linux:rpminfo_object>
+
+  <!-- Perform the particular tests themselves -->
+  <!-- Test for Red Hat release key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
   id="test_package_gpgkey-fd431d51-4ae0493b_installed" version="1"
   comment="Red Hat release key package is installed">
-    <linux:object object_ref="obj_package_gpg-pubkey" />
+    <linux:object object_ref="object_package_gpg-pubkey" />
     <linux:state state_ref="state_package_gpg-pubkey-fd431d51-4ae0493b" />
   </linux:rpminfo_test>
+
   <linux:rpminfo_state id="state_package_gpg-pubkey-fd431d51-4ae0493b" version="1">
     <linux:release>4ae0493b</linux:release>
     <linux:version>fd431d51</linux:version>
   </linux:rpminfo_state>
 
+  <!-- Test for Red Hat auxiliary key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
   id="test_package_gpgkey-2fa658e0-45700c69_installed" version="1"
   comment="Red Hat auxiliary key package is installed">
-    <linux:object object_ref="obj_package_gpg-pubkey" />
+    <linux:object object_ref="object_package_gpg-pubkey" />
     <linux:state state_ref="state_package_gpg-pubkey-2fa658e0-45700c69" />
   </linux:rpminfo_test>
-  <linux:rpminfo_object id="obj_package_gpg-pubkey" version="1">
-    <linux:name>gpg-pubkey</linux:name>
-  </linux:rpminfo_object>
+
   <linux:rpminfo_state id="state_package_gpg-pubkey-2fa658e0-45700c69" version="1">
     <linux:release>45700c69</linux:release>
     <linux:version>2fa658e0</linux:version>
   </linux:rpminfo_state>
 
+  <!-- Test for CentOS7 key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
   id="test_package_gpgkey-f4a80eb5-53a7ff4b_installed" version="1"
   comment="CentOS7 key package is installed">
-    <linux:object object_ref="obj_package_gpg-pubkey" />
+    <linux:object object_ref="object_package_gpg-pubkey" />
     <linux:state state_ref="state_package_gpg-pubkey-f4a80eb5-53a7ff4b" />
   </linux:rpminfo_test>
-  <linux:rpminfo_object id="obj_package_gpg-pubkey" version="1">
-    <linux:name>gpg-pubkey</linux:name>
-  </linux:rpminfo_object>
+
   <linux:rpminfo_state id="state_package_gpg-pubkey-f4a80eb5-53a7ff4b" version="1">
     <linux:release>53a7ff4b</linux:release>
     <linux:version>f4a80eb5</linux:version>
   </linux:rpminfo_state>
 
+  <!-- Test for CentOS6 key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
   id="test_package_gpgkey-c105b9de-4e0fd3a3_installed" version="1"
   comment="CentOS6 key package is installed">
-    <linux:object object_ref="obj_package_gpg-pubkey" />
+    <linux:object object_ref="object_package_gpg-pubkey" />
     <linux:state state_ref="state_package_gpg-pubkey-c105b9de-4e0fd3a3" />
   </linux:rpminfo_test>
-  <linux:rpminfo_object id="obj_package_gpg-pubkey" version="1">
-    <linux:name>gpg-pubkey</linux:name>
-  </linux:rpminfo_object>
+
   <linux:rpminfo_state id="state_package_gpg-pubkey-c105b9de-4e0fd3a3" version="1">
     <linux:release>4e0fd3a3</linux:release>
     <linux:version>c105b9de</linux:version>
   </linux:rpminfo_state>
+
 </def-group>

--- a/shared/oval/installed_OS_is_centos6.xml
+++ b/shared/oval/installed_OS_is_centos6.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_OS_is_centos6" version="1">
+  id="installed_OS_is_centos6" version="2">
     <metadata>
       <title>CentOS 6</title>
       <affected family="unix">
@@ -13,21 +13,12 @@
       <reference source="MP" ref_id="CENTOS6_20150707" ref_url="test_attestation" />
     </metadata>
     <criteria>
-      <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_unix_family" />
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
       <criterion comment="CentOS6 is installed"
       test_ref="test_centos6" />
     </criteria>
   </definition>
-
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
-    <ind:object object_ref="obj_unix_family" />
-    <ind:state state_ref="state_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_unix_family" version="1" />
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 6" id="test_centos6" version="1">
     <linux:object object_ref="obj_centos6" />
@@ -39,4 +30,5 @@
   <linux:rpminfo_object id="obj_centos6" version="1">
     <linux:name>centos-release</linux:name>
   </linux:rpminfo_object>
+
 </def-group>

--- a/shared/oval/installed_OS_is_centos7.xml
+++ b/shared/oval/installed_OS_is_centos7.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_OS_is_centos7" version="1">
+  id="installed_OS_is_centos7" version="2">
     <metadata>
       <title>CentOS 7</title>
       <affected family="unix">
@@ -12,22 +12,13 @@
       CentOS 7</description>
       <reference source="MP" ref_id="CENTOS7_20150707" ref_url="test_attestation" />
     </metadata>
-    <criteria>
-      <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_unix_family" />
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
       <criterion comment="CentOS7 is installed"
       test_ref="test_centos7" />
     </criteria>
   </definition>
-
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
-    <ind:object object_ref="obj_unix_family" />
-    <ind:state state_ref="state_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_unix_family" version="1" />
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="test_centos7" version="1">
     <linux:object object_ref="obj_centos7" />
@@ -39,4 +30,5 @@
   <linux:rpminfo_object id="obj_centos7" version="1">
     <linux:name>centos-release</linux:name>
   </linux:rpminfo_object>
+
 </def-group>

--- a/shared/oval/installed_OS_is_debian8.xml
+++ b/shared/oval/installed_OS_is_debian8.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_OS_is_debian8" version="1">
+  id="installed_OS_is_debian8" version="2">
     <metadata>
       <title>Debian 8</title>
       <affected family="unix">
@@ -12,26 +12,18 @@
       Debian 8</description>
       <reference source="MP" ref_id="DEBIAN8_20151125" ref_url="test_attestation" />
     </metadata>
-    <criteria>
-      <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_unix_family" />
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
       <criterion comment="Debian8 is installed"
       test_ref="test_debian8" />
     </criteria>
   </definition>
-
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
-    <ind:object object_ref="obj_unix_family" />
-    <ind:state state_ref="state_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_unix_family" version="1" />
 
   <ind:textfilecontent54_object id="test_debian8" version="1" comment="Check Debian version">
     <ind:filepath>/etc/debian_version</ind:filepath>
     <ind:pattern operation="pattern match">^8.[0-9]+$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
 </def-group>

--- a/shared/oval/installed_OS_is_fedora.xml
+++ b/shared/oval/installed_OS_is_fedora.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="inventory" id="installed_OS_is_fedora" version="2">
+  <definition class="inventory" id="installed_OS_is_fedora" version="3">
     <metadata>
       <title>Installed operating system is Fedora</title>
       <affected family="unix">
@@ -15,20 +15,11 @@
       <reference source="JL" ref_id="FEDORA21_20150624" ref_url="test_attestation" />
     </metadata>
     <criteria operator="AND">
-      <criterion comment="Installed operating system is part of the unix family" test_ref="test_unix_family" />
+      <extend_definition comment="Installed OS is part of the Unix family" definition_ref="installed_OS_is_part_of_Unix_family" />
       <criterion comment="fedora-release RPM package is installed" test_ref="test_fedora_release_rpm" />
       <criterion comment="CPE vendor is 'fedoraproject' and product is 'fedora'" test_ref="test_fedora_vendor_product" />
     </criteria>
   </definition>
-
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
-    <ind:object object_ref="obj_unix_family" />
-    <ind:state state_ref="state_unix_family" />
-  </ind:family_test>
-  <ind:family_object id="obj_unix_family" version="1" />
-  <ind:family_state id="state_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
 
   <linux:rpminfo_test check="all" check_existence="only_one_exists" comment="fedora-release RPM package is installed" id="test_fedora_release_rpm" version="1">
     <linux:object object_ref="object_fedora_release_rpm" />

--- a/shared/oval/installed_OS_is_part_of_Unix_family.xml
+++ b/shared/oval/installed_OS_is_part_of_Unix_family.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="inventory" id="installed_OS_is_part_of_Unix_family" version="1">
+    <metadata>
+      <title>Installed operating system is part of the Unix family</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>The operating system installed on the system is part of the Unix OS family</description>
+      <reference source="JL" ref_id="RHEL6_20160719" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20160719" ref_url="test_attestation" />
+      <reference source="JL" ref_id="FEDORA22_20160719" ref_url="test_attestation" />
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_unix_family" />
+    </criteria>
+  </definition>
+
+  <ind:family_test id="test_unix_family" check="all" check_existence="at_least_one_exists"
+  comment="Test installed OS is part of the unix family" version="1">
+    <ind:object object_ref="object_unix_family" />
+    <ind:state state_ref="state_unix_family" />
+  </ind:family_test>
+
+  <ind:family_object id="object_unix_family" version="1" />
+
+  <ind:family_state id="state_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+
+</def-group>

--- a/shared/oval/installed_OS_is_rhel6.xml
+++ b/shared/oval/installed_OS_is_rhel6.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_OS_is_rhel6" version="1">
+  id="installed_OS_is_rhel6" version="2">
     <metadata>
       <title>Red Hat Enterprise Linux 6</title>
       <affected family="unix">
@@ -13,9 +13,9 @@
       <reference source="JL" ref_id="RHEL7_20150522" ref_url="test_attestation" />
       <reference source="JL" ref_id="FEDORA20_20150522" ref_url="test_attestation" />
     </metadata>
-    <criteria>
-      <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_unix_family" />
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
       <criteria operator="OR">
         <criterion comment="RHEL 6 Workstation is installed" test_ref="test_rhel_workstation" />
         <criterion comment="RHEL 6 Server is installed" test_ref="test_rhel_server" />
@@ -23,15 +23,6 @@
       </criteria>
     </criteria>
   </definition>
-
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
-    <ind:object object_ref="obj_unix_family" />
-    <ind:state state_ref="state_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_unix_family" version="1" />
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-workstation is version 6" id="test_rhel_workstation" version="1">
     <linux:object object_ref="obj_rhel_workstation" />
@@ -65,4 +56,5 @@
   <linux:rpminfo_object id="obj_rhel_computenode" version="1">
     <linux:name>redhat-release-computenode</linux:name>
   </linux:rpminfo_object>
+
 </def-group>

--- a/shared/oval/installed_OS_is_sl6.xml
+++ b/shared/oval/installed_OS_is_sl6.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_OS_is_sl6" version="1">
+  id="installed_OS_is_sl6" version="2">
     <metadata>
       <title>Scientific Linux 6</title>
       <affected family="unix">
@@ -12,31 +12,25 @@
       Scientific Linux 6</description>
       <reference source="MP" ref_id="SL6_20150707" ref_url="test_attestation" />
     </metadata>
-    <criteria>
-      <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_unix_family" />
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
       <criterion comment="Scientific Linux 6 is installed"
       test_ref="test_sl6" />
     </criteria>
   </definition>
 
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
-    <ind:object object_ref="obj_unix_family" />
-    <ind:state state_ref="state_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_unix_family" version="1" />
-
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sl-release is version 6" id="test_sl6" version="1">
     <linux:object object_ref="obj_sl6" />
     <linux:state state_ref="state_sl6" />
   </linux:rpminfo_test>
+
   <linux:rpminfo_state id="state_sl6" version="1">
     <linux:version operation="pattern match">^6.*$</linux:version>
   </linux:rpminfo_state>
+
   <linux:rpminfo_object id="obj_sl6" version="1">
     <linux:name>sl-release</linux:name>
   </linux:rpminfo_object>
+
 </def-group>

--- a/shared/oval/installed_OS_is_sl7.xml
+++ b/shared/oval/installed_OS_is_sl7.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_OS_is_sl7" version="1">
+  id="installed_OS_is_sl7" version="2">
     <metadata>
       <title>Scientific Linux 7</title>
       <affected family="unix">
@@ -12,31 +12,25 @@
       Scientific Linux 7</description>
       <reference source="MP" ref_id="SL7_20150707" ref_url="test_attestation" />
     </metadata>
-    <criteria>
-      <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_unix_family" />
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
       <criterion comment="Scientific Linux 7 is installed"
       test_ref="test_sl7" />
     </criteria>
   </definition>
 
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_unix_family" version="1">
-    <ind:object object_ref="obj_unix_family" />
-    <ind:state state_ref="state_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_unix_family" version="1" />
-
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="sl-release is version 7" id="test_sl7" version="1">
     <linux:object object_ref="obj_sl7" />
     <linux:state state_ref="state_sl7" />
   </linux:rpminfo_test>
+
   <linux:rpminfo_state id="state_sl7" version="1">
     <linux:version operation="pattern match">^7.*$</linux:version>
   </linux:rpminfo_state>
+
   <linux:rpminfo_object id="obj_sl7" version="1">
     <linux:name>sl-release</linux:name>
   </linux:rpminfo_object>
+
 </def-group>

--- a/shared/oval/mount_option_nodev_removable_partitions.xml
+++ b/shared/oval/mount_option_nodev_removable_partitions.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="mount_option_nodev_removable_partitions" version="2">
+  <definition class="compliance" id="mount_option_nodev_removable_partitions" version="3">
     <metadata>
       <title>Add nodev Option to Removable Media Partitions</title>
       <affected family="unix">
@@ -15,7 +15,8 @@
     <criteria operator="OR">
       <!-- First check if specified removable partition truly exists on the system. If not, don't check /etc/fstab & runtime configuration
            since there's no device to check against -->
-      <criterion test_ref="test_removable_partition_doesnt_exist" comment="Check if removable partition really exists on the system" />
+      <extend_definition comment="Check if removable partition really exists on the system"
+      definition_ref="removable_partition_doesnt_exist" />
       <!-- Removable device exists. Check if it's CD/DVD drive. If so, verify that at least one from all of the possible its alternative
            names in /etc/fstab & runtime configuration are configured with 'nodev' option -->
       <criteria operator="AND">
@@ -31,16 +32,6 @@
       </criteria>
     </criteria>
   </definition>
-
-  <!-- First check if specified removable partition really exists on the system.
-       If not return PASS since there's nothing to check /etc/fstab & runtime settings against. -->
-  <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist" comment="Check if expected removable partitions truly exist on the system" version="1">
-    <unix:object object_ref="object_removable_partition_doesnt_exist" />
-  </unix:file_test>
-
-  <unix:file_object id="object_removable_partition_doesnt_exist" version="1">
-    <unix:filepath var_ref="var_removable_partition" var_check="at least one" />
-  </unix:file_object>
 
   <!-- Specified removable partition exists on the system. Check if it represents a CD / DVD drive -->
   <ind:variable_test id="test_var_removable_partition_is_cd_dvd_drive" check="all" comment="Check if removable partition variable value represents CD/DVD drive" version="1">

--- a/shared/oval/mount_option_nodev_removable_partitions.xml
+++ b/shared/oval/mount_option_nodev_removable_partitions.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="mount_option_nodev_removable_partitions" version="3">
+  <definition class="compliance" id="mount_option_nodev_removable_partitions" version="4">
     <metadata>
       <title>Add nodev Option to Removable Media Partitions</title>
       <affected family="unix">
@@ -20,32 +20,23 @@
       <!-- Removable device exists. Check if it's CD/DVD drive. If so, verify that at least one from all of the possible its alternative
            names in /etc/fstab & runtime configuration are configured with 'nodev' option -->
       <criteria operator="AND">
-        <criterion test_ref="test_var_removable_partition_is_cd_dvd_drive" comment="Check if removable partition value represents CD/DVD drive" />
-        <criterion test_ref="test_nodev_etc_fstab_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'nodev' mount option in /etc/fstab" />
-        <criterion test_ref="test_nodev_runtime_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'nodev' mount option in runtime configuration" />
+        <extend_definition comment="Check if removable partition value represents CD/DVD drive"
+        definition_ref="var_removable_partition_is_cd_dvd_drive" />
+        <criterion test_ref="test_nodev_etc_fstab_cd_dvd_drive"
+        comment="Check if at least one from CD/DVD drive alternative names is using 'nodev' mount option in /etc/fstab" />
+        <criterion test_ref="test_nodev_runtime_cd_dvd_drive"
+        comment="Check if at least one from CD/DVD drive alternative names is using 'nodev' mount option in runtime configuration" />
       </criteria>
       <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with 'nodev' mount option in both
            /etc/fstab & runtime configuration -->
       <criteria operator="AND">
-        <criterion test_ref="test_nodev_etc_fstab_not_cd_dvd_drive" comment="Check if removable partition is using 'nodev' mount option in /etc/fstab" />
-        <criterion test_ref="test_nodev_runtime_not_cd_dvd_drive" comment="Check if removable partition is using 'nodev' mount option in runtime configuration" />
+        <criterion test_ref="test_nodev_etc_fstab_not_cd_dvd_drive"
+        comment="Check if removable partition is using 'nodev' mount option in /etc/fstab" />
+        <criterion test_ref="test_nodev_runtime_not_cd_dvd_drive"
+        comment="Check if removable partition is using 'nodev' mount option in runtime configuration" />
       </criteria>
     </criteria>
   </definition>
-
-  <!-- Specified removable partition exists on the system. Check if it represents a CD / DVD drive -->
-  <ind:variable_test id="test_var_removable_partition_is_cd_dvd_drive" check="all" comment="Check if removable partition variable value represents CD/DVD drive" version="1">
-    <ind:object object_ref="object_var_removable_partition_is_cd_dvd_drive" />
-    <ind:state state_ref="state_var_removable_partition_is_cd_dvd_drive" />
-  </ind:variable_test>
-
-  <ind:variable_object id="object_var_removable_partition_is_cd_dvd_drive" version="1">
-    <ind:var_ref>var_removable_partition</ind:var_ref>
-  </ind:variable_object>
-
-  <ind:variable_state id="state_var_removable_partition_is_cd_dvd_drive" version="1">
-    <ind:value operation="equals">/dev/cdrom</ind:value>
-  </ind:variable_state>
 
   <!-- If specified removable partition represents CD / DVD drive, create a variable
        holding also alternative names for CD / DVD block special device as used by udev -->

--- a/shared/oval/mount_option_noexec_removable_partitions.xml
+++ b/shared/oval/mount_option_noexec_removable_partitions.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="mount_option_noexec_removable_partitions" version="3">
+  <definition class="compliance" id="mount_option_noexec_removable_partitions" version="4">
     <metadata>
       <title>Add noexec Option to Removable Media Partitions</title>
       <affected family="unix">
@@ -21,32 +21,23 @@
       <!-- Removable device exists. Check if it's CD/DVD drive. If so, verify that at least one from all of the possible its alternative
            names in /etc/fstab & runtime configuration are configured with 'noexec' option -->
       <criteria operator="AND">
-        <criterion test_ref="test_var_removable_partition_is_cd_dvd_drive" comment="Check if removable partition value represents CD/DVD drive" />
-        <criterion test_ref="test_noexec_etc_fstab_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'noexec' mount option in /etc/fstab" />
-        <criterion test_ref="test_noexec_runtime_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'noexec' mount option in runtime configuration" />
+        <extend_definition comment="Check if removable partition value represents CD/DVD drive"
+        definition_ref="var_removable_partition_is_cd_dvd_drive" />
+        <criterion test_ref="test_noexec_etc_fstab_cd_dvd_drive"
+        comment="Check if at least one from CD/DVD drive alternative names is using 'noexec' mount option in /etc/fstab" />
+        <criterion test_ref="test_noexec_runtime_cd_dvd_drive"
+        comment="Check if at least one from CD/DVD drive alternative names is using 'noexec' mount option in runtime configuration" />
       </criteria>
       <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with 'noexec' mount option in both
            /etc/fstab & runtime configuration -->
       <criteria operator="AND">
-        <criterion test_ref="test_noexec_etc_fstab_not_cd_dvd_drive" comment="Check if removable partition is using 'noexec' mount option in /etc/fstab" />
-        <criterion test_ref="test_noexec_runtime_not_cd_dvd_drive" comment="Check if removable partition is using 'noexec' mount option in runtime configuration" />
+        <criterion test_ref="test_noexec_etc_fstab_not_cd_dvd_drive"
+        comment="Check if removable partition is using 'noexec' mount option in /etc/fstab" />
+        <criterion test_ref="test_noexec_runtime_not_cd_dvd_drive"
+        comment="Check if removable partition is using 'noexec' mount option in runtime configuration" />
       </criteria>
     </criteria>
   </definition>
-
-  <!-- Specified removable partition exists on the system. Check if it represents a CD / DVD drive -->
-  <ind:variable_test id="test_var_removable_partition_is_cd_dvd_drive" check="all" comment="Check if removable partition variable value represents CD/DVD drive" version="1">
-    <ind:object object_ref="object_var_removable_partition_is_cd_dvd_drive" />
-    <ind:state state_ref="state_var_removable_partition_is_cd_dvd_drive" />
-  </ind:variable_test>
-
-  <ind:variable_object id="object_var_removable_partition_is_cd_dvd_drive" version="1">
-    <ind:var_ref>var_removable_partition</ind:var_ref>
-  </ind:variable_object>
-
-  <ind:variable_state id="state_var_removable_partition_is_cd_dvd_drive" version="1">
-    <ind:value operation="equals">/dev/cdrom</ind:value>
-  </ind:variable_state>
 
   <!-- If specified removable partition represents CD / DVD drive, create a variable
        holding also alternative names for CD / DVD block special device as used by udev -->

--- a/shared/oval/mount_option_noexec_removable_partitions.xml
+++ b/shared/oval/mount_option_noexec_removable_partitions.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="mount_option_noexec_removable_partitions" version="2">
+  <definition class="compliance" id="mount_option_noexec_removable_partitions" version="3">
     <metadata>
       <title>Add noexec Option to Removable Media Partitions</title>
       <affected family="unix">
@@ -16,7 +16,8 @@
     <criteria operator="OR">
       <!-- First check if specified removable partition truly exists on the system. If not, don't check /etc/fstab & runtime configuration
            since there's no device to check against -->
-      <criterion test_ref="test_removable_partition_doesnt_exist" comment="Check if removable partition really exists on the system" />
+      <extend_definition comment="Check if removable partition really exists on the system"
+      definition_ref="removable_partition_doesnt_exist" />
       <!-- Removable device exists. Check if it's CD/DVD drive. If so, verify that at least one from all of the possible its alternative
            names in /etc/fstab & runtime configuration are configured with 'noexec' option -->
       <criteria operator="AND">
@@ -32,16 +33,6 @@
       </criteria>
     </criteria>
   </definition>
-
-  <!-- First check if specified removable partition really exists on the system.
-       If not return PASS since there's nothing to check /etc/fstab & runtime settings against. -->
-  <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist" comment="Check if expected removable partitions truly exist on the system" version="1">
-    <unix:object object_ref="object_removable_partition_doesnt_exist" />
-  </unix:file_test>
-
-  <unix:file_object id="object_removable_partition_doesnt_exist" version="1">
-    <unix:filepath var_ref="var_removable_partition" var_check="at least one" />
-  </unix:file_object>
 
   <!-- Specified removable partition exists on the system. Check if it represents a CD / DVD drive -->
   <ind:variable_test id="test_var_removable_partition_is_cd_dvd_drive" check="all" comment="Check if removable partition variable value represents CD/DVD drive" version="1">

--- a/shared/oval/mount_option_nosuid_removable_partitions.xml
+++ b/shared/oval/mount_option_nosuid_removable_partitions.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="mount_option_nosuid_removable_partitions" version="2">
+  <definition class="compliance" id="mount_option_nosuid_removable_partitions" version="3">
     <metadata>
       <title>Add nosuid Option to Removable Media Partitions</title>
       <affected family="unix">
@@ -16,7 +16,8 @@
     <criteria operator="OR">
       <!-- First check if specified removable partition truly exists on the system. If not, don't check /etc/fstab & runtime configuration
            since there's no device to check against -->
-      <criterion test_ref="test_removable_partition_doesnt_exist" comment="Check if removable partition really exists on the system" />
+      <extend_definition comment="Check if removable partition really exists on the system"
+      definition_ref="removable_partition_doesnt_exist" />
       <!-- Removable device exists. Check if it's CD/DVD drive. If so, verify that at least one from all of the possible its alternative
            names in /etc/fstab & runtime configuration are configured with 'nosuid' option -->
       <criteria operator="AND">
@@ -32,16 +33,6 @@
       </criteria>
     </criteria>
   </definition>
-
-  <!-- First check if specified removable partition really exists on the system.
-       If not return PASS since there's nothing to check /etc/fstab & runtime settings against. -->
-  <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist" comment="Check if expected removable partitions truly exist on the system" version="1">
-    <unix:object object_ref="object_removable_partition_doesnt_exist" />
-  </unix:file_test>
-
-  <unix:file_object id="object_removable_partition_doesnt_exist" version="1">
-    <unix:filepath var_ref="var_removable_partition" var_check="at least one" />
-  </unix:file_object>
 
   <!-- Specified removable partition exists on the system. Check if it represents a CD / DVD drive -->
   <ind:variable_test id="test_var_removable_partition_is_cd_dvd_drive" check="all" comment="Check if removable partition variable value represents CD/DVD drive" version="1">

--- a/shared/oval/mount_option_nosuid_removable_partitions.xml
+++ b/shared/oval/mount_option_nosuid_removable_partitions.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="mount_option_nosuid_removable_partitions" version="3">
+  <definition class="compliance" id="mount_option_nosuid_removable_partitions" version="4">
     <metadata>
       <title>Add nosuid Option to Removable Media Partitions</title>
       <affected family="unix">
@@ -21,32 +21,23 @@
       <!-- Removable device exists. Check if it's CD/DVD drive. If so, verify that at least one from all of the possible its alternative
            names in /etc/fstab & runtime configuration are configured with 'nosuid' option -->
       <criteria operator="AND">
-        <criterion test_ref="test_var_removable_partition_is_cd_dvd_drive" comment="Check if removable partition value represents CD/DVD drive" />
-        <criterion test_ref="test_nosuid_etc_fstab_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'nosuid' mount option in /etc/fstab" />
-        <criterion test_ref="test_nosuid_runtime_cd_dvd_drive" comment="Check if at least one from CD/DVD drive alternative names is using 'nosuid' mount option in runtime configuration" />
+        <extend_definition comment="Check if removable partition value represents CD/DVD drive"
+        definition_ref="var_removable_partition_is_cd_dvd_drive" />
+        <criterion test_ref="test_nosuid_etc_fstab_cd_dvd_drive"
+        comment="Check if at least one from CD/DVD drive alternative names is using 'nosuid' mount option in /etc/fstab" />
+        <criterion test_ref="test_nosuid_runtime_cd_dvd_drive"
+        comment="Check if at least one from CD/DVD drive alternative names is using 'nosuid' mount option in runtime configuration" />
       </criteria>
       <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with 'nosuid' mount option in both
            /etc/fstab & runtime configuration -->
       <criteria operator="AND">
-        <criterion test_ref="test_nosuid_etc_fstab_not_cd_dvd_drive" comment="Check if removable partition is using 'nosuid' mount option in /etc/fstab" />
-        <criterion test_ref="test_nosuid_runtime_not_cd_dvd_drive" comment="Check if removable partition is using 'nosuid' mount option in runtime configuration" />
+        <criterion test_ref="test_nosuid_etc_fstab_not_cd_dvd_drive"
+        comment="Check if removable partition is using 'nosuid' mount option in /etc/fstab" />
+        <criterion test_ref="test_nosuid_runtime_not_cd_dvd_drive"
+        comment="Check if removable partition is using 'nosuid' mount option in runtime configuration" />
       </criteria>
     </criteria>
   </definition>
-
-  <!-- Specified removable partition exists on the system. Check if it represents a CD / DVD drive -->
-  <ind:variable_test id="test_var_removable_partition_is_cd_dvd_drive" check="all" comment="Check if removable partition variable value represents CD/DVD drive" version="1">
-    <ind:object object_ref="object_var_removable_partition_is_cd_dvd_drive" />
-    <ind:state state_ref="state_var_removable_partition_is_cd_dvd_drive" />
-  </ind:variable_test>
-
-  <ind:variable_object id="object_var_removable_partition_is_cd_dvd_drive" version="1">
-    <ind:var_ref>var_removable_partition</ind:var_ref>
-  </ind:variable_object>
-
-  <ind:variable_state id="state_var_removable_partition_is_cd_dvd_drive" version="1">
-    <ind:value operation="equals">/dev/cdrom</ind:value>
-  </ind:variable_state>
 
   <!-- If specified removable partition represents CD / DVD drive, create a variable
        holding also alternative names for CD / DVD block special device as used by udev -->

--- a/shared/oval/removable_partition_doesnt_exist.xml
+++ b/shared/oval/removable_partition_doesnt_exist.xml
@@ -1,0 +1,29 @@
+<def-group>
+  <definition class="compliance" id="removable_partition_doesnt_exist" version="1">
+    <metadata>
+      <title>Device Files for Removable Media Partitions Does Not Exist on the System</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+      </affected>
+      <description>Verify if device file representing removable partitions
+      exist on the system</description>
+      <reference source="JL" ref_id="RHEL6_20160719" ref_url="test_attestation" />
+      <reference source="JL" ref_id="RHEL7_20160719" ref_url="test_attestation" />
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_removable_partition_doesnt_exist" comment="Check if removable partition really exists on the system" />
+    </criteria>
+  </definition>
+
+  <unix:file_test id="test_removable_partition_doesnt_exist" check="all" check_existence="none_exist"
+  comment="Check if expected removable partitions truly exist on the system" version="1">
+    <unix:object object_ref="object_removable_partition_doesnt_exist" />
+  </unix:file_test>
+
+  <unix:file_object id="object_removable_partition_doesnt_exist" version="1">
+    <unix:filepath var_ref="var_removable_partition" var_check="at least one" />
+  </unix:file_object>
+
+  <external_variable comment="removable partition" datatype="string" id="var_removable_partition" version="1" />
+
+</def-group>

--- a/shared/oval/var_removable_partition_is_cd_dvd_drive.xml
+++ b/shared/oval/var_removable_partition_is_cd_dvd_drive.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="var_removable_partition_is_cd_dvd_drive" version="1">
+    <metadata>
+      <title>Value of 'var_removable_partition' variable is set to '/dev/cdrom'</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+      </affected>
+      <description>Verify if value of 'var_removable_partition' variable is set
+      to '/dev/cdrom'</description>
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_var_removable_partition_is_cd_dvd_drive"
+      comment="Check if removable partition value represents CD/DVD drive" />
+    </criteria>
+  </definition>
+
+  <!-- Check if 'var_removable_partition' variable value is set to '/dev/cdrom' -->
+  <ind:variable_test id="test_var_removable_partition_is_cd_dvd_drive" check="all"
+  comment="Check if removable partition variable value represents CD/DVD drive" version="1">
+    <ind:object object_ref="object_var_removable_partition_is_cd_dvd_drive" />
+    <ind:state state_ref="state_var_removable_partition_is_cd_dvd_drive" />
+  </ind:variable_test>
+
+  <ind:variable_object id="object_var_removable_partition_is_cd_dvd_drive" version="1">
+    <ind:var_ref>var_removable_partition</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="state_var_removable_partition_is_cd_dvd_drive" version="1">
+    <ind:value operation="equals">/dev/cdrom</ind:value>
+  </ind:variable_state>
+
+  <external_variable comment="removable partition" datatype="string" id="var_removable_partition" version="1" />
+
+</def-group>


### PR DESCRIPTION
Duplicate (per OVAL check) definition of the same OVAL entities is bad practice. Couple of issues that might arise:
* Duplicate definition on multiple places is prone to "out-of-sync" issue (in the need of update, not all definitions might be updated as required),
* SSG build system [when encountering same ID always uses the (lexicographically) first one](https://github.com/OpenSCAP/scap-security-guide/blob/master/shared/transforms/combineovals.py#L170) [meaning even if the semantics of OVAL entities differ, but ID is the same, the first definition will be used],
* It's not trivial to semantically decide if two XML elements (OVAL entities implementation) is [identical](http://stackoverflow.com/questions/7905380/testing-equivalence-of-xml-etree-elementtree/24349916#24349916),
* Besides of all of the above in some cases it might be truly desired to reference the same OVAL ID (example coming to mind is in the case when need to reference same external variable in various OVAL checks with same variable ID)

Therefore as such it's not possible to rely on the SSG build system to "guess properly" if the same ID should be truly re-used, or a new one should be assigned ("explicit is better than implicit").

Therefore get rid of duplicate definitions of selected OVAL entities, which is not necessary:
* patch https://github.com/OpenSCAP/scap-security-guide/commit/11c9dbc5911f02022bc6522f2e7b00407ab91594 - don't define the same OVAL object multiple times. Define it ones, and reference multiple times on necessary places,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/ac5f2c657691be7c1eb039306e8175e84f2436d0 - don't define same OVAL entities across various OVAL checks. Define it once in dedicated OVAL definition, and in all necessary places reference that definition,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/676c76670214fe3dd559d0c805c92a5fb080b018 - again don't define same OVAL entities across different OVAL checks. Dedicate a new OVAL definition for that, and reference that definition on necessary places,
* patch https://github.com/OpenSCAP/scap-security-guide/commit/9e4922e8171725ccf6696404ac123df644f5ee5a - ditto. Instead of defining same OVAL entities multiple times across various checks, dedicate an OVAL definition for the entities, and reference that newly introduced definition, where necessary.

This is (first) part of https://github.com/OpenSCAP/scap-security-guide/issues/50 (more patches to come in future PRs though).

Please review.

Thank you, Jan
