### PR TITLE
Add support for templated partitons mount flags check

### DIFF
--- a/Debian/8/input/guide.xslt
+++ b/Debian/8/input/guide.xslt
@@ -46,6 +46,7 @@
   <xsl:template match="Group[@id='system']">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document('xccdf/system/hardware.xml')" />
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/software.xml'))" /> 
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/permissions.xml'))" />
       <xsl:apply-templates select="document('xccdf/system/partitions.xml')" />

--- a/Debian/8/input/profiles/anssi_np_nt28_high.xml
+++ b/Debian/8/input/profiles/anssi_np_nt28_high.xml
@@ -3,6 +3,7 @@
 <description override="true">This profile contains items for GNU/Linux installations storing sensitive informations that can be accessible from unauthenticated or uncontroled networks.</description>
 
 <!-- partitioning -->
+<select idref="grub2_enable_iommu_force" selected="true"/>
 <!-- services -->
 <!-- System Logging Requirements -->
 <!-- critical files -->

--- a/Debian/8/input/xccdf/system/hardware.xml
+++ b/Debian/8/input/xccdf/system/hardware.xml
@@ -1,0 +1,18 @@
+<!-- HW install -->
+<Group id="hw-install">
+  <title>Hardening the hardware usage</title>
+  <description>Hardware dependent, but efficient against various risks.</description>
+
+<Rule id="grub2_enable_iommu_force">
+  <title>IOMMU configuration directive</title>
+  <description>
+    On x86 architecture supporting VT-d, the IOMMU manages the access control policy between the hardware devices and some
+    of the system critical units such as the memory.
+  </description>
+  <rationale>On x86 architectures, activating the I/OMMU prevents the system from arbritrary accesses potentially made by
+    hardware devices.</rationale> 
+<oval id="grub2_enable_iommu_force" />
+<ref anssi="NT28(R11)"/>
+</Rule>
+
+</Group>

--- a/Debian/8/templates/csv/partitions_rights.csv
+++ b/Debian/8/templates/csv/partitions_rights.csv
@@ -1,0 +1,13 @@
+/home,nosuid
+/home,nodev
+/var/log,nosuid
+/var/log,nodev
+/var/log,noexec
+/var/lib,nodev
+/var/lib,nosuid
+/var/lib,nodev
+/var/lib,nosuid
+/var/lib,noexec
+/tmp,nodev
+/tmp,nosuid
+/usr,nodev

--- a/Debian/8/templates/static/oval/grub2_enable_iommu_force.xml
+++ b/Debian/8/templates/static/oval/grub2_enable_iommu_force.xml
@@ -1,0 +1,61 @@
+<def-group>
+  <definition class="compliance" id="grub2_enable_iommu_force" version="1">
+    <metadata>
+      <title>Force IOMMU usage in GRUB2</title>
+      <affected family="unix">
+        <platform>multi_platform_debian</platform>
+      </affected>
+      <description>Look for argument iommu=force in the kernel line in /etc/default/grub.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_grub2_default_exists" comment="check for GRUB_CMDLINE_LINUX_DEFAULT exists in /etc/default/grub" />
+      <criteria operator="OR">
+        <criterion test_ref="test_grub2_enable_force_iommu_default" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT" />
+        <criterion test_ref="test_grub2_enable_force_iommu" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu"
+  comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu_default"
+  comment="check for fips=1 in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu_default" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu_default" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_grub2_enable_force_iommu" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^.*iommu=force.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test id="test_grub2_default_exists"
+  comment="check for GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_default_exists" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_default_exists" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT=.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/Debian/8/templates/template_partitions_rights
+++ b/Debian/8/templates/template_partitions_rights
@@ -1,0 +1,26 @@
+<def-group>
+  <definition class="compliance" id="mount_optionPOINTID_FLAGID" version="1">
+    <metadata>
+      <title>Add MOUNTFLAG Option to MOUNTPOINT</title>
+      <affected family="unix">
+        <platform>multi_platform_ubuntu</platform>
+      </affected>
+      <description>MOUNTPOINT should be mounted with mount flag MOUNTFLAG.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="MOUNTFLAG on MOUNTPOINT" test_ref="testPOINTID_FLAGID" />
+    </criteria>
+  </definition>
+  <linux:partition_test check="all" check_existence="all_exist"
+  id="testPOINTID_FLAGID" version="1" comment="MOUNTFLAG on MOUNTPOINT">
+    <linux:object object_ref="objectPOINTID_FLAGID_partition" />
+    <linux:state state_ref="statePOINTID_FLAGID" />
+  </linux:partition_test>
+  <linux:partition_object id="objectPOINTID_FLAGID_partition" version="1">
+    <linux:mount_point>MOUNTPOINT</linux:mount_point>
+  </linux:partition_object>
+  <linux:partition_state id="statePOINTID_FLAGID" version="1">
+    <linux:mount_options datatype="string" entity_check="at least one"
+    operation="equals">MOUNTFLAG</linux:mount_options>
+  </linux:partition_state>
+</def-group>

--- a/Ubuntu/14.04/input/guide.xslt
+++ b/Ubuntu/14.04/input/guide.xslt
@@ -46,6 +46,7 @@
   <xsl:template match="Group[@id='system']">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document('xccdf/system/hardware.xml')" />
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/software.xml'))" /> 
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/permissions.xml'))" />
       <xsl:apply-templates select="document('xccdf/system/partitions.xml')" />

--- a/Ubuntu/14.04/input/profiles/anssi_np_nt28_high.xml
+++ b/Ubuntu/14.04/input/profiles/anssi_np_nt28_high.xml
@@ -3,6 +3,7 @@
 <description override="true">This profile contains items for GNU/Linux installations storing sensitive informations that can be accessible from unauthenticated or uncontroled networks.</description>
 
 <!-- partitioning -->
+<select idref="grub2_enable_iommu_force" selected="true"/>
 <!-- services -->
 <!-- System Logging Requirements -->
 <!-- critical files -->

--- a/Ubuntu/14.04/input/xccdf/system/hardware.xml
+++ b/Ubuntu/14.04/input/xccdf/system/hardware.xml
@@ -1,0 +1,18 @@
+<!-- HW install -->
+<Group id="hw-install">
+  <title>Hardening the hardware usage</title>
+  <description>Hardware dependent, but efficient against various risks.</description>
+
+<Rule id="grub2_enable_iommu_force">
+  <title>IOMMU configuration directive</title>
+  <description>
+    On x86 architecture supporting VT-d, the IOMMU manages the access control policy between the hardware devices and some
+    of the system critical units such as the memory.
+  </description>
+  <rationale>On x86 architectures, activating the I/OMMU prevents the system from arbritrary accesses potentially made by
+    hardware devices.</rationale> 
+<oval id="grub2_enable_iommu_force" />
+<ref anssi="NT28(R11)"/>
+</Rule>
+
+</Group>

--- a/Ubuntu/14.04/templates/static/oval/grub2_enable_iommu_force.xml
+++ b/Ubuntu/14.04/templates/static/oval/grub2_enable_iommu_force.xml
@@ -1,0 +1,61 @@
+<def-group>
+  <definition class="compliance" id="grub2_enable_iommu_force" version="1">
+    <metadata>
+      <title>Force IOMMU usage in GRUB2</title>
+      <affected family="unix">
+        <platform>multi_platform_ubuntu</platform>
+      </affected>
+      <description>Look for argument iommu=force in the kernel line in /etc/default/grub.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_grub2_default_exists" comment="check for GRUB_CMDLINE_LINUX_DEFAULT exists in /etc/default/grub" />
+      <criteria operator="OR">
+        <criterion test_ref="test_grub2_enable_force_iommu_default" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT" />
+        <criterion test_ref="test_grub2_enable_force_iommu" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu"
+  comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu_default"
+  comment="check for fips=1 in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu_default" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu_default" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_grub2_enable_force_iommu" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^.*iommu=force.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test id="test_grub2_default_exists"
+  comment="check for GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_default_exists" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_default_exists" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT=.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/Ubuntu/16.04/input/guide.xslt
+++ b/Ubuntu/16.04/input/guide.xslt
@@ -46,6 +46,7 @@
   <xsl:template match="Group[@id='system']">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document('xccdf/system/hardware.xml')" />
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/software.xml'))" /> 
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/permissions.xml'))" />
       <xsl:apply-templates select="document('xccdf/system/partitions.xml')" />

--- a/Ubuntu/16.04/input/profiles/anssi_np_nt28_high.xml
+++ b/Ubuntu/16.04/input/profiles/anssi_np_nt28_high.xml
@@ -3,6 +3,7 @@
 <description override="true">This profile contains items for GNU/Linux installations storing sensitive informations that can be accessible from unauthenticated or uncontroled networks.</description>
 
 <!-- partitioning -->
+<select idref="grub2_enable_iommu_force" selected="true"/>
 <!-- services -->
 <!-- System Logging Requirements -->
 <!-- critical files -->

--- a/Ubuntu/16.04/input/xccdf/system/hardware.xml
+++ b/Ubuntu/16.04/input/xccdf/system/hardware.xml
@@ -1,0 +1,18 @@
+<!-- HW install -->
+<Group id="hw-install">
+  <title>Hardening the hardware usage</title>
+  <description>Hardware dependent, but efficient against various risks.</description>
+
+<Rule id="grub2_enable_iommu_force">
+  <title>IOMMU configuration directive</title>
+  <description>
+    On x86 architecture supporting VT-d, the IOMMU manages the access control policy between the hardware devices and some
+    of the system critical units such as the memory.
+  </description>
+  <rationale>On x86 architectures, activating the I/OMMU prevents the system from arbritrary accesses potentially made by
+    hardware devices.</rationale> 
+<oval id="grub2_enable_iommu_force" />
+<ref anssi="NT28(R11)"/>
+</Rule>
+
+</Group>

--- a/Ubuntu/16.04/templates/static/oval/grub2_enable_iommu_force.xml
+++ b/Ubuntu/16.04/templates/static/oval/grub2_enable_iommu_force.xml
@@ -1,0 +1,61 @@
+<def-group>
+  <definition class="compliance" id="grub2_enable_iommu_force" version="1">
+    <metadata>
+      <title>Force IOMMU usage in GRUB2</title>
+      <affected family="unix">
+        <platform>multi_platform_ubuntu</platform>
+      </affected>
+      <description>Look for argument iommu=force in the kernel line in /etc/default/grub.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_grub2_default_exists" comment="check for GRUB_CMDLINE_LINUX_DEFAULT exists in /etc/default/grub" />
+      <criteria operator="OR">
+        <criterion test_ref="test_grub2_enable_force_iommu_default" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT" />
+        <criterion test_ref="test_grub2_enable_force_iommu" comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu"
+  comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_grub2_enable_force_iommu_default"
+  comment="check for fips=1 in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_enable_force_iommu_default" />
+    <ind:state state_ref="state_grub2_enable_force_iommu" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_enable_force_iommu_default" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_grub2_enable_force_iommu" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^.*iommu=force.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test id="test_grub2_default_exists"
+  comment="check for GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grub2_default_exists" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_grub2_default_exists" version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT=.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/shared/templates/create_partitions_rights.py
+++ b/shared/templates/create_partitions_rights.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python2
+
+#
+# create_permission.py
+#        generate template-based checks for partition mount rights
+
+
+import sys
+import re
+
+from template_common import *
+
+
+def output_checkfile(target, path_info):
+    # the csv file contains lines that match the following layout:
+    #    directory,file_name,uid,gid,mode
+    #dir_path, file_name, uid, gid, mode = path_info
+	mount_point, mount_flag = path_info
+
+    # build a string out of the path that is suitable for use in id tags
+    # example:	/var/log --> _var_log
+    # path_id maps to MOUNTPOINTID in the template
+	point_id = re.sub('[-\./]', '_', mount_point)
+	flag_id = re.sub('[-\./]', '_', mount_flag)
+
+	if target == "oval":
+        # we are ready to create the check
+        # open the template and perform the conversions
+		file_from_template(
+            "./template_partitions_rights",
+            {
+                "MOUNTPOINT":       mount_point,
+                "MOUNTFLAG":        mount_flag,
+                "POINTID":     point_id,
+                "FLAGID":      flag_id,
+            },
+            "./oval/partitions_rights{0}.xml", point_id + flag_id
+        )
+	else:
+		raise UnknownTargetError(target)
+
+
+def help():
+    print("Usage:\n\t" + __file__ + " <bash/oval/ansible> <csv file>")
+    print("CSV should contains lines of the format: "
+          "directory path,file name,owner uid (numeric),group "
+          "owner gid (numeric),mode")
+
+if __name__ == "__main__":
+    main(sys.argv, help, output_checkfile)

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -19,6 +19,7 @@ class Builder(object):
             "kernel_modules_disabled.csv":  "create_kernel_modules_disabled.py",
             "file_dir_permissions.csv":     "create_permission.py",
             "accounts_password.csv":        "create_accounts_password.py",
+            "partitions_rights.csv":        "create_partitions_rights.py",
         }
         self.supported_ovals = ["oval_5.10"]
         self.langs = ["bash", "ansible", "oval", "anaconda", "puppet"]


### PR DESCRIPTION
Update of the python scripts to support csv+XML template file to generates OVAL files for partitions mount flags check (nodev, noexec, etc.)
No support for remediation by now (don't know how to simply remediate when partition does not exist). Should be easier if the partition is considered as already created.