### PR TITLE
Fix stig testinfo tables for RHEL6 and 7

### DIFF
--- a/RHEL/6/CMakeLists.txt
+++ b/RHEL/6/CMakeLists.txt
@@ -15,7 +15,7 @@ ssg_build_html_cce_table(${PRODUCT})
 
 ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_VERSION})
 
-ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-server" ${DISA_STIG_VERSION})
+ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-server-upstream" ${DISA_STIG_VERSION})
 
 if (SSG_CENTOS_DERIVATIVES_ENABLED)
     ssg_build_derivative_product(${PRODUCT} "centos" "centos6")

--- a/RHEL/7/CMakeLists.txt
+++ b/RHEL/7/CMakeLists.txt
@@ -17,7 +17,7 @@ ssg_build_html_cce_table(${PRODUCT})
 
 ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_VERSION})
 
-ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-server" ${DISA_STIG_VERSION})
+ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-server-upstream" ${DISA_STIG_VERSION})
 
 if (SSG_CENTOS_DERIVATIVES_ENABLED)
     ssg_build_derivative_product(${PRODUCT} "centos" "centos7")

--- a/shared/transforms/shared_xccdf2table-profileccirefs.xslt
+++ b/shared/transforms/shared_xccdf2table-profileccirefs.xslt
@@ -7,6 +7,9 @@
 <xsl:param name="testinfo" select="''" />
 
 	<xsl:template match="/">
+		<xsl:if test="not(/cdf:Benchmark/cdf:Profile[@id=$profile])">
+			<xsl:message terminate="yes">Profile '<xsl:value-of select="$profile"/>' not found.</xsl:message>
+		</xsl:if>
 		<html>
 		<head>
 			<title><xsl:value-of select="/cdf:Benchmark/cdf:Profile[@id=$profile]/cdf:title" /></title>

--- a/shared/transforms/shared_xccdf2table-profileccirefs.xslt
+++ b/shared/transforms/shared_xccdf2table-profileccirefs.xslt
@@ -3,8 +3,8 @@
 
 <!-- this style sheet expects parameter $profile, which is the id of the Profile to be shown -->
 
+<xsl:param name="profile" select="''"/>
 <xsl:param name="testinfo" select="''" />
-<xsl:param name="format" select="''"/>
 
 	<xsl:template match="/">
 		<html>
@@ -18,7 +18,7 @@
 			<div style="text-align: center; font-size: normal "><xsl:value-of select="/cdf:Benchmark/cdf:Profile[@id=$profile]/cdf:description" /></div>
 			<br/>
 			<br/>
-			<xsl:apply-templates select="cdf:Benchmark"/>
+			<xsl:apply-templates select="/cdf:Benchmark"/>
 		</body>
 		</html>
 	</xsl:template>


### PR DESCRIPTION
There were typos in the profile IDs for RHEL6 and 7. That caused the testinfo tables to be empty.

I have altered the XSLT to fail in case we make similar mistakes in the future.