### PR TITLE
[issue 1544] remediation for sshd_use_priv_separation

### DIFF
--- a/RHEL/7/templates/static/bash/sshd_use_priv_separation.sh
+++ b/RHEL/7/templates/static/bash/sshd_use_priv_separation.sh
@@ -1,0 +1,6 @@
+# platform = Red Hat Enterprise Linux 7
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '/etc/ssh/sshd_config' '^UsePrivilegeSeparation' 'yes' '$CCENUM' '%s %s'

--- a/SUSE/12/input/xccdf/services/ssh.xml
+++ b/SUSE/12/input/xccdf/services/ssh.xml
@@ -265,7 +265,7 @@ SSH daemon privilege separation causes the SSH process to drop root privileges
 when not needed which would decrease the impact of software vulnerabilities in
 the unprivileged section.
 </rationale>
-<ident cce="80223-1" />
+<ident cce="TBD" />
 <oval id="sshd_use_priv_separation" />
 <ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="040690"/>
 </Rule>


### PR DESCRIPTION
- Resolves https://github.com/OpenSCAP/scap-security-guide/issues/1544
- SUSE was using RHEL CCE. Removing.