### PR TITLE
Update rhel7-cpe-dictionary.xml

### DIFF
--- a/RHEL/7/input/oval/platform/rhel7-cpe-dictionary.xml
+++ b/RHEL/7/input/oval/platform/rhel7-cpe-dictionary.xml
@@ -36,5 +36,5 @@
             <title xml:lang="en-us">Scientific Linux 7</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_sl7</check>
-      </cpe-item>      
+      </cpe-item>
 </cpe-list>

--- a/RHEL/7/input/oval/platform/rhel7-cpe-dictionary.xml
+++ b/RHEL/7/input/oval/platform/rhel7-cpe-dictionary.xml
@@ -7,6 +7,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel7</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:redhat:enterprise_linux:7::server">
+            <title xml:lang="en-us">Red Hat Enterprise Linux 7 Server</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel7</check>
+      </cpe-item>
       <cpe-item name="cpe:/o:redhat:enterprise_linux:7::client">
             <title xml:lang="en-us">Red Hat Enterprise Linux 7 Client</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -17,14 +22,9 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel7</check>
       </cpe-item>
-      <cpe-item name="cpe:/o:centos:centos:7">
-            <title xml:lang="en-us">CentOS 7</title>
+      <cpe-item name="cpe:/o:redhat:enterprise_linux:7::workstation">
+            <title xml:lang="en-us">Red Hat Enterprise Linux 7 Workstation</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
-            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_centos7</check>
-      </cpe-item>
-      <cpe-item name="cpe:/o:scientificlinux:scientificlinux:7">
-            <title xml:lang="en-us">Scientific Linux 7</title>
-            <!-- the check references an OVAL file that contains an inventory definition -->
-            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_sl7</check>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel7</check>
       </cpe-item>
 </cpe-list>

--- a/RHEL/7/input/oval/platform/rhel7-cpe-dictionary.xml
+++ b/RHEL/7/input/oval/platform/rhel7-cpe-dictionary.xml
@@ -27,4 +27,14 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhel7</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:centos:centos:7">
+            <title xml:lang="en-us">CentOS 7</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_centos7</check>
+      </cpe-item>
+      <cpe-item name="cpe:/o:scientificlinux:scientificlinux:7">
+            <title xml:lang="en-us">Scientific Linux 7</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_sl7</check>
+      </cpe-item>      
 </cpe-list>


### PR DESCRIPTION
* Removed CentOS7 and Scientific Linux 7 as CPE items.
* Updated with supported RHEL variants.

@mpreisler - would these changes break anything ssg+openscap wise?  No sense in having CentOS/Scientific Linux in the CPE dictionary, right?