### PR TITLE
[Enhancement][Infrastructure] Add XCCDF weblink macro

### DIFF
--- a/Debian/8/input/xccdf/services/ssh.xml
+++ b/Debian/8/input/xccdf/services/ssh.xml
@@ -5,7 +5,7 @@ SSH provides both confidentiality and integrity for exchanged data but needs to 
 Cryptography usage, according to the current CVEs associated to the various cryptographic modes<br />
 Authentication and autorization, depending on your needs but requiring some specific initial generic security<br />
 consideration in the OpenSSH configuration writing
-More detailed information is available from the OpenSSH project's website http://www.openssh.org. The Debian package for
+More detailed information is available from the OpenSSH project's website <weblink-macro link="http://www.openssh.org"/>. The Debian package for
 server side implementation is called <tt>openssh-server</tt>.
 </description>
 

--- a/Fedora/input/xccdf/services/ntp.xml
+++ b/Fedora/input/xccdf/services/ntp.xml
@@ -26,7 +26,7 @@ internal servers.
 <br /><br />
 More information on how to configure the NTP server software,
 including configuration of cryptographic authentication for
-time data, is available at http://www.ntp.org.
+time data, is available at <weblink-macro link="http://www.ntp.org"/>.
 </description>
 
 <Rule id="service_chronyd_enabled" severity="medium">
@@ -45,7 +45,7 @@ logs and auditing possible security breaches.
 <br /><br />
 The chrony daemon offers all of the functionality of <tt>ntpdate</tt>, which is now 
 deprecated.  Additional information on this is available at 
-http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate</rationale>
+<weblink-macro link="http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate"/></rationale>
 <oval id="service_chronyd_enabled" />
 <ref nist="AU-8(1)" disa="160" />
 </Rule>

--- a/Fedora/input/xccdf/services/ssh.xml
+++ b/Fedora/input/xccdf/services/ssh.xml
@@ -5,7 +5,7 @@ transfer. SSH provides confidentiality and integrity for data exchanged between
 two systems, as well as server authentication, through the use of public key
 cryptography. The implementation included with the system is called OpenSSH,
 and more detailed documentation is available from its website,
-http://www.openssh.org. Its server program is called <tt>sshd</tt> and
+<weblink-macro link="http://www.openssh.org"/>. Its server program is called <tt>sshd</tt> and
 provided by the RPM package <tt>openssh-server</tt>.</description>
 
 <Value id="sshd_idle_timeout_value" type="number" operator="equals" interactive="0">

--- a/Fedora/input/xccdf/system/accounts/pam.xml
+++ b/Fedora/input/xccdf/system/accounts/pam.xml
@@ -39,7 +39,8 @@ most users.</warning>
 files, destroying any manually made changes and replacing them with
 a series of system defaults. One reference to the configuration
 file syntax can be found at
-http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html.</warning>
+<weblink-macro link="http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html"/>
+.</warning>
 
 <Value id="var_password_pam_unix_remember" type="number"
 operator="equals" interactive="0">

--- a/Fedora/input/xccdf/system/accounts/physical.xml
+++ b/Fedora/input/xccdf/system/accounts/physical.xml
@@ -116,7 +116,7 @@ important bootloader settings. These include which kernel to use,
 and whether to enter single-user mode. For more information on how to configure 
 the grub2 superuser account and password, please refer to 
 <ul>
-<li>https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-GRUB_2_Password_Protection.html</li>.
+<li><weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-GRUB_2_Password_Protection.html"/></li>.
 </ul>
 </rationale>
 <oval id="bootloader_password" />
@@ -349,7 +349,7 @@ is not enabled by default and must be enabled in the system settings.
 <description>
 To enable smart card authentication, consult the documentation at:
 <ul>
-<li>https://docs.fedoraproject.org/docs/en-US/Fedora/18/html/Security_Guide/sect-Security_Guide-Single_Sign_on_SSO-Getting_Started_with_your_new_Smart_Card.html</li>
+<li><weblink-macro link="https://docs.fedoraproject.org/docs/en-US/Fedora/18/html/Security_Guide/sect-Security_Guide-Single_Sign_on_SSO-Getting_Started_with_your_new_Smart_Card.html"/></li>
 </ul>
 </description>
 <ocil clause="non-exempt accounts are not using CAC authentication">

--- a/Fedora/input/xccdf/system/auditing.xml
+++ b/Fedora/input/xccdf/system/auditing.xml
@@ -34,7 +34,7 @@ requirements.
 Examining some example audit records demonstrates how the Linux audit system
 satisfies common requirements.
 The following example from Fedora Documentation available at
-<tt>http://docs.fedoraproject.org/en-US/Fedora/22/html/SELinux_Users_and_Administrators_Guide/sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages.html</tt>
+<tt><weblink-macro link="http://docs.fedoraproject.org/en-US/Fedora/22/html/SELinux_Users_and_Administrators_Guide/sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages.html"/></tt>
 shows the substantial amount of information captured in a
 two typical "raw" audit messages, followed by a breakdown of the most important
 fields. In this example the message is SELinux-related and reports an AVC

--- a/Fedora/input/xccdf/system/network/ssl.xml
+++ b/Fedora/input/xccdf/system/network/ssl.xml
@@ -8,6 +8,6 @@ communications, and many network services include support for it.  TLS or SSL
 can be leveraged to avoid any plaintext transmission of sensitive data.
 <br/>
 For information on how to use OpenSSL, see
-<b>http://www.openssl.org/docs/HOWTO/</b>.
+<b><weblink-macro link="http://www.openssl.org/docs/HOWTO/"/></b>.
 </description>
 </Group>

--- a/Fedora/input/xccdf/system/software/gnome.xml
+++ b/Fedora/input/xccdf/system/software/gnome.xml
@@ -9,7 +9,7 @@ switching contexts as well as display server management.
 GNOME is developed by the GNOME Project and is considered the default
 Fedora Graphical environment.
 <br/><br/>
-For more information on GNOME and the GNOME Project, see <b>https://www.gnome.org</b>
+For more information on GNOME and the GNOME Project, see <b><weblink-macro link="https://www.gnome.org"/></b>
 </description>
 
 <Rule id="enable_dconf_user_profile" severity="high">
@@ -52,7 +52,7 @@ login automatically and/or with a guest account. The login screen should be conf
 to prevent such behavior.
 <br /><br />
 For more information about enforcing preferences in the GNOME3 environment using the DConf
-configuration system, see <b>https://wiki.gnome.org/Projects/dconf/SystemAdministrators</b> and the man page <tt>dconf(1)</tt>.
+configuration system, see <b><weblink-macro link="https://wiki.gnome.org/Projects/dconf/SystemAdministrators"/></b> and the man page <tt>dconf(1)</tt>.
 </description>
 
 <Rule id="gnome_gdm_disable_automatic_login" severity="high">
@@ -261,9 +261,9 @@ The root account can be screen-locked; however, the root account should
 be used to for direct login via console in emergency circumstances.
 <br /><br />
 For more information about enforcing preferences in the GNOME3 environment using the DConf
-configuration system, see <b>http://wiki.gnome.org/dconf</b> and
+configuration system, see <b><weblink-macro link="http://wiki.gnome.org/dconf"/></b> and
 the man page <tt>dconf(1)</tt>. For Red Hat specific information on configuring DConf
-settings, see <b>https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Desktop_Migration_and_Administration_Guide/part-Configuration_and_Administration.html</b>
+settings, see <b><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Desktop_Migration_and_Administration_Guide/part-Configuration_and_Administration.html"/></b>
 </description>
 
 <Value id="inactivity_timeout_value" type="number" operator="equals">

--- a/Firefox/input/xccdf/application/firefox.xml
+++ b/Firefox/input/xccdf/application/firefox.xml
@@ -5,7 +5,7 @@ Web browsers such as Firefox are used for a number of reasons. This section
 provides settings for configuring Firefox policies to meet compliance 
 settings for Firefox running on Red Hat Enterprise Linux systems.
 
-<ul>Refer to <li>http://kb.mozillazine.org/Firefox_:_FAQs_:_About:config_Entries</li>
+<ul>Refer to <li><weblink-macro link="http://kb.mozillazine.org/Firefox_:_FAQs_:_About:config_Entries"/></li>
 for a list of currently supported Firefox settings.</ul>
 </description>
 
@@ -534,7 +534,7 @@ If the system is not configured to update from one of these sources,
 run the following command to list when each package was last updated:
 <pre>$ rpm -qa -last</pre>
 Compare this to Red Hat Security Advisories (RHSA) listed at
-https://access.redhat.com/security/updates/active/
+<weblink-macro link="https://access.redhat.com/security/updates/active/"/>
 to determine if the system is missing applicable updates.
 </ocil>
 <rationale>

--- a/RHEL/5/input/xccdf/services/ldap.xml
+++ b/RHEL/5/input/xccdf/services/ldap.xml
@@ -17,7 +17,7 @@ much control over configuration as manual editing of configuration files. The
 authconfig tools do not allow you to specify locations of SSL certificate
 files, which is useful when trying to use SSL cleanly across several protocols.
 Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 5 is available at
-https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/5/html/Deployment_Guide/ch-ldap.html.
+<weblink-macro link="https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/5/html/Deployment_Guide/ch-ldap.html"/>.
 </description>
 <warning category="general">Before configuring any system to be an
 LDAP client, ensure that a working LDAP server is present on the

--- a/RHEL/5/input/xccdf/services/mail.xml
+++ b/RHEL/5/input/xccdf/services/mail.xml
@@ -20,7 +20,7 @@ The <tt>alternatives</tt> program in Red Hat Enterprise Linux permits selection 
 (such as Sendmail), but Postfix is the default and is preferred.
 Postfix was coded with security in mind and can also be more effectively contained by
 SELinux as its modular design has resulted in separate processes performing specific actions.
-More information is available on its website, http://www.postfix.org.
+More information is available on its website, <weblink-macro link="http://www.postfix.org"/>.
 </description>
 
 <Rule id="mail_up_to_date" severity="high">
@@ -108,7 +108,7 @@ The <tt>alternatives</tt> program in Red Hat Enterprise Linux permits selection 
 (such as Sendmail), but Postfix is the default and is preferred.
 Postfix was coded with security in mind and can also be more effectively contained by
 SELinux as its modular design has resulted in separate processes performing specific actions.
-More information is available on its website, http://www.postfix.org.
+More information is available on its website, <weblink-macro link="http://www.postfix.org"/>.
 </description>
 
 <Rule id="mail_debug_enabled" severity="high">

--- a/RHEL/5/input/xccdf/services/ntp.xml
+++ b/RHEL/5/input/xccdf/services/ntp.xml
@@ -26,7 +26,7 @@ internal servers.
 <br /><br />
 More information on how to configure the NTP server software,
 including configuration of cryptographic authentication for
-time data, is available at http://www.ntp.org.
+time data, is available at <weblink-macro link="http://www.ntp.org"/>.
 </description>
 
 <Rule id="service_ntpd_enabled" severity="medium">
@@ -45,7 +45,7 @@ logs and auditing possible security breaches.
 <br /><br />
 The NTP daemon offers all of the functionality of <tt>ntpdate</tt>, which is now 
 deprecated.  Additional information on this is available at 
-http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate</rationale>
+<weblink-macro link="http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate"/></rationale>
 <ident stig="GEN000241" />
 <oval id="service_ntpd_enabled" />
 <ref nist="ECSC-1" disa="366" />

--- a/RHEL/5/input/xccdf/services/ssh.xml
+++ b/RHEL/5/input/xccdf/services/ssh.xml
@@ -6,7 +6,7 @@ for data exchanged between two systems, as well as server
 authentication, through the use of public key cryptography. The
 implementation included with the system is called OpenSSH, and more
 detailed documentation is available from its website,
-http://www.openssh.org. Its server program is called <tt>sshd</tt> and
+<weblink-macro link="http://www.openssh.org"/>. Its server program is called <tt>sshd</tt> and
 provided by the RPM package <tt>openssh-server</tt>.</description>
 
 <Group id="ssh_server">

--- a/RHEL/5/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/5/input/xccdf/system/accounts/pam.xml
@@ -39,7 +39,7 @@ most users.</warning>
 files, destroying any manually made changes and replacing them with
 a series of system defaults. One reference to the configuration
 file syntax can be found at
-http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html.</warning>
+<weblink-macro link="http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html"/>.</warning>
 
 <Rule id="accounts_global_setting">
 <title>Configure Global Account Settings</title>

--- a/RHEL/5/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/5/input/xccdf/system/accounts/physical.xml
@@ -264,9 +264,9 @@ to log into an X Windows environment, and should only be used to
 for direct login via console in emergency circumstances.
 <br /><br />
 For more information about configuring GNOME screensaver, see
-http://live.gnome.org/GnomeScreensaver. For more information about
+<weblink-macro link="http://live.gnome.org/GnomeScreensaver"/>. For more information about
 enforcing preferences in the GNOME environment using the GConf
-configuration system, see http://projects.gnome.org/gconf and
+configuration system, see <weblink-macro link="http://projects.gnome.org/gconf"/> and
 the man page <tt>gconftool-2(1)</tt>.</description>
 
 <Value id="inactivity_timeout_value" type="number" operator="equals">
@@ -378,7 +378,7 @@ is not enabled by default and must be enabled in the system settings.
 <description>
 To enable smart card authentication, consult the documentation at:
 <ul>
-<li>https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Managing_Smart_Cards/enabling-smart-card-login.html</li>
+<li><weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Managing_Smart_Cards/enabling-smart-card-login.html"/></li>
 </ul>
 </description>
 <ocil clause="non-exempt accounts are not using CAC authentication">

--- a/RHEL/5/input/xccdf/system/auditing.xml
+++ b/RHEL/5/input/xccdf/system/auditing.xml
@@ -14,7 +14,7 @@ requirements.
 Examining some example audit records demonstrates how the Linux audit system
 satisfies common requirements.  
 The following example from Fedora Documentation available at 
-<tt>http://docs.fedoraproject.org/en-US/Fedora/13/html/Security-Enhanced_Linux/sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages.html</tt>
+<tt><weblink-macro link="http://docs.fedoraproject.org/en-US/Fedora/13/html/Security-Enhanced_Linux/sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages.html"/></tt>
 shows the substantial amount of information captured in a
 two typical "raw" audit messages, followed by a breakdown of the most important
 fields. In this example the message is SELinux-related and reports an AVC

--- a/RHEL/5/input/xccdf/system/network/ssl.xml
+++ b/RHEL/5/input/xccdf/system/network/ssl.xml
@@ -8,9 +8,9 @@ communications, and many network services include support for it.  TLS or SSL
 can be leveraged to avoid any plaintext transmission of sensitive data.
 <br/>
 For information on how to use OpenSSL, see
-<b>http://www.openssl.org/docs/HOWTO/</b>.  Information on FIPS validation
-of OpenSSL is available at <b>http://www.openssl.org/docs/fips/fipsvalidation.html</b>
-and <b>http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm</b>.
+<b><weblink-macro link="http://www.openssl.org/docs/HOWTO/"/></b>.  Information on FIPS validation
+of OpenSSL is available at <b><weblink-macro link="http://www.openssl.org/docs/fips/fipsvalidation.html"/></b>
+and <b><weblink-macro link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm"/></b>.
 <!-- Does Red Hat offer any documentation on using OpenSSL? -->
 </description>
 </Group>

--- a/RHEL/5/input/xccdf/system/software/disk_partitioning.xml
+++ b/RHEL/5/input/xccdf/system/software/disk_partitioning.xml
@@ -21,7 +21,7 @@ If a system has already been installed, and the default
 partitioning scheme was used, it is possible but nontrivial to
 modify it to create separate logical volumes for the directories
 listed above. The Logical Volume Manager (LVM) makes this possible.
-See the LVM HOWTO at http://tldp.org/HOWTO/LVM-HOWTO/ for more
+See the LVM HOWTO at <weblink-macro link="http://tldp.org/HOWTO/LVM-HOWTO/"/> for more
 detailed information on LVM.</description>
 
 <Rule id="partition_for_tmp">

--- a/RHEL/5/input/xccdf/system/software/updating.xml
+++ b/RHEL/5/input/xccdf/system/software/updating.xml
@@ -59,7 +59,7 @@ If the system is not configured to update from one of these sources,
 run the following command to list when each package was last updated:
 <pre>$ rpm -qa -last</pre>
 Compare this to Red Hat Security Advisories (RHSA) listed at
-https://access.redhat.com/security/updates/active/
+<weblink-macro link="https://access.redhat.com/security/updates/active/"/>
 to determine if the system is missing applicable updates.
 </ocil>
 <rationale>

--- a/RHEL/6/input/xccdf/services/avahi.xml
+++ b/RHEL/6/input/xccdf/services/avahi.xml
@@ -40,7 +40,7 @@ to improve security. The Avahi daemon configuration file is
 <tt>/etc/avahi/avahi-daemon.conf</tt>. The following security recommendations
 should be applied to this file:
 See the <tt>avahi-daemon.conf(5)</tt> man page, or documentation at
-http://www.avahi.org, for more detailed information about the configuration options.
+<weblink-macro link="http://www.avahi.org"/>, for more detailed information about the configuration options.
 </description>
 
 <Rule id="avahi_ip_only">

--- a/RHEL/6/input/xccdf/services/http.xml
+++ b/RHEL/6/input/xccdf/services/http.xml
@@ -149,7 +149,7 @@ disabled in the configuration file by removing the corresponding LoadModule dire
 Note: A DSO only provides additional functionality if associated directives are included
 in the <tt>httpd</tt> configuration file. It should also be noted that removing a DSO will produce
 errors on <tt>httpd</tt> startup if the configuration file contains directives that apply to that
-module. Refer to <tt>http://httpd.apache.org/docs/</tt> for details on which directives
+module. Refer to <tt><weblink-macro link="http://httpd.apache.org/docs/"/></tt> for details on which directives
 are associated with each DSO.
 <br /><br />
 Following each DSO removal, the configuration can be tested with the following command
@@ -540,7 +540,7 @@ access possible in order to avoid unauthorized access to restricted content or s
 <Rule id="httpd_limit_available_methods">
 <title>Limit Available Methods</title>
 <description>
-Web server methods are defined in section 9 of RFC 2616 (http://www.ietf.org/rfc/rfc2616.txt).
+Web server methods are defined in section 9 of RFC 2616 (<weblink-macro link="http://www.ietf.org/rfc/rfc2616.txt"/>).
 If a web server does not require the implementation of all available methods,
 they should be disabled.
 <br /><br />
@@ -607,11 +607,11 @@ unauthorized parties.
 <description>
 The <tt>security</tt> module provides an application level firewall for <tt>httpd</tt>.
 Following its installation with the base ruleset, specific configuration advice can be found at
-http://www.modsecurity.org/ to design a policy that best matches the security needs of
+<weblink-macro link="http://www.modsecurity.org/"/> to design a policy that best matches the security needs of
 the web applications. Usage of <tt>mod_security</tt> is highly recommended for some environments,
 but it should be noted this module does not ship with Red Hat Enterprise Linux itself,
 and instead is provided via Extra Packages for Enterprise Linux (EPEL).
-For more information on EPEL please refer to http://fedoraproject.org/wiki/EPEL.
+For more information on EPEL please refer to <weblink-macro link="http://fedoraproject.org/wiki/EPEL"/>.
 </description>
 
 <Rule id="httpd_install_mod_security">

--- a/RHEL/6/input/xccdf/services/imap.xml
+++ b/RHEL/6/input/xccdf/services/imap.xml
@@ -1,7 +1,7 @@
 <Group id="imap">
 <title>IMAP and POP3 Server</title>
 <description>Dovecot provides IMAP and POP3 services. It is not
-installed by default. The project page at http://www.dovecot.org
+installed by default. The project page at <weblink-macro link="http://www.dovecot.org"/>
 contains more detailed information about Dovecot
 configuration.</description>
 

--- a/RHEL/6/input/xccdf/services/ldap.xml
+++ b/RHEL/6/input/xccdf/services/ldap.xml
@@ -17,7 +17,7 @@ much control over configuration as manual editing of configuration files. The
 authconfig tools do not allow you to specify locations of SSL certificate
 files, which is useful when trying to use SSL cleanly across several protocols.
 Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 6 is available at
-https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/ch-Directory_Servers.html.
+<weblink-macro link="https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/ch-Directory_Servers.html"/>.
 </description>
 <warning category="general">Before configuring any system to be an
 LDAP client, ensure that a working LDAP server is present on the
@@ -80,7 +80,7 @@ site CA.</rationale>
 <title>Configure OpenLDAP Server</title>
 <description>This section details some security-relevant settings
 for an OpenLDAP server.  Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 6 is available at:
-https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/ch-Directory_Servers.html.
+<weblink-macro link="https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/ch-Directory_Servers.html"/>.
 </description>
 
 <Rule id="package_openldap-servers_removed">

--- a/RHEL/6/input/xccdf/services/mail.xml
+++ b/RHEL/6/input/xccdf/services/mail.xml
@@ -20,7 +20,7 @@ The <tt>alternatives</tt> program in Red Hat Enterprise Linux permits selection 
 (such as Sendmail), but Postfix is the default and is preferred.
 Postfix was coded with security in mind and can also be more effectively contained by
 SELinux as its modular design has resulted in separate processes performing specific actions.
-More information is available on its website, http://www.postfix.org.
+More information is available on its website, <weblink-macro link="http://www.postfix.org"/>.
 </description>
 
 <Rule id="service_postfix_enabled">
@@ -244,7 +244,7 @@ and users of all other machines be required to use SMTP AUTH to send mail.
 <description>
 To configure Postfix to restrict addresses to which it
 will send mail, see:
-http://www.postfix.org/SMTPD_ACCESS_README.html#danger
+<weblink-macro link="http://www.postfix.org/SMTPD_ACCESS_README.html#danger"/>
 <br/>
 The full contents of <tt>smtpd_recipient_restrictions</tt> will
 vary by site, since this is a common place to put spam restrictions and other
@@ -262,7 +262,7 @@ another immediately unless SMTP AUTH is used.
 <description>
 To configure Postfix to restrict addresses to which it
 will send mail, see:
-http://www.postfix.org/SMTPD_ACCESS_README.html#danger
+<weblink-macro link="http://www.postfix.org/SMTPD_ACCESS_README.html#danger"/>
 <br/>
 The full contents of <tt>smtpd_recipient_restrictions</tt> will
 vary by site, since this is a common place to put spam restrictions and other
@@ -281,7 +281,7 @@ another immediately unless SMTP AUTH is used.
 requiring them to authenticate before submitting mail. Postfix's SMTP AUTH uses
 an authentication library called SASL, which is not part of Postfix itself.  To
 enable the use of SASL authentication, see
-http://www.postfix.org/SASL_README.html
+<weblink-macro link="http://www.postfix.org/SASL_README.html"/>
 </description>
 </Group>
 
@@ -292,7 +292,7 @@ Postfix provides options to use TLS for certificate-based
 authentication and encrypted sessions. An encrypted session protects the
 information that is transmitted with SMTP mail or with SASL authentication.
 To configure Postfix to protect all SMTP AUTH transactions
-using TLS, see http://www.postfix.org/TLS_README.html.
+using TLS, see <weblink-macro link="http://www.postfix.org/TLS_README.html"/>.
 </description>
 </Group>
 

--- a/RHEL/6/input/xccdf/services/ntp.xml
+++ b/RHEL/6/input/xccdf/services/ntp.xml
@@ -26,7 +26,7 @@ internal servers.
 <br /><br />
 More information on how to configure the NTP server software,
 including configuration of cryptographic authentication for
-time data, is available at http://www.ntp.org.
+time data, is available at <weblink-macro link="http://www.ntp.org"/>.
 </description>
 
 <Rule id="service_ntpd_enabled" severity="medium">
@@ -45,7 +45,7 @@ logs and auditing possible security breaches.
 <br /><br />
 The NTP daemon offers all of the functionality of <tt>ntpdate</tt>, which is now 
 deprecated.  Additional information on this is available at 
-http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate</rationale>
+<weblink-macro link="http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate"/></rationale>
 <ident cce="27093-4" stig="RHEL-06-000247" />
 <oval id="service_ntpd_enabled" />
 <ref nist="AU-8(1)" disa="160" />

--- a/RHEL/6/input/xccdf/services/printing.xml
+++ b/RHEL/6/input/xccdf/services/printing.xml
@@ -5,7 +5,7 @@ and network printing support. A system running the CUPS service can accept
 print jobs from other systems, process them, and send them to the appropriate
 printer. It also provides an interface for remote administration through a web
 browser. The CUPS service is installed and activated by default. The project
-homepage and more detailed documentation are available at http://www.cups.org.
+homepage and more detailed documentation are available at <weblink-macro link="http://www.cups.org"/>.
 <br /><br /> </description>
 
 <Rule id="service_cups_disabled">

--- a/RHEL/6/input/xccdf/services/ssh.xml
+++ b/RHEL/6/input/xccdf/services/ssh.xml
@@ -6,7 +6,7 @@ for data exchanged between two systems, as well as server
 authentication, through the use of public key cryptography. The
 implementation included with the system is called OpenSSH, and more
 detailed documentation is available from its website,
-http://www.openssh.org. Its server program is called <tt>sshd</tt> and
+<weblink-macro link="http://www.openssh.org"/>. Its server program is called <tt>sshd</tt> and
 provided by the RPM package <tt>openssh-server</tt>.</description>
 
 <Value id="sshd_idle_timeout_value" type="number"

--- a/RHEL/6/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/6/input/xccdf/system/accounts/pam.xml
@@ -39,7 +39,7 @@ most users.</warning>
 files, destroying any manually made changes and replacing them with
 a series of system defaults. One reference to the configuration
 file syntax can be found at
-http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html.</warning>
+<weblink-macro link="http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html"/>.</warning>
 
 <Value id="var_password_pam_unix_remember" type="number"
 operator="equals" interactive="0">

--- a/RHEL/6/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/6/input/xccdf/system/accounts/physical.xml
@@ -168,7 +168,7 @@ prompted before any action is taken.
 
 NOTE: When updating the <tt>initscripts</tt> package on a Red Hat Enterprise
 Linux 6 system, custom changes to <tt>/etc/init/control-alt-delete.conf</tt>
-may be overwritten. Refer to <b>https://access.redhat.com/site/solutions/70464</b>
+may be overwritten. Refer to <b><weblink-macro link="https://access.redhat.com/site/solutions/70464"/></b>
 for additional information.
 </rationale>
 <warning category="general">Disabling the <tt>Ctrl-Alt-Del</tt> key sequence
@@ -273,11 +273,11 @@ is not enabled by default and must be enabled in the system settings.
 <description>
 To enable smart card authentication, consult the documentation at:
 <ul>
-<li><b>https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Managing_Smart_Cards/enabling-smart-card-login.html</b></li>
+<li><b><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Managing_Smart_Cards/enabling-smart-card-login.html"/></b></li>
 </ul>
 For guidance on enabling SSH to authenticate against a Common Access Card (CAC), consult documentation at:
 <ul>
-<li><b>https://access.redhat.com/solutions/82273</b></li>
+<li><b><weblink-macro link="https://access.redhat.com/solutions/82273"/></b></li>
 </ul>
 </description>
 <ocil clause="non-exempt accounts are not using CAC authentication">

--- a/RHEL/6/input/xccdf/system/auditing.xml
+++ b/RHEL/6/input/xccdf/system/auditing.xml
@@ -14,7 +14,7 @@ requirements.
 Examining some example audit records demonstrates how the Linux audit system
 satisfies common requirements.  
 The following example from Fedora Documentation available at 
-<tt>http://docs.fedoraproject.org/en-US/Fedora/13/html/Security-Enhanced_Linux/sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages.html</tt>
+<tt><weblink-macro link="http://docs.fedoraproject.org/en-US/Fedora/13/html/Security-Enhanced_Linux/sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages.html"/></tt>
 shows the substantial amount of information captured in a
 two typical "raw" audit messages, followed by a breakdown of the most important
 fields. In this example the message is SELinux-related and reports an AVC

--- a/RHEL/6/input/xccdf/system/network/ssl.xml
+++ b/RHEL/6/input/xccdf/system/network/ssl.xml
@@ -8,9 +8,9 @@ communications, and many network services include support for it.  TLS or SSL
 can be leveraged to avoid any plaintext transmission of sensitive data.
 <br/>
 For information on how to use OpenSSL, see
-<b>http://www.openssl.org/docs/HOWTO/</b>.  Information on FIPS validation
-of OpenSSL is available at <b>http://www.openssl.org/docs/fips/fipsvalidation.html</b>
-and <b>http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm</b>.
+<b><weblink-macro link="http://www.openssl.org/docs/HOWTO/"/></b>.  Information on FIPS validation
+of OpenSSL is available at <b><weblink-macro link="http://www.openssl.org/docs/fips/fipsvalidation.html"/></b>
+and <b><weblink-macro link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm"/></b>.
 <!-- Does Red Hat offer any documentation on using OpenSSL? -->
 </description>
 </Group>

--- a/RHEL/6/input/xccdf/system/software/disk_partitioning.xml
+++ b/RHEL/6/input/xccdf/system/software/disk_partitioning.xml
@@ -21,7 +21,7 @@ If a system has already been installed, and the default
 partitioning scheme was used, it is possible but nontrivial to
 modify it to create separate logical volumes for the directories
 listed above. The Logical Volume Manager (LVM) makes this possible.
-See the LVM HOWTO at http://tldp.org/HOWTO/LVM-HOWTO/ for more
+See the LVM HOWTO at <weblink-macro link="http://tldp.org/HOWTO/LVM-HOWTO/"/> for more
 detailed information on LVM.</description>
 
 <Rule id="partition_for_tmp">
@@ -148,7 +148,7 @@ installer to pause and interactively ask for the passphrase during installation.
 <br /><br />
 Detailed information on encrypting partitions using LUKS can be found on
 the Red Hat Documentation web site:<br />
-https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security_Guide/chap-Security_Guide-Encryption.html#sect-Security_Guide-LUKS_Disk_Encryption
+<weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security_Guide/chap-Security_Guide-Encryption.html#sect-Security_Guide-LUKS_Disk_Encryption"/>
 </description>
 <ocil clause="encryption must be used and is not employed">
 Determine if encryption must be used to protect data on the system. 

--- a/RHEL/6/input/xccdf/system/software/gnome.xml
+++ b/RHEL/6/input/xccdf/system/software/gnome.xml
@@ -9,7 +9,7 @@ switching contexts as well as display server management.
 GNOME is developed by the GNOME Project and is considered the default
 Red Hat Graphical environment.
 <br/><br/>
-For more information on GNOME and the GNOME Project, see <b>https://www.gnome.org</b>
+For more information on GNOME and the GNOME Project, see <b><weblink-macro link="https://www.gnome.org"/></b>
 </description>
 
 <Group id="gnome_login_screen">
@@ -20,7 +20,7 @@ login automatically and/or with a guest account. The login screen should be conf
 to prevent such behavior.
 <br /><br />
 For more information about enforcing preferences in the GNOME environment using the GConf
-configuration system, see <b>http://projects.gnome.org/gconf</b> and
+configuration system, see <b><weblink-macro link="http://projects.gnome.org/gconf"/></b> and
 the man page <tt>gconftool-2(1)</tt>.
 </description>
 
@@ -154,9 +154,9 @@ to log into an X Windows environment, and should only be used to
 for direct login via console in emergency circumstances.
 <br /><br />
 For more information about configuring GNOME screensaver, see
-<b>http://live.gnome.org/GnomeScreensaver</b>. For more information about
+<b><weblink-macro link="http://live.gnome.org/GnomeScreensaver"/></b>. For more information about
 enforcing preferences in the GNOME environment using the GConf
-configuration system, see <b>http://projects.gnome.org/gconf</b> and
+configuration system, see <b><weblink-macro link="http://projects.gnome.org/gconf"/></b> and
 the man page <tt>gconftool-2(1)</tt>.</description>
 
 <Value id="inactivity_timeout_value" type="number" operator="equals">

--- a/RHEL/6/input/xccdf/system/software/integrity.xml
+++ b/RHEL/6/input/xccdf/system/software/integrity.xml
@@ -280,7 +280,7 @@ FIPS 140-2 is the current standard for validating that mechanisms used to access
 utilize authentication that meets industry and government requirements. For government systems, this allows
 Security Levels 1, 2, 3, or 4 for use on Red Hat Enterprise Linux.
 <br /><br />
-See <b>http://csrc.nist.gov/publications/PubsFIPS.html</b> for more information.
+See <b><weblink-macro link="http://csrc.nist.gov/publications/PubsFIPS.html"/></b> for more information.
 </description>
 
 <Rule id="package_dracut-fips_installed" severity="medium">
@@ -332,7 +332,7 @@ Red Hat, Inc. and Red Hat Enterprise Linux are respectively FIPS certified and c
 projects such as CentOS, Scientific Linux, etc. do not necessarily meet FIPS certification and compliancy.
 Therefore, non-certified vendors and/or projects do not meet this requirement even if technically feasible.
 <br /><br />
-See <b>http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/1401vend.htm</b> for a list of FIPS certified
+See <b><weblink-macro link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/1401vend.htm"/></b> for a list of FIPS certified
 vendors.</warning>
 <ident cce="RHEL6-CCE-TBD" />
 <oval id="grub_enable_fips_mode" />

--- a/RHEL/6/input/xccdf/system/software/updating.xml
+++ b/RHEL/6/input/xccdf/system/software/updating.xml
@@ -123,7 +123,7 @@ If the system is not configured to update from one of these sources,
 run the following command to list when each package was last updated:
 <pre>$ rpm -qa -last</pre>
 Compare this to Red Hat Security Advisories (RHSA) listed at
-https://access.redhat.com/security/updates/active/
+<weblink-macro link="https://access.redhat.com/security/updates/active/"/>
 to determine if the system is missing applicable updates.
 </ocil>
 <rationale>

--- a/RHEL/7/input/xccdf/services/avahi.xml
+++ b/RHEL/7/input/xccdf/services/avahi.xml
@@ -40,7 +40,8 @@ to improve security. The Avahi daemon configuration file is
 <tt>/etc/avahi/avahi-daemon.conf</tt>. The following security recommendations
 should be applied to this file:
 See the <tt>avahi-daemon.conf(5)</tt> man page, or documentation at
-http://www.avahi.org, for more detailed information about the configuration options.
+<weblink-macro link="http://www.avahi.org"/>, for more detailed information
+about the configuration options.
 </description>
 
 <Rule id="avahi_ip_only">

--- a/RHEL/7/input/xccdf/services/docker.xml
+++ b/RHEL/7/input/xccdf/services/docker.xml
@@ -33,8 +33,8 @@ stigid="" />
 To use Docker in production with the device mapper storage driver, the Docker
 daemon should be configured to use direct-lvm instead of loopback device as
 a storage. For setting up the LVM and configuring Docker, see the
-<a xmlns="http://www.w3.org/1999/xhtml" href="https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/">
-Docker Device Mapper Storage Documentation.</a>
+<weblink-macro link="https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/"
+text="Docker Device Mapper Storage Documentation"/>.
 </description>
 <rationale>
 For using Docker in production, the device mapper storage driver with loopback

--- a/RHEL/7/input/xccdf/services/http.xml
+++ b/RHEL/7/input/xccdf/services/http.xml
@@ -149,7 +149,7 @@ disabled in the configuration file by removing the corresponding LoadModule dire
 Note: A DSO only provides additional functionality if associated directives are included
 in the <tt>httpd</tt> configuration file. It should also be noted that removing a DSO will produce
 errors on <tt>httpd</tt> startup if the configuration file contains directives that apply to that
-module. Refer to <tt>http://httpd.apache.org/docs/</tt> for details on which directives
+module. Refer to <tt><weblink-macro link="http://httpd.apache.org/docs/"/></tt> for details on which directives
 are associated with each DSO.
 <br /><br />
 Following each DSO removal, the configuration can be tested with the following command
@@ -540,7 +540,7 @@ access possible in order to avoid unauthorized access to restricted content or s
 <Rule id="httpd_limit_available_methods">
 <title>Limit Available Methods</title>
 <description>
-Web server methods are defined in section 9 of RFC 2616 (http://www.ietf.org/rfc/rfc2616.txt).
+Web server methods are defined in section 9 of RFC 2616 (<weblink-macro link="http://www.ietf.org/rfc/rfc2616.txt"/>).
 If a web server does not require the implementation of all available methods,
 they should be disabled.
 <br /><br />
@@ -607,7 +607,7 @@ unauthorized parties.
 <description>
 The <tt>security</tt> module provides an application level firewall for <tt>httpd</tt>.
 Following its installation with the base ruleset, specific configuration advice can be found at
-http://www.modsecurity.org/ to design a policy that best matches the security needs of
+<weblink-macro link="http://www.modsecurity.org/"/> to design a policy that best matches the security needs of
 the web applications. Usage of <tt>mod_security</tt> is highly recommended for some environments,
 but it should be noted this module does not ship with Red Hat Enterprise Linux itself,
 and instead is provided via Extra Packages for Enterprise Linux (EPEL).

--- a/RHEL/7/input/xccdf/services/imap.xml
+++ b/RHEL/7/input/xccdf/services/imap.xml
@@ -1,7 +1,7 @@
 <Group id="imap">
 <title>IMAP and POP3 Server</title>
 <description>Dovecot provides IMAP and POP3 services. It is not
-installed by default. The project page at http://www.dovecot.org
+installed by default. The project page at <weblink-macro link="http://www.dovecot.org"/>
 contains more detailed information about Dovecot
 configuration.</description>
 

--- a/RHEL/7/input/xccdf/services/ldap.xml
+++ b/RHEL/7/input/xccdf/services/ldap.xml
@@ -17,7 +17,7 @@ much control over configuration as manual editing of configuration files. The
 authconfig tools do not allow you to specify locations of SSL certificate
 files, which is useful when trying to use SSL cleanly across several protocols.
 Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at
-https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Directory_Servers.html.
+<weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Directory_Servers.html"/>.
 </description>
 <warning category="general">Before configuring any system to be an
 LDAP client, ensure that a working LDAP server is present on the
@@ -81,7 +81,7 @@ site CA.</rationale>
 <title>Configure OpenLDAP Server</title>
 <description>This section details some security-relevant settings
 for an OpenLDAP server.  Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at:
-https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Directory_Servers.html.
+<weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Directory_Servers.html"/>.
 </description>
 
 <Rule id="package_openldap-servers_removed">

--- a/RHEL/7/input/xccdf/services/mail.xml
+++ b/RHEL/7/input/xccdf/services/mail.xml
@@ -20,7 +20,7 @@ The <tt>alternatives</tt> program in Red Hat Enterprise Linux permits selection 
 (such as Sendmail), but Postfix is the default and is preferred.
 Postfix was coded with security in mind and can also be more effectively contained by
 SELinux as its modular design has resulted in separate processes performing specific actions.
-More information is available on its website, http://www.postfix.org.
+More information is available on its website, <weblink-macro link="http://www.postfix.org"/>.
 </description>
 
 <Rule id="service_postfix_enabled">
@@ -244,7 +244,7 @@ and users of all other machines be required to use SMTP AUTH to send mail.
 <description>
 To configure Postfix to restrict addresses to which it
 will send mail, see:
-http://www.postfix.org/SMTPD_ACCESS_README.html#danger
+<weblink-macro link="http://www.postfix.org/SMTPD_ACCESS_README.html#danger"/>
 <br/>
 The full contents of <tt>smtpd_recipient_restrictions</tt> will
 vary by site, since this is a common place to put spam restrictions and other
@@ -262,7 +262,7 @@ another immediately unless SMTP AUTH is used.
 <description>
 To configure Postfix to restrict addresses to which it
 will send mail, see:
-http://www.postfix.org/SMTPD_ACCESS_README.html#danger
+<weblink-macro link="http://www.postfix.org/SMTPD_ACCESS_README.html#danger"/>
 <br/>
 The full contents of <tt>smtpd_recipient_restrictions</tt> will
 vary by site, since this is a common place to put spam restrictions and other
@@ -281,7 +281,7 @@ another immediately unless SMTP AUTH is used.
 requiring them to authenticate before submitting mail. Postfix's SMTP AUTH uses
 an authentication library called SASL, which is not part of Postfix itself.  To
 enable the use of SASL authentication, see
-http://www.postfix.org/SASL_README.html
+<weblink-macro link="http://www.postfix.org/SASL_README.html"/>
 </description>
 </Group>
 
@@ -292,7 +292,7 @@ Postfix provides options to use TLS for certificate-based
 authentication and encrypted sessions. An encrypted session protects the
 information that is transmitted with SMTP mail or with SASL authentication.
 To configure Postfix to protect all SMTP AUTH transactions
-using TLS, see http://www.postfix.org/TLS_README.html.
+using TLS, see <weblink-macro link="http://www.postfix.org/TLS_README.html"/>.
 </description>
 </Group>
 

--- a/RHEL/7/input/xccdf/services/ntp.xml
+++ b/RHEL/7/input/xccdf/services/ntp.xml
@@ -45,12 +45,12 @@ for systems which are normally kept permanently on. Systems which are required
 to use broadcast or multicast IP, or to perform authentication of packets with
 the <tt>Autokey</tt> protocol, should consider using <tt>ntpd</tt>.
 <br /><br />
-Refer to https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html for more detailed comparison of features of <tt>chronyd</tt>
+Refer to <weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html"/> for more detailed comparison of features of <tt>chronyd</tt>
 and <tt>ntpd</tt> daemon features respectively, and for further guidance how to
 choose between the two NTP daemons.
 <br /><br />
-The upstream manual pages at http://chrony.tuxfamily.org/manual.html for
-<tt>chronyd</tt> and http://www.ntp.org for <tt>ntpd</tt> provide additional
+The upstream manual pages at <weblink-macro link="http://chrony.tuxfamily.org/manual.html"/> for
+<tt>chronyd</tt> and <weblink-macro link="http://www.ntp.org"/> for <tt>ntpd</tt> provide additional
 information on the capabilities and configuration of each of the NTP daemons.
 </description>
 
@@ -72,7 +72,7 @@ Note: The <tt>chronyd</tt> daemon is enabled by default.
 Note: The <tt>ntpd</tt> daemon is not enabled by default. Though as mentioned
 in the previous sections in certain environments the <tt>ntpd</tt> daemon might
 be preferred to be used rather than the <tt>chronyd</tt> one. Refer to:
-  https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html
+<weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html"/>
 for guidance which NTP daemon to choose depending on the environment used.
 </description>
 <ocil>
@@ -90,7 +90,7 @@ maintaining accurate logs and auditing possible security breaches.
 The <tt>chronyd</tt> and <tt>ntpd</tt> NTP daemons offer all of the
 functionality of <tt>ntpdate</tt>, which is now deprecated. Additional
 information on this is available at
-http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate</rationale>
+<weblink-macro link="http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate"/></rationale>
 <ident cce="27444-9" />
 <oval id="service_chronyd_or_ntpd_enabled" />
 <ref nist="AU-8(1)" disa="160" pcidss="Req-10.4" cis="3.6" />
@@ -103,7 +103,7 @@ http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate</rationale>
 production environment, the Red Hat Enterprise Linux 7 Server system can be
 configured to utilize the services of the <tt>chronyd</tt> NTP daemon (the
 default), or services of the <tt>ntpd</tt> NTP daemon. Refer to
-https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html
+<weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html"/>
 for more detailed comparison of the features of both of the choices, and for
 further guidance how to choose between the two NTP daemons.
 <br />
@@ -147,7 +147,7 @@ logs from multiple sources or correlate computer events with real time events.
 production environment, the Red Hat Enterprise Linux 7 Server system can be
 configured to utilize the services of the <tt>chronyd</tt> NTP daemon (the
 default), or services of the <tt>ntpd</tt> NTP daemon. Refer to
-https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html
+<weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html"/>
 for more detailed comparison of the features of both of the choices, and for
 further guidance how to choose between the two NTP daemons.
 <br />

--- a/RHEL/7/input/xccdf/services/printing.xml
+++ b/RHEL/7/input/xccdf/services/printing.xml
@@ -5,7 +5,8 @@ and network printing support. A system running the CUPS service can accept
 print jobs from other systems, process them, and send them to the appropriate
 printer. It also provides an interface for remote administration through a web
 browser. The CUPS service is installed and activated by default. The project
-homepage and more detailed documentation are available at http://www.cups.org.
+homepage and more detailed documentation are available at
+<weblink-macro link="http://www.cups.org"/>.
 <br /><br /> </description>
 
 <Rule id="service_cups_disabled">

--- a/RHEL/7/input/xccdf/services/ssh.xml
+++ b/RHEL/7/input/xccdf/services/ssh.xml
@@ -6,8 +6,9 @@ for data exchanged between two systems, as well as server
 authentication, through the use of public key cryptography. The
 implementation included with the system is called OpenSSH, and more
 detailed documentation is available from its website,
-http://www.openssh.org. Its server program is called <tt>sshd</tt> and
-provided by the RPM package <tt>openssh-server</tt>.</description>
+<weblink-macro link="http://www.openssh.org"/>. Its server program 
+is called <tt>sshd</tt> and provided by the RPM package
+<tt>openssh-server</tt>.</description>
 
 <Value id="sshd_idle_timeout_value" type="number"
 operator="equals" interactive="0">

--- a/RHEL/7/input/xccdf/services/sssd.xml
+++ b/RHEL/7/input/xccdf/services/sssd.xml
@@ -8,7 +8,7 @@ support to systems utilizing SSSD. SSSD using caching to reduce load on authenti
 servers permit offline authentication as well as store extended user user data.
 <br/><br/>
 For more information, see
-<b>https://access.redhat.com/documentation/en_US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/SSSD.html</b>
+<b><weblink-macro link="https://access.redhat.com/documentation/en_US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/SSSD.html"/></b>
 </description>
 
 <Rule id="package_sssd_installed" severity="medium">

--- a/RHEL/7/input/xccdf/system/accounts/pam.xml
+++ b/RHEL/7/input/xccdf/system/accounts/pam.xml
@@ -39,7 +39,8 @@ most users.</warning>
 files, destroying any manually made changes and replacing them with
 a series of system defaults. One reference to the configuration
 file syntax can be found at
-http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html.</warning>
+<weblink-macro link="http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html"/>
+.</warning>
 
 <Value id="var_password_pam_unix_remember" type="number"
 operator="equals" interactive="0">

--- a/RHEL/7/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/7/input/xccdf/system/accounts/physical.xml
@@ -121,7 +121,7 @@ important bootloader settings. These include which kernel to use,
 and whether to enter single-user mode. For more information on how to configure 
 the grub2 superuser account and password, please refer to 
 <ul>
-<li>https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-GRUB_2_Password_Protection.html</li>.
+<li><weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-GRUB_2_Password_Protection.html"/></li>.
 </ul>
 </rationale>
 <ident cce="27309-4" />
@@ -173,7 +173,7 @@ important bootloader settings. These include which kernel to use,
 and whether to enter single-user mode. For more information on how to configure
 the grub2 superuser account and password, please refer to
 <ul>
-<li>https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-GRUB_2_Password_Protection.html</li>.
+<li><weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-GRUB_2_Password_Protection.html"/></li>.
 </ul>
 </rationale>
 <ident cce="RHEL7-CCE-TBD" />
@@ -375,11 +375,11 @@ is not enabled by default and must be enabled in the system settings.
 <description>
 To enable smart card authentication, consult the documentation at:
 <ul>
-<li><b>https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/smartcards.html#authconfig-smartcards</b></li>
+<li><b><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/smartcards.html#authconfig-smartcards"/></b></li>
 </ul>
 For guidance on enabling SSH to authenticate against a Common Access Card (CAC), consult documentation at:
 <ul>
-<li><b>https://access.redhat.com/solutions/82273</b></li>
+<li><b><weblink-macro link="https://access.redhat.com/solutions/82273"/></b></li>
 </ul>
 </description>
 <ocil clause="non-exempt accounts are not using CAC authentication">

--- a/RHEL/7/input/xccdf/system/auditing.xml
+++ b/RHEL/7/input/xccdf/system/auditing.xml
@@ -35,7 +35,7 @@ requirements.
 Examining some example audit records demonstrates how the Linux audit system
 satisfies common requirements.
 The following example from Fedora Documentation available at
-<tt>https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/SELinux_Users_and_Administrators_Guide/sect-Security-Enhanced_Linux-Troubleshooting-Fixing_Problems.html#sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages</tt>
+<tt><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/SELinux_Users_and_Administrators_Guide/sect-Security-Enhanced_Linux-Troubleshooting-Fixing_Problems.html#sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages"/></tt>
 shows the substantial amount of information captured in a
 two typical "raw" audit messages, followed by a breakdown of the most important
 fields. In this example the message is SELinux-related and reports an AVC

--- a/RHEL/7/input/xccdf/system/network/ssl.xml
+++ b/RHEL/7/input/xccdf/system/network/ssl.xml
@@ -8,10 +8,10 @@ communications, and many network services include support for it.  TLS or SSL
 can be leveraged to avoid any plaintext transmission of sensitive data.
 <br/>
 For information on how to use OpenSSL, see
-<b>http://www.openssl.org/docs/HOWTO/</b>.  Information on FIPS validation
-of OpenSSL is available at <b>http://www.openssl.org/docs/fips/fipsvalidation.html</b>
-and <b>http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm</b>.
+<b><weblink-macro link="http://www.openssl.org/docs/HOWTO/"/></b>.  Information on FIPS validation
+of OpenSSL is available at <b><weblink-macro link="http://www.openssl.org/docs/fips/fipsvalidation.html"/></b>
+and <b><weblink-macro link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm"/></b>.
 For information on how to use and implement OpenSSL on Red Hat Enterprise Linux, see
-<b>https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Using_OpenSSL.html</b>
+<b><weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Using_OpenSSL.html"/></b>
 </description>
 </Group>

--- a/RHEL/7/input/xccdf/system/selinux.xml
+++ b/RHEL/7/input/xccdf/system/selinux.xml
@@ -21,7 +21,7 @@ default (targeted) policy on every Red Hat system, unless that
 system has unusual requirements which make a stronger policy
 appropriate.
 <br /><br />
-For more information on SELinux, see <b>https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/SELinux_Users_and_Administrators_Guide</b>
+For more information on SELinux, see <b><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/SELinux_Users_and_Administrators_Guide"/></b>
 </description>
 
 

--- a/RHEL/7/input/xccdf/system/software/disk_partitioning.xml
+++ b/RHEL/7/input/xccdf/system/software/disk_partitioning.xml
@@ -21,8 +21,8 @@ If a system has already been installed, and the default
 partitioning scheme was used, it is possible but nontrivial to
 modify it to create separate logical volumes for the directories
 listed above. The Logical Volume Manager (LVM) makes this possible.
-See the LVM HOWTO at http://tldp.org/HOWTO/LVM-HOWTO/ for more
-detailed information on LVM.</description>
+See the LVM HOWTO at <weblink-macro link="http://tldp.org/HOWTO/LVM-HOWTO/"/>
+for more detailed information on LVM.</description>
 
 <Rule id="partition_for_tmp" severity="low">
 <title>Ensure /tmp Located On Separate Partition</title>
@@ -152,7 +152,7 @@ installer to pause and interactively ask for the passphrase during installation.
 <br /><br />
 Detailed information on encrypting partitions using LUKS can be found on
 the Red Hat Documentation web site:<br />
-https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html
+<weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html"/>
 </description>
 <ocil clause="partitions do not have a type of crypto_LUKS">
 Check the system partitions to determine if they are encrypted with the following command:

--- a/RHEL/7/input/xccdf/system/software/gnome.xml
+++ b/RHEL/7/input/xccdf/system/software/gnome.xml
@@ -9,7 +9,7 @@ switching contexts as well as display server management.
 GNOME is developed by the GNOME Project and is considered the default
 Red Hat Graphical environment.
 <br/><br/>
-For more information on GNOME and the GNOME Project, see <b>https://www.gnome.org</b>
+For more information on GNOME and the GNOME Project, see <b><weblink-macro link="https://www.gnome.org"/></b>
 </description>
 
 <Rule id="enable_dconf_user_profile" severity="high">
@@ -53,7 +53,7 @@ login automatically and/or with a guest account. The login screen should be conf
 to prevent such behavior.
 <br /><br />
 For more information about enforcing preferences in the GNOME3 environment using the DConf
-configuration system, see <b>https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Desktop_Migration_and_Administration_Guide/index.html</b> and the man page <tt>dconf(1)</tt>.
+configuration system, see <b><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Desktop_Migration_and_Administration_Guide/index.html"/></b> and the man page <tt>dconf(1)</tt>.
 </description>
 
 <Rule id="gnome_gdm_disable_automatic_login" severity="high">
@@ -268,9 +268,9 @@ The root account can be screen-locked; however, the root account should
 be used to for direct login via console in emergency circumstances.
 <br /><br />
 For more information about enforcing preferences in the GNOME3 environment using the DConf
-configuration system, see <b>http://wiki.gnome.org/dconf</b> and
+configuration system, see <b><weblink-macro link="http://wiki.gnome.org/dconf"/></b> and
 the man page <tt>dconf(1)</tt>. For Red Hat specific information on configuring DConf
-settings, see <b>https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Desktop_Migration_and_Administration_Guide/part-Configuration_and_Administration.html</b>
+settings, see <b><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Desktop_Migration_and_Administration_Guide/part-Configuration_and_Administration.html"/></b>
 </description>
 
 <Value id="inactivity_timeout_value" type="number" operator="equals">

--- a/RHEL/7/input/xccdf/system/software/integrity.xml
+++ b/RHEL/7/input/xccdf/system/software/integrity.xml
@@ -392,7 +392,7 @@ FIPS 140-2 is the current standard for validating that mechanisms used to access
 utilize authentication that meets industry and government requirements. For government systems, this allows
 Security Levels 1, 2, 3, or 4 for use on Red Hat Enterprise Linux.
 <br /><br />
-See <b>http://csrc.nist.gov/publications/PubsFIPS.html</b> for more information.
+See <b><weblink-macro link="http://csrc.nist.gov/publications/PubsFIPS.html"/></b> for more information.
 </description>
 
 <Rule id="package_dracut-fips_installed" severity="medium">
@@ -453,7 +453,7 @@ Red Hat, Inc. and Red Hat Enterprise Linux are respectively FIPS certified and c
 projects such as CentOS, Scientific Linux, etc. do not necessarily meet FIPS certification and compliancy.
 Therefore, non-certified vendors and/or projects do not meet this requirement even if technically feasible.
 <br /><br />
-See <b>http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/1401vend.htm</b> for a list of FIPS certified
+See <b><weblink-macro link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/1401vend.htm"/></b> for a list of FIPS certified
 vendors.</warning>
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="grub2_enable_fips_mode" />

--- a/RHEL/7/input/xccdf/system/software/sudo.xml
+++ b/RHEL/7/input/xccdf/system/software/sudo.xml
@@ -7,7 +7,7 @@ users and/or groups, <tt>Sudo</tt> can allow a user or group to execute privileg
 that normally only <tt>root</tt> is allowed to execute.
 <br/><br/>
 For more information on <tt>Sudo</tt> and addition <tt>Sudo</tt> configuration options, see
-<b>https://www.sudo.ws</b>
+<b><weblink-macro link="https://www.sudo.ws"/></b>
 </description>
 
 <Rule id="sudo_remove_nopasswd" severity="medium">

--- a/RHEL/7/input/xccdf/system/software/updating.xml
+++ b/RHEL/7/input/xccdf/system/software/updating.xml
@@ -146,7 +146,7 @@ run the following command to list when each package was last updated:
 <pre>$ rpm -qa -last</pre>
 <br /><br />
 Compare this to Red Hat Security Advisories (RHSA) listed at
-https://access.redhat.com/security/updates/active/
+<weblink-macro link="https://access.redhat.com/security/updates/active/"/>
 to determine if the system is missing applicable updates.
 </ocil>
 <rationale>

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -345,6 +345,17 @@
 
 
   <!-- The next set of templates expand convenience macros for XCCDF prose -->
+  <xsl:template match="weblink-macro">
+    <xsl:choose>
+      <xsl:when test="@text">
+        <a xmlns="http://www.w3.org/1999/xhtml"><xsl:attribute name="href"><xsl:value-of select="@link"/></xsl:attribute><xsl:value-of select="@text"/></a>
+      </xsl:when>
+      <xsl:otherwise>
+        <a xmlns="http://www.w3.org/1999/xhtml"><xsl:attribute name="href"><xsl:value-of select="@link"/></xsl:attribute><xsl:value-of select="@link"/></a>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
   <xsl:template match="sysctl-desc-macro">
     To set the runtime status of the <xhtml:code><xsl:value-of select="@sysctl"/></xhtml:code> kernel parameter,
     run the following command:


### PR DESCRIPTION
- Adds new weblink macro that can handle the following variations:

  With link only:
  \<weblink-macro link="www.foobar.com"/>

  With custom link text:
  \<weblink-macro link="www.foobar.com" text="foobar"/>

- Update existing content to use new weblink macro