### PR TITLE
verify-references.py - use proper OVAL paths, unused OVALs are no longer an error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,7 @@ validate-fedora: fedora
 	cd Fedora/ && $(MAKE) validate
 
 validate-rhel5: rhel5
-	# Enable below when content validates correctly
-	#cd RHEL/5/ && $(MAKE) validate
+	cd RHEL/5/ && $(MAKE) validate
 
 validate-rhel6: rhel6
 	cd RHEL/6/ && $(MAKE) validate

--- a/shared/utils/verify-references.py
+++ b/shared/utils/verify-references.py
@@ -102,7 +102,8 @@ def get_ovalfiles(checks):
                not checkcontentref_hrefattr.startswith("https://"):
                 ovalfiles.add(checkcontentref_hrefattr)
         elif check.get("system") != ocil_cs:
-            print "Non-OVAL checking system found: " + check.get("system")
+            print("ERROR: Non-OVAL checking system found: %s"
+                  % (check.get("system")))
             exit_value = 1
     return ovalfiles
 
@@ -189,22 +190,23 @@ def main():
             refname = check_content_ref.get("name")
             if refname not in ovaldef_ids:
                 rule = check_content_ref.getparent().getparent()
-                print ("Invalid OVAL definition referenced by XCCDF Rule: " +
-                       rule.get("id"))
+                print("ERROR: Invalid OVAL definition referenced by XCCDF Rule: %s"
+                      % (rule.get("id")))
                 exit_value = 1
 
     if options.rules_without_checks or options.all_checks:
         for rule in rules:
             check = rule.find("./{%s}check" % xccdf_ns)
             if check is None:
-                print ("No reference to OVAL definition in XCCDF Rule: " +
-                       rule.get("id"))
+                print("ERROR: No reference to OVAL definition in XCCDF Rule: %s"
+                      % (rule.get("id")))
                 exit_value = 1
 
     if options.rules_without_severity or options.all_checks:
         for rule in rules:
             if rule.get("severity") is None:
-                print "No severity assigned to XCCDF Rule: " + rule.get("id")
+                print("ERROR: No severity assigned to XCCDF Rule: %s"
+                      % (rule.get("id")))
                 exit_value = 1
 
     if options.rules_without_nistrefs or options.rules_without_disarefs or options.all_checks:
@@ -212,7 +214,8 @@ def main():
             # find all references in the current rule
             refs = rule.findall(".//{%s}reference" % xccdf_ns)
             if refs is None:
-                print "No reference assigned to XCCDF Rule: " + rule.get("id")
+                print("ERROR: No reference assigned to XCCDF Rule: %s"
+                      % (rule.get("id")))
                 exit_value = 1
             else:
                 # loop through the Rule's references and put their hrefs
@@ -220,13 +223,13 @@ def main():
                 ref_href_list = [ref.get("href") for ref in refs]
                 # print warning if rule does not have a NIST reference
                 if (not nist_ref_href in ref_href_list) and options.rules_without_nistrefs:
-                    print ("No valid NIST reference in XCCDF Rule: " +
-                           rule.get("id"))
+                    print("ERROR: No valid NIST reference in XCCDF Rule: " +
+                          rule.get("id"))
                     exit_value = 1
                 # print warning if rule does not have a DISA reference
                 if (not disa_ref_href in ref_href_list) and options.rules_without_disarefs:
-                    print ("No valid DISA CCI reference in XCCDF Rule: " +
-                           rule.get("id"))
+                    print("ERROR: No valid DISA CCI reference in XCCDF Rule: " +
+                          rule.get("id"))
                     exit_value = 1
 
     if options.disarefs_not_in_profile or options.nistrefs_not_in_profile:
@@ -241,13 +244,13 @@ def main():
             # print warning if Rule is outside Profile and has a NIST reference
             if options.nistrefs_not_in_profile:
                 if (nist_ref_href in ref_href_list) and (rule.get("id") not in profile_ruleids):
-                    print ("XCCDF Rule found with NIST reference outside Profile %s: "
+                    print("ERROR: XCCDF Rule found with NIST reference outside Profile %s: "
                            % options.profile_name + rule.get("id"))
                     exit_value = 1
             # print warning if Rule is outside Profile and has a DISA reference
             if options.disarefs_not_in_profile:
                 if (disa_ref_href in ref_href_list) and (rule.get("id") not in profile_ruleids):
-                    print ("XCCDF Rule found with DISA CCI reference outside Profile %s: "
+                    print("ERROR: XCCDF Rule found with DISA CCI reference outside Profile %s: "
                            % options.profile_name + rule.get("id"))
                     exit_value = 1
 
@@ -268,7 +271,8 @@ def main():
             # don't print out the OVAL defs that are extended by others,
             # as they're not unused
             if oval_id not in ovaldef_ids_extended:
-                print "OVAL Check is not referenced by XCCDF: %s" % oval_id
+                print("WARNING: OVAL Check is not referenced by XCCDF: %s"
+                      % (oval_id))
                 # Do not treat this as error but only as a warning
                 #exit_value = 1
 

--- a/shared/utils/verify-references.py
+++ b/shared/utils/verify-references.py
@@ -269,7 +269,8 @@ def main():
             # as they're not unused
             if oval_id not in ovaldef_ids_extended:
                 print "OVAL Check is not referenced by XCCDF: %s" % oval_id
-                exit_value = 1
+                # Do not treat this as error but only as a warning
+                #exit_value = 1
 
     sys.exit(exit_value)
 

--- a/shared/utils/verify-references.py
+++ b/shared/utils/verify-references.py
@@ -3,6 +3,8 @@
 import sys
 import optparse
 import lxml.etree as ET
+import os.path
+
 """
 This script can verify consistency of references (linkage) between XCCDF and
 OVAL, and also search based on other criteria such as existence of policy
@@ -148,7 +150,7 @@ def main():
                  "supported by this script.")
 
     # find important elements within the XCCDF and the OVAL
-    ovalfile = ovalfiles.pop()
+    ovalfile = os.path.join(os.path.dirname(xccdffilename), ovalfiles.pop())
     ovaltree = ET.parse(ovalfile)
     # collect all compliance checks (not inventory checks, which are
     # needed by CPE)


### PR DESCRIPTION
I need this for the cmake build system, I want to build everything the same way, no exceptions. RHEL5 currently doesn't validate because it has OVAL checks that are unused. I changed `verify-references.py` to treat that as a warning instead of an error. Furthermore I have changed the script to use parent directory of the input XCCDF as a basis for the OVAL paths. This makes sense with how the XCCDF files work.