### PR TITLE
[Bugfix] Revisit OVAL for "accounts_max_concurrent_login_sessions" ru…

### DIFF
--- a/shared/oval/accounts_max_concurrent_login_sessions.xml
+++ b/shared/oval/accounts_max_concurrent_login_sessions.xml
@@ -11,7 +11,10 @@
     </metadata>
     <criteria operator="OR">
       <criterion comment="the value maxlogins should be set appropriately in /etc/security/limits.d/*.conf" test_ref="test_limitsd_maxlogins" />
-      <criterion comment="the value maxlogins should be set appropriately in /etc/security/limits.conf" test_ref="test_maxlogins" />
+      <criteria operator="AND">
+	  <criterion comment="the value maxlogins should not be set at all in /etc/security/limits.d/*.conf" test_ref="test_limitsd_maxlogins_exists" negate="true" />
+	  <criterion comment="the value maxlogins should be set appropriately in /etc/security/limits.conf" test_ref="test_maxlogins" />
+      </criteria>
     </criteria>
   </definition>
 
@@ -23,6 +26,10 @@
   <ind:textfilecontent54_test check="all" comment="the value maxlogins should be set appropriately in /etc/security/limits.d/*.conf" id="test_limitsd_maxlogins" version="1">
     <ind:object object_ref="object_etc_security_limitsd_conf_maxlogins" />
     <ind:state state_ref="state_maxlogins" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test check="all" comment="the value maxlogins should be set appropriately in /etc/security/limits.d/*.conf" id="test_limitsd_maxlogins_exists" version="1">
+    <ind:object object_ref="object_etc_security_limitsd_conf_maxlogins_exists" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_etc_security_limits_conf_maxlogins" version="1">
@@ -41,6 +48,13 @@
   <ind:textfilecontent54_state id="state_maxlogins" version="1">
     <ind:subexpression operation="less than or equal" var_ref="var_accounts_max_concurrent_login_sessions" datatype="int" />
   </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_object id="object_etc_security_limitsd_conf_maxlogins_exists" version="1">
+    <ind:path>/etc/security/limits.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*\*[\s]+(?:(?:hard)|(?:-))[\s]+maxlogins</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
 
   <external_variable comment="maximum number of concurrent logins per user" datatype="int" id="var_accounts_max_concurrent_login_sessions" version="1" />
 


### PR DESCRIPTION
…le #1329

This improves the logic of the maxlogins configuration file
contents.

If limits.d/*.conf does not specify maxlogins at all, but
limits.conf specifies maxlogins appropriately, then PASS

If limits.d/*.conf specifies maxlogins correctly, then PASS
regardless of the contents of limits.conf

It is still not 100% correct.  The remaining issue is:

1)  If limits.d/*.conf specifies a correct value and an incorrect
    value, this version will always FAIL.  It should pass if the
    last value is appropriate, regardless of previous values.

Signed-off-by: T.O. Radzy Radzykewycz <radzy@windriver.com>