### PR TITLE
Suggest using SELinux to harden the container host

### DIFF
--- a/RHEL/7/input/oval/oval_5.11/docker_selinux_enabled.xml
+++ b/RHEL/7/input/oval/oval_5.11/docker_selinux_enabled.xml
@@ -1,0 +1,29 @@
+<def-group>
+  <definition class="compliance" id="docker_selinux_enabled" version="1">
+    <metadata>
+      <title>Ensure SELinux support is enabled in Docker</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>The Docker daemon should be configured to start with --selinux-enabled option to enable SELinux for the daemon.</description>
+    </metadata>
+    <criteria operator="OR">
+      <criteria operator="AND">
+        <extend_definition comment="docker service active on system" definition_ref="service_docker_enabled"/>
+        <criterion comment="Docker is configured to run with SELinux support" test_ref="test_docker_selinux_enabled"/>
+      </criteria>
+      <extend_definition comment="docker service inactive on system" definition_ref="service_docker_enabled" negate="true"/>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="at least one" check_existence="all_exist" comment="Ensure the /etc/sysconfig/docker contains '--selinux-enabled' in the OPTIONS field" id="test_docker_selinux_enabled" version="1" >
+    <ind:object object_ref="obj_docker_selinux_enabled" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_docker_selinux_enabled" version="2">
+    <ind:filepath operation="equals">/etc/sysconfig/docker</ind:filepath>
+    <ind:pattern operation="pattern match">^(?!#)\s*OPTIONS\s*=.*[\s'](--selinux-enabled)[\s'].*$</ind:pattern>
+    <ind:instance operation="equals" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/RHEL/7/input/profiles/docker-host.xml
+++ b/RHEL/7/input/profiles/docker-host.xml
@@ -6,4 +6,12 @@
 </description>
 
 <select idref="service_docker_enabled" selected="true" />
+
+<!-- Use SELinux to protect the host and containers from each other -->
+<refine-value idref="var_selinux_policy_name" selector="targeted" />
+<refine-value idref="var_selinux_state" selector="enforcing" />
+<select idref="enable_selinux_bootloader" selected="true" />
+<select idref="selinux_state" selected="true" />
+<select idref="selinux_policytype" selected="true" />
+
 </Profile>

--- a/RHEL/7/input/profiles/docker-host.xml
+++ b/RHEL/7/input/profiles/docker-host.xml
@@ -14,4 +14,6 @@
 <select idref="selinux_state" selected="true" />
 <select idref="selinux_policytype" selected="true" />
 
+<select idref="docker_selinux_enabled" selected="true" />
+
 </Profile>

--- a/RHEL/7/input/xccdf/system/selinux.xml
+++ b/RHEL/7/input/xccdf/system/selinux.xml
@@ -198,6 +198,26 @@ cannot properly restrict access to the device file.
 ossrg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
+<Rule id="docker_selinux_enabled" severity="high">
+<title>Ensure SELinux support is enabled in Docker</title>
+<description>
+To enable the SELinux for the Docker service, the Docker service must be
+configured to run the Docker daemon with <tt>--selinux-enabled</tt> option.
+In <tt>/etc/sysconfig/docker</tt> configuration file, add or correct
+the following line to enable SELinux support in the Docker daemon:
+<pre>OPTIONS='--selinux-enabled'</pre>
+</description>
+<rationale>
+If SELinux is not explicitely enabled in the Docker deamon configuration,
+Docker does not use SELinux which means Docker runs unconfined,
+and SELinux will not provide security separation for Docker container
+processes. However enabling SELinux for the Docker service prevents
+an attacker or rogue container from attacking other container processes
+and content as well as prevents taking over the host operating system.
+</rationale>
+<oval id="docker_selinux_enabled" />
+</Rule>
+
 <Group id="selinux-booleans">
 <title>SELinux - Booleans</title>
 <description>


### PR DESCRIPTION
Docker supports SELinux to separate containers from each other and from the host system.
Therefore I think the "Docker SSG profile" should require:
* enabling SELinux on the host in enforcing mode
* enabling SELinux support within Docker

This pull request:
* select some of the existing SElinux-related rules into the profile
* adds one new rule that checks whether Docker is configured to run with SELinux enabled For explanation of this rule, please see https://access.redhat.com/solutions/2429071