### PR TITLE
share architecture rules more easily

### DIFF
--- a/shared/oval/system_info_architecture_64bit.xml
+++ b/shared/oval/system_info_architecture_64bit.xml
@@ -6,8 +6,7 @@
     <metadata>
       <title>Test for 64-bit Architecture</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>Generic test for 64-bit architectures to be used by other tests</description>
       <reference source="galford" ref_id="20160527" ref_url="test_attestation" />

--- a/shared/oval/system_info_architecture_ppc_64.xml
+++ b/shared/oval/system_info_architecture_ppc_64.xml
@@ -6,8 +6,7 @@
     <metadata>
       <title>Test for PPC and PPCLE Architecture</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>Generic test for PPC PPC64LE architecture to be used by other tests</description>
       <reference source="galford" ref_id="20160527" ref_url="test_attestation" />

--- a/shared/oval/system_info_architecture_x86.xml
+++ b/shared/oval/system_info_architecture_x86.xml
@@ -6,8 +6,7 @@
     <metadata>
       <title>Test for x86 Architecture</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>Generic test for x86 architecture to be used by other tests</description>
       <reference source="MED" ref_id="20130819" ref_url="test_attestation" />

--- a/shared/oval/system_info_architecture_x86_64.xml
+++ b/shared/oval/system_info_architecture_x86_64.xml
@@ -6,8 +6,7 @@
     <metadata>
       <title>Test for x86_64 Architecture</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>Generic test for x86_64 architecture to be used by other tests</description>
       <reference source="MED" ref_id="20130819" ref_url="test_attestation" />


### PR DESCRIPTION
When adding one of these rules (or the rules that they depend on)
to a new platform, the rule previously needed to be modified to
explicitly list the new platform.  However, these rules appear
to be fairly generic, so allow any platform to use them.

Signed-off-by: T.O. Radzy Radzykewycz <radzy@windriver.com>