### PR TITLE
replace failing %doc glob

### DIFF
--- a/scap-security-guide.spec.in
+++ b/scap-security-guide.spec.in
@@ -60,7 +60,8 @@ present in %{name} package.
 
 %files doc
 %doc %{_docdir}/%{name}/guides/*.html
-%doc %{_docdir}/%{name}/tables/*.{,x}html
+%doc %{_docdir}/%{name}/tables/*.html
+%doc %{_docdir}/%{name}/tables/*.xhtml
 
 %changelog
 * __DATE__ __REL_MANAGER__ <__REL_MANAGER_MAIL__> __VERSION__-__RELEASE__


### PR DESCRIPTION
Might not be the prettiest solution but it fixes the failing %doc glob.

Closes #1636 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>