### PR TITLE
Added newline to MACs remediation

### DIFF
--- a/shared/templates/static/bash/sshd_use_approved_macs.sh
+++ b/shared/templates/static/bash/sshd_use_approved_macs.sh
@@ -2,5 +2,5 @@
 grep -qi ^MACs /etc/ssh/sshd_config && \
   sed -i "s/MACs.*/MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1/gI" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then
-    echo "MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1" >> /etc/ssh/sshd_config
+    echo -e "\nMACs hmac-sha2-512,hmac-sha2-256,hmac-sha1" >> /etc/ssh/sshd_config
 fi


### PR DESCRIPTION
Previous operations might not use a trailing newline.