### PR TITLE
Change interface of create_*py

### DIFF
--- a/shared/templates/create_accounts_password.py
+++ b/shared/templates/create_accounts_password.py
@@ -26,10 +26,9 @@ def output_checkfile(target, pam_info):
         raise UnknownTargetError(target)
 
 
-def help():
-    print("Usage:\n\t" + __file__ + " <bash> <csv file>")
-    print("CSV should contains lines of the format: " +
+def csv_format():
+    return("CSV should contains lines of the format: " +
                "VARIABLE")
 
 if __name__ == "__main__":
-    main(sys.argv, help, output_checkfile)
+    main(sys.argv, csv_format(), output_checkfile)

--- a/shared/templates/create_kernel_modules_disabled.py
+++ b/shared/templates/create_kernel_modules_disabled.py
@@ -43,11 +43,10 @@ def output_checkfile(target, kerninfo):
         raise UnknownTargetError(target)
 
 
-def help():
-    print("Usage:\n\t" + __file__ + " <bash/ansible/oval> <csv file>")
-    print (
+def csv_format():
+    return (
         "CSV file should contains lines of the format: kernmod"
     )
 
 if __name__ == "__main__":
-    main(sys.argv, help, output_checkfile)
+    main(sys.argv, csv_format(), output_checkfile)

--- a/shared/templates/create_mount_options.py
+++ b/shared/templates/create_mount_options.py
@@ -62,10 +62,9 @@ def output_checkfile(target, path_info):
             raise UnknownTargetError(target)
 
 
-def help():
-    print "Usage:\n\t" + __file__ + " <bash/oval/ansible> <csv file>"
-    print("CSV should contains lines of the format: "
+def csv_format():
+    return("CSV should contains lines of the format: "
           "mount_point,mount_option,[mount_option]+")
 
 if __name__ == "__main__":
-    main(sys.argv, help, output_checkfile)
+    main(sys.argv, csv_format(), output_checkfile)

--- a/shared/templates/create_package_installed.py
+++ b/shared/templates/create_package_installed.py
@@ -59,10 +59,9 @@ def output_checkfile(target, package_info):
     else:
         print "ERROR: input violation: the package name must be defined"
 
-def help():
-    print("Usage:\n\t" + __file__ + " <bash/oval/ansible/anaconda/puppet> <csv file>")
-    print("CSV should contains lines of the format: " +
+def csv_format():
+    return("CSV should contains lines of the format: " +
                "PACKAGE_NAME")
 
 if __name__ == "__main__":
-    main(sys.argv, help, output_checkfile)
+    main(sys.argv, csv_format(), output_checkfile)

--- a/shared/templates/create_package_removed.py
+++ b/shared/templates/create_package_removed.py
@@ -52,10 +52,9 @@ def output_checkfile(target, package_info):
     else:
         print "ERROR: input violation: the package name must be defined"
 
-def help():
-    print("Usage:\n\t" + __file__ + " <bash/oval/ansible/anaconda/puppet> <csv file>")
-    print("CSV should contains lines of the format: " +
+def csv_format():
+    return("CSV should contains lines of the format: " +
                "PACKAGE_NAME")
 
 if __name__ == "__main__":
-    main(sys.argv, help, output_checkfile)
+    main(sys.argv, csv_format(), output_checkfile)

--- a/shared/templates/create_permission.py
+++ b/shared/templates/create_permission.py
@@ -116,11 +116,10 @@ def output_checkfile(target, path_info):
         raise UnknownTargetError(target)
 
 
-def help():
-    print("Usage:\n\t" + __file__ + " <bash/oval/ansible> <csv file>")
-    print("CSV should contains lines of the format: "
+def csv_format():
+    return("CSV should contains lines of the format: "
           "directory path,file name,owner uid (numeric),group "
           "owner gid (numeric),mode")
 
 if __name__ == "__main__":
-    main(sys.argv, help, output_checkfile)
+    main(sys.argv, csv_format(), output_checkfile)

--- a/shared/templates/create_services_disabled.py
+++ b/shared/templates/create_services_disabled.py
@@ -85,10 +85,9 @@ def output_checkfile(target, serviceinfo):
     else:
         raise UnknownTargetError(target)
 
-def help():
-    print("Usage:\n\t" + __file__ + " <bash/oval/ansible/puppet> <csv file>")
-    print("CSV should contains lines of the format: " +
+def csv_format():
+    return("CSV should contains lines of the format: " +
                "servicename,packagename")
 
 if __name__ == "__main__":
-    main(sys.argv, help, output_checkfile)
+    main(sys.argv, csv_format(), output_checkfile)

--- a/shared/templates/create_services_enabled.py
+++ b/shared/templates/create_services_enabled.py
@@ -76,10 +76,9 @@ def output_checkfile(target, serviceinfo):
         raise UnknownTargetError(target)
 
 
-def help():
-    print("Usage:\n\t" + __file__ + " <bash/oval/ansible/puppet> <csv file>")
-    print("CSV should contains lines of the format: " +
+def csv_format():
+    return("CSV should contains lines of the format: " +
                "servicename,packagename")
 
 if __name__ == "__main__":
-    main(sys.argv, help, output_checkfile)
+    main(sys.argv, csv_format(), output_checkfile)

--- a/shared/templates/create_sockets_disabled.py
+++ b/shared/templates/create_sockets_disabled.py
@@ -42,10 +42,10 @@ def output_checkfile(socketinfo):
             {
                 "SOCKETNAME":  socketname,
             },
-            regex_dict = {
-                "\n\s*<criteria.*>\n\s*<extend_definition.*/>": "",
-                "\s*</criteria>\n\s*</criteria>": "\n    </criteria>"
-            }
+            regex_replace = [
+                ("\n\s*<criteria.*>\n\s*<extend_definition.*/>", ""),
+                ("\s*</criteria>\n\s*</criteria>", "\n    </criteria>")
+            ],
             filename_format = "./oval/socket_{0}_disabled.xml",
             filename_value = socketname
         )

--- a/shared/templates/create_sockets_disabled.py
+++ b/shared/templates/create_sockets_disabled.py
@@ -50,17 +50,9 @@ def output_checkfile(socketinfo):
             filename_value = socketname
         )
 
-def main():
-    if len(sys.argv) < 2:
-        print ("Provide a CSV file containing lines of the format: " +
+def csv_format():
+    return ("Provide a CSV file containing lines of the format: " +
                "socketname,packagename")
-        sys.exit(1)
-
-    filename = sys.argv[1]
-    csv_map(filename, output_checkfile, skip_comments = True)
-
-    sys.exit(0)
-
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv, csv_format(), output_checkfile)

--- a/shared/templates/create_sysctl.py
+++ b/shared/templates/create_sysctl.py
@@ -96,10 +96,9 @@ def output_checkfile(target, serviceinfo):
 
         raise UnknownTargetError(target)
 
-def help():
-    print("Usage:\n\t" + __file__ + " <bash/oval> <csv file>")
-    print("CSV should contains lines of the format: " +
+def csv_format():
+    return("CSV should contains lines of the format: " +
                "sysctlvariable,sysctlvalue")
 
 if __name__ == "__main__":
-    main(sys.argv, help, output_checkfile)
+    main(sys.argv, csv_format(), output_checkfile)

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -161,7 +161,7 @@ def csv_map(filename, method, language):
             sys.stderr.write(str(e) + "\n")
             sys.exit(ExitCodes.UNKNOWN_TARGET)
 
-def parse_args():
+def parse_args(csv_format):
     p = argparse.ArgumentParser()
 
     sp = p.add_subparsers(help="actions")
@@ -179,7 +179,7 @@ def parse_args():
     p.add_argument('--language', action="store", default=None, required=True,
                    help="Scripts of which language should we generate?")
     p.add_argument('-c',"--csv", action="store", required=True,
-                   help="csv filename.\n")
+                   help="csv filename.\n" + csv_format)
     p.add_argument('-o','--output_dir', action="store", required=True,
                    help="output dir")
     p.add_argument('-i','--input_dir', action="store", required=True,
@@ -191,9 +191,9 @@ def parse_args():
 
 
 
-def main(argv, help_callback, process_line_callback):
+def main(argv, csv_format, process_line_callback):
 
-    parsed, unknown = parse_args()
+    parsed, unknown = parse_args(csv_format)
 
     if unknown:
         sys.stderr.write(

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -7,8 +7,11 @@ import sys
 import os
 import re
 
-EXIT_NO_TEMPLATE    = 2
-EXIT_UNKNOWN_TARGET = 3
+class ExitCodes:
+    OK = 0
+    ERROR = 1
+    NO_TEMPLATE = 128 + 1
+    UNKNOWN_TARGET = 128 + 2
 
 class UnknownTargetError(ValueError):
     def __init__(self, msg):
@@ -45,7 +48,7 @@ def get_template_filename(filename):
     sys.stderr.write(
         "No specialized or shared template found for {0}\n".format(filename)
     )
-    sys.exit(EXIT_NO_TEMPLATE)
+    sys.exit(ExitCodes.NO_TEMPLATE)
 
 
 def load_modified(filename, constants_dict, regex_replace=[]):
@@ -163,7 +166,7 @@ def csv_map(filename, method, skip_comments = True, target = None):
             map(method, csv_lines_content)
         except UnknownTargetError as e:
             sys.stderr.write(str(e) + "\n")
-            sys.exit(EXIT_UNKNOWN_TARGET)
+            sys.exit(ExitCodes.UNKNOWN_TARGET)
 
 def main(argv, help_callback, process_line_callback):
 
@@ -171,7 +174,7 @@ def main(argv, help_callback, process_line_callback):
 
     if argv_len < 3:
         help_callback()
-        sys.exit(1)
+        sys.exit(ExitCodes.ERROR)
 
     target = sys.argv[1]
     filename = sys.argv[2]
@@ -181,4 +184,4 @@ def main(argv, help_callback, process_line_callback):
         process_line_callback(target, *args)
 
     csv_map(filename, process_line, target=target)
-    sys.exit(0)
+    sys.exit(ExitCodes.OK)

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -22,6 +22,7 @@ class ActionType:
 product_input_dir = None
 output_dir = None
 action = None
+shared_dir = None
 
 class UnknownTargetError(ValueError):
     def __init__(self, msg):
@@ -34,9 +35,7 @@ def get_template_filename(filename):
     if os.path.isfile(template_filename):
         return template_filename
 
-    shared_dir = os.path.dirname(os.path.realpath(__file__))
-
-    shared_template = os.path.join(shared_dir, filename)
+    shared_template = os.path.join(shared_dir, "templates", filename)
     if os.path.isfile(shared_template):
         return shared_template
 
@@ -204,10 +203,12 @@ def main(argv, csv_format, process_line_callback):
     global output_dir
     global action
     global product_input_dir
+    global shared_dir
 
     output_dir = parsed.output_dir
     action = parsed.action
     product_input_dir = parsed.input_dir
+    shared_dir = parsed.shared_dir
 
     csv_map(parsed.csv, process_line_callback, language=parsed.language)
     sys.exit(ExitCodes.OK)

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -25,7 +25,7 @@ action = None
 
 class UnknownTargetError(ValueError):
     def __init__(self, msg):
-        ValueError.__init__(self, "Unknown target: \"{0}\"".format(msg))
+        ValueError.__init__(self, "Unknown target language: \"{0}\"".format(msg))
 
 def get_template_filename(filename):
 
@@ -48,7 +48,7 @@ def get_template_filename(filename):
 
 def load_modified(filename, constants_dict, regex_replace=[]):
     """
-    Load file and replace constants accoring to constants_dict and regex_dict
+    Load file and replace constants according to constants_dict and regex_replace
 
     constants_dict: dict of constants - replace ( key -> value)
     regex_dict: dict of regex substitutions - sub ( key -> value)
@@ -67,7 +67,7 @@ def load_modified(filename, constants_dict, regex_replace=[]):
         filestring = template_file.read()
 
     for key, value in constants_dict.iteritems():
-       filestring = filestring.replace(key, value)
+        filestring = filestring.replace(key, value)
 
     for pattern, replacement in regex_replace:
         filestring = re.sub(pattern, replacement, filestring)
@@ -117,7 +117,7 @@ def process_line(line, target):
 
         if match:
             # if line contains restriction to target, check it
-            supported_targets = [ x.strip() for x in match.group(1).split(",") ]
+            supported_targets = [x.strip() for x in match.group(1).split(",")]
             if target not in supported_targets:
                 return None
 
@@ -125,13 +125,13 @@ def process_line(line, target):
     return (line.split("#")[0]).strip()
 
 
-def filter_out_csv_lines(csv_file, target):
+def filter_out_csv_lines(csv_file, language):
     """
     Filter out not applicable lines
     """
 
     for line in csv_file:
-        processed_line = process_line(line, target)
+        processed_line = process_line(line, language)
 
         if not processed_line:
              continue

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -5,6 +5,9 @@ import os
 import sys
 import argparse
 
+templates_dir = os.path.join(os.path.dirname(__file__), "..", "templates")
+sys.path.append(templates_dir)
+from template_common import ExitCodes
 
 class Builder(object):
     def __init__(self):
@@ -216,7 +219,10 @@ class Builder(object):
 
     def _subprocess_check(self, subprocess):
         subprocess.wait()
-        if subprocess.returncode in [0, 2, 3]:
+        no_error_codes = [
+            ExitCodes.OK, ExitCodes.NO_TEMPLATE, ExitCodes.UNKNOWN_TARGET
+        ]
+        if subprocess.returncode in no_error_codes:
             pass
         else:
             raise RuntimeError("Process returned: %s"

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -176,7 +176,8 @@ class Builder(object):
     def _run_script(self, script, csv_filepath):
         for lang in self.langs:
             sp = self._create_subprocess(
-                script=script, csv=csv_filepath, lang=lang, action="build"
+                script=script, csv=csv_filepath, lang=lang, action="build",
+                print_args=True
             )
             self._subprocess_check(sp)
 
@@ -184,7 +185,7 @@ class Builder(object):
         sp = self._create_subprocess(script, csv, lang, action)
         return self._get_list_from_subprocess(sp)
 
-    def _create_subprocess(self, script, csv, lang, action):
+    def _create_subprocess(self, script, csv, lang, action, print_args=False):
         args= [
             "python", script,
             "--csv", csv,
@@ -194,7 +195,8 @@ class Builder(object):
             "--output", self.output_dir,
             action
         ]
-        sys.stderr.write(" ".join(args) + "\n")
+        if print_args:
+            sys.stderr.write(" ".join(args) + "\n")
         return subprocess.Popen(
                 args,
                 stdout = subprocess.PIPE,

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -225,8 +225,12 @@ class Builder(object):
         if subprocess.returncode in no_error_codes:
             pass
         else:
+            comm = subprocess.communicate()
             raise RuntimeError("Process returned: %s"
-                               % (subprocess.communicate()[1].decode("utf-8")))
+                               % (
+                                   comm[0].decode("utf-8") +
+                                   comm[1].decode("utf-8")
+                                  ))
 
     def _get_list_from_subprocess(self, subprocess):
         self._subprocess_check(subprocess)

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -59,6 +59,10 @@ class Builder(object):
             if not os.path.exists(dir_):
                 os.makedirs(dir_)
 
+        # Build scripts for multiple OVAL versions.
+        # At first for the oldest OVAL, then newer and newer
+        # this will allow to override older implementation
+        # with a never one.
         for oval in self.supported_ovals:
             self._set_current_oval(oval)
 


### PR DESCRIPTION
This PR mainly removes usage of environment variables for create_*py scripts. Side effect is usage argparse.

I don't really like global variables in template_common. I wanted to introduce class in template_common and then inherit it in files create_package_removed.py,... But it would produce huge diff due to indentation changes.