### PR TITLE
Fix so we don't leave remedied config files without trailing newline.

### DIFF
--- a/shared/remediations/bash/templates/remediation_functions
+++ b/shared/remediations/bash/templates/remediation_functions
@@ -787,8 +787,9 @@ function replace_or_append {
   if `grep -qi $key $config_file` ; then
     $sed_command "s/$key.*/$formatted_output/g" $config_file
   else
-    echo -ne "\n# Per $cce: Set $formatted_output in $config_file" >> $config_file
-    echo -ne "\n$formatted_output" >> $config_file
+    # \n is precaution for case where file ends without trailing newline
+    echo -e "\n# Per $cce: Set $formatted_output in $config_file" >> $config_file
+    echo -e "$formatted_output" >> $config_file
   fi
 
 }

--- a/shared/xccdf/remediation_functions.xml
+++ b/shared/xccdf/remediation_functions.xml
@@ -1165,8 +1165,9 @@ function replace_or_append {
   if `grep -qi $key $config_file` ; then
     $sed_command "s/$key.*/$formatted_output/g" $config_file
   else
-    echo -ne "\n# Per $cce: Set $formatted_output in $config_file" >> $config_file
-    echo -ne "\n$formatted_output" >> $config_file
+    # \n is precaution for case where file ends without trailing newline
+    echo -e "\n# Per $cce: Set $formatted_output in $config_file" >> $config_file
+    echo -e "$formatted_output" >> $config_file
   fi
 
 }


### PR DESCRIPTION
POSIX specifies line as "A sequence of zero or more non- <newline> characters plus a terminating <newline> character." We were leaving last line without <newline> character. This may also help us be more stable when dealing with remediation functions, which does not precede newline character when appending something to the config file.

I am not aware of any  bugs this fixes - it's just precautionary fix.