### PR TITLE
DISA usage

### DIFF
--- a/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
@@ -2,6 +2,18 @@
 <title override="true">STIG for Red Hat Enterprise Linux 7 Server</title>
 <description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
 
+<!-- Where is the RHEL7 STIG?  
+From:      http://iase.disa.mil/stigs/Pages/faqs.aspx#STIG
+
+Question:  May I deploy a product if no STIG exists?
+Answer:    Yes, based on mission need and with DAA approval.
+
+Question:  What do I use if there is no STIG?
+Answer:    DISA FSO developed Security Requirement Guides (SRGs) to address technology areas. 
+           In the absence of a STIG, an SRG can be used to determine compliance with DoD policies. 
+           If there is no applicable SRG or STIG, industry or vendor recommended practices may be used. 
+           Examples include Center for Internet Security Benchmarks, Payment Card Industry requirements or the vendor's own security documentation. -->
+
 <!-- DISA FSO REFINEMENT VALUES
      The following refine-values tailor the NIAP OSPP profile
      to DoD-specific settings, as deemed approriate by DISA FSO (RE71) -->


### PR DESCRIPTION
Adding usage steps if there isn't an official STIG from DISA.
This should help direct customers to the official DISA website stating they (customers) can use the vendor provided STIG.