### PR TITLE
combineovals: remove deprecated branch of code

### DIFF
--- a/shared/transforms/combineovals.py
+++ b/shared/transforms/combineovals.py
@@ -286,18 +286,6 @@ def checks(product):
                     body = body + xml_content
                     included_checks_count += 1
 
-    if len(sys.argv) == 6:
-        for filename in os.listdir(sys.argv[4]):
-            if filename.endswith(".xml"):
-                with open(os.path.join(sys.argv[4], filename), 'r') as xml_file:
-                    filecontent = xml_file.read()
-                    if '<platform>multi_platform_all</platform>' in filecontent:
-                        body = body + filecontent
-                    elif '<platform>' + sys.argv[5] + '</platform>' in filecontent:
-                        body = body + filecontent
-                    elif '<platform>' + sys.argv[6] + '</platform>' in filecontent:
-                        body = body + filecontent
-
     sys.stderr.write("\nNotification: Merged %d OVAL checks into OVAL document.\n" % included_checks_count)
 
     return body


### PR DESCRIPTION
I don't know purpose of this code and I think that it is currently dead code - I haven't found any usage of it.

It seems like some legacy version for usage shared oval (currently we use check_is_applicable_for_product instead of such code)

Some historical version:
https://github.com/OpenSCAP/scap-security-guide/blob/f0065da17332827924f072b0ff8170a4bac8cb89/shared/transforms/combinechecks.py

I would like to remove it and replace to use multiple folders with oval files