### PR TITLE
Auto-generate contributor lists

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,48 +1,75 @@
-The following people have contributed to the OpenSCAP Security Guide project
-(listed in alphabetical order within category):
+The following people have contributed to the SCAP Security Guide project
+(listed in alphabetical order):
 
-Developers:
-* Gabe Alford
-* Christopher Anderson
-* Jeff Blank
-* Blake Burkhart
-* Frank Caviggia
-* Eric Christensen
-* Caleb Cooper
-* Nick Crawford
-* Maura Dailey
-* Greg Elin
-* Andrew Gilmore
-* Jeremiah Jahn
-* Luke Kordell
-* Ján Lieskovský
-* Šimon Lukašík
-* Michael McConachie
-* Rodney Mercer
-* Brian Millett
-* Michael Moseley
-* Joe Nall
-* Michele Newman
-* Michael Palmiotto
-* Kenneth Peeples
-* Martin Preisler
-* Rick Renshaw
-* Willy Santos
-* Satoru Satoh
-* Ray Shaw
-* Spencer Shimko
-* Francisco Slavin
-* Dave Smith
-* Kevin Spargur
-* Kenneth Stailey
-* Leland Steinke
-* Paul Tittle
-* Jeb Trayer
-* Shawn Wells
-* Jan Černý
-* Zbyněk Moravec
-* Michal Šrubař
-* Jean-Baptiste Donnette
-* Philippe Thierry
-
-Testing:
+* Gabe Alford <redhatrises@gmail.com>
+* Christopher Anderson <cba@fedoraproject.org>
+* Chuck Atkins <chuck.atkins@kitware.com>
+* Molly Jo Bault <Molly.Jo.Bault@ballardtech.com>
+* Joseph Bisch <joseph.bisch@gmail.com>
+* Jeffrey Blank <blank@eclipse.ncsc.mil>
+* Blake Burkhart <blake.burkhart@us.af.mil>
+* Patrick Callahan <pmc@patrickcallahan.com>
+* Nick Carboni <ncarboni@redhat.com>
+* Frank Caviggia <fcaviggi@ra.iad.redhat.com>
+* Eric Christensen <echriste@redhat.com>
+* Caleb Cooper <coopercd@ornl.gov>
+* Maura Dailey <maura@eclipse.ncsc.mil>
+* Klaas Demter <demter@atix.de>
+* Jean-Baptiste Donnette <jean-baptiste.donnette@epita.fr>
+* drax <applezip@gmail.com>
+* Greg Elin <gregelin@gitmachines.com>
+* Andrew Gilmore <agilmore2@gmail.com>
+* Andrew F. Gilmore <agilmore@ecahdb2.bor.doi.net>
+* Joshua Glemza <jglemza@nasa.gov>
+* Steve Grubb <sgrubb@redhat.com>
+* Trey Henefield <thenefield@gmail.com>
+* Robin Price II <robin@redhat.com>
+* Jeremiah Jahn <jeremiah@goodinassociates.com>
+* Stephan Joerrens <Stephan.Joerrens@fiduciagad.de>
+* Yuli Khodorkovskiy <ykhodorkovskiy@tresys.com>
+* Luke Kordell <luke.t.kordell@lmco.com>
+* kspargur <kspargur@kspargur.csb>
+* Fen Labalme <fen@civicactions.com>
+* Jan Lieskovsky <jlieskov@redhat.com>
+* Šimon Lukašík <slukasik@redhat.com>
+* Jamie Lorwey Martin <jlmartin@redhat.com>
+* Michael McConachie <michael@redhat.com>
+* Rodney Mercer <rmercer@harris.com>
+* Brian Millett <bmillett@gmail.com>
+* mmosel <mmosel@kde.example.com>
+* Zbynek Moravec <zmoravec@redhat.com>
+* Kazuo Moriwaka <moriwaka@users.noreply.github.com>
+* Michael Moseley <michael@eclipse.ncsc.mil>
+* Joe Nall <joe@nall.com>
+* Michele Newman <mnewman@redhat.com>
+* Kaustubh Padegaonkar <theTuxRacer@gmail.com>
+* Michael Palmiotto <mpalmiotto@tresys.com>
+* pcactr <paul.c.arnold4.ctr@mail.mil>
+* Kenneth Peeples <kennethwpeeples@gmail.com>
+* Frank Lin PIAT <fpiat@klabs.be>
+* Martin Preisler <mpreisle@redhat.com>
+* T.O. Radzy Radzykewycz <radzy@windriver.com>
+* Rick Renshaw <Richard_Renshaw@xtoenergy.com>
+* Chris Reynolds <c.reynolds82@gmail.com>
+* Pat Riehecky <riehecky@fnal.gov>
+* Joshua Roys <roysjosh@gmail.com>
+* rrenshaw <bofh69@yahoo.com>
+* Ray Shaw (Cont ARL/CISD) rvshaw <rvshaw@esme.arl.army.mil>
+* Willy Santos <wsantos@redhat.com>
+* Gautam Satish <gautams@hpe.com>
+* Satoru SATOH <satoru.satoh@gmail.com>
+* Spencer Shimko <sshimko@tresys.com>
+* Francisco Slavin <fslavin@tresys.com>
+* David Smith <dsmith@eclipse.ncsc.mil>
+* Kevin Spargur <kspargur@redhat.com>
+* Kenneth Stailey <kstailey.lists@gmail.com>
+* Leland Steinke <leland.j.steinke.ctr@mail.mil>
+* Philippe Thierry <phil@internal.reseau-libre.net>
+* Paul Tittle <ptittle@cmf.nrl.navy.mil>
+* Jeb Trayer <jeb.d.trayer@uscg.mil>
+* Shawn Wells <shawn@redhat.com>
+* Rob Wilmoth <rwilmoth@redhat.com>
+* Lucas Yamanishi <lucas.yamanishi@onyxpoint.com>
+* Kevin Zimmerman <kevin.zimmerman@kitware.com>
+* Jan Černý <jcerny@redhat.com>
+* Michal Šrubař <msrubar@redhat.com>

--- a/Contributors.md
+++ b/Contributors.md
@@ -19,7 +19,6 @@ The following people have contributed to the SCAP Security Guide project
 * drax <applezip@gmail.com>
 * Greg Elin <gregelin@gitmachines.com>
 * Andrew Gilmore <agilmore2@gmail.com>
-* Andrew F. Gilmore <agilmore@ecahdb2.bor.doi.net>
 * Joshua Glemza <jglemza@nasa.gov>
 * Steve Grubb <sgrubb@redhat.com>
 * Trey Henefield <thenefield@gmail.com>

--- a/Contributors.xml
+++ b/Contributors.xml
@@ -17,7 +17,6 @@
 <contributor>drax &lt;applezip@gmail.com&gt;</contributor>
 <contributor>Greg Elin &lt;gregelin@gitmachines.com&gt;</contributor>
 <contributor>Andrew Gilmore &lt;agilmore2@gmail.com&gt;</contributor>
-<contributor>Andrew F. Gilmore &lt;agilmore@ecahdb2.bor.doi.net&gt;</contributor>
 <contributor>Joshua Glemza &lt;jglemza@nasa.gov&gt;</contributor>
 <contributor>Steve Grubb &lt;sgrubb@redhat.com&gt;</contributor>
 <contributor>Trey Henefield &lt;thenefield@gmail.com&gt;</contributor>

--- a/Contributors.xml
+++ b/Contributors.xml
@@ -1,0 +1,74 @@
+<text>
+<contributor>Gabe Alford &lt;redhatrises@gmail.com&gt;</contributor>
+<contributor>Christopher Anderson &lt;cba@fedoraproject.org&gt;</contributor>
+<contributor>Chuck Atkins &lt;chuck.atkins@kitware.com&gt;</contributor>
+<contributor>Molly Jo Bault &lt;Molly.Jo.Bault@ballardtech.com&gt;</contributor>
+<contributor>Joseph Bisch &lt;joseph.bisch@gmail.com&gt;</contributor>
+<contributor>Jeffrey Blank &lt;blank@eclipse.ncsc.mil&gt;</contributor>
+<contributor>Blake Burkhart &lt;blake.burkhart@us.af.mil&gt;</contributor>
+<contributor>Patrick Callahan &lt;pmc@patrickcallahan.com&gt;</contributor>
+<contributor>Nick Carboni &lt;ncarboni@redhat.com&gt;</contributor>
+<contributor>Frank Caviggia &lt;fcaviggi@ra.iad.redhat.com&gt;</contributor>
+<contributor>Eric Christensen &lt;echriste@redhat.com&gt;</contributor>
+<contributor>Caleb Cooper &lt;coopercd@ornl.gov&gt;</contributor>
+<contributor>Maura Dailey &lt;maura@eclipse.ncsc.mil&gt;</contributor>
+<contributor>Klaas Demter &lt;demter@atix.de&gt;</contributor>
+<contributor>Jean-Baptiste Donnette &lt;jean-baptiste.donnette@epita.fr&gt;</contributor>
+<contributor>drax &lt;applezip@gmail.com&gt;</contributor>
+<contributor>Greg Elin &lt;gregelin@gitmachines.com&gt;</contributor>
+<contributor>Andrew Gilmore &lt;agilmore2@gmail.com&gt;</contributor>
+<contributor>Andrew F. Gilmore &lt;agilmore@ecahdb2.bor.doi.net&gt;</contributor>
+<contributor>Joshua Glemza &lt;jglemza@nasa.gov&gt;</contributor>
+<contributor>Steve Grubb &lt;sgrubb@redhat.com&gt;</contributor>
+<contributor>Trey Henefield &lt;thenefield@gmail.com&gt;</contributor>
+<contributor>Robin Price II &lt;robin@redhat.com&gt;</contributor>
+<contributor>Jeremiah Jahn &lt;jeremiah@goodinassociates.com&gt;</contributor>
+<contributor>Stephan Joerrens &lt;Stephan.Joerrens@fiduciagad.de&gt;</contributor>
+<contributor>Yuli Khodorkovskiy &lt;ykhodorkovskiy@tresys.com&gt;</contributor>
+<contributor>Luke Kordell &lt;luke.t.kordell@lmco.com&gt;</contributor>
+<contributor>kspargur &lt;kspargur@kspargur.csb&gt;</contributor>
+<contributor>Fen Labalme &lt;fen@civicactions.com&gt;</contributor>
+<contributor>Jan Lieskovsky &lt;jlieskov@redhat.com&gt;</contributor>
+<contributor>Šimon Lukašík &lt;slukasik@redhat.com&gt;</contributor>
+<contributor>Jamie Lorwey Martin &lt;jlmartin@redhat.com&gt;</contributor>
+<contributor>Michael McConachie &lt;michael@redhat.com&gt;</contributor>
+<contributor>Rodney Mercer &lt;rmercer@harris.com&gt;</contributor>
+<contributor>Brian Millett &lt;bmillett@gmail.com&gt;</contributor>
+<contributor>mmosel &lt;mmosel@kde.example.com&gt;</contributor>
+<contributor>Zbynek Moravec &lt;zmoravec@redhat.com&gt;</contributor>
+<contributor>Kazuo Moriwaka &lt;moriwaka@users.noreply.github.com&gt;</contributor>
+<contributor>Michael Moseley &lt;michael@eclipse.ncsc.mil&gt;</contributor>
+<contributor>Joe Nall &lt;joe@nall.com&gt;</contributor>
+<contributor>Michele Newman &lt;mnewman@redhat.com&gt;</contributor>
+<contributor>Kaustubh Padegaonkar &lt;theTuxRacer@gmail.com&gt;</contributor>
+<contributor>Michael Palmiotto &lt;mpalmiotto@tresys.com&gt;</contributor>
+<contributor>pcactr &lt;paul.c.arnold4.ctr@mail.mil&gt;</contributor>
+<contributor>Kenneth Peeples &lt;kennethwpeeples@gmail.com&gt;</contributor>
+<contributor>Frank Lin PIAT &lt;fpiat@klabs.be&gt;</contributor>
+<contributor>Martin Preisler &lt;mpreisle@redhat.com&gt;</contributor>
+<contributor>T.O. Radzy Radzykewycz &lt;radzy@windriver.com&gt;</contributor>
+<contributor>Rick Renshaw &lt;Richard_Renshaw@xtoenergy.com&gt;</contributor>
+<contributor>Chris Reynolds &lt;c.reynolds82@gmail.com&gt;</contributor>
+<contributor>Pat Riehecky &lt;riehecky@fnal.gov&gt;</contributor>
+<contributor>Joshua Roys &lt;roysjosh@gmail.com&gt;</contributor>
+<contributor>rrenshaw &lt;bofh69@yahoo.com&gt;</contributor>
+<contributor>Ray Shaw (Cont ARL/CISD) rvshaw &lt;rvshaw@esme.arl.army.mil&gt;</contributor>
+<contributor>Willy Santos &lt;wsantos@redhat.com&gt;</contributor>
+<contributor>Gautam Satish &lt;gautams@hpe.com&gt;</contributor>
+<contributor>Satoru SATOH &lt;satoru.satoh@gmail.com&gt;</contributor>
+<contributor>Spencer Shimko &lt;sshimko@tresys.com&gt;</contributor>
+<contributor>Francisco Slavin &lt;fslavin@tresys.com&gt;</contributor>
+<contributor>David Smith &lt;dsmith@eclipse.ncsc.mil&gt;</contributor>
+<contributor>Kevin Spargur &lt;kspargur@redhat.com&gt;</contributor>
+<contributor>Kenneth Stailey &lt;kstailey.lists@gmail.com&gt;</contributor>
+<contributor>Leland Steinke &lt;leland.j.steinke.ctr@mail.mil&gt;</contributor>
+<contributor>Philippe Thierry &lt;phil@internal.reseau-libre.net&gt;</contributor>
+<contributor>Paul Tittle &lt;ptittle@cmf.nrl.navy.mil&gt;</contributor>
+<contributor>Jeb Trayer &lt;jeb.d.trayer@uscg.mil&gt;</contributor>
+<contributor>Shawn Wells &lt;shawn@redhat.com&gt;</contributor>
+<contributor>Rob Wilmoth &lt;rwilmoth@redhat.com&gt;</contributor>
+<contributor>Lucas Yamanishi &lt;lucas.yamanishi@onyxpoint.com&gt;</contributor>
+<contributor>Kevin Zimmerman &lt;kevin.zimmerman@kitware.com&gt;</contributor>
+<contributor>Jan Černý &lt;jcerny@redhat.com&gt;</contributor>
+<contributor>Michal Šrubař &lt;msrubar@redhat.com&gt;</contributor>
+</text>

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -65,17 +65,8 @@ $(OUT)/shorthand.xml: $(OUT)/guide.xml $(IN)/guide.xslt $(guide_xslt_deps)
 $(SHARED)/$(OUT):
 	mkdir -p $@
 
-# Benchmark metadata prerequisite - derive $(SHARED)/$(OUT)/contributors.xml from the content of Contributors.md
-$(SHARED)/$(OUT)/contributors.xml: $(SHARED)/$(OUT)
-	# Create $(SHARED)/$(OUT)/contributors.xml file:
-	# * holding <text> like root element and
-	# * names of the individual SSG contributor(s) within <contributor> element(s)
-	echo "<text>" > $@
-	sed -n -e 's/\* \(.*\)/<contributor>\1<\/contributor>/p' $(SHARED)/../Contributors.md >> $@
-	echo "</text>" >> $@
-
 # Common build targets - convert shorthand format to an XCCDF stub
-$(OUT)/xccdf-unlinked-unresolved.xml: $(OUT)/shorthand.xml $(SHARED)/$(OUT)/contributors.xml $(TRANS)/shorthand2xccdf.xslt $(TRANS)/constants.xslt $(SHARED)/$(TRANS)/shared_constants.xslt
+$(OUT)/xccdf-unlinked-unresolved.xml: $(OUT)/shorthand.xml $(TRANS)/shorthand2xccdf.xslt $(TRANS)/constants.xslt $(SHARED)/$(TRANS)/shared_constants.xslt
 	xsltproc --stringparam ssg_version "$(SSG_MAJOR_VERSION).$(SSG_MINOR_VERSION)" -o $@ $(TRANS)/shorthand2xccdf.xslt $<
 
 # Common build targets - improve the XCCDF stub - first resolve

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -47,7 +47,7 @@
       <!-- Insert benchmark creator -->
       <dc:creator><xsl:value-of select="$ssg-project-name"/></dc:creator>
       <!-- Insert list of individual contributors for benchmark -->
-      <xsl:for-each select="document('../output/contributors.xml')/text/contributor">
+      <xsl:for-each select="document('../../Contributors.xml')/text/contributor">
         <dc:contributor><xsl:value-of select="current()" /></dc:contributor>
       </xsl:for-each>
       <!-- Insert benchmark source -->

--- a/shared/utils/generate-contributors.py
+++ b/shared/utils/generate-contributors.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import re
+import os.path
 
 email_mappings = {
     # Dave / David Smith
@@ -45,7 +46,7 @@ name_mappings = {
 
 def main():
     emails = {}
-    output = subprocess.check_output(["git", "shortlog", "-se"])
+    output = subprocess.check_output(["git", "shortlog", "-se"]).decode("utf-8")
     for line in output.split("\n"):
         match = re.match(r"[\s]*([0-9]+)[\s+](.+)[\s]+\<(.+)\>", line)
         if match is None:
@@ -73,9 +74,19 @@ def main():
 
         contributors[name] = email
 
+    contributors_md = \
+        "The following people have contributed to the SCAP Security Guide project\n"
+    contributors_md += "(listed in alphabetical order):\n\n"
+
     for name in sorted(contributors.keys(), key=lambda x: x.split(" ")[-1].upper()):
         email = contributors[name]
-        print("%s <%s>" % (name, email))
+        contributors_md += "* %s <%s>\n" % (name, email)
+
+    root_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    with open(os.path.join(root_dir, "Contributors.md"), "w") as f:
+        f.write(contributors_md)
+
+    print("Don't forget to commit Contributors.md!")
 
 if __name__ == "__main__":
     main()

--- a/shared/utils/generate-contributors.py
+++ b/shared/utils/generate-contributors.py
@@ -33,6 +33,8 @@ email_mappings = {
     "shawnw@localhost.localdomain": "shawn@redhat.com",
     # Simon Lukasik
     "isimluk@fedoraproject.org": "slukasik@redhat.com",
+    # Andrew Gilmore
+    "agilmore@ecahdb2.bor.doi.net": "agilmore2@gmail.com",
 
     # No idea / ignore
     "lyd@chippy.(none)": "",

--- a/shared/utils/generate-contributors.py
+++ b/shared/utils/generate-contributors.py
@@ -9,7 +9,8 @@ email_mappings = {
     # Dave / David Smith
     "dsmith@secure-innovations.net": "dsmith@eclipse.ncsc.mil",
     "dsmith@fornax.eclipse.ncsc.mil": "dsmith@eclipse.ncsc.mil",
-    "fcaviggia@users.noreply.github.com": "dsmith@eclipse.ncsc.mil",
+    # Frank Caviggia
+    "fcaviggia@users.noreply.github.com": "fcaviggi@ra.iad.redhat.com",
     # Greg Elin
     "greg@fotonotes.net": "gregelin@gitmachines.com",
     # Jean-Baptiste Donnette

--- a/shared/utils/generate-contributors.py
+++ b/shared/utils/generate-contributors.py
@@ -3,6 +3,7 @@
 import subprocess
 import re
 import os.path
+import codecs
 
 email_mappings = {
     # Dave / David Smith
@@ -88,9 +89,11 @@ def main():
     contributors_xml += "</text>\n"
 
     root_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-    with open(os.path.join(root_dir, "Contributors.md"), "w") as f:
+    with codecs.open(os.path.join(root_dir, "Contributors.md"),
+                     mode="w", encoding="utf-8") as f:
         f.write(contributors_md)
-    with open(os.path.join(root_dir, "Contributors.xml"), "w") as f:
+    with codecs.open(os.path.join(root_dir, "Contributors.xml"),
+                     mode="w", encoding="utf-8") as f:
         f.write(contributors_xml)
 
     print("Don't forget to commit Contributors.md!")

--- a/shared/utils/generate-contributors.py
+++ b/shared/utils/generate-contributors.py
@@ -96,7 +96,7 @@ def main():
                      mode="w", encoding="utf-8") as f:
         f.write(contributors_xml)
 
-    print("Don't forget to commit Contributors.md!")
+    print("Don't forget to commit Contributors.md and Contributors.xml!")
 
 if __name__ == "__main__":
     main()

--- a/shared/utils/generate-contributors.py
+++ b/shared/utils/generate-contributors.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python
+
+import subprocess
+import re
+
+email_mappings = {
+    # Dave / David Smith
+    "dsmith@secure-innovations.net": "dsmith@eclipse.ncsc.mil",
+    "dsmith@fornax.eclipse.ncsc.mil": "dsmith@eclipse.ncsc.mil",
+    "fcaviggia@users.noreply.github.com": "dsmith@eclipse.ncsc.mil",
+    # Greg Elin
+    "greg@fotonotes.net": "gregelin@gitmachines.com",
+    # Jean-Baptiste Donnette
+    "donnet_j@epita.fr": "jean-baptiste.donnette@epita.fr",
+    # Martin Preisler
+    "martin@preisler.me": "mpreisle@redhat.com",
+    # Philippe Thierry
+    "phil@reseau-libre.net": "phil@internal.reseau-libre.net",
+    "philippe.thierry@reseau-libre.net": "phil@internal.reseau-libre.net",
+    "philippe.thierry@thalesgroup.com": "phil@internal.reseau-libre.net",
+    # Robin Price II
+    "rprice@users.noreply.github.com": "robin@redhat.com",
+    "rprice@redhat.com": "robin@redhat.com",
+    # Zbynek Moravec
+    "ybznek@users.noreply.github.com": "zmoravec@redhat.com",
+    # Jeff Blank
+    "jeff@t440.local": "blank@eclipse.ncsc.mil",
+    # Shawn Wells
+    "shawn@localhost.localdomain": "shawn@redhat.com",
+    "shawnw@localhost.localdomain": "shawn@redhat.com",
+    # Simon Lukasik
+    "isimluk@fedoraproject.org": "slukasik@redhat.com",
+
+    # No idea / ignore
+    "lyd@chippy.(none)": "",
+    "nick@null.net": "",
+    "root@localhost.localdomain": "",
+    "root@rhel6.(none)": "",
+}
+
+name_mappings = {
+    "Gabe": "Gabe Alford"
+}
+
+
+def main():
+    emails = {}
+    output = subprocess.check_output(["git", "shortlog", "-se"])
+    for line in output.split("\n"):
+        match = re.match(r"[\s]*([0-9]+)[\s+](.+)[\s]+\<(.+)\>", line)
+        if match is None:
+            continue
+
+        commits, name, email = match.groups()
+
+        if email in email_mappings:
+            email = email_mappings[email]
+
+        if email == "":
+            continue  # ignored
+
+        if email not in emails:
+            emails[email] = []
+
+        emails[email].append((int(commits), name))
+
+    contributors = {}
+    # We will use the most used full name
+    for email in emails:
+        _, name = sorted(emails[email], reverse=True)[0]
+        if name in name_mappings:
+            name = name_mappings[name]
+
+        contributors[name] = email
+
+    for name in sorted(contributors.keys(), key=lambda x: x.split(" ")[-1].upper()):
+        email = contributors[name]
+        print("%s <%s>" % (name, email))
+
+if __name__ == "__main__":
+    main()

--- a/shared/utils/generate-contributors.py
+++ b/shared/utils/generate-contributors.py
@@ -78,13 +78,20 @@ def main():
         "The following people have contributed to the SCAP Security Guide project\n"
     contributors_md += "(listed in alphabetical order):\n\n"
 
+    contributors_xml = "<text>\n"
+
     for name in sorted(contributors.keys(), key=lambda x: x.split(" ")[-1].upper()):
         email = contributors[name]
         contributors_md += "* %s <%s>\n" % (name, email)
+        contributors_xml += "<contributor>%s &lt;%s&gt;</contributor>\n" % (name, email)
+
+    contributors_xml += "</text>\n"
 
     root_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
     with open(os.path.join(root_dir, "Contributors.md"), "w") as f:
         f.write(contributors_md)
+    with open(os.path.join(root_dir, "Contributors.xml"), "w") as f:
+        f.write(contributors_xml)
 
     print("Don't forget to commit Contributors.md!")
 


### PR DESCRIPTION
More effort to streamline the build process and rip out odd things.

In this case it's a target generating the same contributors.xml file but the rules are there for each and every SSG product. So this file gets generated multiple times over the course of the build and gets overwritten again and again.

I went a bit over the top here and instead of just fixing the Makefile target and create a script that uses git to query all contributor information and generates both files - Contributors.md and Contributors.xml.

Let me know what you think.

Known issues:
* Czech surnames (Jan Cerny and Michal Srubar) come last in the alphabet ordered list. This is because python sorting doesn't collate and doesn't deal with unicode characters very well. I could work around this by mapping the accented chars to C and S respectively but I am hoping this is not a big deal and not worth the effort.