### PR TITLE
Reorder find global options

### DIFF
--- a/RHEL/5/references/U_RedHat_5_V1R8_Manual-xccdf.xml
+++ b/RHEL/5/references/U_RedHat_5_V1R8_Manual-xccdf.xml
@@ -6670,7 +6670,7 @@ Procedure:
 
 Check local initialization files for the configured umask value.
 Procedure: 
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep umask {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep umask {} \;
 
 If the system and user default umask is not 077, this a finding. 
 
@@ -13647,7 +13647,7 @@ Procedure:
 
 NOTE: This must be done in the BASH shell.
 
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep -l PATH {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep -l PATH {} \;
 This variable is formatted as a colon-separated list of directories. If there is an empty entry, such as a leading or trailing colon, or two consecutive colons, this is a finding. If an entry begins with a character other than a slash (/) this is a relative path, ask the SA or IAO if the relative path is required for the operation of a specific application. If it is not, this is a finding.</check-content>
 			</check>
 		</Rule>
@@ -17044,7 +17044,7 @@ Procedure:
 
 NOTE: This must be done in the BASH shell.
 
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep -H LD_LIBRARY_PATH {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep -H LD_LIBRARY_PATH {} \;
 This variable is formatted as a colon-separated list of directories. If there is an empty entry, such as a leading or trailing colon, or two consecutive colons, this is a finding. If an entry begins with a character other than a slash (/) this is a relative path, this is a finding.</check-content>
 			</check>
 		</Rule>
@@ -17073,7 +17073,7 @@ This variable is formatted as a colon-separated list of directories. If there is
 NOTE: The following must be done in the BASH shell.
 
 Procedure:
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep -H LD_PRELOAD {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep -H LD_PRELOAD {} \;
 This variable is formatted as a colon-separated list of paths. If there is an empty entry, such as a leading or trailing colon, or two consecutive colons, this is a finding. If an entry begins with a character other than a slash (/) this is a relative path, this is a finding.</check-content>
 			</check>
 		</Rule>

--- a/RHEL/5/templates/static/bash/file_permissions_unauthorized_world_writable.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_unauthorized_world_writable.sh
@@ -1,1 +1,1 @@
-find / /var /home -follow -xdev -type f -perm -002 2>/dev/null | xargs chmod o-w
+find / /var /home -xdev -follow -type f -perm -002 2>/dev/null | xargs chmod o-w

--- a/RHEL/7/input/xccdf/system/permissions/files.xml
+++ b/RHEL/7/input/xccdf/system/permissions/files.xml
@@ -449,7 +449,7 @@ appropriate user.
 <ocil clause="files exist that are not owned by a valid user">
 The following command will discover and print any
 files on local partitions which do not belong to a valid user.
-<pre>$ sudo find / -fstype local -xdev -nouser</pre>
+<pre>$ sudo find / -xdev -fstype local -nouser</pre>
 <br /><br />
 Either remove all files and directories from the system that do not have a
 valid user, or assign a valid user to all unowned files and directories on
@@ -480,7 +480,7 @@ appropriate group.
 <ocil clause="there is output">
 The following command will discover and print any
 files on local partitions which do not belong to a valid group.
-<pre>$ sudo find / -fstype local -xdev -nogroup</pre>
+<pre>$ sudo find / -xdev -fstype local -nogroup</pre>
 <br />
 Either remove all files and directories from the system that do not have a valid group,
 or assign a valid group with the chgrp command:

--- a/SUSE/12/input/xccdf/system/permissions/files.xml
+++ b/SUSE/12/input/xccdf/system/permissions/files.xml
@@ -449,7 +449,7 @@ appropriate user.
 <ocil clause="files exist that are not owned by a valid user">
 The following command will discover and print any
 files on local partitions which do not belong to a valid user.
-<pre>$ sudo find / -fstype local -xdev -nouser</pre>
+<pre>$ sudo find / -xdev -fstype local -nouser</pre>
 <br /><br />
 Either remove all files and directories from the system that do not have a
 valid user, or assign a valid user to all unowned files and directories on
@@ -480,7 +480,7 @@ appropriate group.
 <ocil clause="there is output">
 The following command will discover and print any
 files on local partitions which do not belong to a valid group.
-<pre>$ sudo find / -fstype local -xdev -nogroup</pre>
+<pre>$ sudo find / -xdev -fstype local -nogroup</pre>
 <br />
 Either remove all files and directories from the system that do not have a valid group,
 or assign a valid group with the chgrp command:

--- a/WRLinux/input/xccdf/system/permissions/files.xml
+++ b/WRLinux/input/xccdf/system/permissions/files.xml
@@ -420,7 +420,7 @@ Following this, the files should be deleted or assigned to an appropriate user.
 <ocil clause="files exist that are not owned by a valid user">
 The following command will discover and print any
 files on local partitions which do not belong to a valid user.
-<pre>$ sudo find / -fstype local -xdev -nouser</pre>
+<pre>$ sudo find / -xdev -fstype local -nouser</pre>
 <br/><br/>
 Either remove all files and directories from the system that do not have a
 valid user, or assign a valid user to all unowned files and directories on
@@ -444,7 +444,7 @@ Following this, the files should be deleted or assigned to an appropriate group.
 <ocil clause="there is output">
 The following command will discover and print any
 files on local partitions which do not belong to a valid group.
-<pre>$ sudo find / -fstype local -xdev -nogroup</pre>
+<pre>$ sudo find / -xdev -fstype local -nogroup</pre>
 <br/>
 Either remove all files and directories from the system that do not have a valid group,
 or assign a valid group with the chgrp command:

--- a/shared/references/disa-stig-rhel5-v1r15-xccdf-manual.xml
+++ b/shared/references/disa-stig-rhel5-v1r15-xccdf-manual.xml
@@ -457,7 +457,7 @@ Procedure:
 
 Check local initialization files for the configured umask value.
 Procedure: 
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep umask {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep umask {} \;
 
 If the system and user default umask is not 077, this a finding. 
 
@@ -2624,7 +2624,7 @@ Procedure:
 
 NOTE: This must be done in the BASH shell.
 
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep -l PATH {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep -l PATH {} \;
 This variable is formatted as a colon-separated list of directories. 
 
 If there is an empty entry, such as a leading or trailing colon, or two consecutive colons, this is a finding. 
@@ -3476,7 +3476,7 @@ Procedure:
 
 NOTE: This must be done in the BASH shell.
 
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep -H LD_LIBRARY_PATH {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep -H LD_LIBRARY_PATH {} \;
 
 This variable is formatted as a colon-separated list of directories.
  
@@ -3487,7 +3487,7 @@ If an entry begins with a character other than a slash (/) or other than "$PATH"
 NOTE: The following must be done in the BASH shell.
 
 Procedure:
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep -H LD_PRELOAD {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep -H LD_PRELOAD {} \;
 
 This variable is formatted as a colon-separated list of paths.
  

--- a/shared/references/disa-stig-rhel7-v1r0.2-xccdf-manual.xml
+++ b/shared/references/disa-stig-rhel7-v1r0.2-xccdf-manual.xml
@@ -4574,7 +4574,7 @@ If any accounts other than root have a UID of “0”, this is a finding.</check
 
 Check the owner of all files and directories with the following command:
 
-# find / -fstype local -xdev -nouser
+# find / -xdev -fstype local -nouser
 
 If any files on the system do not have an assigned owner, this is a finding.</check-content>
       </check>
@@ -4598,7 +4598,7 @@ If any files on the system do not have an assigned owner, this is a finding.</ch
 
 Check the owner of all files and directories with the following command:
 
-# find / -fstype local -xdev -nogroup
+# find / -xdev -fstype local -nogroup
 
 If any files on the system do not have an assigned group, this is a finding.</check-content>
       </check>

--- a/shared/references/disa-stig-sles11-v1r7-xccdf-manual.xml
+++ b/shared/references/disa-stig-sles11-v1r7-xccdf-manual.xml
@@ -6367,7 +6367,7 @@ Procedure:
 
 Check local initialization files for the configured umask value.
 Procedure: 
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep umask {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep umask {} \;
 
 If the system and user default umask is not 077, this a finding. 
 
@@ -12452,7 +12452,7 @@ Procedure:
 
 NOTE: This must be done in the BASH shell.
 
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep -l PATH {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep -l PATH {} \;
 This variable is formatted as a colon-separated list of directories. If there is an empty entry, such as a leading or trailing colon, or two consecutive colons, this is a finding. If an entry begins with a character other than a slash (/) this is a relative path, ask the SA or IAO if the relative path is required for the operation of a specific application. If it is not, this is a finding.</check-content>
 			</check>
 		</Rule>
@@ -15329,7 +15329,7 @@ If the permissions include a '+', the file has an extended ACL. If the file has 
 				<check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SuSe zLinux.xml"/>
 				<check-content>Verify local initialization files have library search path containing only absolute paths.
 Procedure:
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep -H LD_LIBRARY_PATH {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep -H LD_LIBRARY_PATH {} \;
 This variable is formatted as a colon-separated list of directories. If there is an empty entry, such as a leading or trailing colon, or two consecutive colons, this is a finding. If an entry begins with a character other than a slash (/) this is a relative path, this is a finding.</check-content>
 			</check>
 		</Rule>
@@ -15356,7 +15356,7 @@ This variable is formatted as a colon-separated list of directories. If there is
 				<check-content>Verify local initialization files have library preload list containing only absolute paths.
 
 Procedure:
-# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -name ".*" -type f -maxdepth 1 -exec grep -H LD_PRELOAD {} \;
+# cut -d: -f6 /etc/passwd |xargs -n1 -IDIR find DIR -maxdepth 1 -name ".*" -type f -exec grep -H LD_PRELOAD {} \;
 This variable is formatted as a colon-separated list of paths. If there is an empty entry, such as a leading or trailing colon, or two consecutive colons, this is a finding. If an entry begins with a character other than a slash (/) this is a relative path, this is a finding.</check-content>
 			</check>
 		</Rule>


### PR DESCRIPTION
Some version of the `find(1)` command require non-positional (global)
options to occur first in the expression, otherwise returning an error.
In the context of the SSG, this can cause false-positives.  This commit
rearranges all occurrences of such options to come first in their
respective expressions.