### PR TITLE
combineremediations.py to support multiple directories as input

### DIFF
--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -93,12 +93,7 @@ $(OUT)/xccdf-unlinked-ocilrefs.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/oc
 # Common build targets - a catalogue of XCCDF remediations
 bash_remediations_deps= $(wildcard $(IN)/remediations/bash/*.sh) $(wildcard $(SHARED_REMEDIATIONS)/*.sh)
 $(OUT)/bash-remediations.xml: $(SHARED)/$(TRANS)/combineremediations.py $(bash_remediations_deps)
-	# Make intermediate $(BUILD_REMEDIATIONS) directory to hold final list of remediation scripts for $(PROD)
-	mkdir -p $(BUILD_REMEDIATIONS)
-	# Search $(SHARED_REMEDIATIONS) and $(IN)/remediations directories to find all product specific remediation scripts,
-	# which are regular files (not symlinks). Merge the final list into $(BUILD_REMEDIATIONS) directory
-	find $(SHARED_REMEDIATIONS) $(IN)/remediations/bash -maxdepth 1 -type f -name '*.sh' -exec cp {} $(BUILD_REMEDIATIONS) ';'
-	$(SHARED)/$(TRANS)/combineremediations.py $(PROD) $(BUILD_REMEDIATIONS) $(OUT)/bash-remediations.xml
+	$(SHARED)/$(TRANS)/combineremediations.py $(PROD) $(SHARED_REMEDIATIONS) $(IN)/remediations/bash $(OUT)/bash-remediations.xml
 
 # Common build targets - an XCCDF with remediations but not linked to OVAL yet
 # Prefer "$(OUT)/xccdf-unlinked-ocilrefs.xml" document below since it contains OCIL expanded to official OCIL-2.0 syntax

--- a/shared/transforms/combineremediations.py
+++ b/shared/transforms/combineremediations.py
@@ -69,7 +69,7 @@ def fix_is_applicable_for_product(platform, product):
         if mp in platform and product in ['rhel', 'fedora']:
             return True
 
-    # Get official name for product 
+    # Get official name for product
     if product_version is not None:
         product_name = map_product(product) + ' ' + product_version
     else:
@@ -270,8 +270,7 @@ def main():
         sys.exit(1)
 
     product = sys.argv[1]
-    fixdir = sys.argv[2]
-    output = sys.argv[3]
+    output = sys.argv[-1]
 
     fixcontent = etree.Element("fix-content", system="urn:xccdf:fix:script:sh",
                                xmlns="http://checklists.nist.gov/xccdf/1.1")
@@ -283,28 +282,29 @@ def main():
 
     platform = {}
     included_fixes_count = 0
-    for filename in os.listdir(fixdir):
-        if filename.endswith(".sh"):
-            # Create and populate new fix element based on shell file
-            fixname = os.path.splitext(filename)[0]
+    for fixdir in sys.argv[2:-1]:
+        for filename in os.listdir(fixdir):
+            if filename.endswith(".sh"):
+                # Create and populate new fix element based on shell file
+                fixname = os.path.splitext(filename)[0]
 
-            with open(fixdir + "/" + filename, 'r') as fix_file:
-                # Assignment automatically escapes shell characters for XML
-                script_platform = fix_file.readline().strip('#').strip().split('=')
-                if len(script_platform) > 1:
-                    platform[script_platform[0].strip()] = script_platform[1].strip()
-                if script_platform[0].strip() == 'platform':
-                    if fix_is_applicable_for_product(platform['platform'], product):
-                        fix = etree.SubElement(fixgroup, "fix", rule=fixname)
-                        fix.text = fix_file.read()
-                        included_fixes_count += 1
+                with open(fixdir + "/" + filename, 'r') as fix_file:
+                    # Assignment automatically escapes shell characters for XML
+                    script_platform = fix_file.readline().strip('#').strip().split('=')
+                    if len(script_platform) > 1:
+                        platform[script_platform[0].strip()] = script_platform[1].strip()
+                    if script_platform[0].strip() == 'platform':
+                        if fix_is_applicable_for_product(platform['platform'], product):
+                            fix = etree.SubElement(fixgroup, "fix", rule=fixname)
+                            fix.text = fix_file.read()
+                            included_fixes_count += 1
 
-                        # Expand shell variables and remediation functions into
-                        # corresponding XCCDF <sub> elements
-                        expand_xccdf_subs(fix, remediation_functions)
-                else:
-                    print("\nNotification: Removed the '%s' remediation script from merging as " \
-                          "the platform identifier in the script is missing!" % filename)
+                            # Expand shell variables and remediation functions into
+                            # corresponding XCCDF <sub> elements
+                            expand_xccdf_subs(fix, remediation_functions)
+                    else:
+                        print("\nNotification: Removed the '%s' remediation script from merging as " \
+                            "the platform identifier in the script is missing!" % filename)
 
     sys.stderr.write("\nNotification: Merged %d remediation scripts into XML document.\n" % included_fixes_count)
     tree = etree.ElementTree(fixcontent)

--- a/shared/transforms/combineremediations.py
+++ b/shared/transforms/combineremediations.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import os.path
 import re
 import lxml.etree as etree
 
@@ -289,7 +290,7 @@ def main():
                 # Create and populate new fix element based on shell file
                 fixname = os.path.splitext(filename)[0]
 
-                with open(fixdir + "/" + filename, 'r') as fix_file:
+                with open(os.path.join(fixdir, filename), 'r') as fix_file:
                     # Assignment automatically escapes shell characters for XML
                     script_platform = fix_file.readline().strip('#').strip().split('=')
                     if len(script_platform) > 1:

--- a/shared/transforms/combineremediations.py
+++ b/shared/transforms/combineremediations.py
@@ -277,6 +277,7 @@ def main():
     fixgroup = etree.SubElement(fixcontent, "fix-group", id="bash",
                                 system="urn:xccdf:fix:script:sh",
                                 xmlns="http://checklists.nist.gov/xccdf/1.1")
+    fixes = dict()
 
     remediation_functions = get_available_remediation_functions()
 
@@ -295,9 +296,15 @@ def main():
                         platform[script_platform[0].strip()] = script_platform[1].strip()
                     if script_platform[0].strip() == 'platform':
                         if fix_is_applicable_for_product(platform['platform'], product):
-                            fix = etree.SubElement(fixgroup, "fix", rule=fixname)
+                            if fixname in fixes:
+                                fix = fixes[fixname]
+                            else:
+                                fix = etree.SubElement(fixgroup, "fix")
+                                fix.set("rule", fixname)
+                                fixes[fixname] = fix
+                                included_fixes_count += 1
+
                             fix.text = fix_file.read()
-                            included_fixes_count += 1
 
                             # Expand shell variables and remediation functions into
                             # corresponding XCCDF <sub> elements


### PR DESCRIPTION
This means we no longer have to copy things around as a workaround. Makes the build simpler.

@ybznek mentioned this would help with his Ansible remediation script work.