### PR TITLE
Fix doubled fixes

### DIFF
--- a/shared/transforms/combineremediations.py
+++ b/shared/transforms/combineremediations.py
@@ -301,6 +301,8 @@ def main():
                     if fix_is_applicable_for_product(platform['platform'], product):
                         if fixname in fixes:
                             fix = fixes[fixname]
+                            for child in list(fix):
+                                fix.remove(child)
                         else:
                             fix = etree.SubElement(fixgroup, "fix")
                             fix.set("rule", fixname)


### PR DESCRIPTION
I was getting this in output, because fix.text="" doesn't remove whole content of element
```
    <fix rule="package_aide_installed"><sub idref="function_package_command"/>
package_command install aide
<sub idref="function_package_command"/>
package_command install audit (specific)
</fix>```