### PR TITLE
Correct filenames for EL7 derivatives in OSP confgurations.

### DIFF
--- a/OpenStack/RHEL-OSP/7/Makefile
+++ b/OpenStack/RHEL-OSP/7/Makefile
@@ -95,11 +95,11 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 	# Fixes https://github.com/OpenSCAP/scap-security-guide/issues/1101
 	$(SHARED)/$(TRANS)/datastream_move_ocil_to_ds_checks.py $(OUT)/$(ID)-$(PROD)-ds.xml $(OUT)/$(ID)-$(PROD)-ds.xml
 #	Make CentOS variants of XCCDF and Source DataStream
-	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-centos -i $(OUT)/$(ID)-$(PROD)-xccdf.xml -o $(OUT)/$(ID)-centos7-xccdf.xml
-	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-centos -i $(OUT)/$(ID)-$(PROD)-ds.xml -o $(OUT)/$(ID)-centos7-ds.xml
+	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-centos -i $(OUT)/$(ID)-$(PROD)-xccdf.xml -o $(OUT)/$(ID)-centos-osp7-xccdf.xml
+	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-centos -i $(OUT)/$(ID)-$(PROD)-ds.xml -o $(OUT)/$(ID)-centos-osp7-ds.xml
 #	Make Scientific Linux variants of XCCDF and Source DataStream
-	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-sl -i $(OUT)/$(ID)-$(PROD)-xccdf.xml -o $(OUT)/$(ID)-sl7-xccdf.xml
-	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-sl -i $(OUT)/$(ID)-$(PROD)-ds.xml -o $(OUT)/$(ID)-sl7-ds.xml
+	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-sl -i $(OUT)/$(ID)-$(PROD)-xccdf.xml -o $(OUT)/$(ID)-sl-osp7-xccdf.xml
+	$(SHARED)/$(UTILS)/enable-derivatives.py --enable-sl -i $(OUT)/$(ID)-$(PROD)-ds.xml -o $(OUT)/$(ID)-sl-osp7-ds.xml
 
 content-stig: table-stigs guide checks
 	xmllint --format --output $(OUT)/unlinked-stig-$(PROD)-xccdf.xml $(OUT)/unlinked-stig-$(PROD)-xccdf.xml
@@ -110,13 +110,13 @@ content-stig: table-stigs guide checks
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos-osp7-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl-osp7-ds.xml
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
 	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos-osp7-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl-osp7-xccdf.xml
 endif
 
 submission-stig-check: table-stigs
@@ -131,10 +131,10 @@ validate-xml:
 	oscap cpe validate-xml $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml
 	oscap oval validate-xml --schematron $(OUT)/$(ID)-$(PROD)-cpe-oval.xml
 	oscap ds sds-validate $(OUT)/$(ID)-$(PROD)-ds.xml
-	oscap xccdf validate-xml $(OUT)/$(ID)-centos7-xccdf.xml
-	oscap ds sds-validate $(OUT)/$(ID)-centos7-ds.xml
-	oscap xccdf validate-xml $(OUT)/$(ID)-sl7-xccdf.xml
-	oscap ds sds-validate $(OUT)/$(ID)-sl7-ds.xml
+	oscap xccdf validate-xml $(OUT)/$(ID)-centos-osp7-xccdf.xml
+	oscap ds sds-validate $(OUT)/$(ID)-centos-osp7-ds.xml
+	oscap xccdf validate-xml $(OUT)/$(ID)-sl-osp7-xccdf.xml
+	oscap ds sds-validate $(OUT)/$(ID)-sl-osp7-ds.xml
 
 validate: validate-xml
 	cd $(OUT); ../$(SHARED)/$(UTILS)/verify-references.py --rules-with-invalid-checks --ovaldefs-unused ssg-$(PROD)-xccdf.xml
@@ -150,10 +150,10 @@ dist: tables guide content
 	cp $(OUT)/$(ID)-$(PROD)-ds.xml $(DIST)/content
 	mkdir -p $(DIST)/guide
 	cp $(OUT)/*-guide-*.html $(DIST)/guide
-	cp $(OUT)/$(ID)-centos7-xccdf.xml $(DIST)/content
-	cp $(OUT)/$(ID)-centos7-ds.xml $(DIST)/content
-	cp $(OUT)/$(ID)-sl7-xccdf.xml $(DIST)/content
-	cp $(OUT)/$(ID)-sl7-ds.xml $(DIST)/content
+	cp $(OUT)/$(ID)-centos-osp7-xccdf.xml $(DIST)/content
+	cp $(OUT)/$(ID)-centos-osp7-ds.xml $(DIST)/content
+	cp $(OUT)/$(ID)-sl-osp7-xccdf.xml $(DIST)/content
+	cp $(OUT)/$(ID)-sl-osp7-ds.xml $(DIST)/content
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv


### PR DESCRIPTION
Currently the generated filennames for the RHEL OSP7 derivatives
overrites the files generated by the standard RHEL7 derivatives.  This
fixes the output filenames to be distinct.