### PR TITLE
Add support to restrict targets in csv file

### DIFF
--- a/shared/templates/Makefile
+++ b/shared/templates/Makefile
@@ -28,4 +28,4 @@ ansible:
 	$(SHARED_DIR)/create_package_removed.py                 ansible ${CSV_DIR}/package_removed.csv
 
 clean:
-	rm -rf $(TARGET_DIR)/output
+	rm -rf $(PREFIX_DIR)/output


### PR DESCRIPTION
Right now it doesn't make sense much, but once we will be generating oval/bash/ansible/*, it will allows us to have shared csv file and we will able to restrict some lines to some target.

Example
```
aide # only-for: bash
audit # only-for: bash,oval
vsftpd
```