### PR TITLE
Refactor template - create_*.py

### DIFF
--- a/Chromium/input/remediations/bash/templates/Makefile
+++ b/Chromium/input/remediations/bash/templates/Makefile
@@ -1,6 +1,7 @@
 templates: sysctls services kernel_modules
 
 SHARED_DIR=../../../../../../shared/remediations/bash/templates
+export PYTHONPATH=../../../../../shared
 
 OUTPUT:=$(shell mkdir -p output)
 

--- a/Debian/8/input/oval/oval_5.11/templates/Makefile
+++ b/Debian/8/input/oval/oval_5.11/templates/Makefile
@@ -1,4 +1,5 @@
 SHARED_DIR:=../../../../../../shared/oval/templates
+export PYTHONPATH=../../../../../../shared
 OUTPUT:=$(shell mkdir -p output)
 
 all:

--- a/Debian/8/input/oval/templates/Makefile
+++ b/Debian/8/input/oval/templates/Makefile
@@ -1,4 +1,5 @@
 SHARED_DIR:=../../../../../shared/oval/templates
+export PYTHONPATH=../../../../../shared
 OUTPUT:=$(shell mkdir -p output)
 
 all:

--- a/Fedora/input/oval/templates/Makefile
+++ b/Fedora/input/oval/templates/Makefile
@@ -1,6 +1,7 @@
 templates: services packages kernel_modules permissions umasks sysctls
 
 SHARED_DIR=../../../../shared/oval/templates
+export PYTHONPATH=../../../../shared
 SHARED_TEMPLATES=../../../../shared/templates
 
 OUTPUT:=$(shell mkdir -p output)

--- a/OpenSUSE/input/oval/templates/Makefile
+++ b/OpenSUSE/input/oval/templates/Makefile
@@ -1,6 +1,7 @@
 templates: services packages kernel_modules permissions umasks sysctls
 
 SHARED_DIR=../../../../shared/oval/templates
+export PYTHONPATH=../../../../shared
 SHARED_TEMPLATES=../../../../shared/templates
 
 OUTPUT:=$(shell mkdir -p output)

--- a/OpenStack/RHEL-OSP/7/input/oval/oval_5.11/templates/Makefile
+++ b/OpenStack/RHEL-OSP/7/input/oval/oval_5.11/templates/Makefile
@@ -1,7 +1,7 @@
 templates: services
 
 SHARED_DIR=../../../../../../../shared/oval/templates
-
+export PYTHONPATH=../../../../../../../shared
 OUTPUT:=$(shell mkdir -p output)
 
 packages:

--- a/RHEL/5/input/oval/templates/Makefile
+++ b/RHEL/5/input/oval/templates/Makefile
@@ -1,6 +1,7 @@
 templates: services packages kernel_modules permissions umasks sysctls
 
 SHARED_DIR=../../../../../shared/oval/templates
+export PYTHONPATH=../../../../../shared
 SHARED_TEMPLATES=../../../../../shared/templates
 
 OUTPUT:=$(shell mkdir -p output)

--- a/RHEL/5/input/remediations/bash/templates/Makefile
+++ b/RHEL/5/input/remediations/bash/templates/Makefile
@@ -1,6 +1,7 @@
 templates: sysctls services kernel_modules
 
 SHARED_DIR=../../../../../../shared/remediations/bash/templates
+export PYTHONPATH=../../../../../../shared
 
 OUTPUT:=$(shell mkdir -p output)
 

--- a/RHEL/6/input/oval/templates/Makefile
+++ b/RHEL/6/input/oval/templates/Makefile
@@ -1,6 +1,7 @@
 templates: services packages kernel_modules permissions umasks sysctls
 
 SHARED_DIR=../../../../../shared/oval/templates
+export PYTHONPATH=../../../../../shared
 SHARED_TEMPLATES=../../../../../shared/templates
 
 OUTPUT:=$(shell mkdir -p output)

--- a/RHEL/6/input/remediations/bash/templates/Makefile
+++ b/RHEL/6/input/remediations/bash/templates/Makefile
@@ -1,6 +1,7 @@
 templates: sysctls services kernel_modules
 
 SHARED_DIR=../../../../../../shared/remediations/bash/templates
+export PYTHONPATH=../../../../../../shared
 
 OUTPUT:=$(shell mkdir -p output)
 

--- a/RHEL/7/input/oval/oval_5.11/templates/Makefile
+++ b/RHEL/7/input/oval/oval_5.11/templates/Makefile
@@ -1,6 +1,7 @@
 templates: services
 
 SHARED_DIR=../../../../../../shared/oval/templates
+export PYTHONPATH=../../../../../../shared
 
 OUTPUT:=$(shell mkdir -p output)
 

--- a/RHEL/7/input/oval/templates/Makefile
+++ b/RHEL/7/input/oval/templates/Makefile
@@ -1,6 +1,7 @@
 templates: packages kernel_modules permissions umasks sysctls
 
 SHARED_DIR=../../../../../shared/oval/templates
+export PYTHONPATH=../../../../../shared
 SHARED_TEMPLATES=../../../../../shared/templates
 
 OUTPUT:=$(shell mkdir -p output)

--- a/RHEL/7/input/remediations/bash/templates/Makefile
+++ b/RHEL/7/input/remediations/bash/templates/Makefile
@@ -1,6 +1,7 @@
 templates: sysctls services kernel_modules
 
 SHARED_DIR=../../../../../../shared/remediations/bash/templates
+export PYTHONPATH=../../../../../../shared
 
 OUTPUT:=$(shell mkdir -p output)
 

--- a/RHEVM3/input/oval/templates/Makefile
+++ b/RHEVM3/input/oval/templates/Makefile
@@ -1,7 +1,7 @@
 templates: services packages kernel_modules permissions umasks sysctls
 
 SHARED_DIR=../../../../shared/oval/templates
-
+export PYTHONPATH=../../../../shared
 OUTPUT:=$(shell mkdir -p output)
 
 services:

--- a/RHEVM3/input/remediations/bash/templates/Makefile
+++ b/RHEVM3/input/remediations/bash/templates/Makefile
@@ -1,6 +1,7 @@
 templates: sysctls services kernel_modules
 
 SHARED_DIR=../../../../../shared/remediations/bash/templates
+export PYTHONPATH=../../../../../shared
 
 OUTPUT:=$(shell mkdir -p output)
 

--- a/SUSE/11/input/oval/templates/Makefile
+++ b/SUSE/11/input/oval/templates/Makefile
@@ -1,6 +1,7 @@
 templates: services packages kernel_modules permissions umasks sysctls
 
 SHARED_DIR=../../../../../shared/oval/templates
+export PYTHONPATH=../../../../../shared
 SHARED_TEMPLATES=../../../../../shared/templates
 
 OUTPUT:=$(shell mkdir -p output)

--- a/SUSE/11/input/remediations/bash/templates/Makefile
+++ b/SUSE/11/input/remediations/bash/templates/Makefile
@@ -1,7 +1,7 @@
 templates: sysctls services kernel_modules
 
 SHARED_DIR=../../../../../../shared/remediations/bash/templates
-
+export PYTHONPATH=../../../../../../shared
 OUTPUT:=$(shell mkdir -p output)
 
 sysctls:

--- a/SUSE/12/input/oval/oval_5.11/templates/Makefile
+++ b/SUSE/12/input/oval/oval_5.11/templates/Makefile
@@ -1,6 +1,7 @@
 templates: services
 
 SHARED_DIR=../../../../../../shared/oval/templates
+export PYTHONPATH=../../../../../../shared
 
 OUTPUT:=$(shell mkdir -p output)
 

--- a/SUSE/12/input/oval/templates/Makefile
+++ b/SUSE/12/input/oval/templates/Makefile
@@ -1,6 +1,8 @@
 templates: packages kernel_modules permissions umasks sysctls
 
 SHARED_DIR=../../../../../shared/oval/templates
+export PYTHONPATH=../../../../../shared
+
 SHARED_TEMPLATES=../../../../../shared/templates
 
 OUTPUT:=$(shell mkdir -p output)

--- a/SUSE/12/input/remediations/bash/templates/Makefile
+++ b/SUSE/12/input/remediations/bash/templates/Makefile
@@ -1,6 +1,7 @@
 templates: sysctls services kernel_modules
 
 SHARED_DIR=../../../../../../shared/remediations/bash/templates
+export PYTHONPATH=../../../../../../shared
 
 OUTPUT:=$(shell mkdir -p output)
 

--- a/Webmin/input/oval/templates/Makefile
+++ b/Webmin/input/oval/templates/Makefile
@@ -1,6 +1,7 @@
 templates: services packages kernel_modules permissions sysctls
 
 SHARED_DIR=../../../../../shared/oval/templates
+export PYTHONPATH=../../../../../shared
 
 OUTPUT:=$(shell mkdir -p output)
 

--- a/Webmin/input/remediations/bash/templates/Makefile
+++ b/Webmin/input/remediations/bash/templates/Makefile
@@ -1,6 +1,7 @@
 templates: sysctls services kernel_modules
 
 SHARED_DIR=../../../../../../shared/remediations/bash/templates
+export PYTHONPATH=../../../../../../shared
 
 OUTPUT:=$(shell mkdir -p output)
 

--- a/shared/oval/templates/create_kernel_modules_disabled.py
+++ b/shared/oval/templates/create_kernel_modules_disabled.py
@@ -22,7 +22,7 @@ def output_checkfile(kerninfo):
     file_from_template(
             "./template_kernel_module_disabled",
             { "KERNMODULE": kernmod },
-            "./output/kernel_module_{}_disabled.xml", kernmod
+            "./output/kernel_module_{0}_disabled.xml", kernmod
     )
 
 def main():

--- a/shared/oval/templates/create_kernel_modules_disabled.py
+++ b/shared/oval/templates/create_kernel_modules_disabled.py
@@ -12,35 +12,26 @@
 #
 
 import sys
-import csv
 
+from template_common import *
 
 def output_checkfile(kerninfo):
     # get the items out of the list
     kernmod = kerninfo[0]
-    with open("./template_kernel_module_disabled", 'r') as templatefile:
-        filestring = templatefile.read()
-        filestring = filestring.replace("KERNMODULE", kernmod)
-        with open("./output/kernel_module_" + kernmod +
-                  "_disabled.xml", 'w+') as outputfile:
-            outputfile.write(filestring)
-            outputfile.close()
 
+    file_from_template(
+            "./template_kernel_module_disabled",
+            { "KERNMODULE": kernmod },
+            "./output/kernel_module_{}_disabled.xml", kernmod
+    )
 
 def main():
     if len(sys.argv) < 2:
         print "Provide a CSV file containing lines of the format: kernmod"
         sys.exit(1)
-    with open(sys.argv[1], 'r') as csv_file:
-        # put the CSV line's items into a list
-        lines = csv.reader(csv_file)
-        for line in lines:
 
-            # Skip lines of input file starting with comment '#' character
-            if line[0].startswith('#'):
-                continue
-
-            output_checkfile(line)
+    filename = sys.argv[1]
+    csv_map(filename, output_checkfile, skip_comments = True)
 
     sys.exit(0)
 

--- a/shared/oval/templates/create_package_installed.py
+++ b/shared/oval/templates/create_package_installed.py
@@ -22,13 +22,13 @@ def output_check(package_info):
         file_from_template(
             "./template_OVAL_package_installed",
             { "PKGNAME" : pkgname },
-            "./output/package_{}_installed.xml", pkgname
+            "./output/package_{0}_installed.xml", pkgname
         )
 
         file_from_template(
             "./template_BASH_package_installed",
             { "PKGNAME" : pkgname },
-            "./output/package_{}_installed.sh", pkgname
+            "./output/package_{0}_installed.sh", pkgname
         )
 
     else:

--- a/shared/oval/templates/create_package_installed.py
+++ b/shared/oval/templates/create_package_installed.py
@@ -12,28 +12,25 @@
 #
 
 import sys
-import csv
 
+from template_common import *
 
 def output_check(package_info):
     pkgname = package_info[0]
     if pkgname:
-        with open("./template_OVAL_package_installed",
-                  'r') as oval_template_file:
-            filestring = oval_template_file.read()
-            filestring = filestring.replace("PKGNAME", pkgname)
-            with open("./output/package_" + pkgname +
-                      "_installed.xml", 'w+') as oval_output_file:
-                oval_output_file.write(filestring)
-                oval_output_file.close()
-            with open("./template_BASH_package_installed",
-                      'r') as bash_template_file:
-                filestring = bash_template_file.read()
-                filestring = filestring.replace("PKGNAME", pkgname)
-        with open("./output/package_" + pkgname +
-                  "_installed.sh", 'w+') as bash_output_file:
-            bash_output_file.write(filestring)
-            bash_output_file.close()
+
+        file_from_template(
+            "./template_OVAL_package_installed",
+            { "PKGNAME" : pkgname },
+            "./output/package_{}_installed.xml", pkgname
+        )
+
+        file_from_template(
+            "./template_BASH_package_installed",
+            { "PKGNAME" : pkgname },
+            "./output/package_{}_installed.sh", pkgname
+        )
+
     else:
         print "ERROR: input violation: the package name must be defined"
 
@@ -44,15 +41,9 @@ def main():
         print("   the csv file should contain lines of the format:")
         print("   PACKAGE_NAME")
         sys.exit(1)
-    with open(sys.argv[1], 'r') as csv_file:
-        csv_lines = csv.reader(csv_file)
-        for line in csv_lines:
 
-            # Skip lines of input file starting with comment '#' character
-            if line[0].startswith('#'):
-                continue
-
-            output_check(line)
+    filename = sys.argv[1]
+    csv_map(filename, output_check, skip_comments = True)
 
     sys.exit(0)
 

--- a/shared/oval/templates/create_package_removed.py
+++ b/shared/oval/templates/create_package_removed.py
@@ -12,25 +12,25 @@
 #
 
 import sys
-import csv
 
+from template_common import *
 
 def output_check(package_info):
 	pkgname = package_info[0]
 	if pkgname:
-		with open("./template_package_removed", 'r') as templatefile:
-			filestring = templatefile.read()
-			filestring = filestring.replace("PKGNAME", pkgname)
-		with open("./output/package_" + pkgname + "_removed.xml", 'w+') as outputfile:
-			outputfile.write(filestring)
-			outputfile.close()
 
-		with open("./template_BASH_package_removed", 'r') as bash_template_file:
-			filestring = bash_template_file.read()
-			filestring = filestring.replace("PKGNAME", pkgname)
-		with open("./output/package_" + pkgname + "_removed.sh", 'w+') as bash_output_file:
-			bash_output_file.write(filestring)
-			bash_output_file.close()
+		file_from_template(
+			"./template_package_removed",
+			{ "PKGNAME" : pkgname},
+			"./output/package_{}_removed.xml", pkgname
+		)
+
+		file_from_template(
+			"./template_BASH_package_removed",
+			{ "PKGNAME" : pkgname },
+			"./output/package_{}_removed.sh", pkgname
+		)
+
 	else:
 		print "ERROR: input violation: the package name must be defined"
 
@@ -42,15 +42,8 @@ def main():
         print "   PACKAGE_NAME"
         sys.exit(1)
 
-    with open(sys.argv[1], 'r') as csv_file:
-        csv_lines = csv.reader(csv_file)
-        for line in csv_lines:
-
-            # Skip lines of input file starting with comment '#' character
-            if line[0].startswith('#'):
-                continue
-
-            output_check(line)
+    filename = sys.argv[1]
+    csv_map(filename, output_check, skip_comments = True)
 
     sys.exit(0)
 

--- a/shared/oval/templates/create_package_removed.py
+++ b/shared/oval/templates/create_package_removed.py
@@ -22,13 +22,13 @@ def output_check(package_info):
 		file_from_template(
 			"./template_package_removed",
 			{ "PKGNAME" : pkgname},
-			"./output/package_{}_removed.xml", pkgname
+			"./output/package_{0}_removed.xml", pkgname
 		)
 
 		file_from_template(
 			"./template_BASH_package_removed",
 			{ "PKGNAME" : pkgname },
-			"./output/package_{}_removed.sh", pkgname
+			"./output/package_{0}_removed.sh", pkgname
 		)
 
 	else:

--- a/shared/oval/templates/create_permission_checks.py
+++ b/shared/oval/templates/create_permission_checks.py
@@ -68,7 +68,7 @@ def output_check(path_info):
             "STATEMODE":     mode_str,
             "UNIX_FILENAME": unix_filename
         },
-        "./output/file_permissions{}.xml", path_id
+        "./output/file_permissions{0}.xml", path_id
     )
 
 def main():

--- a/shared/oval/templates/create_services_disabled.py
+++ b/shared/oval/templates/create_services_disabled.py
@@ -37,7 +37,7 @@ def output_checkfile(serviceinfo):
                 "DAEMONNAME":  daemonname,
                 "PACKAGENAME": packagename
             },
-            "./output/service_{}_disabled.xml", servicename
+            "./output/service_{0}_disabled.xml", servicename
         )
     else:
         file_from_template(
@@ -50,7 +50,7 @@ def output_checkfile(serviceinfo):
                 "\n\s*<criteria.*>\n\s*<extend_definition.*/>": "",
                 "\s*</criteria>\n\s*</criteria>": "\n    </criteria>"
             },
-            filename_format = "./output/service_{}_disabled.xml",
+            filename_format = "./output/service_{0}_disabled.xml",
             filename_value = servicename
         )
 

--- a/shared/oval/templates/create_services_enabled.py
+++ b/shared/oval/templates/create_services_enabled.py
@@ -29,7 +29,7 @@ def output_checkfile(serviceinfo):
                 "SERVICENAME": servicename,
                 "PACKAGENAME": packagename
             },
-            "./output/service_{}_enabled.xml", servicename
+            "./output/service_{0}_enabled.xml", servicename
         )
     else:
         file_from_template(
@@ -39,7 +39,7 @@ def output_checkfile(serviceinfo):
                 "\n\s*<criteria.*>\n\s*<extend_definition.*/>": "",
                 "\s*</criteria>\n\s*</criteria>": "\n    </criteria>" 
             },
-            filename_format = "./output/service_{}_enabled.xml",
+            filename_format = "./output/service_{0}_enabled.xml",
             filename_value = servicename
         )
 

--- a/shared/oval/templates/create_services_enabled.py
+++ b/shared/oval/templates/create_services_enabled.py
@@ -13,44 +13,44 @@
 #
 
 import sys
-import csv
 import re
 
+from template_common import *
 
 def output_checkfile(serviceinfo):
     # get the items out of the list
     servicename, packagename = serviceinfo
-    with open("./template_service_enabled", 'r') as templatefile:
-        filestring = templatefile.read()
-        filestring = filestring.replace("SERVICENAME", servicename)
-        if packagename:
-            filestring = filestring.replace("PACKAGENAME", packagename)
-        else:
-            filestring = re.sub("\n\s*<criteria.*>\n\s*<extend_definition.*/>",
-                                "", filestring)
-            filestring = re.sub("\s*</criteria>\n\s*</criteria>",
-                                "\n    </criteria>", filestring)
-        with open("./output/service_" + servicename +
-                  "_enabled.xml", 'w+') as outputfile:
-            outputfile.write(filestring)
-            outputfile.close()
 
+    
+    if packagename:
+        file_from_template(
+            "./template_service_enabled",
+            {
+                "SERVICENAME": servicename,
+                "PACKAGENAME": packagename
+            },
+            "./output/service_{}_enabled.xml", servicename
+        )
+    else:
+        file_from_template(
+            "./template_service_enabled",
+            { "SERVICENAME": servicename },
+            regex_replace = {
+                "\n\s*<criteria.*>\n\s*<extend_definition.*/>": "",
+                "\s*</criteria>\n\s*</criteria>": "\n    </criteria>" 
+            },
+            filename_format = "./output/service_{}_enabled.xml",
+            filename_value = servicename
+        )
 
 def main():
     if len(sys.argv) < 2:
         print ("Provide a CSV file containing lines of the format: " +
                "servicename,packagename")
         sys.exit(1)
-    with open(sys.argv[1], 'r') as csv_file:
-        # put the CSV line's items into a list
-        servicelines = csv.reader(csv_file)
-        for line in servicelines:
 
-            # Skip lines of input file starting with comment '#' character
-            if line[0].startswith('#'):
-                continue
-
-            output_checkfile(line)
+    filename = sys.argv[1]
+    csv_map(filename, output_checkfile, skip_comments = True)
 
     sys.exit(0)
 

--- a/shared/oval/templates/create_sockets_disabled.py
+++ b/shared/oval/templates/create_sockets_disabled.py
@@ -33,7 +33,7 @@ def output_checkfile(socketinfo):
                 "SOCKETNAME":  socketname,
                 "PACKAGENAME": packagename
             },
-            "./output/socket_{}_disabled.xml", socketname
+            "./output/socket_{0}_disabled.xml", socketname
         )
 
     else:
@@ -46,7 +46,7 @@ def output_checkfile(socketinfo):
                 "\n\s*<criteria.*>\n\s*<extend_definition.*/>": "",
                 "\s*</criteria>\n\s*</criteria>": "\n    </criteria>"
             }
-            filename_format = "./output/socket_{}_disabled.xml",
+            filename_format = "./output/socket_{0}_disabled.xml",
             filename_value = socketname
         )
 

--- a/shared/oval/templates/create_sockets_disabled.py
+++ b/shared/oval/templates/create_sockets_disabled.py
@@ -13,44 +13,51 @@
 #
 
 import sys
-import csv
 import re
 
+from template_common import *
 
 def output_checkfile(socketinfo):
     # get the items out of the list
     socketname, packagename = socketinfo
-    with open("./template_socket_disabled", 'r') as templatefile:
-        filestring = templatefile.read()
-        filestring = filestring.replace("SOCKETNAME", socketname)
-        if packagename:
-            filestring = filestring.replace("PACKAGENAME", packagename)
-        else:
-            filestring = re.sub("\n\s*<criteria.*>\n\s*<extend_definition.*/>",
-                                "", filestring)
-            filestring = re.sub("\s*</criteria>\n\s*</criteria>",
-                                "\n    </criteria>", filestring)
-        with open("./output/socket_" + socketname +
-                  "_disabled.xml", 'w+') as outputfile:
-            outputfile.write(filestring)
-            outputfile.close()
 
+    file_content = load_modified(
+        "./template_socket_disabled",
+        { "SOCKETNAME":  socketname }
+    )
+
+    if packagename:
+        file_from_template(
+            "./template_socket_disabled",
+            {
+                "SOCKETNAME":  socketname,
+                "PACKAGENAME": packagename
+            },
+            "./output/socket_{}_disabled.xml", socketname
+        )
+
+    else:
+        file_from_template(
+            "./template_socket_disabled",
+            {
+                "SOCKETNAME":  socketname,
+            },
+            regex_dict = {
+                "\n\s*<criteria.*>\n\s*<extend_definition.*/>": "",
+                "\s*</criteria>\n\s*</criteria>": "\n    </criteria>"
+            }
+            filename_format = "./output/socket_{}_disabled.xml",
+            filename_value = socketname
+        )
 
 def main():
     if len(sys.argv) < 2:
         print ("Provide a CSV file containing lines of the format: " +
                "socketname,packagename")
         sys.exit(1)
-    with open(sys.argv[1], 'r') as csv_file:
-        # put the CSV line's items into a list
-        socketlines = csv.reader(csv_file)
-        for line in socketlines:
 
-            # Skip lines of input file starting with comment '#' character
-            if line[0].startswith('#'):
-                continue
-
-            output_checkfile(line)
+    filename = sys.argv[1]
+    csv_map(filename, output_checkfile, skip_comments = True)
 
     sys.exit(0)
 

--- a/shared/oval/templates/create_sysctl_checks.py
+++ b/shared/oval/templates/create_sysctl_checks.py
@@ -31,7 +31,7 @@ def output_checkfile(serviceinfo):
                     "SYSCTLID":  sysctl_var_id,
                     "SYSCTLVAR": sysctl_var,
                 },
-                "./output/{}.xml", files_var[sysctlfile] + sysctl_var_id
+                "./output/{0}.xml", files_var[sysctlfile] + sysctl_var_id
             )
     else:
 
@@ -44,7 +44,7 @@ def output_checkfile(serviceinfo):
                      "SYSCTLVAR": sysctl_var,
                      "SYSCTLVAL": sysctl_val
                 },
-                "./output/{}.xml", files[sysctlfile] + sysctl_var_id
+                "./output/{0}.xml", files[sysctlfile] + sysctl_var_id
             )
 
 def main():

--- a/shared/oval/templates/create_sysctl_checks.py
+++ b/shared/oval/templates/create_sysctl_checks.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python2
 
 import sys
-import csv
 import re
+
+from template_common import *
 
 # Define input template filename to resulting output filename mapping
 files = { 'template_sysctl_static' : 'sysctl_static_',
@@ -21,48 +22,39 @@ def output_checkfile(serviceinfo):
     
     # if the sysctl value is not present, use the variable template
     if not sysctl_val.strip():
+
         # open the template files and perform the conversions
         for sysctlfile in files_var.keys():
-            with open(sysctlfile, 'r') as templatefile:
-                filestring = templatefile.read()
-                filestring = filestring.replace("SYSCTLID", sysctl_var_id)
-                filestring = filestring.replace("SYSCTLVAR", sysctl_var)
-                # write the check
-                with open("./output/" + files_var[sysctlfile] + sysctl_var_id +
-                          ".xml", 'w+') as outputfile:
-                    outputfile.write(filestring)
-                    outputfile.close()
-
+            file_from_template(
+                sysctlfile,
+                {
+                    "SYSCTLID":  sysctl_var_id,
+                    "SYSCTLVAR": sysctl_var,
+                },
+                "./output/{}.xml", files_var[sysctlfile] + sysctl_var_id
+            )
     else:
+
         # open the template files and perform the conversions
         for sysctlfile in files.keys():
-            with open(sysctlfile, 'r') as templatefile:
-                filestring = templatefile.read()
-                filestring = filestring.replace("SYSCTLID", sysctl_var_id)
-                filestring = filestring.replace("SYSCTLVAR", sysctl_var)
-                filestring = filestring.replace("SYSCTLVAL", sysctl_val)
-                # write the check
-                with open("./output/" + files[sysctlfile] + sysctl_var_id +
-                          ".xml", 'w+') as outputfile:
-                    outputfile.write(filestring)
-                    outputfile.close()
-
+            file_from_template(
+                sysctlfile,
+                {
+                     "SYSCTLID":  sysctl_var_id,
+                     "SYSCTLVAR": sysctl_var,
+                     "SYSCTLVAL": sysctl_val
+                },
+                "./output/{}.xml", files[sysctlfile] + sysctl_var_id
+            )
 
 def main():
     if len(sys.argv) < 2:
         print ("Provide a CSV file containing lines of the format: " +
                "sysctlvariable,sysctlvalue")
         sys.exit(1)
-    with open(sys.argv[1], 'r') as csv_file:
-        # put the CSV line's items into a list
-        sysctl_lines = csv.reader(csv_file)
-        for line in sysctl_lines:
 
-            # Skip lines of input file starting with comment '#' character
-            if line[0].startswith('#'):
-                continue
-
-            output_checkfile(line)
+    filename = sys.argv[1]
+    csv_map(filename, output_checkfile, skip_comments = True)
 
     sys.exit(0)
 

--- a/shared/oval/templates/create_sysctl_ipv6_checks.py
+++ b/shared/oval/templates/create_sysctl_ipv6_checks.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python2
 
 import sys
-import csv
 import re
+
+from template_common import *
 
 # Define input template filename to resulting output filename mapping
 files = { 'template_sysctl_static' : 'sysctl_static_',
@@ -22,47 +23,36 @@ def output_checkfile(serviceinfo):
     # if the sysctl value is not present, use the variable template
     if not sysctl_val.strip():
         # open the template files and perform the conversions
-        for sysctlfile in files_var.keys():
-            with open(sysctlfile, 'r') as templatefile:
-                filestring = templatefile.read()
-                filestring = filestring.replace("SYSCTLID", sysctl_var_id)
-                filestring = filestring.replace("SYSCTLVAR", sysctl_var)
-                # write the check
-                with open("./output/" + files_var[sysctlfile] + sysctl_var_id +
-                          ".xml", 'w+') as outputfile:
-                    outputfile.write(filestring)
-                    outputfile.close()
+        file_from_template(
+            sysctlfile,
+            {
+                "SYSCTLID":  sysctl_var_id,
+                "SYSCTLVAR": sysctl_var
+            },
+            "./output/{}.xml", files_var[sysctlfile] + sysctl_var_id
+        )
 
     else:
         # open the template files and perform the conversions
         for sysctlfile in files.keys():
-            with open(sysctlfile, 'r') as templatefile:
-                filestring = templatefile.read()
-                filestring = filestring.replace("SYSCTLID", sysctl_var_id)
-                filestring = filestring.replace("SYSCTLVAR", sysctl_var)
-                filestring = filestring.replace("SYSCTLVAL", sysctl_val)
-                # write the check
-                with open("./output/" + files[sysctlfile] + sysctl_var_id +
-                          ".xml", 'w+') as outputfile:
-                    outputfile.write(filestring)
-                    outputfile.close()
-
+            file_from_template(
+                sysctlfile,
+                {
+                    "SYSCTLID":  sysctl_var_id,
+                    "SYSCTLVAR": sysctl_var,
+                    "SYSCTLVAL": sysctl_val
+                },
+                "./output/{}.xml", files[sysctlfile] + sysctl_var_id
+            )
 
 def main():
     if len(sys.argv) < 2:
         print ("Provide a CSV file containing lines of the format: " +
                "sysctlvariable,sysctlvalue")
         sys.exit(1)
-    with open(sys.argv[1], 'r') as csv_file:
-        # put the CSV line's items into a list
-        sysctl_lines = csv.reader(csv_file)
-        for line in sysctl_lines:
 
-            # Skip lines of input file starting with comment '#' character
-            if line[0].startswith('#'):
-                continue
-
-            output_checkfile(line)
+    filename = argv[1]
+    csv_map(filename, output_checkfile, skip_comments = True)
 
     sys.exit(0)
 

--- a/shared/oval/templates/create_sysctl_ipv6_checks.py
+++ b/shared/oval/templates/create_sysctl_ipv6_checks.py
@@ -29,7 +29,7 @@ def output_checkfile(serviceinfo):
                 "SYSCTLID":  sysctl_var_id,
                 "SYSCTLVAR": sysctl_var
             },
-            "./output/{}.xml", files_var[sysctlfile] + sysctl_var_id
+            "./output/{0}.xml", files_var[sysctlfile] + sysctl_var_id
         )
 
     else:
@@ -42,7 +42,7 @@ def output_checkfile(serviceinfo):
                     "SYSCTLVAR": sysctl_var,
                     "SYSCTLVAL": sysctl_val
                 },
-                "./output/{}.xml", files[sysctlfile] + sysctl_var_id
+                "./output/{0}.xml", files[sysctlfile] + sysctl_var_id
             )
 
 def main():

--- a/shared/remediations/bash/templates/create_kernel_module_disabled.py
+++ b/shared/remediations/bash/templates/create_kernel_module_disabled.py
@@ -24,7 +24,7 @@ def output_checkfile(kerninfo):
         {
            "KERNMODULE": kernmod
         },
-        "./output/kernel_module_{}_disabled.sh", kernmod
+        "./output/kernel_module_{0}_disabled.sh", kernmod
     )
 
 def main():

--- a/shared/remediations/bash/templates/create_kernel_module_disabled.py
+++ b/shared/remediations/bash/templates/create_kernel_module_disabled.py
@@ -12,30 +12,28 @@
 #
 
 import sys
-import csv
+from template_common import *
 
 
 def output_checkfile(kerninfo):
     # get the items out of the list
     kernmod = kerninfo[0]
-    with open("./template_kernel_module_disabled", 'r') as templatefile:
-        filestring = templatefile.read()
-        filestring = filestring.replace("KERNMODULE", kernmod)
-        with open("./output/kernel_module_" + kernmod +
-                  "_disabled.sh", 'w+') as outputfile:
-            outputfile.write(filestring)
-            outputfile.close()
 
+    file_from_template(
+        "./template_kernel_module_disabled",
+        {
+           "KERNMODULE": kernmod
+        },
+        "./output/kernel_module_{}_disabled.sh", kernmod
+    )
 
 def main():
     if len(sys.argv) < 2:
         print "Provide a CSV file containing lines of the format: kernmod"
         sys.exit(1)
-    with open(sys.argv[1], 'r') as csv_file:
-        # put the CSV line's items into a list
-        lines = csv.reader(csv_file)
-        for line in lines:
-            output_checkfile(line)
+
+    filename = sys.argv[1]
+    csv_map(filename, output_checkfile)
 
     sys.exit(0)
 

--- a/shared/remediations/bash/templates/create_services_disabled.py
+++ b/shared/remediations/bash/templates/create_services_disabled.py
@@ -13,36 +13,26 @@
 #
 
 import sys
-import csv
-
+from template_common import *
 
 def output_checkfile(serviceinfo):
     # get the items out of the list
     servicename, packagename,daemonname = serviceinfo
-    with open("./template_service_disabled", 'r') as templatefile:
-        filestring = templatefile.read()
-        filestring = filestring.replace("SERVICENAME", servicename)
-        with open("./output/service_" + servicename +
-                  "_disabled.sh", 'w+') as outputfile:
-            outputfile.write(filestring)
-            outputfile.close()
 
+    file_from_template(
+        "./template_service_disabled",
+        { "SERVICENAME": servicename },
+        "./output/service_{}_disabled.sh", servicename
+    )
 
 def main():
     if len(sys.argv) < 2:
         print ("Provide a CSV file containing lines of the format: " +
                "servicename,packagename")
         sys.exit(1)
-    with open(sys.argv[1], 'r') as csv_file:
-        # put the CSV line's items into a list
-        servicelines = csv.reader(csv_file)
-        for line in servicelines:
 
-            # Skip lines of input file starting with comment '#' character
-            if line[0].startswith('#'):
-                continue
-
-            output_checkfile(line)
+    filename = sys.argv[1]
+    csv_map(filename, output_checkfile, skip_comments=True)
 
     sys.exit(0)
 

--- a/shared/remediations/bash/templates/create_services_disabled.py
+++ b/shared/remediations/bash/templates/create_services_disabled.py
@@ -22,7 +22,7 @@ def output_checkfile(serviceinfo):
     file_from_template(
         "./template_service_disabled",
         { "SERVICENAME": servicename },
-        "./output/service_{}_disabled.sh", servicename
+        "./output/service_{0}_disabled.sh", servicename
     )
 
 def main():

--- a/shared/remediations/bash/templates/create_services_enabled.py
+++ b/shared/remediations/bash/templates/create_services_enabled.py
@@ -13,31 +13,26 @@
 #
 
 import sys
-import csv
-
+from template_common import *
 
 def output_checkfile(serviceinfo):
     # get the items out of the list
     servicename, packagename = serviceinfo
-    with open("./template_service_enabled", 'r') as templatefile:
-        filestring = templatefile.read()
-        filestring = filestring.replace("SERVICENAME", servicename)
-        with open("./output/service_" + servicename +
-                  "_enabled.sh", 'w+') as outputfile:
-            outputfile.write(filestring)
-            outputfile.close()
 
+    file_from_template(
+        "./template_service_enabled",
+        { "SERVICENAME": servicename },
+        "./output/service_{}_enabled.sh", servicename
+    )
 
 def main():
     if len(sys.argv) < 2:
         print ("Provide a CSV file containing lines of the format: " +
                "servicename,packagename")
         sys.exit(1)
-    with open(sys.argv[1], 'r') as csv_file:
-        # put the CSV line's items into a list
-        servicelines = csv.reader(csv_file)
-        for line in servicelines:
-            output_checkfile(line)
+
+    filename = sys.argv[1]
+    csv_map(filename, output_checkfile)
 
     sys.exit(0)
 

--- a/shared/remediations/bash/templates/create_services_enabled.py
+++ b/shared/remediations/bash/templates/create_services_enabled.py
@@ -22,7 +22,7 @@ def output_checkfile(serviceinfo):
     file_from_template(
         "./template_service_enabled",
         { "SERVICENAME": servicename },
-        "./output/service_{}_enabled.sh", servicename
+        "./output/service_{0}_enabled.sh", servicename
     )
 
 def main():

--- a/shared/remediations/bash/templates/create_sysctl_bash.py
+++ b/shared/remediations/bash/templates/create_sysctl_bash.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python
 
 import sys
-import csv
 import re
-
+from template_common import *
 
 def output_checkfile(serviceinfo):
     # get the items out of the list
@@ -14,45 +13,33 @@ def output_checkfile(serviceinfo):
     # if the sysctl value is not present, use the variable template
     if not sysctl_val.strip():
         # open the template and perform the conversions 
-        with open("template_sysctl_var", 'r') as templatefile:
-            filestring = templatefile.read()
-            filestring = filestring.replace("SYSCTLID", sysctl_var_id)
-            filestring = filestring.replace("SYSCTLVAR", sysctl_var)
-	    # write the check
-            with open("./output/sysctl_"  + sysctl_var_id +
-                      ".sh", 'w+') as outputfile:
-                outputfile.write(filestring)
-                outputfile.close()
-
+        file_from_template(
+            "template_sysctl_var",
+            {
+                "SYSCTLID":  sysctl_var_id,
+                "SYSCTLVAR": sysctl_var
+            },
+            "./output/sysctl_{}.sh", sysctl_var_id
+        )
     else:
-        # open the template and perform the conversions
-        with open("template_sysctl", 'r') as templatefile:
-            filestring = templatefile.read()
-            filestring = filestring.replace("SYSCTLID", sysctl_var_id)
-            filestring = filestring.replace("SYSCTLVAR", sysctl_var)
-            filestring = filestring.replace("SYSCTLVAL", sysctl_val)
-            # write the check
-            with open("./output/sysctl_" + sysctl_var_id +
-                      ".sh", 'w+') as outputfile:
-                outputfile.write(filestring)
-                outputfile.close()
-
+        file_from_template(
+            "./template_sysctl",
+            {
+                "SYSCTLID":  sysctl_var_id,
+                "SYSCTLVAR": sysctl_var,
+                "SYSCTLVAL": sysctl_val
+            },
+            "./output/sysctl_{}.sh", sysctl_var_id
+        )
 
 def main():
     if len(sys.argv) < 2:
         print ("Provide a CSV file containing lines of the format: " +
                "sysctlvariable,sysctlvalue")
         sys.exit(1)
-    with open(sys.argv[1], 'r') as csv_file:
-        # put the CSV line's items into a list
-        sysctl_lines = csv.reader(csv_file)
-        for line in sysctl_lines:
 
-            # Skip lines of input file starting with comment '#' character
-            if line[0].startswith('#'):
-                continue
-
-            output_checkfile(line)
+    filename = sys.argv[1]
+    csv_map(filename, output_checkfile, skip_comments = True)
 
     sys.exit(0)
 

--- a/shared/remediations/bash/templates/create_sysctl_bash.py
+++ b/shared/remediations/bash/templates/create_sysctl_bash.py
@@ -19,7 +19,7 @@ def output_checkfile(serviceinfo):
                 "SYSCTLID":  sysctl_var_id,
                 "SYSCTLVAR": sysctl_var
             },
-            "./output/sysctl_{}.sh", sysctl_var_id
+            "./output/sysctl_{0}.sh", sysctl_var_id
         )
     else:
         file_from_template(
@@ -29,7 +29,7 @@ def output_checkfile(serviceinfo):
                 "SYSCTLVAR": sysctl_var,
                 "SYSCTLVAL": sysctl_val
             },
-            "./output/sysctl_{}.sh", sysctl_var_id
+            "./output/sysctl_{0}.sh", sysctl_var_id
         )
 
 def main():

--- a/shared/template_common.py
+++ b/shared/template_common.py
@@ -1,0 +1,79 @@
+"""
+Common methods for generating files from templates
+"""
+
+import csv
+import sys
+import os
+import re
+
+def get_template_file(filename):
+    try:
+        return open(filename, 'r')
+    except IOError:
+        # guess shared template
+        if 'SHARED_DIR' in os.environ:
+            shared_template = os.environ['SHARED_DIR'] + filename
+            return open(shared_template, "r")
+        else:
+            sys.stderr.write(
+                "No specialized or shared template found for {}\n".format(filename)
+            )
+            
+
+def load_modified(filename, constants_dict, regex_dict = None):
+    """
+    Load file and replace constants accoring to constants_dict and regex_dict
+
+    constants_dict: dict of constants - replace ( key -> value)
+    regex_dict: dict of regex substitutions - sub ( key -> value)
+    """
+
+    with get_template_file(filename) as template_file:
+        filestring = template_file.read()
+
+    for key, value in constants_dict.iteritems():
+       filestring = filestring.replace(key, value)
+
+    if regex_dict:
+        for pattern, replacement in regex_dict.iteritems():
+            filestring = re.sub(pattern, replacement, filestring)
+
+    return filestring
+
+def save_modified(filename_format, filename_value, string):
+    """
+    Save string to file
+    """
+    filename = filename_format.format(filename_value)
+    dir = os.environ.get('TARGET_DIR', '')
+    filename = dir + filename
+    with open(filename, 'w+') as outputfile:
+        outputfile.write(string)
+
+
+def file_from_template(template_filename, constants,
+                       filename_format, filename_value, regex_replace = None):
+    """
+    Load template, fill constant and create new file
+    """
+
+    filled_template = load_modified(template_filename, constants, regex_replace)
+
+    save_modified(filename_format, filename_value, filled_template)
+
+
+def csv_map(filename, method, skip_comments = False):
+    """
+    Call specified function on every line of file
+    """
+    with open(filename, 'r') as csv_file:
+        # put the CSV line's items into a list
+        lines = csv.reader(csv_file)
+        for line in lines:
+            if not line:
+                continue
+            if skip_comments and line[0].startswith('#'):
+                continue
+            method(line)
+


### PR DESCRIPTION
These scripts now use common syntax and using template_common.py. We can now modify behavior of all these scripts from 1 place - `template_common.py`.

I think, the script are now more readable and doesn't contains so much common code.
I have modified all relevant makefiles what I have found. But quite lot of them didn't work (before & after my changes)