### PR TITLE
Generate guides outputs

### DIFF
--- a/Chromium/Makefile
+++ b/Chromium/Makefile
@@ -82,10 +82,10 @@ content-stig: table-stigs guide checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
 endif
 
 submission-stig-check: table-stigs

--- a/Debian/8/Makefile
+++ b/Debian/8/Makefile
@@ -82,10 +82,10 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
 endif
 
 validate-xml:

--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -28,10 +28,10 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
 endif
 
 validate-xml:

--- a/Firefox/Makefile
+++ b/Firefox/Makefile
@@ -82,10 +82,10 @@ content-stig: table-stigs guide checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
 endif
 
 submission-stig-check: table-stigs

--- a/JRE/Makefile
+++ b/JRE/Makefile
@@ -82,10 +82,10 @@ content-stig: table-stigs guide checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
 endif
 
 submission-stig-check: table-stigs

--- a/OpenSUSE/Makefile
+++ b/OpenSUSE/Makefile
@@ -30,10 +30,10 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
 endif
 
 validate-xml:

--- a/OpenStack/RHEL-OSP/7/Makefile
+++ b/OpenStack/RHEL-OSP/7/Makefile
@@ -101,14 +101,14 @@ content-stig: table-stigs guide checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos-osp7-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl-osp7-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos-osp7-ds.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl-osp7-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos-osp7-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl-osp7-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos-osp7-xccdf.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl-osp7-xccdf.xml --output $(OUT)/ build
 endif
 
 submission-stig-check: table-stigs

--- a/RHEL/5/Makefile
+++ b/RHEL/5/Makefile
@@ -91,14 +91,14 @@ content-stig: table-stigs guide checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos5-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl5-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos5-ds.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl5-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos5-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl5-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos5-xccdf.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl5-xccdf.xml --output $(OUT)/ build
 endif
 
 submission-stig-check: table-stigs

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -99,14 +99,14 @@ content-stig: table-stigs guide checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos6-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl6-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos6-ds.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl6-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos6-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl6-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos6-xccdf.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl6-xccdf.xml --output $(OUT)/ build
 endif
 
 submission-stig-check: table-stigs

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -93,14 +93,14 @@ content-stig: table-stigs guide checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-ds.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-xccdf.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-xccdf.xml --output $(OUT)/ build
 endif
 
 submission-stig-check: table-stigs

--- a/RHEVM3/Makefile
+++ b/RHEVM3/Makefile
@@ -100,10 +100,10 @@ content-stig: table-stigs guide checks
 guide: content
 	# TODO: enable datastream builds once RHEVM3 can successfuly build a datastream
 #ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-#	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+#	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
 #else
 #	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
 #endif
 
 submission-stig-check: table-stigs

--- a/SUSE/11/Makefile
+++ b/SUSE/11/Makefile
@@ -97,10 +97,10 @@ content-stig: table-stigs guide checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
 endif
 
 submission-stig-check: table-stigs

--- a/SUSE/12/Makefile
+++ b/SUSE/12/Makefile
@@ -96,14 +96,14 @@ content-stig: table-stigs guide checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-ds.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-ds.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-xccdf.xml
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-centos7-xccdf.xml --output $(OUT)/ build
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-sl7-xccdf.xml --output $(OUT)/ build
 endif
 
 submission-stig-check: table-stigs

--- a/Ubuntu/16.04/Makefile
+++ b/Ubuntu/16.04/Makefile
@@ -82,10 +82,10 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
 endif
 
 validate-xml:

--- a/WRLinux/Makefile
+++ b/WRLinux/Makefile
@@ -29,10 +29,10 @@ content: $(OUT)/xccdf-unlinked-final.xml checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
 endif
 
 validate-xml:

--- a/Webmin/Makefile
+++ b/Webmin/Makefile
@@ -82,10 +82,10 @@ content-stig: table-stigs guide checks
 
 guide: content
 ifeq ($(OPENSCAP_1_1_OR_LATER), 0)
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-ds.xml --output $(OUT)/ build
 else
 	@echo "Building guides from XCCDF 1.1, use OpenSCAP 1.1.0 or later for guides from datastreams!"
-	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml
+	$(SHARED)/$(UTILS)/build-all-guides.py --input $(OUT)/$(ID)-$(PROD)-xccdf.xml --output $(OUT)/ build
 endif
 
 submission-stig-check: table-stigs

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -201,8 +201,8 @@ def main():
 
     p.add_argument("-i", "--input", action="store", required=True,
                    help="input file, can be XCCDF or Source DataStream")
-    #p.add_argument("-o", "--output", action="store", required=True,
-    #               help="output directory")
+    p.add_argument("-o", "--output", action="store", required=True,
+                   help="output directory")
 
     args, unknown = p.parse_known_args()
     if unknown:
@@ -211,7 +211,7 @@ def main():
         )
         sys.exit(1)
 
-    parent_dir = os.path.dirname(os.path.abspath(args.input))
+    output_dir = os.path.abspath(args.output)
     input_basename = os.path.basename(args.input)
     path_base, _ = os.path.splitext(input_basename)
     # avoid -ds and -xccdf suffices in guide filenames
@@ -306,7 +306,7 @@ def main():
                 "%s-%s-guide-%s.html" % \
                 (path_base, benchmark_id_for_path,
                  get_profile_short_id(profile_id_for_path))
-        guide_path = os.path.join(parent_dir, guide_filename)
+        guide_path = os.path.join(output_dir, guide_filename)
 
         index_links.append(
             "<a target=\"guide\" href=\"%s\">%s</a>" %
@@ -425,7 +425,7 @@ def main():
     index_source += "\t</body>\n"
     index_source += "</html>\n"
 
-    index_path = os.path.join(parent_dir, "%s-guide-index.html" % (path_base))
+    index_path = os.path.join(output_dir, "%s-guide-index.html" % (path_base))
     with open(index_path, "w") as f:
         f.write(index_source.encode("utf-8"))
 

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -184,7 +184,7 @@ def get_cpu_count():
 def main():
     p = argparse.ArgumentParser()
 
-    sp = p.add_subparsers(dest="cmd", help="actions")
+    sp = p.add_subparsers(help="actions")
 
     make_sp = sp.add_parser("build", help="Build all the HTML guides")
     make_sp.set_defaults(cmd="build")

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -62,11 +62,11 @@ class Builder(object):
                 )
                 self._run_script(script, csv_filepath)
 
-    def input(self):
+    def list_inputs(self):
         for file_ in self.get_input_list():
             print(file_)
 
-    def output(self):
+    def list_outputs(self):
         for file_ in self.get_output_list():
             print(file_)
 
@@ -234,11 +234,11 @@ if __name__ == "__main__":
     make_sp = sp.add_parser('build', help="Build remediations")
     make_sp.set_defaults(cmd="build")
 
-    input_sp = sp.add_parser('input', help="Generate input list")
-    input_sp.set_defaults(cmd="input")
+    input_sp = sp.add_parser('list-inputs', help="Generate input list")
+    input_sp.set_defaults(cmd="list_inputs")
 
-    output_sp = sp.add_parser('output', help="Generate output list")
-    output_sp.set_defaults(cmd="output")
+    output_sp = sp.add_parser('list-outputs', help="Generate output list")
+    output_sp.set_defaults(cmd="list_outputs")
 
     p.add_argument('--language', metavar="LANG", default=None,
                    help="Scripts of which language should we generate? "

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -229,7 +229,7 @@ if __name__ == "__main__":
     builder = Builder()
     p = argparse.ArgumentParser()
 
-    sp = p.add_subparsers(dest='cmd', help="actions")
+    sp = p.add_subparsers(help="actions")
 
     make_sp = sp.add_parser('build', help="Build remediations")
     make_sp.set_defaults(cmd="build")

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -203,8 +203,10 @@ class Builder(object):
             return self._get_list_from_subprocess(sp)
 
         finally:
-            del os.environ["GENERATE_INPUT_LIST"]
-            del os.environ["GENERATE_OUTPUT_LIST"]
+            if gen_input:
+                del os.environ["GENERATE_INPUT_LIST"]
+            else:
+                del os.environ["GENERATE_OUTPUT_LIST"]
 
     def _subprocess_check(self, subprocess):
         subprocess.wait()

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -243,9 +243,9 @@ if __name__ == "__main__":
     p.add_argument('--language', metavar="LANG", default=None,
                    help="Scripts of which language should we generate? "
                    "Default: all.")
-    p.add_argument('--input', action="store", required=True,
+    p.add_argument("-i", "--input", action="store", required=True,
                    help="input directory")
-    p.add_argument('--output', action="store", required=True,
+    p.add_argument("-o", "--output", action="store", required=True,
                    help="output directory")
     p.add_argument('--oval_version', action="store", default="oval_5.10",
                    help="oval version")


### PR DESCRIPTION
The main goal of this PR is to bring `build-all-guides.py` features in line with `generate-from-templates.py`. I added input as well as output listings. That way we will be able to make proper cmake targets.

I have renamed `input` mode to `list-inputs` because the former was not self documenting. Same with `output`.

I have also fixed a few issues in `generate-from-templates.py` that I discovered while testing inputs and outputs features.