### PR TITLE
Correct default and other values in var_password_pam_difok

### DIFF
--- a/shared/xccdf/system/accounts/pam.xml
+++ b/shared/xccdf/system/accounts/pam.xml
@@ -220,14 +220,14 @@ password</description>
 <description>Minimum number of characters not present in old
 password</description>
 <warning category="general">Keep this high for short passwords</warning>
-<value selector="">15</value>
+<value selector="">8</value>
 <value selector="2">2</value>
 <value selector="3">3</value>
 <value selector="4">4</value>
 <value selector="5">5</value>
-<value selector="6">5</value>
-<value selector="7">5</value>
-<value selector="8">5</value>
+<value selector="6">6</value>
+<value selector="7">7</value>
+<value selector="8">8</value>
 <value selector="15">15</value>
 </Value>
 


### PR DESCRIPTION
Bring default value in line with RHEL 7 STIG.  Correct other values to match selectors.