### PR TITLE
New install location

### DIFF
--- a/JRE/input/oscap-scan-java
+++ b/JRE/input/oscap-scan-java
@@ -4,5 +4,5 @@ SCAN_OPTIONS="xccdf eval
              --profile java-stig
              --report /var/log/oscap-scan-java-report.html
              --results /var/log/oscap-scan-java-results.xml
-             --cpe /usr/share/xml/scap/ssg/content/ssg-java-cpe-dictionary.xml
-             /usr/share/xml/scap/ssg/content/ssg-java-xccdf.xml"
+             --cpe /usr/share/scap/ssg/ssg-java-cpe-dictionary.xml
+             /usr/share/scap/ssg/ssg-java-xccdf.xml"

--- a/Makefile
+++ b/Makefile
@@ -233,33 +233,36 @@ clean:
 	cd Chromium && $(MAKE) clean
 
 install: dist
-	install -d $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
+	install -d $(PREFIX)/$(DATADIR)/scap/ssg
 	install -d $(PREFIX)/$(DATADIR)/scap-security-guide
 	install -d $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
 	install -d $(PREFIX)/$(MANDIR)/en/man8/
 	install -d $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
-	install -m 0644 Fedora/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
+	install -m 0644 Fedora/dist/content/* $(PREFIX)/$(DATADIR)/scap/ssg/
 	install -m 0644 Fedora/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
-	install -m 0644 RHEL/6/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
+	install -m 0644 RHEL/6/dist/content/* $(PREFIX)/$(DATADIR)/scap/ssg/
 	install -m 0644 RHEL/6/kickstart/*-ks.cfg $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
 	install -m 0644 RHEL/7/kickstart/*-ks.cfg $(PREFIX)/$(DATADIR)/scap-security-guide/kickstart
 	install -m 0644 RHEL/6/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
-	install -m 0644 RHEL/7/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
+	install -m 0644 RHEL/7/dist/content/* $(PREFIX)/$(DATADIR)/scap/ssg/
 	install -m 0644 RHEL/7/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
-	install -m 0644 OpenStack/RHEL-OSP/7/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
+	install -m 0644 OpenStack/RHEL-OSP/7/dist/content/* $(PREFIX)/$(DATADIR)/scap/ssg/
 	install -m 0644 OpenStack/RHEL-OSP/7/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
-	install -m 0644 Chromium/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
+	install -m 0644 Chromium/dist/content/* $(PREFIX)/$(DATADIR)/scap/ssg/
 	install -m 0644 Chromium/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
-	install -m 0644 Firefox/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
+	install -m 0644 Firefox/dist/content/* $(PREFIX)/$(DATADIR)/scap/ssg/
 	install -m 0644 Firefox/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
-	install -m 0644 JRE/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
+	install -m 0644 JRE/dist/content/* $(PREFIX)/$(DATADIR)/scap/ssg/
 	install -m 0644 JRE/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
-	install -m 0644 Debian/8/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
+	install -m 0644 Debian/8/dist/content/* $(PREFIX)/$(DATADIR)/scap/ssg/
 	install -m 0644 Debian/8/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
-	install -m 0644 WRLinux/dist/content/* $(PREFIX)/$(DATADIR)/xml/scap/ssg/content/
+	install -m 0644 WRLinux/dist/content/* $(PREFIX)/$(DATADIR)/scap/ssg/
 	install -m 0644 WRLinux/dist/guide/* $(PREFIX)/$(DOCDIR)/scap-security-guide/guides
 	install -m 0644 docs/scap-security-guide.8 $(PREFIX)/$(MANDIR)/en/man8/
 	install -m 0644 LICENSE $(PREFIX)/$(DOCDIR)/scap-security-guide
 	install -m 0644 README.md $(PREFIX)/$(DOCDIR)/scap-security-guide
+	@# install a symlink in the old content location for compatibility
+	install -d $(PREFIX)/$(DATADIR)/xml/scap/ssg
+	ln -s $(PREFIX)/$(DATADIR)/scap/ssg $(PREFIX)/$(DATADIR)/xml/scap/ssg/content
 
 .PHONY: rhel5 rhel6 rhel7 rhel-osp7 debian8 wrlinux jre firefox webmin tarball zipfile clean all

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ go through a few of them here.
 The `oscap` tool is a low-level command line interface that comes from
 the OpenSCAP project. It can be used to scan the local machine.
 ```
-# oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_usgcb-rhel6-server --results-arf arf.xml --report report.html /usr/share/xml/scap/ssg/content/ssg-rhel6-ds.xml
+# oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_usgcb-rhel6-server --results-arf arf.xml --report report.html /usr/share/scap/ssg/ssg-rhel6-ds.xml
 ```
 After evaluation, the `arf.xml` file will contain all results in a reusable
 *Result DataStream* format, `report.html` will contain a human readable
@@ -48,7 +48,7 @@ report that can be opened in a browser.
 Replace the profile with other profile of your choice, you can display
 all possible choices using:
 ```
-# oscap info /usr/share/xml/scap/ssg/content/ssg-rhel6-ds.xml
+# oscap info /usr/share/scap/ssg/ssg-rhel6-ds.xml
 ```
 
 Please see the [User Manual](http://static.open-scap.org/openscap-1.0/oscap_user_manual.html)
@@ -71,7 +71,7 @@ The following command evaluates machine with IP `192.168.1.123` with content
 stored on local machine. Keep in mind that `oscap` has to be installed on the
 remote machine but the SSG content doesn't need to be.
 ```
-# oscap-ssh root@192.168.1.123 22 xccdf eval --profile xccdf_org.ssgproject.content_profile_usgcb-rhel6-server --results-arf arf.xml --report report.html /usr/share/xml/scap/ssg/content/ssg-rhel6-ds.xml
+# oscap-ssh root@192.168.1.123 22 xccdf eval --profile xccdf_org.ssgproject.content_profile_usgcb-rhel6-server --results-arf arf.xml --report report.html /usr/share/scap/ssg/ssg-rhel6-ds.xml
 ```
 
 ## Support

--- a/RHEL/5/input/oscap-scan-rhel5
+++ b/RHEL/5/input/oscap-scan-rhel5
@@ -1,9 +1,9 @@
 
 #oscap-scan command line options:
 SCAN_OPTIONS="xccdf eval
-		 --remediate
+         --remediate
          --profile stig-rhel5-server
          --report /var/log/oscap-scan-rhel5-report.html
          --results /var/log/oscap-scan-rhel5-results.xml
-		 --cpe /usr/share/xml/scap/ssg/content/ssg-rhel5-cpe-dictionary.xml
-         /usr/share/xml/scap/ssg/content/ssg-rhel5-xccdf.xml"
+         --cpe /usr/share/scap/ssg/ssg-rhel5-cpe-dictionary.xml
+         /usr/share/scap/ssg/ssg-rhel5-xccdf.xml"

--- a/Webmin/input/oscap-scan-webmin
+++ b/Webmin/input/oscap-scan-webmin
@@ -1,9 +1,9 @@
 
 #oscap-scan command line options:
 SCAN_OPTIONS="xccdf eval
-		 --remediate
+         --remediate
          --profile webmin-stig-upstream
          --report /var/log/oscap-scan-webmin-report.html
          --results /var/log/oscap-scan-webmin-results.xml
-		 --cpe /usr/share/xml/scap/ssg/content/ssg-webmin-cpe-dictionary.xml
-         /usr/share/xml/scap/ssg/content/ssg-webmin-xccdf.xml"
+         --cpe /usr/share/scap/ssg/ssg-webmin-cpe-dictionary.xml
+         /usr/share/scap/ssg/ssg-webmin-xccdf.xml"

--- a/docs/User_Guide/en-US/ch003-Scanning.xml
+++ b/docs/User_Guide/en-US/ch003-Scanning.xml
@@ -103,8 +103,8 @@
 			<programlisting>$ sudo oscap xccdf eval --profile stig-rhel6-server \
 --results /root/ssg-results.xml \
 --report /root/ssg-report.xml \
---cpe /usr/share/xml/scap/ssg/ssg-rhel6-cpe-dictionary.xml \
-/usr/share/xml/scap/ssg/ssg-rhel6-xccdf.xml </programlisting></para>
+--cpe /usr/share/scap/ssg/ssg-rhel6-cpe-dictionary.xml \
+/usr/share/scap/ssg/ssg-rhel6-xccdf.xml </programlisting></para>
 		<para>While the scan is running, you will see output similar to the following on your
 			screen:</para>
 		<para><programlisting>Title   Install AIDE

--- a/docs/scap-security-guide.8
+++ b/docs/scap-security-guide.8
@@ -123,15 +123,15 @@ stig-rhel6-server-upstream profile:
 oscap  xccdf eval --profile stig-rhel6-server-upstream \
 --results /tmp/`hostname`-ssg-results.xml \
 --report /tmp/`hostname`-ssg-results.html \
---cpe /usr/share/xml/scap/ssg/content/ssg-rhel6-cpe-dictionary.xml \
-/usr/share/xml/scap/ssg/content/ssg-rhel6-xccdf.xml
+--cpe /usr/share/scap/ssg/ssg-rhel6-cpe-dictionary.xml \
+/usr/share/scap/ssg/ssg-rhel6-xccdf.xml
 .PP
 Additional details can be found on the projects wiki page:
 https://www.github.com/OpenSCAP/scap-security-guide/wiki
 
 
 .SH FILES
-.I /usr/share/xml/scap/ssg/content/
+.I /usr/share/scap/ssg/
 .RS
 Houses SCAP content utilizing the following naming conventions:
 
@@ -148,15 +148,9 @@ ssg-{profile}-oval.xml
 ssg-{profile}-xccdf.xml
 .RE
 
-.I /usr/share/xml/scap/ssg/guides/
+.I /usr/share/doc/scap-security-guide/guides/
 .RS
 HTML versions of SSG profiles.
-.RE
-
-.I /usr/share/xml/scap/ssg/policytables/
-.RS
-HTML tables reflecting which institutionalized policy a particular SSG rule
-conforms to.
 .RE
 
 .SH STATEMENT OF SUPPORT

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -367,7 +367,7 @@ def main():
     index_source += "\t\t\t\tvar benchmark_id=option_element.getAttribute('data-benchmark-id');\n"
     index_source += "\t\t\t\tvar profile_id=option_element.getAttribute('data-profile-id');\n"
     index_source += "\t\t\t\tvar eval_snippet=document.getElementById('eval_snippet');\n"
-    index_source += "\t\t\t\tvar input_path='/usr/share/xml/scap/ssg/content/%s';\n" % (input_basename)
+    index_source += "\t\t\t\tvar input_path='/usr/share/scap/ssg/%s';\n" % (input_basename)
     index_source += "\t\t\t\tif (profile_id == '')\n"
     index_source += "\t\t\t\t{\n"
     index_source += "\t\t\t\t\tif (benchmark_id == '')\n"


### PR DESCRIPTION
I opened a discussion about the install location `/usr/share/xml/scap/ssg/content` being way too long. The consensus in the mailing list thread was to move to `/usr/share/scap/ssg`. This PR does just that.

I have changed various texts in documentation but I left the references to existing RPMs with the original paths. We can change those later when the RPMs are changed.

Also fixed locations of HTML guides in manpage, they were wrong.

See the thread here: https://lists.fedorahosted.org/archives/list/scap-security-guide@lists.fedorahosted.org/thread/WYU5VPWF7LT65QAEZFOFMLNPXLLQKRJK/