### PR TITLE
Move built remediations away from templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,6 @@
 **/dist
 !**/dist/README
 
-# Ignore .sh files in the following directories:
-#     */templates/output
-**/templates/output/*.sh
-
 # Ignore .ini files in the following directories
 #     */input/oval
 #     */transforms
@@ -22,9 +18,7 @@
 **/output/*.ini
 
 # Ignore .xml files in the following directories:
-#     */templates/output
 #     */output
-**/templates/output/*
 **/output/*.xml
 
 # Ignore .html files in the following directories:
@@ -63,6 +57,9 @@
 # Ignore the following directories in */output
 **/output/scap-security-guide-*/
 **/output/RPMS/
+**/output/ansible
+**/output/bash
+**/output/oval
 
 # Ignore docs tmp directories
 docs/Developer_Guide/tmp

--- a/Debian/8/Makefile
+++ b/Debian/8/Makefile
@@ -4,19 +4,20 @@ SHARED = ../../shared
 include $(SHARED)/product-make.include
 
 PROD = debian8
-OVAL_DIRS = $(SHARED_OVAL) templates/output/oval templates/static/oval
+OVAL_DIRS = $(SHARED_OVAL) $(OUT)/oval templates/static/oval
 VENDOR = ssgproject
 
-checks: templates/output
+checks:
 	# If openscap on the system supports OVAL-5.11 language version, include also OVAL-5.11 checks
 	# add local Debian8 specific templated ovals
 	# into final list of OVAL checks
 ifeq ($(OVAL_5_11), 0)
 	# System supports OVAL-5.11 => propagate 'RUNTIME_OVAL_VERSION' variable into the environment
 	$(eval MOD_ENV := env RUNTIME_OVAL_VERSION='5.11')
-	$(eval OVAL_DIRS+=$(SHARED_OVAL_5_11) templates/output/oval templates/static/oval_5.11)
+	$(eval OVAL_DIRS+=$(SHARED_OVAL_5_11) $(OUT)/oval templates/static/oval_5.11)
 endif
 	find $(OVAL_DIRS) -name "*.xml" | xargs xmlwf
+	$(SHARED)/utils/generate-from-templates.py --oval_version $(OVAL_VERSION) --input ./templates --output $(OUT) --language oval build
 	$(MOD_ENV) $(SHARED)/$(UTILS)/combine-ovals.py $(CONF) $(PROD) $(OVAL_DIRS) > $(OUT)/unlinked-$(PROD)-oval.xml
 	xmllint --format --output $(OUT)/unlinked-$(PROD)-oval.xml $(OUT)/unlinked-$(PROD)-oval.xml
 
@@ -125,5 +126,5 @@ dist: guide content
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
 	rm -rf $(DIST)/content $(DIST)/guide
-	rm -rf ./templates/output
+	rm -rf $(OUT)/bash $(OUT)/ansible $(OUT)/oval
 	rm -rf $(BUILD)

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -67,6 +67,6 @@ dist: guide content
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
 	rm -f $(IN)/remediations/bash/templates/output/*.sh
-	rm -rf ./templates/output
+	rm -rf $(OUT)/bash $(OUT)/ansible
 	rm -rf $(DIST)/content $(DIST)/guide
 	rm -rf $(BUILD)

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -140,5 +140,5 @@ dist: tables guide content
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
 	rm -rf $(DIST)/content $(DIST)/guide
-	rm -rf ./templates/output
+	rm -rf $(OUT)/bash $(OUT)/ansible
 	rm -rf $(BUILD)

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -165,5 +165,5 @@ dist: tables guide content
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
 	rm -rf $(DIST)/content $(DIST)/guide
-	rm -rf ./templates/output
+	rm -rf $(OUT)/bash $(OUT)/ansible
 	rm -rf $(BUILD)

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -156,6 +156,6 @@ dist: tables guide content
 
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
-	rm -rf ./templates/output
+	rm -rf $(OUT)/bash $(OUT)/ansible
 	rm -rf $(DIST)/content $(DIST)/guide
 	rm -rf $(BUILD)

--- a/WRLinux/Makefile
+++ b/WRLinux/Makefile
@@ -68,6 +68,6 @@ dist: guide content
 clean:
 	rm -f $(OUT)/*.xml $(OUT)/*.html $(OUT)/*.xhtml $(OUT)/*.pdf  $(OUT)/*.spec $(OUT)/*.tar $(OUT)/*.gz $(OUT)/*.ini $(OUT)/*.csv
 	rm -f $(IN)/remediations/bash/templates/output/*.sh
-	rm -rf ./templates/output
+	rm -rf $(OUT)/bash $(OUT)/ansible
 	rm -rf $(DIST)/content $(DIST)/guide
 	rm -rf $(BUILD)

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -21,9 +21,8 @@ SHARED_OVAL = $(SHARED)/oval
 SHARED_OVAL_5_11 = $(SHARED_OVAL)/oval_5.11
 SHARED_BASH_REMEDIATIONS =    $(BUILD)/shared/output/bash       $(SHARED)/templates/static/bash # Currently we cannot build shared remediations only once
 SHARED_ANSIBLE_REMEDIATIONS = $(BUILD)/shared/output/ansible    $(SHARED)/templates/static/ansible # Currently we cannot build shared remediations only once
-PRODUCT_REMEDIATIONS_OUTPUT = templates/output
-PRODUCT_BASH_REMEDIATIONS = $(PRODUCT_REMEDIATIONS_OUTPUT)/bash
-PRODUCT_ANSIBLE_REMEDIATIONS = $(PRODUCT_REMEDIATIONS_OUTPUT)/ansible
+PRODUCT_BASH_REMEDIATIONS = $(OUT)/bash
+PRODUCT_ANSIBLE_REMEDIATIONS = $(OUT)/ansible
 STANDARD_OVAL_DIRS = $(SHARED_OVAL) $(IN)/oval
 REFS = $(SHARED)/references
 CONF = $(SHARED)/../config
@@ -93,8 +92,11 @@ $(OUT)/ocil-unlinked.xml: $(OUT)/xccdf-unlinked-resolved.xml $(SHARED)/$(TRANS)/
 $(OUT)/xccdf-unlinked-ocilrefs.xml: $(OUT)/xccdf-unlinked-resolved.xml $(OUT)/ocil-unlinked.xml $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $(SHARED)/$(TRANS)/shared_constants.xslt
 	xsltproc -stringparam product "$(PROD)" -o $@ $(SHARED)/$(TRANS)/xccdf-ocilcheck2ref.xslt $<
 
-$(PRODUCT_REMEDIATIONS_OUTPUT):
-	$(SHARED)/utils/generate-from-templates.py --oval_version $(OVAL_VERSION) --input ./templates --output ./templates/output build
+$(PRODUCT_ANSIBLE_REMEDIATIONS):
+	$(SHARED)/utils/generate-from-templates.py --oval_version $(OVAL_VERSION) --input ./templates --output $(OUT) --language ansible build
+
+$(PRODUCT_BASH_REMEDIATIONS):
+	$(SHARED)/utils/generate-from-templates.py --oval_version $(OVAL_VERSION) --input ./templates --output $(OUT) --language bash build
 
 $(BUILD)/shared/output:
 	$(SHARED)/utils/generate-from-templates.py --oval_version $(OVAL_VERSION) --input $(SHARED)/templates --output $(BUILD)/shared/output build
@@ -109,7 +111,7 @@ templates/static/ansible:
 product_bash_remediations_deps=$(wildcard templates/static/bash/*.sh)
 shared_bash_remediations_deps= $(wildcard $(SHARED_BASH_REMEDIATIONS)/*.sh)
 bash_remediations_deps= $(product_bash_remediations_deps) $(shared_bash_remediations_deps)
-$(OUT)/bash-remediations.xml: $(SHARED)/$(UTILS)/combine-remediations.py $(bash_remediations_deps) $(PRODUCT_REMEDIATIONS_OUTPUT) $(BUILD)/shared/output templates/static/bash
+$(OUT)/bash-remediations.xml: $(SHARED)/$(UTILS)/combine-remediations.py $(bash_remediations_deps) $(PRODUCT_BASH_REMEDIATIONS) $(BUILD)/shared/output templates/static/bash
 	$(SHARED)/$(UTILS)/combine-remediations.py $(PROD) bash $(SHARED_BASH_REMEDIATIONS) $(PRODUCT_BASH_REMEDIATIONS) templates/static/bash $(OUT)/bash-remediations.xml
 
 
@@ -117,7 +119,7 @@ $(OUT)/bash-remediations.xml: $(SHARED)/$(UTILS)/combine-remediations.py $(bash_
 product_ansible_remediations_deps=$(wildcard templates/static/ansible/*.sh)
 shared_ansible_remediations_deps= $(wildcard $(SHARED_ANSIBLE_REMEDIATIONS)/*.sh)
 ansible_remediations_deps= $(product_ansible_remediations_deps) $(shared_ansible_remediations_deps)
-$(OUT)/ansible-remediations.xml: $(SHARED)/$(UTILS)/combine-remediations.py $(ansible_remediations_deps) $(PRODUCT_REMEDIATIONS_OUTPUT) $(BUILD)/shared/output templates/static/ansible
+$(OUT)/ansible-remediations.xml: $(SHARED)/$(UTILS)/combine-remediations.py $(ansible_remediations_deps) $(PRODUCT_ANSIBLE_REMEDIATIONS) $(BUILD)/shared/output templates/static/ansible
 	$(SHARED)/$(UTILS)/combine-remediations.py $(PROD) ansible $(SHARED_ANSIBLE_REMEDIATIONS) $(PRODUCT_ANSIBLE_REMEDIATIONS) templates/static/ansible $(OUT)/ansible-remediations.xml
 
 # Common build targets - an XCCDF with remediations but not linked to OVAL yet

--- a/shared/product-make.include
+++ b/shared/product-make.include
@@ -15,7 +15,6 @@ include $(SHARED)/../VERSION
 IN = input
 OUT = output
 BUILD = build
-BUILD_REMEDIATIONS=$(BUILD)/remediations
 TRANS = transforms
 SHARED_OVAL = $(SHARED)/oval
 SHARED_OVAL_5_11 = $(SHARED_OVAL)/oval_5.11


### PR DESCRIPTION
The built scripts from templates were stored in templates/output.
This commit moves them to $(OUT) directory.