### PR TITLE
Converted XML comment DISA STIG note to XHTML

### DIFF
--- a/RHEL/7/input/profiles/stig-rhel7-server-gui-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-gui-upstream.xml
@@ -1,19 +1,21 @@
 <Profile id="stig-rhel7-server-gui-upstream" extends="stig-rhel7-server-upstream">
 <title override="true">STIG for Red Hat Enterprise Linux 7 Server Running GUIs</title>
-<description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
+<description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.<br /><br />
 
-<!-- Where is the RHEL7 STIG?  
-     From:      http://iase.disa.mil/stigs/Pages/faqs.aspx#STIG
+<p>
+    <strong>Where is the RHEL7 STIG?</strong>
+    <ul>
+        <li>Question: May I deploy a product if no STIG exists?<br />
+            Answer: Yes, based on mission need and with DAA approval.
+        </li>
+        <li>Question: What do I use if there is no STIG?<br />
+            Answer: DISA FSO developed Security Requirement Guides (SRGs) to address technology areas. In the absence of a STIG, an SRG can be used to determine compliance with DoD policies. If there is no applicable SRG or STIG, industry or vendor recommended practices may be used. Examples include Center for Internet Security Benchmarks, Payment Card Industry requirements or the vendor's own security documentation.
+        </li>
+    </ul>
+    <small>Source: http://iase.disa.mil/stigs/Pages/faqs.aspx#STIG</small>
+</p>
+</description>
 
-Question:  May I deploy a product if no STIG exists?
-Answer:    Yes, based on mission need and with DAA approval.
-
-Question:  What do I use if there is no STIG?
-Answer:    DISA FSO developed Security Requirement Guides (SRGs) to address technology areas. 
-           In the absence of a STIG, an SRG can be used to determine compliance with DoD policies. 
-           If there is no applicable SRG or STIG, industry or vendor recommended practices may be used. 
-           Examples include Center for Internet Security Benchmarks, Payment Card Industry 
-           requirements or the vendor's own security documentation. -->
 
 <!-- DISA FSO REFINEMENT VALUES
      The following refine-values tailor the NIAP OSPP profile

--- a/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
@@ -1,19 +1,20 @@
 <Profile id="stig-rhel7-server-upstream" extends="ospp-rhel7-server">
 <title override="true">STIG for Red Hat Enterprise Linux 7 Server</title>
-<description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
+<description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.<br /><br />
 
-<!-- Where is the RHEL7 STIG?  
-From:      http://iase.disa.mil/stigs/Pages/faqs.aspx#STIG
-
-Question:  May I deploy a product if no STIG exists?
-Answer:    Yes, based on mission need and with DAA approval.
-
-Question:  What do I use if there is no STIG?
-Answer:    DISA FSO developed Security Requirement Guides (SRGs) to address technology areas. 
-           In the absence of a STIG, an SRG can be used to determine compliance with DoD policies. 
-           If there is no applicable SRG or STIG, industry or vendor recommended practices may be used. 
-           Examples include Center for Internet Security Benchmarks, Payment Card Industry 
-           requirements or the vendor's own security documentation. -->
+<p>
+    <strong>Where is the RHEL7 STIG?</strong>
+    <ul>
+        <li>Question: May I deploy a product if no STIG exists?<br />
+            Answer: Yes, based on mission need and with DAA approval.
+        </li>
+        <li>Question: What do I use if there is no STIG?<br />
+            Answer: DISA FSO developed Security Requirement Guides (SRGs) to address technology areas. In the absence of a STIG, an SRG can be used to determine compliance with DoD policies. If there is no applicable SRG or STIG, industry or vendor recommended practices may be used. Examples include Center for Internet Security Benchmarks, Payment Card Industry requirements or the vendor's own security documentation.
+        </li>
+    </ul>
+    <small>Source: http://iase.disa.mil/stigs/Pages/faqs.aspx#STIG</small>
+</p>
+</description>
 
 <!-- DISA FSO REFINEMENT VALUES
      The following refine-values tailor the NIAP OSPP profile

--- a/RHEL/7/input/profiles/stig-rhel7-workstation-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-workstation-upstream.xml
@@ -1,6 +1,20 @@
 <Profile id="stig-rhel7-workstation-upstream" extends="stig-rhel7-server-gui-upstream">
 <title override="true">STIG for Red Hat Enterprise Linux 7 Workstation</title>
-<description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.</description>
+<description override="true">This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become a STIG in coordination with DISA FSO.<br /><br />
+
+<p>
+    <strong>Where is the RHEL7 STIG?</strong>
+    <ul>
+        <li>Question: May I deploy a product if no STIG exists?<br />
+            Answer: Yes, based on mission need and with DAA approval.
+        </li>
+        <li>Question: What do I use if there is no STIG?<br />
+            Answer: DISA FSO developed Security Requirement Guides (SRGs) to address technology areas. In the absence of a STIG, an SRG can be used to determine compliance with DoD policies. If there is no applicable SRG or STIG, industry or vendor recommended practices may be used. Examples include Center for Internet Security Benchmarks, Payment Card Industry requirements or the vendor's own security documentation.
+        </li>
+    </ul>
+    <small>Source: http://iase.disa.mil/stigs/Pages/faqs.aspx#STIG</small>
+</p>
+</description>
 
 <!-- Where is the RHEL7 STIG?  
      From:      http://iase.disa.mil/stigs/Pages/faqs.aspx#STIG


### PR DESCRIPTION
Now it shows up in HTML guides.

![image](https://cloud.githubusercontent.com/assets/753153/19779777/97bf2680-9c50-11e6-808d-4639e8e91a78.png)

It's a bit screwed up in SCAP Workbench but it does show up as well. Issue reported in https://github.com/OpenSCAP/scap-workbench/issues/91

![image](https://cloud.githubusercontent.com/assets/753153/19779824/bef924e4-9c50-11e6-8243-348468565fb0.png)
