### PR TITLE
[BugFix] [RHEL/7] Rewrite RHEL-7 remediation for 'smartcard_auth' rule

### DIFF
--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -375,7 +375,7 @@ is not enabled by default and must be enabled in the system settings.
 <description>
 To enable smart card authentication, consult the documentation at:
 <ul>
-<li><b>https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7-Beta/html/System-Level_Authentication_Guide/authconfig-addl-auth.html#authconfig-smartcard</b></li>
+<li><b>https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/smartcards.html#authconfig-smartcards</b></li>
 </ul>
 For guidance on enabling SSH to authenticate against a Common Access Card (CAC), consult documentation at:
 <ul>


### PR DESCRIPTION
Since per downstream bug:
  https://bugzilla.redhat.com/show_bug.cgi?id=1357019

we can't use 'authconfig' binary direct call, because it will discard the changes as performed and required by other remediation scripts also touching ```/etc/pam.d/system-auth{,-ac}``` files

Therefore return to previous version updating necessary files directly via 'sed' tool (rather than using 'authconfig' binary)

Note: While on the rule also update XCCDF link providing further info how to setup smartcard auth (since the current one returns HTTP 404 Not Found)

Testing result:
The change has been tested on RHEL-7 local system and seems to be working properly (AFAICT).

Please review.

Thank you, Jan.