### PR TITLE
[Bugfix][Infrastructure] Remove RHEL idents for derivative OSes

### DIFF
--- a/shared/utils/enable-derivatives.py
+++ b/shared/utils/enable-derivatives.py
@@ -188,7 +188,8 @@ def remove_rh_idents(tree_root, namespace):
     for rule in tree_root.findall(".//{%s}Rule" % (namespace)):
         for ident in rule.findall(".//{%s}ident" % (namespace)):
             if ident is not None:
-                rule.remove(ident)
+                if re.search('CCE-*', ident.text) or re.search('.*RHEL-*', ident.text):
+                    rule.remove(ident)
 
         for ref in rule.findall(".//{%s}reference" % (namespace)):
             if ref.text is not None:

--- a/shared/utils/enable-derivatives.py
+++ b/shared/utils/enable-derivatives.py
@@ -191,6 +191,9 @@ def remove_rh_idents(tree_root, namespace):
         if ident is not None:
             if re.search('CCE-*', ident.text) or re.search('.*RHEL-[0-9]+-*', ident.text):
                 rule.remove(ident)
+        ident = rule.find(".//{%s}ident[@system=\"%s\"]" % (namespace, DISA_OS_STIG_REF))
+        if ident is not None:
+            rule.remove(ident)
         ref =  rule.find(".//{%s}reference[@href=\"%s\"]" % (namespace, DISA_OS_STIG_REF))
         if ref is not None:
             rule.remove(ref)

--- a/shared/utils/enable-derivatives.py
+++ b/shared/utils/enable-derivatives.py
@@ -22,6 +22,7 @@ from optparse import OptionParser
 
 XCCDF11_NS = "http://checklists.nist.gov/xccdf/1.1"
 XCCDF12_NS = "http://checklists.nist.gov/xccdf/1.2"
+DISA_OS_STIG_REF = "http://iase.disa.mil/stigs/os/unix-linux/Pages/index.aspx"
 
 RHEL_CENTOS_CPE_MAPPING = {
     "cpe:/o:redhat:enterprise_linux:4": "cpe:/o:centos:centos:4",
@@ -185,9 +186,14 @@ def add_derivative_notice(benchmark, namespace, notice, warning):
 
 
 def remove_rh_idents(tree_root, namespace):
-    for elem in tree_root.findall(".//{%s}ident" % (namespace)):
-        if re.search('CCE-*', elem.text) or re.search('.*RHEL-[0-9]+-*', elem.text):
-            elem.text = ''
+    for rule in tree_root.findall(".//{%s}Rule" % (namespace)):
+        ident = rule.find(".//{%s}ident" % (namespace))
+        if ident is not None:
+            if re.search('CCE-*', ident.text) or re.search('.*RHEL-[0-9]+-*', ident.text):
+                rule.remove(ident)
+        ref =  rule.find(".//{%s}reference[@href=\"%s\"]" % (namespace, DISA_OS_STIG_REF))
+        if ref is not None:
+            rule.remove(ref)
 
 
 def main():

--- a/shared/utils/enable-derivatives.py
+++ b/shared/utils/enable-derivatives.py
@@ -22,7 +22,6 @@ from optparse import OptionParser
 
 XCCDF11_NS = "http://checklists.nist.gov/xccdf/1.1"
 XCCDF12_NS = "http://checklists.nist.gov/xccdf/1.2"
-DISA_OS_STIG_REF = "http://iase.disa.mil/stigs/os/unix-linux/Pages/index.aspx"
 
 RHEL_CENTOS_CPE_MAPPING = {
     "cpe:/o:redhat:enterprise_linux:4": "cpe:/o:centos:centos:4",
@@ -187,16 +186,14 @@ def add_derivative_notice(benchmark, namespace, notice, warning):
 
 def remove_rh_idents(tree_root, namespace):
     for rule in tree_root.findall(".//{%s}Rule" % (namespace)):
-        ident = rule.find(".//{%s}ident" % (namespace))
-        if ident is not None:
-            if re.search('CCE-*', ident.text) or re.search('.*RHEL-[0-9]+-*', ident.text):
+        for ident in rule.findall(".//{%s}ident" % (namespace)):
+            if ident is not None:
                 rule.remove(ident)
-        ident = rule.find(".//{%s}ident[@system=\"%s\"]" % (namespace, DISA_OS_STIG_REF))
-        if ident is not None:
-            rule.remove(ident)
-        ref =  rule.find(".//{%s}reference[@href=\"%s\"]" % (namespace, DISA_OS_STIG_REF))
-        if ref is not None:
-            rule.remove(ref)
+
+        for ref in rule.findall(".//{%s}reference" % (namespace)):
+            if ref.text is not None:
+                if re.search('RHEL-*', ref.text):
+                    rule.remove(ref)
 
 
 def main():


### PR DESCRIPTION
- Remove RHEL DISA references for derivatives to stand on their own.
- Fixes #1452