### PR TITLE
[issue 391] NIST mappings for restrict_nfs_clients_to_privileged_port…

### DIFF
--- a/shared/xccdf/services/nfs.xml
+++ b/shared/xccdf/services/nfs.xml
@@ -230,7 +230,7 @@ is not designated as a NFS server then this service should be disabled.
 <systemd-check-macro enable="false" service="nfs" />
 </ocil>
 <rationale>Unnecessary services should be disabled to decrease the attack surface of the system.</rationale>
-<ident prodtype="rhel7" cce="80237-1" />
+<ident prodtype="rhel7" cce="80237-1" nist="AC-3" />
 <oval id="service_nfs_disabled" />
 </Rule>
 
@@ -404,7 +404,7 @@ To ensure that the default has not been changed, ensure no line in
 <rationale>Allowing client requests to be made from ports higher than 1024 could allow a unprivileged
 user to initiate an NFS connection. If the unprivileged user account has been compromised, an
 attacker could gain access to data on the NFS server.</rationale>
-<ident prodtype="rhel7" cce="80242-1" />
+<ident prodtype="rhel7" cce="80242-1" nist="AC-3" />
 </Rule>
 
 <Rule id="no_insecure_locks_exports" severity="medium" prodtype="rhel7">

--- a/shared/xccdf/services/nfs.xml
+++ b/shared/xccdf/services/nfs.xml
@@ -230,7 +230,8 @@ is not designated as a NFS server then this service should be disabled.
 <systemd-check-macro enable="false" service="nfs" />
 </ocil>
 <rationale>Unnecessary services should be disabled to decrease the attack surface of the system.</rationale>
-<ident prodtype="rhel7" cce="80237-1" nist="AC-3" />
+<ident prodtype="rhel7" cce="80237-1" />
+<ref prodtype="rhel7" nist="AC-3" />
 <oval id="service_nfs_disabled" />
 </Rule>
 
@@ -404,7 +405,8 @@ To ensure that the default has not been changed, ensure no line in
 <rationale>Allowing client requests to be made from ports higher than 1024 could allow a unprivileged
 user to initiate an NFS connection. If the unprivileged user account has been compromised, an
 attacker could gain access to data on the NFS server.</rationale>
-<ident prodtype="rhel7" cce="80242-1" nist="AC-3" />
+<ident prodtype="rhel7" cce="80242-1" />
+<ref prodtype="rhel7" nist="AC-3" />
 </Rule>
 
 <Rule id="no_insecure_locks_exports" severity="medium" prodtype="rhel7">


### PR DESCRIPTION
…s and service_nfs_disabled

resolves https://github.com/OpenSCAP/scap-security-guide/issues/391

AC-3 states "The information system enforces approved authorizations for logical access to information
and system resources in accordance with applicable access control policies."

A US Gov customer feels particularly strongly these XCCDF rules are related to AC-3. Can see the correlation
through "enforcing approved authorizations," e.g. ports and services running (or disabled) reflect
authorizations.