### PR TITLE
[Enhancement] Enhance the 'profile-stats.py' helper yet

### DIFF
--- a/shared/utils/profile_stats.py
+++ b/shared/utils/profile_stats.py
@@ -97,7 +97,7 @@ class XCCDFBenchmark(object):
             print("* Available profiles:")
             profiles_avail = self.tree.findall("./{%s}Profile" % (xccdf_ns))
             for profile in profiles_avail:
-                print("** %s" % profile.get('profile_id'))
+                print("** %s" % profile.get('id'))
             sys.exit(1)
 
         rules = xccdf_profile.findall("./{%s}select[@selected=\"true\"]" %

--- a/shared/utils/profile_stats.py
+++ b/shared/utils/profile_stats.py
@@ -1,11 +1,14 @@
 #!/usr/bin/python
 
+import json
 import lxml.etree as ET
 import optparse
 import sys
 
 script_usage = """
-%prog -b XCCDF_file [-p XCCDF_profile] [--full-stats]
+%prog -b XCCDF_file [-p XCCDF_profile] [--implemented] [--missing] [--all]
+                    [--implemented-ovals] [--implemented-fixes] [--assigned-cces]
+                    [--missing-ovals] [--missing-fixes] [--missing-cces] [--json]
 
 Obtains and displays XCCDF profile statistics like:
 * Count of rules present in the <xccdf:Profile>
@@ -18,9 +21,21 @@ Unless -p or --profile option was provided, it will display statistics
 for all profiles found in the benchmark. Use -p or --profile XCCDF_profile
 to obtain statistics solely for particular profile.
 
-If --full-stats option was provided it will also display the IDs
-of unimplemented OVAL checks, remediation scripts, and IDs of rules
-not having CCE identifier assigned yet.
+If --implemented option was provided it will also display the IDs
+of implemented OVAL checks, remediation scripts, and IDs of rules
+having CCE identifier already assigned. It is a shortcut for combination
+of --implemented-ovals, --implemented-fixes, and --assigned-cces options.
+
+If --missing option was provided it will also display the IDs of
+not implemented OVAL checks, remediation scripts, and IDs of rules
+not having CCE identifier assigned yet. It is a shortcut for combination
+of --missing-ovals, --missing-fixes, and --missing-cces options.
+
+If --all option was provided, it will display all available information.
+It is a shortcut for combination of --implemented and --missing options.
+
+If --json option is provided, it will display the statistics in the form
+of json format file (rather than default text form)
 
 NOTE: Does NOT work on DataStream benchmark format (yet)!
 """
@@ -30,6 +45,7 @@ xccdf_ns = "http://checklists.nist.gov/xccdf/1.1"
 oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
 rem_system = "urn:xccdf:fix:script:sh"
 cce_system = "https://nvd.nist.gov/cce/index.cfm"
+ssg_version_uri = "https://github.com/OpenSCAP/scap-security-guide/releases/latest"
 console_width = 80
 
 
@@ -44,7 +60,6 @@ class RuleStats(object):
 class XCCDFBenchmark(object):
     def __init__(self, filepath):
         self.tree = None
-        self.stats = []
         try:
             with open(filepath, 'r') as xccdf_file:
                 file_string = xccdf_file.read()
@@ -54,9 +69,27 @@ class XCCDFBenchmark(object):
             print("%s" % ioerr)
             sys.exit(1)
 
-    def get_profile_stats(self, profile=None, full_stats=False):
+    def get_profile_stats(self, profile = None):
         """Obtain statistics for the profile"""
 
+        # Holds the intermediary statistics for profile
+        profile_stats = { 'profile_id' : None,
+                          'ssg_version' : 0,
+                          'rules_count' : 0,
+                          'implemented_ovals' : [],
+                          'implemented_ovals_pct' : 0,
+                          'missing_ovals' : [],
+                          'implemented_fixes' : [],
+                          'implemented_fixes_pct' : 0,
+                          'missing_fixes' : [],
+                          'assigned_cces' : [],
+                          'assigned_cces_pct' : 0,
+                          'missing_cces' : []
+                         }
+
+        rule_stats = []
+        ssg_version_elem = self.tree.find("./{%s}version[@update=\"%s\"]" %
+                                          (xccdf_ns, ssg_version_uri))
         xccdf_profile = self.tree.find("./{%s}Profile[@id=\"%s\"]" %
                                        (xccdf_ns, profile))
         if xccdf_profile is None:
@@ -64,7 +97,7 @@ class XCCDFBenchmark(object):
             print("* Available profiles:")
             profiles_avail = self.tree.findall("./{%s}Profile" % (xccdf_ns))
             for profile in profiles_avail:
-                print("** %s" % profile.get('id'))
+                print("** %s" % profile.get('profile_id'))
             sys.exit(1)
 
         rules = xccdf_profile.findall("./{%s}select[@selected=\"true\"]" %
@@ -80,51 +113,135 @@ class XCCDFBenchmark(object):
                                       (xccdf_ns, rem_system))
                 cce = xccdf_rule.find("./{%s}ident[@system=\"%s\"]" %
                                       (xccdf_ns, cce_system))
-                self.stats.append(RuleStats(rule_id, oval, fix, cce))
+                rule_stats.append(RuleStats(rule_id, oval, fix, cce))
 
-    def show_profile_stats(self, profile=None, full_stats=False):
+        if not rule_stats:
+            print('Unable to retrieve statistics for %s profile' % profile)
+            sys.exit(1)
+
+        profile_stats['profile_id'] = profile
+        if ssg_version_elem is not None:
+            profile_stats['ssg_version'] = \
+                'SCAP Security Guide %s' % ssg_version_elem.text
+        profile_stats['rules_count'] = len(rule_stats)
+        profile_stats['implemented_ovals'] = \
+            [x.dict['id'] for x in rule_stats if x.dict['oval'] is not None]
+        profile_stats['implemented_ovals_pct'] = \
+            float(len(profile_stats['implemented_ovals'])) / \
+            profile_stats['rules_count'] * 100
+        profile_stats['missing_ovals'] = \
+            [x.dict['id'] for x in rule_stats if x.dict['oval'] is None]
+        profile_stats['implemented_fixes'] = \
+            [x.dict['id'] for x in rule_stats if x.dict['fix'] is not None]
+        profile_stats['implemented_fixes_pct'] = \
+            float(len(profile_stats['implemented_fixes'])) / \
+            profile_stats['rules_count'] * 100
+        profile_stats['missing_fixes'] = \
+            [x.dict['id'] for x in rule_stats if x.dict['fix'] is None]
+        profile_stats['assigned_cces'] = \
+            [x.dict['id'] for x in rule_stats if x.dict['cce'] is not None]
+        profile_stats['assigned_cces_pct'] = \
+            float(len(profile_stats['assigned_cces'])) / \
+            profile_stats['rules_count'] * 100
+        profile_stats['missing_cces'] = \
+            [x.dict['id'] for x in rule_stats if x.dict['cce'] is None]
+
+        return profile_stats
+
+    def show_profile_stats(self, profile, options):
         """Displays statistics for specific profile"""
 
-        self.get_profile_stats(profile, full_stats)
-        print("* Statistics of '%s' profile:" % profile)
-        rules_count = len(self.stats)
-        print("** Count of rules: %d" % rules_count)
-        ovals_count = len([x for x in self.stats
-                           if x.dict['oval'] is not None])
-        print("** Count of ovals: %d [%d%% complete]" %
-              (ovals_count, float(ovals_count) / rules_count * 100))
-        fixes_count = len([x for x in self.stats if x.dict['fix'] is not None])
-        print("** Count of fixes: %d [%d%% complete]" %
-              (fixes_count, float(fixes_count) / rules_count * 100))
-        if full_stats:
-            missing_ovals = [x.dict['id'] for x in self.stats
-                             if x.dict['oval'] is None]
-            if missing_ovals:
-                print("** Rules of '%s' profile missing OVAL:" % profile)
-                self.console_print(missing_ovals, console_width)
-            else:
-                print("** All rules of '%s' " % profile + "profile have " +
-                      "OVAL implemented.")
-            missing_fixes = [x.dict['id'] for x in self.stats
-                             if x.dict['fix'] is None]
-            if missing_fixes:
-                print("** Rules of '%s' profile missing remediation:" %
-                      profile)
-                self.console_print(missing_fixes, console_width)
-            else:
-                print("** All rules of '%s' " % profile + "profile have " +
-                      "remediation implemented.")
-            missing_cces = [x.dict['id'] for x in self.stats
-                            if x.dict['cce'] is None]
-            if missing_cces:
-                print("** Rules of '%s' profile missing CCE identifier:" %
-                      profile)
-                self.console_print(missing_cces, console_width)
-            else:
-                print("** All rules of '%s' " % profile + "profile have " +
-                      "CCE identifier assigned.")
-        print("\n")
-        self.stats = []
+        profile_stats = self.get_profile_stats(profile)
+        rules_count = profile_stats['rules_count']
+        impl_ovals_count = len(profile_stats['implemented_ovals'])
+        impl_fixes_count = len(profile_stats['implemented_fixes'])
+        impl_cces_count = len(profile_stats['assigned_cces'])
+
+        if not options.json:
+            print("\n* %s statistics of '%s' profile:" %
+                  (profile_stats['ssg_version'], profile))
+            print("** Count of rules: %d" % rules_count)
+            print("** Count of ovals: %d [%d%% complete]" %
+                  (impl_ovals_count, \
+                  profile_stats['implemented_ovals_pct']))
+            print("** Count of fixes: %d [%d%% complete]" %
+                  (impl_fixes_count, \
+                  profile_stats['implemented_fixes_pct']))
+            print("** Count of CCEs: %d [%d%% complete]" %
+                  (impl_cces_count, \
+                  profile_stats['assigned_cces_pct']))
+
+            if options.implemented_ovals and \
+               profile_stats['implemented_ovals']:
+                print("*** Rules of '%s' " % profile +
+                      "profile having OVAL check: %d of %d [%d%% complete]" %
+                      (impl_ovals_count, rules_count,
+                      profile_stats['implemented_ovals_pct']))
+                self.console_print(profile_stats['implemented_ovals'],
+                                   console_width)
+
+            if options.implemented_fixes and \
+               profile_stats['implemented_fixes']:
+                print("*** Rules of '%s' " % profile + "profile having " +
+                      "remediation script: %d of %d [%d%% complete]" %
+                      (impl_fixes_count, rules_count,
+                      profile_stats['implemented_fixes_pct']))
+                self.console_print(profile_stats['implemented_fixes'],
+                                   console_width)
+
+            if options.assigned_cces and \
+               profile_stats['assigned_cces']:
+                print("*** Rules of '%s' " % profile +
+                      "profile having CCE assigned: %d of %d [%d%% complete]" %
+                      (impl_cces_count, rules_count,
+                      profile_stats['assigned_cces_pct']))
+                self.console_print(profile_stats['assigned_cces'],
+                                   console_width)
+
+            if options.missing_ovals and profile_stats['missing_ovals']:
+                print("*** Rules of '%s' " % profile + "profile missing " +
+                      "OVAL: %d of %d [%d%% complete]" %
+                      (rules_count - impl_ovals_count, rules_count,
+                      profile_stats['implemented_ovals_pct']))
+                self.console_print(profile_stats['missing_ovals'],
+                                   console_width)
+
+            if options.missing_fixes and profile_stats['missing_fixes']:
+                print("*** Rules of '%s' " % profile + "profile missing " +
+                      "remediation: %d of %d [%d%% complete]" %
+                      (rules_count - impl_fixes_count, rules_count,
+                      profile_stats['implemented_fixes_pct']))
+                self.console_print(profile_stats['missing_fixes'],
+                                   console_width)
+
+            if options.missing_cces and profile_stats['missing_cces']:
+                print("***Rules of '%s' " % profile + "profile missing " +
+                      "CCE identifier: %d of %d [%d%% complete]" %
+                      (rules_count - impl_cces_count, rules_count,
+                      profile_stats['assigned_cces_pct']))
+                self.console_print(profile_stats['missing_cces'],
+                                   console_width)
+
+        else:
+            # First delete the not requested information
+            if not options.missing_ovals:
+                del profile_stats['missing_ovals']
+            if not options.missing_fixes:
+                del profile_stats['missing_fixes']
+            if not options.missing_cces:
+                del profile_stats['missing_cces']
+            if not options.implemented_ovals:
+                del profile_stats['implemented_ovals']
+                del profile_stats['implemented_ovals_pct']
+            if not options.implemented_fixes:
+                del profile_stats['implemented_fixes']
+                del profile_stats['implemented_fixes_pct']
+            if not options.assigned_cces:
+                del profile_stats['assigned_cces']
+                del profile_stats['assigned_cces_pct']
+
+            # Then json dump the rest
+            print json.dumps(profile_stats, indent = 4)
 
     def console_print(self, content, width):
         """Prints the 'content' array left aligned, each time 45 characters
@@ -145,14 +262,43 @@ def parse_options():
     parser = optparse.OptionParser(usage=script_usage, version="%prog 1.0")
     parser.add_option("-p", "--profile", default=False,
                       action="store", dest="profile",
-                      help="Show statistics for this XCCDF Profile only")
+                      help="Show statistics for this XCCDF Profile only.")
     parser.add_option("-b", "--benchmark", default=False,
                       action="store", dest="benchmark_file",
-                      help="Specify XCCDF benchmark to act on")
-    parser.add_option("--full-stats", default=False,
-                      action="store_true", dest="full_stats",
-                      help="Show advanced statistics (missing OVALs, "
-                      "remediations, and CCE identifiers)")
+                      help="Specify XCCDF benchmark to act on.")
+    parser.add_option("--implemented-ovals", default=False,
+                      action="store_true", dest="implemented_ovals",
+                      help="Show also IDs of implemented OVAL checks.")
+    parser.add_option("--missing-ovals", default=False,
+                      action="store_true", dest="missing_ovals",
+                      help="Show also IDs of unimplemented OVAL checks.")
+    parser.add_option("--implemented-fixes", default=False,
+                      action="store_true", dest="implemented_fixes",
+                      help="Show also IDs of implemented remediations.")
+    parser.add_option("--missing-fixes", default=False,
+                      action="store_true", dest="missing_fixes",
+                      help="Show also IDs of unimplemented remediations.")
+    parser.add_option("--assigned-cces", default=False,
+                      action="store_true", dest="assigned_cces",
+                      help="Show IDs of rules having CCE assigned.")
+    parser.add_option("--missing-cces", default=False,
+                      action="store_true", dest="missing_cces",
+                      help="Show IDs of rules missing CCE element.")
+    parser.add_option("--implemented", default=False,
+                      action="store_true", dest="implemented",
+                      help="Equivalent like --implemented-ovals, \
+                      --implemented_fixes, and --assigned-cves \
+                      would be set.")
+    parser.add_option("--missing", default=False,
+                      action="store_true", dest="missing",
+                      help="Equivalent like --missing-ovals, --missing-fixes, \
+                      and --missing-cces would be set.")
+    parser.add_option("--all", default=False,
+                      action="store_true", dest="all",
+                      help="Show all available statistics.")
+    parser.add_option("--json", default=False,
+                      action="store_true", dest="json",
+                      help="Show the statistics in json file format.")
 
     (options, args) = parser.parse_args()
     if not options.benchmark_file:
@@ -163,19 +309,42 @@ def parse_options():
     return (options, args)
 
 
+def propagate_options(options):
+    """Propagate child option values depending on selected parent options
+       being specified"""
+
+    if options.all:
+        options.implemented = True
+        options.missing = True
+
+    if options.implemented:
+        options.implemented_ovals = True
+        options.implemented_fixes = True
+        options.assigned_cces = True
+
+    if options.missing:
+        options.missing_ovals = True
+        options.missing_fixes = True
+        options.missing_cces = True
+
+    return options
+
+
 def main():
     (options, args) = parse_options()
 
+    options = propagate_options(options)
     benchmark = XCCDFBenchmark(options.benchmark_file)
     if options.profile:
-        benchmark.show_profile_stats(options.profile, options.full_stats)
+        profile = options.profile
+        benchmark.show_profile_stats(profile, options)
     else:
         all_profile_elems = benchmark.tree.findall("./{%s}Profile" %
                                                    (xccdf_ns))
         for elem in all_profile_elems:
             profile = elem.get('id')
             if profile is not None:
-                benchmark.show_profile_stats(profile, options.full_stats)
+                benchmark.show_profile_stats(profile, options)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
It to be able also to:

* Print also implemented OVALs, remediations, and CCEs assigned (this could be handy to create release notes / diffs across releases easily),
* Print the stats in the form of JSON file if --json option was provided (suitable for further machine processing)

Please review.

Thank you, Jan