### PR TITLE
Align SSG to DISA RHEL6 V1R13 content

### DIFF
--- a/RHEL/6/input/profiles/common.xml
+++ b/RHEL/6/input/profiles/common.xml
@@ -231,7 +231,7 @@ these should likely be moved out of common.
 <!-- Refine Values -->
 <refine-value idref="var_umask_for_daemons" selector="027"/>
 <!-- daemon umask -->
-<refine-value idref="var_accounts_password_minlen_login_defs" selector="14"/>
+<refine-value idref="var_accounts_password_minlen_login_defs" selector="15"/>
 <!-- password minimum length -->
 <refine-value idref="var_accounts_maximum_age_login_defs" selector="90"/>
 <!-- maximum password age -->

--- a/RHEL/6/input/profiles/stig-rhel6-server-upstream.xml
+++ b/RHEL/6/input/profiles/stig-rhel6-server-upstream.xml
@@ -119,4 +119,8 @@ upstream project homepage is https://www.open-scap.org/security-policies/scap-se
 <refine-value idref="var_password_pam_lcredit" selector="1"/>
 <refine-value idref="sshd_idle_timeout_value" selector="15_minutes"/>
 
+<!-- dropped from DISA content in V1R13 -->
+<select idref="ldap_client_start_tls" selected="false" />
+<select idref="ldap_client_tls_cacertpath" selected="false" />
+
 </Profile>

--- a/RHEL/6/input/xccdf/services/cron.xml
+++ b/RHEL/6/input/xccdf/services/cron.xml
@@ -40,7 +40,6 @@ attack surface for an intruder.
 <ident cce="27158-5" />
 </Rule>
 
-
 <Rule id="service_atd_disabled">
 <title>Disable At Service (atd)</title>
 <description>The <tt>at</tt> and <tt>batch</tt> commands can be used to

--- a/RHEL/6/input/xccdf/services/ldap.xml
+++ b/RHEL/6/input/xccdf/services/ldap.xml
@@ -98,9 +98,9 @@ run the following command:
 The output should show the following:
 <pre>package openldap-servers is not installed</pre>
 </ocil>
-<rationale>Unnecessary packages should not be installed to decrease the attack
-surface of the system.  While this software is clearly essential on an LDAP
-server, it is not necessary on typical desktop or workstation systems.
+<rationale>The <tt>openldap-servers</tt> package is not installed by default on RHEL6 machines.
+It is needed only by the OpenLDAP server system, not clients which use LDAP for authentication. If
+the system is not intended for use as an LDAP server, <tt>openldap-servers</tt> should be removed.
 </rationale>
 <ident cce="26858-1" stig="RHEL-06-000256" />
 <oval id="package_openldap-servers_removed" />

--- a/RHEL/6/input/xccdf/system/accounts/restrictions/password_expiration.xml
+++ b/RHEL/6/input/xccdf/system/accounts/restrictions/password_expiration.xml
@@ -83,7 +83,7 @@ edit the file <tt>/etc/login.defs</tt> and add or correct the following
 lines:
 <pre>PASS_MIN_LEN <sub idref="var_accounts_password_minlen_login_defs" /></pre>
 <br/><br/>
-The DoD requirement is <tt>14</tt>.
+As of the DISA Red Hat 6 STIG - Ver 1, Rel 13 (28-OCT-2016), the DoD requirement is now <tt>15</tt>.
 The FISMA requirement is <tt>12</tt>.
 If a program consults <tt>/etc/login.defs</tt> and also another PAM module
 (such as <tt>pam_cracklib</tt>) during a password change operation,
@@ -93,7 +93,7 @@ for more information about enforcing password quality requirements.
 <ocil clause="it is not set to the required value">
 To check the minimum password length, run the command:
 <pre>$ grep PASS_MIN_LEN /etc/login.defs</pre>
-The DoD requirement is <tt>14</tt>.
+The DoD requirement is <tt>15</tt>.
 </ocil>
 <rationale>
 Requiring a minimum password length makes password

--- a/RHEL/6/input/xccdf/system/network/ipsec.xml
+++ b/RHEL/6/input/xccdf/system/network/ipsec.xml
@@ -16,6 +16,8 @@ networks.
 <ocil clause="the package is not installed" >
 <package-check-macro package="openswan" />
 <package-check-macro package="libreswan" />
+<br /><br />
+If the system does not communicate over untrusted networks, this is not applicable.
 </ocil>
 <rationale>Providing the ability for remote users or systems
 to initiate a secure VPN connection protects information when it is


### PR DESCRIPTION
DISA released an update to their RHEL6 content, V1R13, on 10/28/2016. This patch set aligns SSG to the changes DISA identified in their release notes.

Most significant change was upping passwords from 14 to 15 chars. Other were mostly rationale and OCIL language updates.

https://github.com/OpenSCAP/scap-security-guide/commit/98c63bdf36f0af0f89089acd697857826516df23 drops requiring OpenLDAP to use TLS -- which is extremely odd. Disabling the XCCDF rule in the RHEL6 STIG profile, leaving enabled in common profile.