### PR TITLE
Start marking rules that apply only for baremetal / VM  environment or only for container environment

### DIFF
--- a/shared/xccdf/services/base.xml
+++ b/shared/xccdf/services/base.xml
@@ -117,6 +117,7 @@ multiple processors.
 <ocil><systemd-check-macro enable="false" service="irqbalance" /></ocil>
 <rationale>In an environment with multiple processors (now common), the irqbalance service
 provides potential speedups for handling interrupt requests.</rationale>
+<platform idref="cpe:/a:machine"/>
 <ident prodtype="rhel7" cce="80257-9" />
 <oval id="service_irqbalance_enabled" />
 <ref prodtype="rhel7" nist="CM-7" />

--- a/shared/xccdf/services/base.xml
+++ b/shared/xccdf/services/base.xml
@@ -18,7 +18,7 @@ system such as RHTSupport.
 </description>
 <ocil><systemd-check-macro enable="false" service="abrtd" /></ocil>
 <rationale> Mishandling crash data could expose sensitive information about
-vulnerabilities in software executing on the local machine, as well as sensitive
+vulnerabilities in software executing on the system, as well as sensitive
 information from within a process's address space or registers.</rationale>
 <ident prodtype="rhel7" cce="26872-2" />
 <oval id="service_abrtd_disabled" />

--- a/shared/xccdf/services/dhcp.xml
+++ b/shared/xccdf/services/dhcp.xml
@@ -144,7 +144,7 @@ unnecessarily rely on DHCP for this information.
 to request much of the above information from the DHCP server. In particular,
 domain-name, domain-name-servers, and routers are configured via DHCP.  These
 settings are typically necessary for proper network functionality, but are also
-usually static across machines at a given site.</warning>
+usually static across systems at a given site.</warning>
 <!-- <ident prodtype="rhel7" cce="80335-3" /> -->
 <!--<oval id="dhcp_server_minimize_served_info" /> -->
 <ref prodtype="rhel7" nist="CM-7" />
@@ -257,7 +257,7 @@ assigned statically, and only options which must vary on a host-by-host basis
 be assigned via DHCP. This limits the damage which can be done by a rogue DHCP
 server.  If appropriate for your site, it is also possible to supersede the
 host-name directive in <tt>/etc/dhcp/dhclient.conf</tt>, establishing a static
-hostname for the machine. However, dhclient does not use the host name option
+hostname for the system. However, dhclient does not use the host name option
 provided by the DHCP server (instead using the value provided by a reverse DNS
 lookup).</rationale>
 <warning category="general">In this example, the options nis-servers and

--- a/shared/xccdf/services/dns.xml
+++ b/shared/xccdf/services/dns.xml
@@ -9,10 +9,10 @@ on which it is not needed.</description>
 <Group id="disabling_dns_server">
 <title>Disable DNS Server</title>
 <description>
-DNS software should be disabled on any machine which does not
+DNS software should be disabled on any systems which does not
 need to be a nameserver. Note that the BIND DNS server software is
 not installed on Red Hat Enterprise Linux 7 by default. The remainder of this section
-discusses secure configuration of machines which must be
+discusses secure configuration of systems which must be
 nameservers.
 </description>
 
@@ -60,7 +60,7 @@ attacks on nameservers more difficult.</description>
 <title>Run DNS Software on Dedicated Servers</title> <description>Since DNS is
 a high-risk service which must frequently be made available to the entire
 Internet, it is strongly recommended that no other services be offered by
-machines which act as organizational DNS servers.</description>
+systems which act as organizational DNS servers.</description>
 </Group>
 
 <Group id="dns_server_chroot">
@@ -108,7 +108,7 @@ DNS data.</description>
 <Group id="dns_server_separate_internal_external">
 <title>Run Separate DNS Servers for External and Internal Queries</title>
 <description>Is it possible to run external and internal nameservers on
-separate machines? If so, follow the configuration guidance in this section. On
+separate systems? If so, follow the configuration guidance in this section. On
 the external nameserver, edit <tt>/etc/named.conf</tt> to add or correct the
 following directives:
 <pre>options {
@@ -135,24 +135,24 @@ zone "internal.example.com " IN {
 };</pre>
 </description>
 <rationale>Enterprise nameservers generally serve two functions. One is to
-provide public information about the machines in a domain for the benefit of
-outside users who wish to contact those machines, for instance in order to send
+provide public information about the systems in a domain for the benefit of
+outside users who wish to contact those systems, for instance in order to send
 mail to users in the enterprise, or to visit the enterprise's external web
-page. The other is to provide nameservice to client machines within the
-enterprise. Client machines require both private information about enterprise
-machines (which may be different from the public information served to the rest
-of the world) and public information about machines outside the enterprise,
+page. The other is to provide nameservice to client systems within the
+enterprise. Client systems require both private information about enterprise
+systems (which may be different from the public information served to the rest
+of the world) and public information about systems outside the enterprise,
 which is used to send mail or visit websites outside of the organization.
 <br />
 In order to provide the public nameservice function, it is necessary to share
-data with untrusted machines which request it - otherwise, the enterprise
+data with untrusted systems which request it - otherwise, the enterprise
 cannot be conveniently contacted by outside users. However, internal data
 should be protected from disclosure, and serving irrelevant public name queries
 for outside domains leaves the DNS server open to cache poisoning and other
 attacks. Therefore, local network nameservice functions should not be provided
-to untrusted machines.
+to untrusted systems.
 <br />
-Separate machines should be used to fill these two functions whenever possible.
+Separate systems should be used to fill these two functions whenever possible.
 </rationale>
 
 </Group>
@@ -160,7 +160,7 @@ Separate machines should be used to fill these two functions whenever possible.
 <Group id="dns_server_partition_with_views">
 <title>Use Views to Partition External and Internal Information</title>
 <description>If it is not possible to run external and internal nameservers on
-separate physical machines, run BIND9 and simulate this feature using views.
+separate physical systems, run BIND9 and simulate this feature using views.
 Edit <tt>/etc/named.conf</tt>. Add or correct the following directives (where
 SUBNET is the numerical IP representation of your organization in the form
 xxx.xxx.xxx.xxx/xx):
@@ -190,7 +190,7 @@ view "external-view" {
 <rationale>The view feature is provided by BIND9 as a way to allow a single
 nameserver to make different sets of data available to different sets of
 clients. If possible, it is always better to run external and internal
-nameservers on separate machines, so that even complete compromise of the
+nameservers on separate systems, so that even complete compromise of the
 external server cannot be used to obtain internal data or confuse internal DNS
 clients. However, this is not always feasible, and use of a feature like views
 is preferable to leaving internal DNS data entirely unprotected.</rationale>

--- a/shared/xccdf/services/docker.xml
+++ b/shared/xccdf/services/docker.xml
@@ -20,6 +20,7 @@ To be able to find any problems with misconfiguration of
 the docker daemon and running containers, the docker service
 has to be enabled.
 </rationale>
+<platform idref="cpe:/a:machine"/>
 <ident prodtype="rhel7" cce="" />
 <ref prodtype="rhel7" nist="" disa=""
 ossrg=""
@@ -42,6 +43,7 @@ devices is discouraged. The suggested way of configuring device mapper storage
 driver is direct-lvm. Choosing the right storage driver and backing filesystem
 is crucial to stability and performance.
 </rationale>
+<platform idref="cpe:/a:machine"/>
 <oval id="docker_storage_configured" />
 </Rule>
 

--- a/shared/xccdf/services/ftp.xml
+++ b/shared/xccdf/services/ftp.xml
@@ -61,7 +61,7 @@ set-up vsftpd to provide it.</description>
 
 <Rule id="package_vsftpd_installed" prodtype="rhel7">
 <title>Install vsftpd Package</title>
-<description>If this machine must operate as an FTP server, install the <tt>vsftpd</tt> package via the standard channels.
+<description>If this system must operate as an FTP server, install the <tt>vsftpd</tt> package via the standard channels.
 <pre>$ sudo yum install vsftpd</pre>
 </description>
 <rationale>After Red Hat Enterprise Linux 2.1, Red Hat switched from distributing wu-ftpd with Red Hat Enterprise Linux to distributing vsftpd. For security
@@ -207,7 +207,7 @@ to the FTP server port.
 FTP is an older protocol which is not very compatible with firewalls. During the initial FTP dialogue, the client
 and server negotiate an arbitrary port to be used for data transfer. The <tt>ip_conntrack_ftp</tt>  module is used by
 firewalld to listen to that dialogue and allow connections to the data ports which FTP negotiates. This allows an
-FTP server to operate on a machine which is running a firewall.</rationale>
+FTP server to operate on a system which is running a firewall.</rationale>
 <!--<oval id="ftp_configure_firewall" />-->
 <!--<ref prodtype="rhel7" nist="CM-7" /> -->
 </Group>


### PR DESCRIPTION
This is an initial effort to better support scanning of containers.
By marking rules that only make sense for a bare metal and virtual machine environment or container environment we can avoid false positives when scanning such systems.
