### PR TITLE
Do not install the shared remediation_functions file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,6 @@ install: dist
 	install -m 0644 Fedora/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
 	install -m 0644 Fedora/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
 	install -m 0644 RHEL/6/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
-	install -m 0644 shared/remediations/bash/templates/remediation_functions $(PREFIX)/$(DATADIR)/scap-security-guide/
 	install -m 0644 RHEL/6/kickstart/*-ks.cfg $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
 	install -m 0644 RHEL/7/kickstart/*-ks.cfg $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
 	install -m 0644 RHEL/6/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides


### PR DESCRIPTION
remediation_functions are now included in XCCDF files, this file is not used anymore.

Encountered this while porting installation steps over to cmake.