### PR TITLE
Update smartcard auth OVAL to not require the esc package for non-GUI environments

### DIFF
--- a/RHEL/6/input/oval/smartcard_auth.xml
+++ b/RHEL/6/input/oval/smartcard_auth.xml
@@ -12,6 +12,10 @@
       <extend_definition comment="esc package is installed" definition_ref="package_esc_installed" />
       <extend_definition comment="pcscd service is enabled" definition_ref="service_pcscd_enabled" />
       <criterion comment="cert_policy directive contains oscp_on" test_ref="test_pam_pkcs11_cert_policy_ocsp_on" />
+      <criteria operator="OR">
+        <extend_definition comment="GConf2 installed" definition_ref="package_GConf2_installed" negate="true" />
+        <extend_definition comment="esc package is installed" definition_ref="package_esc_installed" />
+      </criteria>
       <criteria comment="smart card authentication is enabled or required in system-auth" operator="OR">
           <!-- Smartcard authentication enabled, but login is allowed also by other means -->
           <criterion comment="smart card authentication is enabled in /etc/pam.d/system-auth" test_ref="test_smart_card_enabled_system_auth" />

--- a/RHEL/7/input/oval/oval_5.11/smartcard_auth.xml
+++ b/RHEL/7/input/oval/oval_5.11/smartcard_auth.xml
@@ -9,8 +9,11 @@
     </metadata>
     <criteria comment="smart card authentication is configured" operator="AND">
       <extend_definition comment="pam_pkcs11 package is installed" definition_ref="package_pam_pkcs11_installed" />
-      <extend_definition comment="esc package is installed" definition_ref="package_esc_installed" />
       <extend_definition comment="pcscd service is enabled" definition_ref="pcscd_activation_socket_enabled" />
+      <criteria operator="OR">
+        <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+        <extend_definition comment="esc package is installed" definition_ref="package_esc_installed" />
+      </criteria>
       <criterion comment="cert_policy directive contains oscp_on" test_ref="test_pam_pkcs11_cert_policy_ocsp_on" />
       <criteria comment="smart card authentication is enabled or required in system-auth" operator="OR">
           <!-- Smartcard authentication enabled, but login is allowed also by other means -->


### PR DESCRIPTION
- Fixes #1698 