### PR TITLE
Remove ldap_client_start_tls check in RHEL7 STIG profile

### DIFF
--- a/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-server-upstream.xml
@@ -189,7 +189,6 @@
 <select idref="package_vsftpd_removed" selected="true" />
 
 <!-- LDAP -->
-<select idref="ldap_client_start_tls" selected="true" />
 
 <!-- Currently uncategorized -->
 <select idref="disable_ctrlaltdel_reboot" selected="true" />


### PR DESCRIPTION
- As the ldap_client_start_tls check utilizes pam_ldap, remove the check
until it is rewritten using SSSD as pam_ldap has been removed from RHEL7.
- Fixes #1706