### PR TITLE
Don't include @platform in <fix> element

### DIFF
--- a/shared/transforms/combineremediations.py
+++ b/shared/transforms/combineremediations.py
@@ -390,8 +390,6 @@ def main():
                                 fix.set("complexity", complexity)
                             if disruption is not None:
                                 fix.set("disruption", disruption)
-                            if platform is not None:
-                                fix.set("platform", product_name)
                             if reboot is not None:
                                 fix.set("reboot", reboot)
                             if strategy is not None:


### PR DESCRIPTION
This is a fix for a serious regression, the remediations won't be run at all if the attribute is included! Since we have one benchmark per product it makes no sense to include it anyway.

Regression was introduced in:
https://github.com/OpenSCAP/scap-security-guide/pull/1491

Thanks goes to @bkogami and @xmtrcv who have reported this issue.

Fixes https://github.com/OpenSCAP/scap-security-guide/issues/1509