### PR TITLE
Marking more machine only rules

### DIFF
--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -356,6 +356,7 @@ session lock.
 <br /><br />
 The <tt>screen</tt> package allows for a session lock to be implemented and configured.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27351-6" />
 <oval id="package_screen_installed" />
 <ref prodtype="rhel7" nist="AC-11(a)" disa="57" ossrg="SRG-OS-000029-GPOS-00010" stigid="010072" 

--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -33,6 +33,7 @@ or modification of the file.
 <rationale>
 Only root should be able to modify important boot parameters.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="26860-7" />
 <oval id="file_user_owner_grub2_cfg" />
 <ref prodtype="rhel7" nist="AC-6(7)" disa="225" pcidss="Req-7.1" cis="1.5.1" cjis="5.5.2.2" />
@@ -50,6 +51,7 @@ destruction or modification of the file.
 The <tt>root</tt> group is a highly-privileged group. Furthermore, the group-owner of this
 file should not have any access privileges anyway.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="26812-8" />
 <oval id="file_group_owner_grub2_cfg" />
 <ref prodtype="rhel7" nist="AC-6(7)" disa="225" pcidss="Req-7.1" cis="1.5.1" cjis="5.5.2.2" />
@@ -70,6 +72,7 @@ permissions: <tt>-rw-------</tt>
 Proper permissions ensure that only the root user can modify important boot
 parameters.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27054-6" />
 <oval id="file_permissions_grub2_cfg" />
 <ref prodtype="rhel7" nist="AC-6(7)" disa="225" cis="1.5.2" />
@@ -121,6 +124,7 @@ the grub2 superuser account and password, please refer to
 <li><weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-GRUB_2_Password_Protection.html"/></li>.
 </ul>
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27309-4" />
 <oval id="bootloader_password" />
 <ref prodtype="rhel7" nist="IA-2(1),IA-5(e),AC-3" disa="213" ossrg="SRG-OS-000080-GPOS-00048" stigid="010460" cis="1.5.3" />
@@ -172,6 +176,7 @@ the grub2 superuser account and password, please refer to
 <li><weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-GRUB_2_Password_Protection.html"/></li>.
 </ul>
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80354-4" />
 <oval id="bootloader_uefi_password" />
 <ref prodtype="rhel7" nist="AC-3" disa="213" ossrg="SRG-OS-000080-GPOS-00048" stigid="010470" />
@@ -201,6 +206,7 @@ This prevents attackers with physical access from trivially bypassing security
 on the machine and gaining root access. Such accesses are further prevented
 by configuring the bootloader password.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27287-2" />
 <oval id="require_singleuser_auth" />
 <ref prodtype="rhel7" nist="IA-2(1),AC-3" disa="213" cui="3.1.1" />
@@ -226,6 +232,7 @@ This prevents attackers with physical access from trivially bypassing security
 on the machine through valid troubleshooting configurations and gaining root
 access when the system is rebooted.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80206-6" />
 <oval id="service_debug-shell_disabled" />
 <!--ref nist="IA-2(1),AC-3" disa="213" /-->
@@ -291,6 +298,7 @@ that interactive boot is enabled at boot time.
 Using interactive boot, the console user could disable auditing, firewalls,
 or other services, weakening system security.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">The GRUB 2 configuration file, <tt>grub.cfg</tt>,
 is automatically updated each time a new kernel is installed. Note that any
 changes to <tt>/etc/default/grub</tt> require rebuilding the <tt>grub.cfg</tt>

--- a/shared/xccdf/system/auditing.xml
+++ b/shared/xccdf/system/auditing.xml
@@ -117,6 +117,7 @@ Additionally, a properly configured audit subsystem ensures that actions of
 individual system users can be uniquely traced to those users so they
 can be held accountable for their actions.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27407-6" />
 <oval id="service_auditd_enabled" />
 <ref prodtype="rhel7" nist="AU-3,AC-17(1),AU-1(b),AU-10,AU-12(a),AU-12(c),AU-14(1),IR-5" disa="126,131"
@@ -297,6 +298,7 @@ determine how many logs the system is configured to retain after rotation:
 <rationale>The total storage for audit log files must be large enough to retain
 log information over the period required. This is a function of the maximum log
 file size and the number of logs retained.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27348-2" />
 <oval id="auditd_data_retention_num_logs" value="var_auditd_num_logs" />
 <ref prodtype="rhel7" nist="AU-1(b),AU-11,IR-5" pcidss="Req-10.7" cjis="5.4.1.1"
@@ -322,6 +324,7 @@ determine how much data the system will retain in each audit log file:
 <rationale>The total storage for audit log files must be large enough to retain
 log information over the period required. This is a function of the maximum
 log file size and the number of logs retained.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27319-3" />
 <oval id="auditd_data_retention_max_log_file" value="var_auditd_max_log_file" />
 <ref prodtype="rhel7" nist="AU-1(b),AU-11,IR-5" pcidss="Req-10.7" cis="5.2.1.1" cjis="5.4.1.1" />
@@ -357,6 +360,7 @@ minimizes the chances of the system unexpectedly running out of disk space by
 being overwhelmed with log data. However, for systems that must never discard
 log data, or which use external processes to transfer it and reclaim space,
 <tt>keep_logs</tt> can be employed.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27231-0" />
 <oval id="auditd_data_retention_max_log_file_action" value="var_auditd_max_log_file_action" />
 <ref prodtype="rhel7" nist="AU-1(b),AU-4,AU-11,IR-5" pcidss="Req-10.7" cis="5.2.1.3" cjis="5.4.1.1" />
@@ -409,6 +413,7 @@ Acceptable values are <tt>email</tt>, <tt>suspend</tt>, <tt>single</tt>, and <tt
 </ocil>
 <rationale>Notifying administrators of an impending disk space problem may
 allow them to take corrective action prior to any disruption.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27375-5" />
 <oval id="auditd_data_retention_space_left_action" value="var_auditd_space_left_action"/>
 <ref prodtype="rhel7" nist="AU-1(b),AU-4,AU-5(1),AU-5(b),IR-5" disa="1855" pcidss="Req-10.7" cis="5.2.1.2"
@@ -440,6 +445,7 @@ or halt when disk space has run low:
 audit records. If a separate partition or logical volume of adequate size
 is used, running low on space for audit records should never occur.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27370-6" />
 <oval id="auditd_data_retention_admin_space_left_action" value="var_auditd_admin_space_left_action" />
 <ref prodtype="rhel7" nist="AU-1(b),AU-4,AU-5(b),IR-5" disa="140,1343" pcidss="Req-10.7" cis="5.2.1.2"
@@ -462,6 +468,7 @@ account when it needs to notify an administrator:
 </ocil>
 <rationale>Email sent to the root account is typically aliased to the
 administrators of the system, who can take appropriate action.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27394-6" />
 <oval id="auditd_data_retention_action_mail_acct" value="var_auditd_action_mail_acct" />
 <ref prodtype="rhel7" nist="AU-1(b),AU-4,AU-5(1),AU-5(a),IR-5" disa="1855" pcidss="Req-10.7.a" cis="5.2.1.2"
@@ -489,6 +496,7 @@ case-insensitive.
 <rationale>Audit data should be synchronously written to disk to ensure
 log integrity. These parameters assure that all audit event data is fully
 synchronized with the log files on the disk.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27331-8" />
 <oval id="auditd_data_retention_flush" value="var_auditd_flush" />
 <ref prodtype="rhel7" nist="AU-9,AU-12(1)" disa="1576" cui="3.3.1" />
@@ -511,6 +519,7 @@ If the plugin is active, the output will show <tt>yes</tt>.
 records to a centralized server for management directly. It does, however,
 include a plug-in for audit event multiplexor (audispd) to pass audit records
 to the local syslog server</rationale>
+<platform idref="cpe:/a:machine" />
 <ref prodtype="rhel7" nist="AU-1(b),AU-3(2),IR-5" disa="136" pcidss="Req-10.5.3" cjis="5.4.1.1"
 cui="3.3.1" />
 <oval id="auditd_audispd_syslog_plugin_activated" />
@@ -585,6 +594,7 @@ the audit capability, and system operation may be adversely affected.
 Audit processing failures include software/hardware errors, failures in the
 audit capturing mechanisms, and audit storage capacity being reached or
 exceeded.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80381-7" />
 <oval id="audit_rules_system_shutdown" />
 <ref prodtype="rhel7" nist="AU-5,AU-5(a)" disa="139" stigid="030090"
@@ -626,6 +636,7 @@ not required. See an example of multiple combined syscalls:
 nefarious activities in log files, as well as to confuse network services that
 are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27290-6" />
 <oval id="audit_rules_time_adjtimex" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" cis="5.2.4"
@@ -660,6 +671,7 @@ not required. See an example of multiple combined syscalls:
 nefarious activities in log files, as well as to confuse network services that
 are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27216-1" />
 <oval id="audit_rules_time_settimeofday" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" cis="5.2.4"
@@ -700,6 +712,7 @@ If the system is 64-bit only, this is not applicable<br />
 nefarious activities in log files, as well as to confuse network services that
 are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27299-7" />
 <oval id="audit_rules_time_stime" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" 
@@ -734,6 +747,7 @@ desired, but is not required. See an example of multiple combined syscalls:
 nefarious activities in log files, as well as to confuse network services that
 are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27219-5" />
 <oval id="audit_rules_time_clock_settime" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" cis="5.2.4" 
@@ -766,6 +780,7 @@ If the system is configured to audit this activity, it will return a line.
 nefarious activities in log files, as well as to confuse network services that
 are highly dependent upon an accurate system time (such as sshd). All changes
 to the system time should be audited.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27310-2" />
 <oval id="audit_rules_time_watch_localtime" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(b),IR-5" cis="5.2.4"
@@ -806,6 +821,7 @@ each file specified (and with <tt>perm=wa</tt> for each).
 <rationale>In addition to auditing new user and group accounts, these watches
 will alert the system administrator(s) to any modifications. Any unexpected
 users, groups, or modifications should be investigated for legitimacy.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27192-4" />
 <oval id="audit_rules_usergroup_modification" />
 <ref prodtype="rhel7" nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5"
@@ -846,6 +862,7 @@ each file specified (and <tt>perm=wa</tt> should be indicated for each).
 <rationale>The network environment should not be modified by anything other
 than administrator action. Any change to network parameters should be
 audited.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27076-9" />
 <oval id="audit_rules_networkconfig_modification" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" pcidss="Req-10.5.5" 
@@ -870,6 +887,7 @@ Audit logs must be mode 0640 or less permissive.
 <rationale>
 If users can write to audit logs, audit trails can be modified or destroyed.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27205-4" />
 <oval id="file_permissions_var_log_audit" />
 <ref prodtype="rhel7" nist="AC-6,AU-1(b),AU-9,IR-5" disa="" pcidss="Req-10.5" cjis="5.4.1.1"
@@ -886,6 +904,7 @@ cui="3.3.1" />
 </ocil>
 <rationale>Unauthorized disclosure of audit records can reveal system and configuration data to
 attackers, thus compromising its confidentiality.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80125-8" />
 <oval id="file_ownership_var_log_audit" />
 <ref prodtype="rhel7" nist="AC-6,AU-1(b),AU-9,IR-5" disa="163" ossrg="SRG-OS-000058-GPOS-00028" 
@@ -915,6 +934,7 @@ configuration, a line should be returned (including
 <rationale>The system's mandatory access policy (SELinux) should not be
 arbitrarily changed by anything other than administrator action. All changes to
 MAC policy should be audited.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27168-4" />
 <oval id="audit_rules_mac_modification" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" pcidss="Req-10.5.5" 
@@ -944,6 +964,7 @@ arch=b32 replaced with arch=b64 as follows:
 attempting to gain access to information that would otherwise be disallowed.
 Auditing DAC modifications can facilitate the identification of patterns of
 abuse among both authorized and unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 
 <Rule id="audit_rules_dac_modification_chmod" prodtype="rhel7">
 <title>Record Events that Modify the System's Discretionary Access Controls - chmod</title>
@@ -966,6 +987,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <ocil clause="the system is not configured to audit permission changes">
 <audit-syscall-check-macro syscall="chmod" />
 </ocil>
@@ -1005,6 +1027,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1042,6 +1065,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1079,6 +1103,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1116,6 +1141,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1153,6 +1179,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1195,6 +1222,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1232,6 +1260,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1269,6 +1298,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1311,6 +1341,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1348,6 +1379,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1389,6 +1421,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1426,6 +1459,7 @@ If the system is 64 bit then also add the following line:
 gain access to information that would otherwise be disallowed. Auditing DAC modifications
 can facilitate the identification of patterns of abuse among both authorized and
 unauthorized users.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1484,6 +1518,7 @@ edits of files involved in storing logon events:
 </description>
 <rationale>Manual editing of these files may indicate nefarious activity, such
 as an attacker attempting to remove evidence of an intrusion.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27204-7" />
 <oval id="audit_rules_login_events" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" disa="172,2884"
@@ -1511,6 +1546,7 @@ To verify that auditing is configured for system administrator actions, run the 
 </ocil>
 <rationale>Manual editing of these files may indicate nefarious activity, such
 as an attacker attempting to remove evidence of an intrusion.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80382-5" />
 <oval id="audit_rules_login_events_tallylog" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" disa="172,2884,126"
@@ -1539,6 +1575,7 @@ To verify that auditing is configured for system administrator actions, run the 
 </ocil>
 <rationale>Manual editing of these files may indicate nefarious activity, such
 as an attacker attempting to remove evidence of an intrusion.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80383-3" />
 <oval id="audit_rules_login_events_faillock" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" disa="172,2884,126"
@@ -1567,6 +1604,7 @@ To verify that auditing is configured for system administrator actions, run the 
 </ocil>
 <rationale>Manual editing of these files may indicate nefarious activity, such
 as an attacker attempting to remove evidence of an intrusion.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80384-1" />
 <oval id="audit_rules_login_events_lastlog" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" disa="172,2884,126"
@@ -1597,6 +1635,7 @@ edits of files involved in storing such process information:
 </description>
 <rationale>Manual editing of these files may indicate nefarious activity, such
 as an attacker attempting to remove evidence of an intrusion.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27301-1" />
 <oval id="audit_rules_session_events" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" 
@@ -1653,6 +1692,7 @@ To verify that the audit system collects unauthorized file accesses, run the fol
 </ocil>
 <rationale>Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing
 these events could serve as evidence of potential system compromise.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27347-4" />
 <oval id="audit_rules_unsuccessful_file_modification" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884"
@@ -1687,6 +1727,7 @@ If the system is 64 bit then also add the following lines:
 </ocil>
 <rationale>Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing
 these events could serve as evidence of potential system compromise.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1727,6 +1768,7 @@ If the system is 64 bit then also add the following lines:
 </ocil>
 <rationale>Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing
 these events could serve as evidence of potential system compromise.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1767,6 +1809,7 @@ If the system is 64 bit then also add the following lines:
 </ocil>
 <rationale>Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing
 these events could serve as evidence of potential system compromise.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1807,6 +1850,7 @@ If the system is 64 bit then also add the following lines:
 </ocil>
 <rationale>Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing
 these events could serve as evidence of potential system compromise.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1847,6 +1891,7 @@ If the system is 64 bit then also add the following lines:
 </ocil>
 <rationale>Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing
 these events could serve as evidence of potential system compromise.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1887,6 +1932,7 @@ If the system is 64 bit then also add the following lines:
 </ocil>
 <rationale>Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing
 these events could serve as evidence of potential system compromise.</rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Note that these rules can be configured in a
 number of ways while still achieving the desired effect. Here the system calls
 have been placed independent of other system calls. Grouping these system
@@ -1948,6 +1994,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80391-6" />
 <oval id="audit_rules_execution_semanage" />
 <ref prodtype="rhel7" nist="AU-12(c)" disa="172,2884"
@@ -1985,6 +2032,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80392-4" />
 <oval id="audit_rules_execution_setsebool" />
 <ref prodtype="rhel7" nist="AU-12(c)" disa="172,2884"
@@ -2022,6 +2070,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80393-2" />
 <oval id="audit_rules_execution_chcon" />
 <ref prodtype="rhel7" nist="AU-12(c)" disa="172,2884"
@@ -2059,6 +2108,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80394-0" />
 <oval id="audit_rules_execution_restorecon" />
 <ref prodtype="rhel7" nist="AU-12(c)" disa="172,2884"
@@ -2128,6 +2178,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27437-3" />
 <oval id="audit_rules_privileged_commands" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-2(4),AU-6(9),AU-12(a),AU-12(c),IR-5" disa="2234"
@@ -2164,6 +2215,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80395-7" />
 <oval id="audit_rules_privileged_commands_passwd" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030510"
@@ -2201,6 +2253,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80396-5" />
 <oval id="audit_rules_privileged_commands_unix_chkpwd" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030511"
@@ -2238,6 +2291,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80397-3" />
 <oval id="audit_rules_privileged_commands_gpasswd" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030512"
@@ -2275,6 +2329,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80398-1" />
 <oval id="audit_rules_privileged_commands_chage" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030513"
@@ -2312,6 +2367,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80399-9" />
 <oval id="audit_rules_privileged_commands_userhelper" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030514"
@@ -2349,6 +2405,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80400-5" />
 <oval id="audit_rules_privileged_commands_su" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030521"
@@ -2386,6 +2443,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80401-3" />
 <oval id="audit_rules_privileged_commands_sudo" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030522"
@@ -2423,6 +2481,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80402-1" />
 <oval id="audit_rules_privileged_commands_sudoedit" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030526"
@@ -2460,6 +2519,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80403-9" />
 <oval id="audit_rules_privileged_commands_newgrp" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030524"
@@ -2497,6 +2557,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80404-7" />
 <oval id="audit_rules_privileged_commands_chsh" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030525"
@@ -2534,6 +2595,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80405-4" />
 <oval id="audit_rules_privileged_commands_umount" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030531"
@@ -2571,6 +2633,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80406-2" />
 <oval id="audit_rules_privileged_commands_postdrop" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030540"
@@ -2608,6 +2671,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80407-0" />
 <oval id="audit_rules_privileged_commands_postqueue" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030541"
@@ -2645,6 +2709,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80408-8" />
 <oval id="audit_rules_privileged_commands_ssh_keysign" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030550"
@@ -2682,6 +2747,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80409-6" />
 <oval id="audit_rules_privileged_commands_pt_chown" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030560"
@@ -2719,6 +2785,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80410-4" />
 <oval id="audit_rules_privileged_commands_crontab" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030561"
@@ -2756,6 +2823,7 @@ which attempt to subvert their normal role of providing some necessary but
 limited capability. As such, motivation exists to monitor these programs for
 unusual activity.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80411-2" />
 <oval id="audit_rules_privileged_commands_pam_timestamp_check" />
 <ref prodtype="rhel7" nist="AU-3(1),AU-12(c)" disa="135,172,2884" stigid="030630"
@@ -2788,6 +2856,7 @@ To verify that auditing is configured for all media exportation events, run the 
 where classified information, Privacy Act information, and intellectual property could be lost. An audit
 trail should be created each time a filesystem is mounted to help identify and guard against information
 loss.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27447-2" />
 <oval id="audit_rules_media_export" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-3(1),AU-12(a),AU-12(c),IR-5" disa="135,2884"
@@ -2836,6 +2905,7 @@ appropriate for your system:
 <rationale>Auditing file deletions will create an audit trail for files that are removed
 from the system. The audit trail could aid in system troubleshooting, as well as, detecting
 malicious processes that attempt to delete log files to conceal their presence.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27206-2" />
 <oval id="audit_rules_file_deletion_events" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5"
@@ -2863,6 +2933,7 @@ appropriate for your system:
 <rationale>Auditing file deletions will create an audit trail for files that are removed
 from the system. The audit trail could aid in system troubleshooting, as well as, detecting
 malicious processes that attempt to delete log files to conceal their presence.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80412-0" />
 <oval id="audit_rules_file_deletion_events_rmdir" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884"
@@ -2891,6 +2962,7 @@ appropriate for your system:
 <rationale>Auditing file deletions will create an audit trail for files that are removed
 from the system. The audit trail could aid in system troubleshooting, as well as, detecting
 malicious processes that attempt to delete log files to conceal their presence.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27206-2" />
 <oval id="audit_rules_file_deletion_events_unlink" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884"
@@ -2919,6 +2991,7 @@ appropriate for your system:
 <rationale>Auditing file deletions will create an audit trail for files that are removed
 from the system. The audit trail could aid in system troubleshooting, as well as, detecting
 malicious processes that attempt to delete log files to conceal their presence.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27206-2" />
 <oval id="audit_rules_file_deletion_events_unlinkat" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884"
@@ -2947,6 +3020,7 @@ appropriate for your system:
 <rationale>Auditing file deletions will create an audit trail for files that are removed
 from the system. The audit trail could aid in system troubleshooting, as well as, detecting
 malicious processes that attempt to delete log files to conceal their presence.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27206-2" />
 <oval id="audit_rules_file_deletion_events_rename" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884"
@@ -2975,6 +3049,7 @@ appropriate for your system:
 <rationale>Auditing file deletions will create an audit trail for files that are removed
 from the system. The audit trail could aid in system troubleshooting, as well as, detecting
 malicious processes that attempt to delete log files to conceal their presence.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80413-8" />
 <oval id="audit_rules_file_deletion_events_renameat" />
 <ref prodtype="rhel7" nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884"
@@ -3005,6 +3080,7 @@ To verify that auditing is configured for system administrator actions, run the 
 </ocil>
 <rationale>The actions taken by system administrators should be audited to keep a record
 of what was executed on the system, as well as, for accountability purposes.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27461-3" />
 <oval id="audit_rules_sysadmin_actions" />
 <ref prodtype="rhel7" nist="AC-2(7)(b),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),iAU-3(1),AU-12(a),AU-12(c),IR-5"
@@ -3225,6 +3301,7 @@ With this setting, a reboot will be required to change any audit rules.
 well as malicious modification of the audit rules, although it may be
 problematic if legitimate changes are needed during system
 operation</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27097-5" />
 <oval id="audit_rules_immutable" />
 <ref prodtype="rhel7" nist="AC-6,AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5" pcidss="Req-10.5.2" 

--- a/shared/xccdf/system/selinux.xml
+++ b/shared/xccdf/system/selinux.xml
@@ -87,6 +87,7 @@ potentially compromised processes to the security policy, which is designed to
 prevent them from causing damage to the system or further elevating their
 privileges.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27334-2" />
 <oval id="selinux_state" value="var_selinux_state"/>
 <ref prodtype="rhel7" nist="AC-3,AC-3(3),AC-3(4),AC-4,AC-6,AU-9,SI-6(a)" disa="2165,2696" cis="1.4.2"
@@ -119,6 +120,7 @@ temporary cases, SELinux policies should be developed, and once work
 is completed, the system should be reconfigured to
 <tt><sub idref="var_selinux_policy_name" /></tt>.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27279-9" />
 <oval id="selinux_policytype" value="var_selinux_policy_name"/>
 <ref prodtype="rhel7" nist="AC-3,AC-3(3),AC-3(4),AC-4,AC-6,AU-9,SI-6(a)" disa="2696" cis="1.4.3"
@@ -172,6 +174,7 @@ It should produce no output in a well-configured system.
 Daemons which run with the <tt>initrc_t</tt> context may cause AVC denials,
 or allow privileges that the daemon does not require.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <oval id="selinux_confinement_of_daemons" />
 <ref prodtype="rhel7" nist="AC-6,AU-9,CM-7" cis="1.4.6" cui="3.1.2, 3.1.5" />
 <ident prodtype="rhel7" cce="27288-0" />

--- a/shared/xccdf/system/software/gnome.xml
+++ b/shared/xccdf/system/software/gnome.xml
@@ -41,6 +41,7 @@ system-db:distro</pre>
 Failure to have a functional DConf profile prevents GNOME3 configuration settings
 from being enforced for all users and allows various security risks.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27446-4" />
 <oval id="enable_dconf_user_profile" />
 </Rule>
@@ -77,6 +78,7 @@ AutomaticLoginEnable=false</pre>
 Failure to restrict system access to authenticated users negatively impacts operating
 system security.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80104-3" />
 <oval id="gnome_gdm_disable_automatic_login" />
 <ref prodtype="rhel7" nist="CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00229" stigid="010430"
@@ -104,6 +106,7 @@ TimedLoginEnable=false</pre>
 Failure to restrict system access to authenticated users negatively impacts operating
 system security.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80105-0" />
 <oval id="gnome_gdm_disable_guest_login" />
 <ref prodtype="rhel7" nist="CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00229" stigid="010431"
@@ -138,6 +141,7 @@ If properly configured, the output should be <tt>/org/gnome/login-screen/disable
 <rationale>Leaving the user list enabled is a security risk since it allows anyone
 with physical access to the system to quickly enumerate known user accounts
 without logging in.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80106-8" />
 <oval id="dconf_gnome_disable_user_list" />
 <ref prodtype="rhel7" nist="AC-23" />
@@ -174,6 +178,7 @@ A user who is at the console can reboot the system at the login screen. If resta
 are pressed at the login screen, this can create the risk of short-term loss of availability of systems
 due to reboot.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80107-6" />
 <oval id="dconf_gnome_disable_restart_shutdown" />
 <ref prodtype="rhel7" nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="TBD" 
@@ -209,6 +214,7 @@ Smart card login provides two-factor authentication stronger than
 that provided by a username and password combination. Smart cards leverage PKI
 (public key infrastructure) in order to provide and verify credentials.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80108-4" />
 <oval id="dconf_gnome_enable_smartcard_auth" />
 <ref prodtype="rhel7" disa="765,766,767,768,771,772,884" pcidss="Req-8.3" />
@@ -246,6 +252,7 @@ Setting the password retry prompts that are permitted on a per-session basis to 
 requires some software, such as SSH, to re-connect. This can slow down and
 draw additional attention to some types of password-guessing attacks.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80109-2" />
 <ref prodtype="rhel7" cui="3.1.8" />
 <oval id="dconf_gnome_login_retries" />
@@ -318,6 +325,7 @@ temporary nature of the absence. Rather than relying on the user to manually loc
 system session prior to vacating the vicinity, GNOME3 can be configured to identify when
 a user's session has idled and take action to initiate a session lock.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80110-0" />
 <oval id="dconf_gnome_screensaver_idle_delay" value="inactivity_timeout_value" />
 <ref prodtype="rhel7" nist="AC-11(a)" disa="57" pcidss="Req-8.1.8"
@@ -359,6 +367,7 @@ real-time screen display (such as network management products) require the
 login session does not have administrator rights and the display station is located in a
 controlled-access area.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80111-8" />
 <oval id="dconf_gnome_screensaver_idle_activation_enabled" />
 <ref prodtype="rhel7" nist="AC-11(a)" disa="57" ossrg="SRG-OS-000029-GPOS-00010" stigid="010073" pcidss="Req-8.1.8"
@@ -392,6 +401,7 @@ If properly configured, the output for <tt>lock-enabled</tt> should be <tt>/org/
 A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity
 of the information system but does not want to logout because of the temporary nature of the absense.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80112-6" />
 <oval id="dconf_gnome_screensaver_lock_enabled" />
 <ref prodtype="rhel7" nist="AC-11(b)" disa="56" pcidss="Req-8.1.8"
@@ -427,6 +437,7 @@ If properly configured, the output for <tt>lock-delay</tt> should be <tt>/org/gn
 A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity
 of the information system but does not want to logout because of the temporary nature of the absense.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80370-0" />
 <oval id="dconf_gnome_screensaver_lock_delay" />
 <ref prodtype="rhel7" nist="AC-11(a)" disa="56" pcidss="Req-8.1.8"
@@ -461,6 +472,7 @@ If properly configured, the output should be <tt>/org/gnome/desktop/screensaver/
 Setting the screensaver mode to blank-only conceals the
 contents of the display from passersby.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80113-4" />
 <oval id="dconf_gnome_screensaver_mode_blank" />
 <ref prodtype="rhel7" nist="AC-11(b)" disa="60" pcidss="Req-8.1.8" cjis="5.5.5" cui="3.1.10" />
@@ -495,6 +507,7 @@ If properly configured, the output should be <tt>/org/gnome/desktop/screensaver/
 Setting the splash screen to not reveal the logged in user's name
 conceals who has access to the system from passersby.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80114-2" />
 <oval id="dconf_gnome_screensaver_user_info" />
 </Rule>
@@ -522,6 +535,7 @@ Rather than relying on the user to manually lock their operating system session 
 GNOME desktops can be configured to identify when a user's session has idled and take action to initiate the
 session lock. As such, users should not be allowed to change session settings.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80371-8" />
 <oval id="dconf_gnome_session_user_locks" />
 <ref prodtype="rhel7" nist="AC-11(a)" disa="57"
@@ -576,6 +590,7 @@ can reboot the system. If accidentally pressed, as could happen in
 the case of mixed OS environment, this can create the risk of short-term
 loss of availability of systems due to unintentional reboot.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <oval id="dconf_gnome_disable_ctrlaltdel_reboot" />
 <ident prodtype="rhel7" cce="80124-1" />
 <ref prodtype="rhel7" nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="TBD"
@@ -616,6 +631,7 @@ the Graphical User Interface (GUI) when they would not have them otherwise could
 unintended configuration changes as well as a nefarious user the capability to make system
 changes such as adding new accounts, etc.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <oval id="dconf_gnome_disable_user_admin" />
 <ident prodtype="rhel7" cce="80115-9" />
 <ref prodtype="rhel7" cui="3.1.5" />
@@ -652,6 +668,7 @@ Power settings should not be enabled on systems that are not mobile devices.
 Enabling power settings on non-mobile devices could have unintended processing
 consequences on standard systems.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <oval id="dconf_gnome_disable_power_settings" />
 <ident prodtype="rhel7" cce="80116-7" />
 </Rule>
@@ -695,6 +712,7 @@ Power settings should not be enabled on systems that are not mobile devices.
 Enabling power settings on non-mobile devices could have unintended processing
 consequences on standard systems.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <oval id="dconf_gnome_disable_geolocation" />
 <ident prodtype="rhel7" cce="80117-5" />
 </Rule>
@@ -736,6 +754,7 @@ If properly configured, the output should be
 Wireless network connections should not be allowed to be configured by general
 users on a given system as it could open the system to backdoor attacks.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <oval id="dconf_gnome_disable_wifi_create" />
 <ident prodtype="rhel7" cce="80118-3" />
 <ref prodtype="rhel7" cui="3.1.16" />
@@ -772,6 +791,7 @@ If properly configured, the output should be
 Wireless network connections should not be allowed to be configured by general
 users on a given system as it could open the system to backdoor attacks.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <oval id="dconf_gnome_disable_wifi_notification" />
 <ident prodtype="rhel7" cce="80119-1" />
 <ref prodtype="rhel7" cui="3.1.16" />
@@ -814,6 +834,7 @@ If properly configured, the output should be
 Username and password prompting is required for remote access. Otherwise, non-authorized
 and nefarious users can access the system freely.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <oval id="dconf_gnome_remote_access_credential_prompt" />
 <ident prodtype="rhel7" cce="80120-9" />
 <ref prodtype="rhel7" cui="3.1.12" />
@@ -848,6 +869,7 @@ If properly configured, the output should be
 Open X displays allow an attacker to capture keystrokes and to execute commands
 remotely.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <oval id="dconf_gnome_remote_access_encryption" />
 <ident prodtype="rhel7" cce="80121-7" />
 <ref prodtype="rhel7" nist="CM-2(1)(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00227"
@@ -901,6 +923,7 @@ the introduction of malware via removable media.
 It will, however, also prevent desktop users from legitimate use
 of removable media.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80122-5" />
 <oval id="dconf_gnome_disable_automount" />
 <ref prodtype="rhel7" nist="AC-19(a),AC-19(d),AC-19(e)" cui="3.1.7" />
@@ -937,6 +960,7 @@ file to exploit this flaw. Assuming the attacker could place the malicious file 
 (via a web upload for example) and assuming a user browses the same location using Nautilus, the
 malicious file would exploit the thumbnailer with the potential for malicious code execution. It
 is best to disable these thumbnailer applications unless they are explicitly required.</rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80123-3" />
 <oval id="dconf_gnome_disable_thumbnailers" />
 <ref prodtype="rhel7" nist="CM-7" />


### PR DESCRIPTION
Marking rules listed below as not applicable to containers:

- Boot and screen locking
- GNOME
- SELinux
- Audit