### PR TITLE
Fix build-remediations for oval_5.11

### DIFF
--- a/Debian/8/templates/oval_5.11_templates/template_BASH_package_installed
+++ b/Debian/8/templates/oval_5.11_templates/template_BASH_package_installed
@@ -1,4 +1,0 @@
-# platform = Debian 8
-# Include source function library.
-
-apt-get install PKGNAME

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -31,7 +31,7 @@ def get_template_filename(filename):
         return shared_template
 
     sys.stderr.write(
-        "No specialized or shared template found for {}\n".format(filename)
+        "No specialized or shared template found for {0}\n".format(filename)
     )
     sys.exit(EXIT_NO_TEMPLATE)
 

--- a/shared/utils/build-remediations.py
+++ b/shared/utils/build-remediations.py
@@ -117,9 +117,6 @@ class Builder(object):
     def _get_csv_dir(self):
         return self.csv_dirs[self.current_oval]
 
-    def _get_template_dir(self):
-        return self.input_dir
-
     def _get_csv_list(self):
         dir = self._get_csv_dir()
 


### PR DESCRIPTION
+ OVAL_5.11 OVAL templates weren't used for Debian8 build 
(because there was duplicate method with behavior in the code python code)
+ delete useless template - it is already in (/s2/Debian/8/templates/template_BASH_package_installed )

thank you @mpreisler 
https://github.com/OpenSCAP/scap-security-guide/pull/1513