### PR TITLE
Fixed wording in min password age description text

### DIFF
--- a/RHEL/5/input/xccdf/system/accounts/restrictions/password_expiration.xml
+++ b/RHEL/5/input/xccdf/system/accounts/restrictions/password_expiration.xml
@@ -69,7 +69,7 @@ age, and 7 day warning period with the following command:
 edit the file <tt>/etc/login.defs</tt>
 and add or correct the following line, replacing <i>DAYS</i> appropriately:
 <pre>PASS_MIN_DAYS <i>DAYS</i></pre>
-A value of 1 day is considered for sufficient for many
+A value of 1 day is considered sufficient for many
 environments.
 The DoD requirement is 1. 
 </description>

--- a/RHEL/6/input/xccdf/system/accounts/restrictions/password_expiration.xml
+++ b/RHEL/6/input/xccdf/system/accounts/restrictions/password_expiration.xml
@@ -114,7 +114,7 @@ behavior that may result.
 edit the file <tt>/etc/login.defs</tt>
 and add or correct the following line:
 <pre>PASS_MIN_DAYS <i><sub idref="var_accounts_minimum_age_login_defs" /></i></pre>
-A value of 1 day is considered for sufficient for many
+A value of 1 day is considered sufficient for many
 environments.
 The DoD requirement is 1. 
 </description>

--- a/SUSE/12/input/xccdf/system/accounts/restrictions/password_expiration.xml
+++ b/SUSE/12/input/xccdf/system/accounts/restrictions/password_expiration.xml
@@ -113,7 +113,7 @@ behavior that may result.
 edit the file <tt>/etc/login.defs</tt>
 and add or correct the following line, replacing <i>DAYS</i> appropriately:
 <pre>PASS_MIN_DAYS <i>DAYS</i></pre>
-A value of 1 day is considered for sufficient for many
+A value of 1 day is considered sufficient for many
 environments. The DoD requirement is 1. 
 </description>
 <ocil clause="it is not equal to or greater than the required value">

--- a/shared/xccdf/system/accounts/restrictions/password_expiration.xml
+++ b/shared/xccdf/system/accounts/restrictions/password_expiration.xml
@@ -114,7 +114,7 @@ behavior that may result.
 edit the file <tt>/etc/login.defs</tt>
 and add or correct the following line, replacing <i>DAYS</i> appropriately:
 <pre>PASS_MIN_DAYS <i>DAYS</i></pre>
-A value of 1 day is considered for sufficient for many
+A value of 1 day is considered sufficient for many
 environments. The DoD requirement is 1. 
 </description>
 <ocil clause="it is not equal to or greater than the required value">


### PR DESCRIPTION
Nothing to say here really, the wording was a bit off in the password expiration text.