### PR TITLE
Fix xpath to handle empty element in gconf_gnome_disable_ctrlaltdel_reboot

### DIFF
--- a/RHEL/6/input/oval/gconf_gnome_disable_ctrlaltdel_reboot.xml
+++ b/RHEL/6/input/oval/gconf_gnome_disable_ctrlaltdel_reboot.xml
@@ -17,25 +17,20 @@
   comment="set Ctrl-Alt-Del key sequence to nothing"
   id="test_gnome_disable_ctrlaltdel_reboot" version="1">
     <ind:object object_ref="object_gnome_disable_ctrlaltdel_reboot" />
-    <ind:state state_ref="state_gnome_disable_ctrlaltdel_reboot" />
   </ind:xmlfilecontent_test>
   <ind:xmlfilecontent_object id="object_gnome_disable_ctrlaltdel_reboot" version="1">
     <ind:filepath>/etc/gconf/gconf.xml.mandatory/apps/gnome_settings_daemon/keybindings/%gconf.xml</ind:filepath>
-    <ind:xpath>/gconf/entry[@name='power']/stringvalue[1]/text()</ind:xpath>
+    <ind:xpath>/gconf/entry[@name='power']/stringvalue[1][not(text())]</ind:xpath>
   </ind:xmlfilecontent_object>
 
   <ind:xmlfilecontent_test check="all"
   comment="set Ctrl-Alt-Del key sequence to nothing"
   id="test_gconf_tree_gnome_disable_ctrlaltdel_reboot" version="1">
     <ind:object object_ref="object_gconf_tree_gnome_disable_ctrlaltdel_reboot" />
-    <ind:state state_ref="state_gnome_disable_ctrlaltdel_reboot" />
   </ind:xmlfilecontent_test>
   <ind:xmlfilecontent_object id="object_gconf_tree_gnome_disable_ctrlaltdel_reboot" version="1">
     <ind:filepath>/etc/gconf/gconf.xml.mandatory/%gconf-tree.xml</ind:filepath>
-    <ind:xpath>/gconf/dir/dir/dir/entry[@name='power']/stringvalue[1]/text()</ind:xpath>
+    <ind:xpath>/gconf/dir/dir/dir/entry[@name='power']/stringvalue[1][not(text())]</ind:xpath>
   </ind:xmlfilecontent_object>
 
-  <ind:xmlfilecontent_state id="state_gnome_disable_ctrlaltdel_reboot" version="1">
-    <ind:value_of datatype="string"></ind:value_of>
-  </ind:xmlfilecontent_state>
 </def-group>


### PR DESCRIPTION
- Fixes #1650