### PR TITLE
[issue 1545] remediation for sshd_enable_strictmodes

### DIFF
--- a/RHEL/7/templates/static/bash/sshd_enable_strictmodes.sh
+++ b/RHEL/7/templates/static/bash/sshd_enable_strictmodes.sh
@@ -1,0 +1,6 @@
+# platform = Red Hat Enterprise Linux 7
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '/etc/ssh/sshd_config' '^StrictModes' 'yes' '$CCENUM' '%s %s'

--- a/SUSE/12/input/xccdf/services/ssh.xml
+++ b/SUSE/12/input/xccdf/services/ssh.xml
@@ -242,7 +242,7 @@ If configured properly, output should be <pre>yes</pre>
 If other users have access to modify user-specific SSH configuration files, they
 may be able to log into the system as another user.
 </rationale>
-<ident cce="80222-3" />
+<ident cce="TBD" />
 <oval id="sshd_enable_strictmodes" />
 <ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="040680"/>
 </Rule>


### PR DESCRIPTION
- resolves https://github.com/OpenSCAP/scap-security-guide/issues/1545
- removes RHEL CCE from SuSE content