### PR TITLE
Passwd file password field shadowed value

### DIFF
--- a/shared/oval/accounts_password_all_shadowed.xml
+++ b/shared/oval/accounts_password_all_shadowed.xml
@@ -19,6 +19,6 @@
     <unix:username operation="pattern match">.*</unix:username>
   </unix:password_object>
   <unix:password_state id="state_accounts_password_all_shadowed" version="1">
-    <unix:password>x</unix:password>
+    <unix:password operation="pattern match">x|\*</unix:password>
   </unix:password_state>
 </def-group>

--- a/shared/xccdf/system/accounts/restrictions/password_storage.xml
+++ b/shared/xccdf/system/accounts/restrictions/password_storage.xml
@@ -46,14 +46,14 @@ stigid="010290" pcidss="Req-8.2.3" cjis="5.5.2" cui="3.1.1, 3.1.5" />
 <title>Verify All Account Password Hashes are Shadowed</title>
 <description>
 If any password hashes are stored in <tt>/etc/passwd</tt> (in the second field,
-instead of an <tt>x</tt>), the cause of this misconfiguration should be
+instead of an <tt>x</tt> or <tt>*</tt>), the cause of this misconfiguration should be
 investigated. The account should have its password reset and the hash should be
 properly stored, or the account should be deleted entirely.
 </description>
 <ocil clause="any stored hashes are found in /etc/passwd">
 To check that no password hashes are stored in
 <tt>/etc/passwd</tt>, run the following command:
-<pre>$ awk -F: '($2 != "x") {print}' /etc/passwd</pre>
+<pre>awk '!/\S:x|\*/ {print}' /etc/passwd</pre>
 If it produces any output, then a password hash is
 stored in <tt>/etc/passwd</tt>.
 </ocil>


### PR DESCRIPTION
Password field in /etc/passwd may not always be `x` when shadowed.
According to man, it can be a `*` too. Also, when using some kind of external
authentication, the password field might get set as `*`.