### PR TITLE
Add RHEL6/PCI-DSS centric-benchmark

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -534,7 +534,7 @@ macro(ssg_build_pci_dss_xccdf PRODUCT)
 endmacro()
 
 macro(ssg_build_sds PRODUCT)
-    if("${PRODUCT}" STREQUAL "rhel7")
+    if("${PRODUCT}" MATCHES "rhel(6|7)")
         add_custom_command(
             OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
@@ -627,7 +627,7 @@ macro(ssg_build_product PRODUCT)
     ssg_build_xccdf_final(${PRODUCT})
     ssg_build_oval_final(${PRODUCT})
     ssg_build_ocil_final(${PRODUCT})
-    if("${PRODUCT}" STREQUAL "rhel7")
+    if("${PRODUCT}" MATCHES "rhel(6|7)")
         ssg_build_pci_dss_xccdf(${PRODUCT})
     endif()
     ssg_build_sds(${PRODUCT})


### PR DESCRIPTION
According to latest release we should create rhel6 pci-dss benchmark, too.
```
$ oscap info /home/zmoravec/Downloads/scap-security-guide-0.1.31/ssg-rhel6-ds.xml 
Document type: Source Data Stream
Imported: 2016-11-28T09:42:56

Stream: scap_org.open-scap_datastream_from_xccdf_ssg-rhel6-xccdf-1.2.xml
Generated: (null)
Version: 1.2
Checklists:
	Ref-Id: scap_org.open-scap_cref_ssg-rhel6-xccdf-1.2.xml
		Status: draft
		Generated: 2016-11-28
		Resolved: true
		Profiles:
			xccdf_org.ssgproject.content_profile_standard
			xccdf_org.ssgproject.content_profile_CS2
			xccdf_org.ssgproject.content_profile_common
			xccdf_org.ssgproject.content_profile_desktop
			xccdf_org.ssgproject.content_profile_server
			xccdf_org.ssgproject.content_profile_ftp-server
			xccdf_org.ssgproject.content_profile_stig-rhel6-workstation-upstream
			xccdf_org.ssgproject.content_profile_stig-rhel6-server-gui-upstream
			xccdf_org.ssgproject.content_profile_stig-rhel6-server-upstream
			xccdf_org.ssgproject.content_profile_usgcb-rhel6-server
			xccdf_org.ssgproject.content_profile_rht-ccp
			xccdf_org.ssgproject.content_profile_CSCF-RHEL6-MLS
			xccdf_org.ssgproject.content_profile_C2S
			xccdf_org.ssgproject.content_profile_pci-dss
			xccdf_org.ssgproject.content_profile_nist-cl-il-al
			xccdf_org.ssgproject.content_profile_fisma-medium-rhel6-server
		Referenced check files:
			ssg-rhel6-oval.xml
				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
			ssg-rhel6-ocil.xml
				system: http://scap.nist.gov/schema/ocil/2
			http://www.redhat.com/security/data/oval/Red_Hat_Enterprise_Linux_6.xml
				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
	Ref-Id: scap_org.open-scap_cref_output--ssg-rhel6-pcidss-xccdf-1.2.xml
		Status: draft
		Generated: 2016-11-28
		Resolved: true
		Profiles:
			xccdf_org.ssgproject.content_profile_pci-dss_centric
		Referenced check files:
			ssg-rhel6-oval.xml
				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
			ssg-rhel6-ocil.xml
				system: http://scap.nist.gov/schema/ocil/2
			http://www.redhat.com/security/data/oval/Red_Hat_Enterprise_Linux_6.xml
				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
Checks:
	Ref-Id: scap_org.open-scap_cref_ssg-rhel6-oval.xml
	Ref-Id: scap_org.open-scap_cref_ssg-rhel6-ocil.xml
	Ref-Id: scap_org.open-scap_cref_output--ssg-rhel6-oval.xml
	Ref-Id: scap_org.open-scap_cref_output--ssg-rhel6-ocil.xml
	Ref-Id: scap_org.open-scap_cref_output--ssg-rhel6-cpe-oval.xml
Dictionaries:
	Ref-Id: scap_org.open-scap_cref_output--ssg-rhel6-cpe-dictionary.xml
```
