### PR TITLE
Rename PCI-DSS centric profile ID

### DIFF
--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -179,7 +179,13 @@ def main():
     # filter out all profiles except PCI-DSS
     for profile in \
             benchmark.findall("./{%s}Profile" % (XCCDF_NAMESPACE)):
-        if not profile.get("id").endswith("pci-dss"):
+        if profile.get("id").endswith("pci-dss"):
+            # change the profile ID to avoid validation issues
+            profile.set(
+                "id",
+                profile.get("id").replace("pci-dss", "pci-dss_centric")
+            )
+        else:
             root_element.remove(profile)
             continue
 


### PR DESCRIPTION
To avoid validation issues with NIST SCAP Content Validator Tool we
rename the profile ID of the PCI-DSS centric benchmark.

Should fix #1344.