### PR TITLE
Issue #1346: Add a check for configuration of Docker storage driver

### DIFF
--- a/RHEL/7/input/oval/oval_5.11/docker_storage_configured.xml
+++ b/RHEL/7/input/oval/oval_5.11/docker_storage_configured.xml
@@ -1,0 +1,69 @@
+<def-group>
+
+  <definition class="compliance" id="docker_storage_configured" version="1">
+    <metadata>
+      <title>Use direct-lvm with device mapper storage driver</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>To use Docker in production with the device mapper storage driver, the Docker daemon should be configured to use direct-lvm instead of loopback device as a storage.</description>
+    </metadata>
+    <criteria operator="OR">
+      <criteria operator="AND">
+        <extend_definition comment="docker service is active on system" definition_ref="service_docker_enabled"/>
+        <criteria operator="OR">
+          <criteria operator="AND">
+            <criterion comment="Docker uses devicemapper as a storage driver" test_ref="test_docker_devicemapper"/>
+            <criterion comment="Docker is configured to use a thinpool device" test_ref="test_docker_thinpool_device"/>
+            <criterion comment="The thinpool device configured to be used by Docker exists on the system" test_ref="test_device_exists"/>
+          </criteria>
+          <criterion comment="Docker does not use devicemapper as a storage driver" test_ref="test_docker_devicemapper" negate="true"/>
+        </criteria>
+      </criteria>
+      <extend_definition comment="Docker service is inactive on system" definition_ref="service_docker_enabled" negate="true"/>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="Check if the docker storage configuration files contain STORAGE_DRIVER=devicemapper" id="test_docker_devicemapper" version="1" >
+    <ind:object object_ref="obj_docker_storage_driver"/>
+    <ind:state state_ref="state_docker_storage_driver"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test check="at least one" check_existence="all_exist" comment="Ensure the docker storage configuration files contain --storage-opt dm.thinpooldev set" id="test_docker_thinpool_device" version="1" >
+    <ind:object object_ref="obj_storage_device_path" />
+  </ind:textfilecontent54_test>
+
+  <unix:file_test check="at least one" comment="Ensure the file specified as thinpool device exists" id="test_device_exists" version="1" >
+    <unix:object object_ref="obj_storage_device"/>
+  </unix:file_test>
+
+  <ind:textfilecontent54_object id="obj_storage_device_path" version="1">
+    <ind:filepath operation="equals" var_ref="var_configuration_files_storage" var_check="at least one" />
+      <ind:pattern operation="pattern match">^(?!#).*(?:--storage-opt[\s=]dm\.thinpooldev=([^\s]*)).*$</ind:pattern>
+    <ind:instance operation="equals" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_docker_storage_driver" version="1">
+    <ind:filepath operation="equals" var_ref="var_configuration_files_storage" var_check="at least one" />
+    <ind:pattern operation="pattern match">^(?!#)\s*STORAGE_DRIVER\s*=\s*"?([a-z]*)"?\s*$</ind:pattern>
+    <ind:instance operation="equals" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <unix:file_object id="obj_storage_device" version="1" comment="Thinpool device">
+    <unix:filepath operation="equals" var_ref="var_storage_device" var_check="at least one" />
+  </unix:file_object>
+
+  <ind:textfilecontent54_state id="state_docker_storage_driver" version="1" comment="devicemapper storage driver">
+    <ind:subexpression operation="equals">devicemapper</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <constant_variable id="var_configuration_files_storage" version="1" comment="Docker storage configuration files" datatype="string">
+    <value>/etc/sysconfig/docker-storage</value>
+    <value>/usr/lib/docker-storage-setup/docker-storage-setup</value>
+  </constant_variable>
+
+  <local_variable id="var_storage_device" version="1" comment="File specified in --storage-opt dm.thinpooldev" datatype="string">
+    <object_component object_ref="obj_storage_device_path" item_field="subexpression" />
+  </local_variable>
+
+</def-group>

--- a/RHEL/7/input/profiles/docker-host.xml
+++ b/RHEL/7/input/profiles/docker-host.xml
@@ -16,4 +16,6 @@
 
 <select idref="docker_selinux_enabled" selected="true" />
 
+<select idref="docker_storage_configured" selected="true" />
+
 </Profile>

--- a/RHEL/7/input/xccdf/services/docker.xml
+++ b/RHEL/7/input/xccdf/services/docker.xml
@@ -26,4 +26,23 @@ ossrg=""
 stigid="" />
 <oval id="service_docker_enabled" />
 </Rule>
+
+<Rule id="docker_storage_configured" severity="low">
+<title>Use direct-lvm with the Device Mapper Storage Driver</title>
+<description>
+To use Docker in production with the device mapper storage driver, the Docker
+daemon should be configured to use direct-lvm instead of loopback device as
+a storage. For setting up the LVM and configuring Docker, see the
+<a xmlns="http://www.w3.org/1999/xhtml" href="https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/">
+Docker Device Mapper Storage Documentation.</a>
+</description>
+<rationale>
+For using Docker in production, the device mapper storage driver with loopback
+devices is discouraged. The suggested way of configuring device mapper storage
+driver is direct-lvm. Choosing the right storage driver and backing filesystem
+is crucial to stability and performance.
+</rationale>
+<oval id="docker_storage_configured" />
+</Rule>
+
 </Group>


### PR DESCRIPTION
This new rule checks whether docker uses direct-lvm as a storage
with the device mapper storage driver.