### PR TITLE
Use https:// for CVE OVALs

### DIFF
--- a/RHEL/6/input/xccdf/system/software/updating.xml
+++ b/RHEL/6/input/xccdf/system/software/updating.xml
@@ -105,11 +105,8 @@ If the system is not configured to use one of these sources, updates (in the for
 can be manually downloaded from the Red Hat Network and installed using <tt>rpm</tt>.
 </description>
 <!-- Directly define remotely located OVAL to be executed when scanning this rule -->
-<!-- Since OpenSCAP for now supports only "http://" protocol being specified when
-     fetching remote resources (see https://fedorahosted.org/openscap/ticket/213
-     for further details) use "http://" version of the remotely located OVAL below -->
 <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-  <check-content-ref href="http://www.redhat.com/security/data/oval/Red_Hat_Enterprise_Linux_6.xml" />
+  <check-content-ref href="https://www.redhat.com/security/data/oval/Red_Hat_Enterprise_Linux_6.xml" />
 </check>
 <ocil clause="updates are not installed">
 If the system is joined to the Red Hat Network, a Red Hat Satellite Server, or

--- a/shared/xccdf/system/software/updating.xml
+++ b/shared/xccdf/system/software/updating.xml
@@ -126,11 +126,8 @@ NOTE: U.S. Defense systems are required to be patched within 30 days or sooner a
 dictates.
 </description>
 <!-- Directly define remotely located OVAL to be executed when scanning this rule -->
-<!-- Since OpenSCAP for now supports only "http://" protocol being specified when
-     fetching remote resources (see https://fedorahosted.org/openscap/ticket/213
-     for further details) use "http://" version of the remotely located OVAL below -->
 <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-  <check-content-ref href="http://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2" />
+  <check-content-ref href="https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2" />
 </check>
 <ocil clause="updates are not installed">
 If the system is joined to the Red Hat Network, a Red Hat Satellite Server, or


### PR DESCRIPTION
This should be a no-brainer, support for https has been in openscap since 1.2.8.