### PR TITLE
Debs: add iommu=force check NT28(R11)

### DIFF
--- a/Debian/8/input/guide.xslt
+++ b/Debian/8/input/guide.xslt
@@ -46,6 +46,7 @@
   <xsl:template match="Group[@id='system']">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document('xccdf/system/hardware.xml')" />
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/software.xml'))" /> 
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/permissions.xml'))" />
       <xsl:apply-templates select="document('xccdf/system/partitions.xml')" />

--- a/Debian/8/input/profiles/anssi_np_nt28_high.xml
+++ b/Debian/8/input/profiles/anssi_np_nt28_high.xml
@@ -3,6 +3,7 @@
 <description override="true">This profile contains items for GNU/Linux installations storing sensitive informations that can be accessible from unauthenticated or uncontroled networks.</description>
 
 <!-- partitioning -->
+<select idref="grub2_enable_iommu_force" selected="true"/>
 <!-- services -->
 <!-- System Logging Requirements -->
 <!-- critical files -->

--- a/Debian/8/input/xccdf/system/hardware.xml
+++ b/Debian/8/input/xccdf/system/hardware.xml
@@ -1,0 +1,18 @@
+<!-- HW install -->
+<Group id="hw-install">
+  <title>Hardening the hardware usage</title>
+  <description>Hardware dependent, but efficient against various risks.</description>
+
+<Rule id="grub2_enable_iommu_force">
+  <title>IOMMU configuration directive</title>
+  <description>
+    On x86 architecture supporting VT-d, the IOMMU manages the access control policy between the hardware devices and some
+    of the system critical units such as the memory.
+  </description>
+  <rationale>On x86 architectures, activating the I/OMMU prevents the system from arbritrary accesses potentially made by
+    hardware devices.</rationale> 
+<oval id="grub2_enable_iommu_force" />
+<ref anssi="NT28(R11)"/>
+</Rule>
+
+</Group>

--- a/Debian/8/templates/static/oval/grub2_enable_iommu_force.xml
+++ b/Debian/8/templates/static/oval/grub2_enable_iommu_force.xml
@@ -1,0 +1,61 @@
+<def-group>
+  <definition class="compliance" id="grub2_enable_iommu_force" version="1">
+    <metadata>
+      <title>Force IOMMU usage in GRUB2</title>
+      <affected family="unix">
+        <platform>multi_platform_debian</platform>
+      </affected>
+      <description>Look for argument iommu=force in the kernel line in /etc/default/grub.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_grub2_default_exists" comment="check for GRUB_CMDLINE_LINUX_DEFAULT exists in /etc/default/grub" />
+      <criteria operator="OR">
+        <criterion test_ref="test_grub2_enable_force_iommu_default" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT" />
+        <criterion test_ref="test_grub2_enable_force_iommu" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu"
+  comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu_default"
+  comment="check for fips=1 in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu_default" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu_default" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_grub2_enable_force_iommu" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^.*iommu=force.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test id="test_grub2_default_exists"
+  comment="check for GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_default_exists" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_default_exists" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT=.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/Ubuntu/14.04/input/guide.xslt
+++ b/Ubuntu/14.04/input/guide.xslt
@@ -46,6 +46,7 @@
   <xsl:template match="Group[@id='system']">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document('xccdf/system/hardware.xml')" />
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/software.xml'))" /> 
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/permissions.xml'))" />
       <xsl:apply-templates select="document('xccdf/system/partitions.xml')" />

--- a/Ubuntu/14.04/input/profiles/anssi_np_nt28_high.xml
+++ b/Ubuntu/14.04/input/profiles/anssi_np_nt28_high.xml
@@ -3,6 +3,7 @@
 <description override="true">This profile contains items for GNU/Linux installations storing sensitive informations that can be accessible from unauthenticated or uncontroled networks.</description>
 
 <!-- partitioning -->
+<select idref="grub2_enable_iommu_force" selected="true"/>
 <!-- services -->
 <!-- System Logging Requirements -->
 <!-- critical files -->

--- a/Ubuntu/14.04/input/xccdf/system/hardware.xml
+++ b/Ubuntu/14.04/input/xccdf/system/hardware.xml
@@ -1,0 +1,18 @@
+<!-- HW install -->
+<Group id="hw-install">
+  <title>Hardening the hardware usage</title>
+  <description>Hardware dependent, but efficient against various risks.</description>
+
+<Rule id="grub2_enable_iommu_force">
+  <title>IOMMU configuration directive</title>
+  <description>
+    On x86 architecture supporting VT-d, the IOMMU manages the access control policy between the hardware devices and some
+    of the system critical units such as the memory.
+  </description>
+  <rationale>On x86 architectures, activating the I/OMMU prevents the system from arbritrary accesses potentially made by
+    hardware devices.</rationale> 
+<oval id="grub2_enable_iommu_force" />
+<ref anssi="NT28(R11)"/>
+</Rule>
+
+</Group>

--- a/Ubuntu/14.04/templates/static/oval/grub2_enable_iommu_force.xml
+++ b/Ubuntu/14.04/templates/static/oval/grub2_enable_iommu_force.xml
@@ -1,0 +1,61 @@
+<def-group>
+  <definition class="compliance" id="grub2_enable_iommu_force" version="1">
+    <metadata>
+      <title>Force IOMMU usage in GRUB2</title>
+      <affected family="unix">
+        <platform>multi_platform_ubuntu</platform>
+      </affected>
+      <description>Look for argument iommu=force in the kernel line in /etc/default/grub.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_grub2_default_exists" comment="check for GRUB_CMDLINE_LINUX_DEFAULT exists in /etc/default/grub" />
+      <criteria operator="OR">
+        <criterion test_ref="test_grub2_enable_force_iommu_default" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT" />
+        <criterion test_ref="test_grub2_enable_force_iommu" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu"
+  comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu_default"
+  comment="check for fips=1 in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu_default" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu_default" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_grub2_enable_force_iommu" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^.*iommu=force.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test id="test_grub2_default_exists"
+  comment="check for GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_default_exists" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_default_exists" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT=.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/Ubuntu/16.04/input/guide.xslt
+++ b/Ubuntu/16.04/input/guide.xslt
@@ -46,6 +46,7 @@
   <xsl:template match="Group[@id='system']">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document('xccdf/system/hardware.xml')" />
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/software.xml'))" /> 
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/permissions.xml'))" />
       <xsl:apply-templates select="document('xccdf/system/partitions.xml')" />

--- a/Ubuntu/16.04/input/profiles/anssi_np_nt28_high.xml
+++ b/Ubuntu/16.04/input/profiles/anssi_np_nt28_high.xml
@@ -3,6 +3,7 @@
 <description override="true">This profile contains items for GNU/Linux installations storing sensitive informations that can be accessible from unauthenticated or uncontroled networks.</description>
 
 <!-- partitioning -->
+<select idref="grub2_enable_iommu_force" selected="true"/>
 <!-- services -->
 <!-- System Logging Requirements -->
 <!-- critical files -->

--- a/Ubuntu/16.04/input/xccdf/system/hardware.xml
+++ b/Ubuntu/16.04/input/xccdf/system/hardware.xml
@@ -1,0 +1,18 @@
+<!-- HW install -->
+<Group id="hw-install">
+  <title>Hardening the hardware usage</title>
+  <description>Hardware dependent, but efficient against various risks.</description>
+
+<Rule id="grub2_enable_iommu_force">
+  <title>IOMMU configuration directive</title>
+  <description>
+    On x86 architecture supporting VT-d, the IOMMU manages the access control policy between the hardware devices and some
+    of the system critical units such as the memory.
+  </description>
+  <rationale>On x86 architectures, activating the I/OMMU prevents the system from arbritrary accesses potentially made by
+    hardware devices.</rationale> 
+<oval id="grub2_enable_iommu_force" />
+<ref anssi="NT28(R11)"/>
+</Rule>
+
+</Group>

--- a/Ubuntu/16.04/templates/static/oval/grub2_enable_iommu_force.xml
+++ b/Ubuntu/16.04/templates/static/oval/grub2_enable_iommu_force.xml
@@ -1,0 +1,61 @@
+<def-group>
+  <definition class="compliance" id="grub2_enable_iommu_force" version="1">
+    <metadata>
+      <title>Force IOMMU usage in GRUB2</title>
+      <affected family="unix">
+        <platform>multi_platform_ubuntu</platform>
+      </affected>
+      <description>Look for argument iommu=force in the kernel line in /etc/default/grub.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_grub2_default_exists" comment="check for GRUB_CMDLINE_LINUX_DEFAULT exists in /etc/default/grub" />
+      <criteria operator="OR">
+        <criterion test_ref="test_grub2_enable_force_iommu_default" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT" />
+        <criterion test_ref="test_grub2_enable_force_iommu" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu"
+  comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu_default"
+  comment="check for fips=1 in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu_default" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu_default" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_grub2_enable_force_iommu" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^.*iommu=force.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test id="test_grub2_default_exists"
+  comment="check for GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_default_exists" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_default_exists" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT=.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>


### PR DESCRIPTION
Continuing ANSSI best-practices integration in Debian and derivatives.