### PR TITLE
Use a more specific pattern match in the fix for require_singleuser_auth

### DIFF
--- a/shared/templates/static/bash/require_singleuser_auth.sh
+++ b/shared/templates/static/bash/require_singleuser_auth.sh
@@ -1,5 +1,5 @@
 # platform = Red Hat Enterprise Linux 7
-grep -q sulogin /usr/lib/systemd/system/rescue.service 
+grep -q "^ExecStart=\-.*/sbin/sulogin" /usr/lib/systemd/system/rescue.service
 if ! [ $? -eq 0 ]; then
     sed -i "s/-c \"/-c \"\/sbin\/sulogin; /g" /usr/lib/systemd/system/rescue.service
 fi

--- a/shared/templates/static/bash/require_singleuser_auth.sh
+++ b/shared/templates/static/bash/require_singleuser_auth.sh
@@ -1,5 +1,5 @@
 # platform = Red Hat Enterprise Linux 7
 grep -q "^ExecStart=\-.*/sbin/sulogin" /usr/lib/systemd/system/rescue.service
 if ! [ $? -eq 0 ]; then
-    sed -i "s/-c \"/-c \"\/sbin\/sulogin; /g" /usr/lib/systemd/system/rescue.service
+    sed -i "s/ExecStart=-.*-c \"/&\/sbin\/sulogin; /g" /usr/lib/systemd/system/rescue.service
 fi


### PR DESCRIPTION
The simple `grep -q sulogin /usr/lib/systemd/system/rescue.service` was causing a false positive because a typical rescue.service file includes the line:

```plain
Documentation=man:sulogin(8)
```

This causes the `grep` command to succeed and the end result is the remediation does not get run.

This change also makes the `grep` command match the pattern specified in the [require_singleuser_auth.xml oval file](https://github.com/OpenSCAP/scap-security-guide/blob/d0af7b820664fe193195eebe498840b654bdf509/shared/oval/require_singleuser_auth.xml#L28).

https://bugzilla.redhat.com/show_bug.cgi?id=1219253