### PR TITLE
template_common.py/create*py: Use classes

### DIFF
--- a/shared/templates/create_accounts_password.py
+++ b/shared/templates/create_accounts_password.py
@@ -7,28 +7,29 @@
 import sys
 import re
 
-from template_common import *
+from template_common import FilesGenerator, UnknownTargetError
 
-def output_checkfile(target, pam_info):
-    VARIABLE, = pam_info
+class AccountsPasswordGenerator(FilesGenerator):
 
-    if target == "bash":
+    def generate(self, target, pam_info):
+        VARIABLE, = pam_info
 
-        file_from_template(
-            "./template_BASH_accounts_password",
-            {
-                "VARIABLE":   VARIABLE
-            },
-            "./bash/accounts_password_pam_{0}.sh", VARIABLE
-        )
+        if target == "bash":
 
-    else:
-        raise UnknownTargetError(target)
+            self.file_from_template(
+                "./template_BASH_accounts_password",
+                {
+                    "VARIABLE":   VARIABLE
+                },
+                "./bash/accounts_password_pam_{0}.sh", VARIABLE
+            )
 
+        else:
+            raise UnknownTargetError(target)
 
-def csv_format():
-    return("CSV should contains lines of the format: " +
-               "VARIABLE")
+    def csv_format(self):
+        return("CSV should contains lines of the format: " +
+                   "VARIABLE")
 
 if __name__ == "__main__":
-    main(sys.argv, csv_format(), output_checkfile)
+    AccountsPasswordGenerator().main()

--- a/shared/templates/create_kernel_modules_disabled.py
+++ b/shared/templates/create_kernel_modules_disabled.py
@@ -5,48 +5,49 @@
 #   automatically generate checks for disabled kernel modules
 
 import sys
-from template_common import *
+from template_common import FilesGenerator, UnknownTargetError
+
+class KernelModulesDisabledGenerator(FilesGenerator):
+
+    def generate(self, target, kerninfo):
+        # get the items out of the list
+        kernmod = kerninfo[0]
+
+        if target == "bash":
+            self.file_from_template(
+                "./template_BASH_kernel_module_disabled",
+                {
+                   "KERNMODULE": kernmod
+                },
+                "./bash/kernel_module_{0}_disabled.sh", kernmod
+            )
+
+        elif target == "oval":
+            self.file_from_template(
+                "./template_kernel_module_disabled",
+                {
+                    "KERNMODULE": kernmod
+                },
+                "./oval/kernel_module_{0}_disabled.xml", kernmod
+            )
+
+        elif target == "ansible":
+            self.file_from_template(
+                "./template_ANSIBLE_kernel_module_disabled",
+                {
+                   "KERNMODULE": kernmod
+                },
+                "./ansible/kernel_module_{0}_disabled.yml", kernmod
+            )
+
+        else:
+            raise UnknownTargetError(target)
 
 
-def output_checkfile(target, kerninfo):
-    # get the items out of the list
-    kernmod = kerninfo[0]
-
-    if target == "bash":
-        file_from_template(
-            "./template_BASH_kernel_module_disabled",
-            {
-               "KERNMODULE": kernmod
-            },
-            "./bash/kernel_module_{0}_disabled.sh", kernmod
+    def csv_format(self):
+        return (
+            "CSV file should contains lines of the format: kernmod"
         )
-
-    elif target == "oval":
-        file_from_template(
-            "./template_kernel_module_disabled",
-            {
-                "KERNMODULE": kernmod
-            },
-            "./oval/kernel_module_{0}_disabled.xml", kernmod
-        )
-
-    elif target == "ansible":
-        file_from_template(
-            "./template_ANSIBLE_kernel_module_disabled",
-            {
-               "KERNMODULE": kernmod
-            },
-            "./ansible/kernel_module_{0}_disabled.yml", kernmod
-        )
-
-    else:
-        raise UnknownTargetError(target)
-
-
-def csv_format():
-    return (
-        "CSV file should contains lines of the format: kernmod"
-    )
 
 if __name__ == "__main__":
-    main(sys.argv, csv_format(), output_checkfile)
+    KernelModulesDisabledGenerator().main()

--- a/shared/templates/create_mount_options.py
+++ b/shared/templates/create_mount_options.py
@@ -8,63 +8,64 @@
 import sys
 import re
 
-from template_common import *
+from template_common import FilesGenerator, UnknownTargetError
+
+class MountOptionsGenerator(FilesGenerator):
+
+    def generate(self, target, path_info):
+        # the csv file contains lines that match the following layout:
+        #    mount_point,option,[option]+
+        # first col is the mount point, others are options, at least one
+        mount_infos = list()
+        mount_infos = path_info
+        mount_point = mount_infos[0]
+
+        # build a string out of the path that is suitable for use in id tags
+        # example:	/var/log --> _var_log
+        point_id = re.sub('[-\./]', '_', mount_point)
+        for option in mount_infos[1:]:
+            option_id = re.sub('[-\./ ]', '_', option)
+
+            if target == "ansible":
+                self.file_from_template(
+                    "./template_ANSIBLE_mount_options",
+                    {
+                        "MOUNTPOINT":       mount_point,
+                        "MOUNTOPTION":       re.sub(' ', ',', option),
+                    },
+                    "./ansible/mount_options{0}.yml", point_id + '_' + option_id
+                )
+
+            elif target == "oval":
+                # we are ready to create the check
+                # open the template and perform the conversions
+                option_str = ""
+                state_str = ""
+                #for option in mount_options.split():
+                state_str = "    <linux:state state_ref=\"object" + point_id + "_" +  option_id + "\" />\n"
+                option_str = "  <linux:partition_state id=\"object" + point_id + "_" + option_id + "\" version=\"1\">\n\
+        <linux:mount_options datatype=\"string\" entity_check=\"at least one\" operation=\"equals\">" + option + "</linux:mount_options>\n\
+      </linux:partition_state>\n"
+
+                self.file_from_template(
+                    "./template_mount_options",
+                    {
+                        "MOUNTPOINT":       mount_point,
+                        "MOUNTOPTIONS":        option_str,
+                        "OPTIONLIST":       option,
+                        "MOUNTSTATES":	state_str,
+                        "POINTID":     point_id,
+                        "OPTIONID":      option_id,
+                    },
+                    "./oval/mount_options{0}.xml", point_id + "_" + option_id
+                )
+            else:
+                raise UnknownTargetError(target)
 
 
-def output_checkfile(target, path_info):
-    # the csv file contains lines that match the following layout:
-    #    mount_point,option,[option]+
-    # first col is the mount point, others are options, at least one
-    mount_infos = list()
-    mount_infos = path_info
-    mount_point = mount_infos[0]
-
-    # build a string out of the path that is suitable for use in id tags
-    # example:	/var/log --> _var_log
-    point_id = re.sub('[-\./]', '_', mount_point)
-    for option in mount_infos[1:]:
-        option_id = re.sub('[-\./ ]', '_', option)
-
-        if target == "ansible":
-            file_from_template(
-                "./template_ANSIBLE_mount_options",
-                {
-                    "MOUNTPOINT":       mount_point,
-                    "MOUNTOPTION":       re.sub(' ', ',', option),
-                },
-                "./ansible/mount_options{0}.yml", point_id + '_' + option_id
-            )
-
-        elif target == "oval":
-            # we are ready to create the check
-            # open the template and perform the conversions
-            option_str = ""
-            state_str = ""
-            #for option in mount_options.split():
-            state_str = "    <linux:state state_ref=\"object" + point_id + "_" +  option_id + "\" />\n"
-            option_str = "  <linux:partition_state id=\"object" + point_id + "_" + option_id + "\" version=\"1\">\n\
-    <linux:mount_options datatype=\"string\" entity_check=\"at least one\" operation=\"equals\">" + option + "</linux:mount_options>\n\
-  </linux:partition_state>\n"
-
-            file_from_template(
-                "./template_mount_options",
-                {
-                    "MOUNTPOINT":       mount_point,
-                    "MOUNTOPTIONS":        option_str,
-                    "OPTIONLIST":       option,
-                    "MOUNTSTATES":	state_str,
-                    "POINTID":     point_id,
-                    "OPTIONID":      option_id,
-                },
-                "./oval/mount_options{0}.xml", point_id + "_" + option_id
-            )
-        else:
-            raise UnknownTargetError(target)
-
-
-def csv_format():
-    return("CSV should contains lines of the format: "
-          "mount_point,mount_option,[mount_option]+")
+    def csv_format(self):
+        return("CSV should contains lines of the format: "
+              "mount_point,mount_option,[mount_option]+")
 
 if __name__ == "__main__":
-    main(sys.argv, csv_format(), output_checkfile)
+    MountOptionsGenerator().main()

--- a/shared/templates/create_package_installed.py
+++ b/shared/templates/create_package_installed.py
@@ -13,55 +13,57 @@
 
 import sys
 
-from template_common import *
+from template_common import FilesGenerator, UnknownTargetError
 
-def output_checkfile(target, package_info):
-    pkgname = package_info[0]
-    if pkgname:
-        if target == "oval":
-            file_from_template(
-                "./template_OVAL_package_installed",
-                { "PKGNAME" : pkgname },
-                "./oval/package_{0}_installed.xml", pkgname
-            )
+class PackageInstalledGenerator(FilesGenerator):
 
-        elif target == "bash":
-            file_from_template(
-                "./template_BASH_package_installed",
-                { "PKGNAME" : pkgname },
-                "./bash/package_{0}_installed.sh", pkgname
-            )
+    def generate(self, target, package_info):
+        pkgname = package_info[0]
+        if pkgname:
+            if target == "oval":
+                self.file_from_template(
+                    "./template_OVAL_package_installed",
+                    { "PKGNAME" : pkgname },
+                    "./oval/package_{0}_installed.xml", pkgname
+                )
 
-        elif target == "ansible":
-            file_from_template(
-                "./template_ANSIBLE_package_installed",
-                { "PKGNAME" : pkgname },
-                "./ansible/package_{0}_installed.yml", pkgname
-            )
+            elif target == "bash":
+                self.file_from_template(
+                    "./template_BASH_package_installed",
+                    { "PKGNAME" : pkgname },
+                    "./bash/package_{0}_installed.sh", pkgname
+                )
 
-        elif target == "anaconda":
-            file_from_template(
-                "./template_ANACONDA_package_installed",
-                { "PKGNAME" : pkgname },
-                "./anaconda/package_{0}_installed.anaconda", pkgname
-            )
+            elif target == "ansible":
+                self.file_from_template(
+                    "./template_ANSIBLE_package_installed",
+                    { "PKGNAME" : pkgname },
+                    "./ansible/package_{0}_installed.yml", pkgname
+                )
 
-        elif target == "puppet":
-            file_from_template(
-                "./template_PUPPET_package_installed",
-                { "PKGNAME" : pkgname },
-                "./puppet/package_{0}_installed.pp", pkgname
-            )
+            elif target == "anaconda":
+                self.file_from_template(
+                    "./template_ANACONDA_package_installed",
+                    { "PKGNAME" : pkgname },
+                    "./anaconda/package_{0}_installed.anaconda", pkgname
+                )
+
+            elif target == "puppet":
+                self.file_from_template(
+                    "./template_PUPPET_package_installed",
+                    { "PKGNAME" : pkgname },
+                    "./puppet/package_{0}_installed.pp", pkgname
+                )
+
+            else:
+                raise UnknownTargetError(target)
 
         else:
-            raise UnknownTargetError(target)
+            print "ERROR: input violation: the package name must be defined"
 
-    else:
-        print "ERROR: input violation: the package name must be defined"
-
-def csv_format():
-    return("CSV should contains lines of the format: " +
-               "PACKAGE_NAME")
+    def csv_format(self):
+        return("CSV should contains lines of the format: " +
+                   "PACKAGE_NAME")
 
 if __name__ == "__main__":
-    main(sys.argv, csv_format(), output_checkfile)
+    PackageInstalledGenerator().main()

--- a/shared/templates/create_package_removed.py
+++ b/shared/templates/create_package_removed.py
@@ -6,55 +6,57 @@
 
 import sys
 
-from template_common import *
+from template_common import FilesGenerator, UnknownTargetError
 
-def output_checkfile(target, package_info):
-    pkgname = package_info[0]
-    if pkgname:
-        if target == "oval":
+class PackageRemovedGenerator(FilesGenerator):
 
-            file_from_template(
-                "./template_package_removed",
-                { "PKGNAME" : pkgname},
-                "./oval/package_{0}_removed.xml", pkgname
-            )
+    def generate(self, target, package_info):
+        pkgname = package_info[0]
+        if pkgname:
+            if target == "oval":
 
-        elif target == "bash":
-            file_from_template(
-                "./template_BASH_package_removed",
-                { "PKGNAME" : pkgname },
-                "./bash/package_{0}_removed.sh", pkgname
-            )
+                self.file_from_template(
+                    "./template_package_removed",
+                    { "PKGNAME" : pkgname},
+                    "./oval/package_{0}_removed.xml", pkgname
+                )
 
-        elif target == "ansible":
-            file_from_template(
-                "./template_ANSIBLE_package_removed",
-                { "PKGNAME" : pkgname },
-                "./ansible/package_{0}_removed.yml", pkgname
-            )
+            elif target == "bash":
+                self.file_from_template(
+                    "./template_BASH_package_removed",
+                    { "PKGNAME" : pkgname },
+                    "./bash/package_{0}_removed.sh", pkgname
+                )
 
-        elif target == "anaconda":
-            file_from_template(
-                "./template_ANACONDA_package_removed",
-                { "PKGNAME" : pkgname },
-                "./anaconda/package_{0}_removed.anaconda", pkgname
-            )
+            elif target == "ansible":
+                self.file_from_template(
+                    "./template_ANSIBLE_package_removed",
+                    { "PKGNAME" : pkgname },
+                    "./ansible/package_{0}_removed.yml", pkgname
+                )
 
-        elif target == "puppet":
-            file_from_template(
-                "./template_PUPPET_package_removed",
-                { "PKGNAME" : pkgname },
-                "./puppet/package_{0}_removed.pp", pkgname
-            )
+            elif target == "anaconda":
+                self.file_from_template(
+                    "./template_ANACONDA_package_removed",
+                    { "PKGNAME" : pkgname },
+                    "./anaconda/package_{0}_removed.anaconda", pkgname
+                )
 
+            elif target == "puppet":
+                self.file_from_template(
+                    "./template_PUPPET_package_removed",
+                    { "PKGNAME" : pkgname },
+                    "./puppet/package_{0}_removed.pp", pkgname
+                )
+
+            else:
+                raise UnknownTargetError(target)
         else:
-            raise UnknownTargetError(target)
-    else:
-        print "ERROR: input violation: the package name must be defined"
+            print "ERROR: input violation: the package name must be defined"
 
-def csv_format():
-    return("CSV should contains lines of the format: " +
-               "PACKAGE_NAME")
+    def csv_format(self):
+        return("CSV should contains lines of the format: " +
+                   "PACKAGE_NAME")
 
 if __name__ == "__main__":
-    main(sys.argv, csv_format(), output_checkfile)
+    PackageRemovedGenerator().main()

--- a/shared/templates/create_permission.py
+++ b/shared/templates/create_permission.py
@@ -8,118 +8,118 @@
 import sys
 import re
 
-from template_common import *
+from template_common import FilesGenerator, UnknownTargetError
 
+class PermissionGenerator(FilesGenerator):
 
-def output_checkfile(target, path_info):
-    # the csv file contains lines that match the following layout:
-    #    directory,file_name,uid,gid,mode
-    dir_path, file_name, uid, gid, mode = path_info
+    def generate(self, target, path_info):
+        # the csv file contains lines that match the following layout:
+        #    directory,file_name,uid,gid,mode
+        dir_path, file_name, uid, gid, mode = path_info
 
-    # build a string out of the path that is suitable for use in id tags
-    # example:	/etc/resolv.conf --> _etc_resolv_conf
-    # path_id maps to FILEID in the template
-    if file_name == '[NULL]':
-        path_id = re.sub('[-\./]', '_', dir_path)
-    elif re.match( r'\^.*\$', file_name, 0):
-        path_id = re.sub('[-\./]', '_', dir_path) + '_' + re.sub('[-\\\./^$*(){}|]',
-                                                                 '_', file_name)
-        # cleaning trailing end multiple underscores, make sure id is lowercase
-        path_id = re.sub(r'_+','_', path_id)
-        path_id = re.sub(r'_$','', path_id)
-        path_id = path_id.lower()
-    else:
-        path_id = re.sub('[-\./]', '_', dir_path) + '_' + re.sub('[-\./]',
-                                                                 '_', file_name)
-        path_id = path_id.lower()
+        # build a string out of the path that is suitable for use in id tags
+        # example:	/etc/resolv.conf --> _etc_resolv_conf
+        # path_id maps to FILEID in the template
+        if file_name == '[NULL]':
+            path_id = re.sub('[-\./]', '_', dir_path)
+        elif re.match( r'\^.*\$', file_name, 0):
+            path_id = re.sub('[-\./]', '_', dir_path) + '_' + re.sub('[-\\\./^$*(){}|]',
+                                                                     '_', file_name)
+            # cleaning trailing end multiple underscores, make sure id is lowercase
+            path_id = re.sub(r'_+','_', path_id)
+            path_id = re.sub(r'_$','', path_id)
+            path_id = path_id.lower()
+        else:
+            path_id = re.sub('[-\./]', '_', dir_path) + '_' + re.sub('[-\./]',
+                                                                     '_', file_name)
+            path_id = path_id.lower()
 
-    # build a string that contains the full path to the file
-    # full_path maps to FILEPATH in the template
-    if file_name == '[NULL]':
-        full_path = dir_path
-    else:
-        full_path = dir_path + '/' + file_name
+        # build a string that contains the full path to the file
+        # full_path maps to FILEPATH in the template
+        if file_name == '[NULL]':
+            full_path = dir_path
+        else:
+            full_path = dir_path + '/' + file_name
 
-    if target == "bash":
-        if not re.match( r'\^.*\$', file_name, 0):
-            file_from_template(
-                "./template_BASH_permissions",
+        if target == "bash":
+            if not re.match( r'\^.*\$', file_name, 0):
+                self.file_from_template(
+                    "./template_BASH_permissions",
+                    {
+                        "FILEPATH":      full_path,
+                        "FILEMODE":      mode,
+                    },
+                    "./bash/file_permissions{0}.sh", path_id
+                )
+            else:
+                file_name = re.sub('^\^','', file_name)
+                self.file_from_template(
+                    "./template_BASH_regex_permissions",
+                    {
+                        "FILEPATH":      dir_path,
+                        "FILENAME":      file_name,
+                        "FILEMODE":      mode,
+                    },
+                    "./bash/file_permissions{0}.sh", path_id
+                )
+
+        elif target == "ansible" and not re.match( r'\^.*\$', file_name, 0):
+            self.file_from_template(
+                "./template_ANSIBLE_permissions",
                 {
                     "FILEPATH":      full_path,
                     "FILEMODE":      mode,
                 },
-                "./bash/file_permissions{0}.sh", path_id
-            )
-        else:
-            file_name = re.sub('^\^','', file_name)
-            file_from_template(
-                "./template_BASH_regex_permissions",
-                {
-                    "FILEPATH":      dir_path,
-                    "FILENAME":      file_name,
-                    "FILEMODE":      mode,
-                },
-                "./bash/file_permissions{0}.sh", path_id
+                "./ansible/file_permissions{0}.yml", path_id
             )
 
-    elif target == "ansible" and not re.match( r'\^.*\$', file_name, 0):
-        file_from_template(
-            "./template_ANSIBLE_permissions",
-            {
-                "FILEPATH":      full_path,
-                "FILEMODE":      mode,
-            },
-            "./ansible/file_permissions{0}.yml", path_id
-        )
+        elif target == "oval":
+            # build the state that describes our mode
+            # mode_str maps to STATEMODE in the template
+            fields = ['oexec', 'owrite', 'oread', 'gexec', 'gwrite', 'gread',
+                      'uexec', 'uwrite', 'uread', 'sticky', 'sgid', 'suid']
+            mode_int = int(mode, 8)
+            mode_str = "  </unix:file_state>"
+            for field in fields:
+                if mode_int & 0x01 == 1:
+                    mode_str = "	<unix:" + field + " datatype=\"boolean\">true</unix:" + field + ">\n" + mode_str
+                else:
+                    mode_str = "	<unix:" + field + " datatype=\"boolean\">false</unix:" + field + ">\n" + mode_str
+                mode_int = mode_int >> 1
 
-    elif target == "oval":
-        # build the state that describes our mode
-        # mode_str maps to STATEMODE in the template
-        fields = ['oexec', 'owrite', 'oread', 'gexec', 'gwrite', 'gread',
-                  'uexec', 'uwrite', 'uread', 'sticky', 'sgid', 'suid']
-        mode_int = int(mode, 8)
-        mode_str = "  </unix:file_state>"
-        for field in fields:
-            if mode_int & 0x01 == 1:
-                mode_str = "	<unix:" + field + " datatype=\"boolean\">true</unix:" + field + ">\n" + mode_str
+            # support pattern matching, requiring that the filename starts with '^'
+            # and fichishes with '$'
+            if file_name == '[NULL]':
+                unix_filename = "<unix:filename xsi:nil=\"true\" />"
+            elif re.match( r'\^.*\$', file_name, 0):
+                unix_filename = "<unix:filename operation=\"pattern match\">" + file_name + "</unix:filename>"
             else:
-                mode_str = "	<unix:" + field + " datatype=\"boolean\">false</unix:" + field + ">\n" + mode_str
-            mode_int = mode_int >> 1
+                unix_filename = "<unix:filename>" + file_name + "</unix:filename>"
 
-        # support pattern matching, requiring that the filename starts with '^'
-        # and fichishes with '$'
-        if file_name == '[NULL]':
-            unix_filename = "<unix:filename xsi:nil=\"true\" />"
-        elif re.match( r'\^.*\$', file_name, 0):
-            unix_filename = "<unix:filename operation=\"pattern match\">" + file_name + "</unix:filename>"
+            # we are ready to create the check
+            # open the template and perform the conversions
+            self.file_from_template(
+                "./template_permissions",
+                {
+                    "FILEID":        path_id,
+                    "FILEPATH":      full_path,
+                    "FILEDIR":       dir_path,
+                    "FILEUID":       uid,
+                    "FILEGID":       gid,
+                    "FILEMODE":      mode,
+                    "STATEMODE":     mode_str,
+                    "UNIX_FILENAME": unix_filename
+                },
+                "./oval/file_permissions{0}.xml", path_id
+            )
+
         else:
-            unix_filename = "<unix:filename>" + file_name + "</unix:filename>"
+            raise UnknownTargetError(target)
 
-        # we are ready to create the check
-        # open the template and perform the conversions
-        file_from_template(
-            "./template_permissions",
-            {
-                "FILEID":        path_id,
-                "FILEPATH":      full_path,
-                "FILEDIR":       dir_path,
-                "FILEUID":       uid,
-                "FILEGID":       gid,
-                "FILEMODE":      mode,
-                "STATEMODE":     mode_str,
-                "UNIX_FILENAME": unix_filename
-            },
-            "./oval/file_permissions{0}.xml", path_id
-        )
-
-    else:
-        raise UnknownTargetError(target)
-
-
-def csv_format():
-    return("CSV should contains lines of the format: "
-          "directory path,file name,owner uid (numeric),group "
-          "owner gid (numeric),mode")
+    def csv_format(self):
+        return("CSV should contains lines of the format: "
+              "directory path,file name,owner uid (numeric),group "
+              "owner gid (numeric),mode")
 
 if __name__ == "__main__":
-    main(sys.argv, csv_format(), output_checkfile)
+    PermissionGenerator().main()

--- a/shared/templates/create_services_disabled.py
+++ b/shared/templates/create_services_disabled.py
@@ -15,79 +15,81 @@
 import sys
 import re
 
-from template_common import *
+from template_common import FilesGenerator, UnknownTargetError
 
-def output_checkfile(target, serviceinfo):
-    try:
-        # get the items out of the list
-        servicename, packagename, daemonname = serviceinfo
-    except ValueError as e:
-        print "\tEntry: %s\n" % serviceinfo
-        print "\tError unpacking servicename, packagename, and daemonname: ", str(e)
-        sys.exit(1)
+class ServiceDisabledGenerator(FilesGenerator):
 
-    if not daemonname:
-        daemonname = servicename
+    def generate(self, target, serviceinfo):
+        try:
+            # get the items out of the list
+            servicename, packagename, daemonname = serviceinfo
+        except ValueError as e:
+            print "\tEntry: %s\n" % serviceinfo
+            print "\tError unpacking servicename, packagename, and daemonname: ", str(e)
+            sys.exit(1)
 
-    if target == "bash":
-        file_from_template(
-            "./template_BASH_service_disabled",
-            {
-                "SERVICENAME": servicename
-            },
-            "./bash/service_{0}_disabled.sh", servicename
-        )
+        if not daemonname:
+            daemonname = servicename
 
-    elif target == "ansible":
-        file_from_template(
-            "./template_ANSIBLE_service_disabled",
-            {
-                "SERVICENAME": servicename
-            },
-            "./ansible/service_{0}_disabled.yml", servicename
-        )
-
-    elif target == "puppet":
-        file_from_template(
-            "./template_PUPPET_service_disabled",
-            {
-                "SERVICENAME": servicename
-            },
-            "./puppet/service_{0}_disabled.yml", servicename
-        )
-
-    elif target == "oval":
-        if packagename:
-            file_from_template(
-                "./template_service_disabled",
+        if target == "bash":
+            self.file_from_template(
+                "./template_BASH_service_disabled",
                 {
-                    "SERVICENAME": servicename,
-                    "DAEMONNAME":  daemonname,
-                    "PACKAGENAME": packagename
+                    "SERVICENAME": servicename
                 },
-                "./oval/service_{0}_disabled.xml", servicename
+                "./bash/service_{0}_disabled.sh", servicename
             )
+
+        elif target == "ansible":
+            self.file_from_template(
+                "./template_ANSIBLE_service_disabled",
+                {
+                    "SERVICENAME": servicename
+                },
+                "./ansible/service_{0}_disabled.yml", servicename
+            )
+
+        elif target == "puppet":
+            self.file_from_template(
+                "./template_PUPPET_service_disabled",
+                {
+                    "SERVICENAME": servicename
+                },
+                "./puppet/service_{0}_disabled.yml", servicename
+            )
+
+        elif target == "oval":
+            if packagename:
+                self.file_from_template(
+                    "./template_service_disabled",
+                    {
+                        "SERVICENAME": servicename,
+                        "DAEMONNAME":  daemonname,
+                        "PACKAGENAME": packagename
+                    },
+                    "./oval/service_{0}_disabled.xml", servicename
+                )
+            else:
+                self.file_from_template(
+                    "./template_service_disabled",
+                    {
+                        "SERVICENAME": servicename,
+                        "DAEMONNAME":  daemonname
+                    },
+                    regex_replace = [
+                        ("\n\s*<criteria.*>\n\s*<extend_definition.*/>", ""),
+                        ("\s*</criteria>\n\s*</criteria>", "\n    </criteria>")
+                    ],
+                    filename_format = "./oval/service_{0}_disabled.xml",
+                    filename_value = servicename
+                )
+
         else:
-            file_from_template(
-                "./template_service_disabled",
-                {
-                    "SERVICENAME": servicename,
-                    "DAEMONNAME":  daemonname
-                },
-                regex_replace = [
-                    ("\n\s*<criteria.*>\n\s*<extend_definition.*/>", ""),
-                    ("\s*</criteria>\n\s*</criteria>", "\n    </criteria>")
-                ],
-                filename_format = "./oval/service_{0}_disabled.xml",
-                filename_value = servicename
-            )
+            raise UnknownTargetError(target)
 
-    else:
-        raise UnknownTargetError(target)
-
-def csv_format():
-    return("CSV should contains lines of the format: " +
-               "servicename,packagename")
+    def csv_format(self):
+        return("CSV should contains lines of the format: " +
+                   "servicename,packagename")
 
 if __name__ == "__main__":
-    main(sys.argv, csv_format(), output_checkfile)
+    ServiceDisabledGenerator().main()

--- a/shared/templates/create_sysctl.py
+++ b/shared/templates/create_sysctl.py
@@ -3,102 +3,103 @@
 import sys
 import re
 
-from template_common import *
+from template_common import FilesGenerator, UnknownTargetError
 
-def is_ipv6_id(var_id):
-    return var_id.find("ipv6") >= 0
+class SysctlGenerator(FilesGenerator):
 
-def get_files_var_for_id(var_id):
+    def is_ipv6_id(self, var_id):
+        return var_id.find("ipv6") >= 0
 
-    if is_ipv6_id(var_id):
-          template_name = 'template_sysctl_ipv6'
-    else:
-          template_name = 'template_sysctl'
+    def get_files_var_for_id(self, var_id):
 
-    return {
-        'template_sysctl_static_var' : 'sysctl_static_',
-        'template_sysctl_runtime_var' : 'sysctl_runtime_',
-        template_name : 'sysctl_'
-    }
-
-
-def get_files_for_id(var_id):
-
-    if is_ipv6_id(var_id):
-          template_name = 'template_sysctl_ipv6'
-    else:
-          template_name = 'template_sysctl'
-
-    return {
-          'template_sysctl_static' : 'sysctl_static_',
-          'template_sysctl_runtime' : 'sysctl_runtime_',
-          template_name: 'sysctl_'
-    }
-
-
-def output_checkfile(target, serviceinfo):
-    # get the items out of the list
-    sysctl_var, sysctl_val = serviceinfo
-    # convert variable name to a format suitable for 'id' tags
-    sysctl_var_id = re.sub('[-\.]', '_', sysctl_var)
-
-    if target == "bash":
-        # if the sysctl value is not present, use the variable template
-        if not sysctl_val.strip():
-            # open the template and perform the conversions
-            file_from_template(
-                "template_BASH_sysctl_var",
-                {
-                    "SYSCTLID":  sysctl_var_id,
-                    "SYSCTLVAR": sysctl_var
-                },
-                "./bash/sysctl_{0}.sh", sysctl_var_id
-            )
+        if self.is_ipv6_id(var_id):
+              template_name = 'template_sysctl_ipv6'
         else:
-            file_from_template(
-                "./template_BASH_sysctl",
-                {
-                    "SYSCTLID":  sysctl_var_id,
-                    "SYSCTLVAR": sysctl_var,
-                    "SYSCTLVAL": sysctl_val
-                },
-                "./bash/sysctl_{0}.sh", sysctl_var_id
-        )
+              template_name = 'template_sysctl'
 
-    elif target == "oval":
-        # if the sysctl value is not present, use the variable template
-        if not sysctl_val.strip():
+        return {
+            'template_sysctl_static_var' : 'sysctl_static_',
+            'template_sysctl_runtime_var' : 'sysctl_runtime_',
+            template_name : 'sysctl_'
+        }
 
-            # open the template files and perform the conversions
-            for sysctlfile, prefix in get_files_var_for_id(sysctl_var_id).items():
-                file_from_template(
-                    sysctlfile,
+
+    def get_files_for_id(self, var_id):
+
+        if self.is_ipv6_id(var_id):
+              template_name = 'template_sysctl_ipv6'
+        else:
+              template_name = 'template_sysctl'
+
+        return {
+              'template_sysctl_static' : 'sysctl_static_',
+              'template_sysctl_runtime' : 'sysctl_runtime_',
+              template_name: 'sysctl_'
+        }
+
+    def generate(self, target, serviceinfo):
+        # get the items out of the list
+        sysctl_var, sysctl_val = serviceinfo
+        # convert variable name to a format suitable for 'id' tags
+        sysctl_var_id = re.sub('[-\.]', '_', sysctl_var)
+
+        if target == "bash":
+            # if the sysctl value is not present, use the variable template
+            if not sysctl_val.strip():
+                # open the template and perform the conversions
+                self.file_from_template(
+                    "template_BASH_sysctl_var",
                     {
                         "SYSCTLID":  sysctl_var_id,
-                        "SYSCTLVAR": sysctl_var,
+                        "SYSCTLVAR": sysctl_var
                     },
-                    "./oval/{0}.xml", prefix + sysctl_var_id
+                    "./bash/sysctl_{0}.sh", sysctl_var_id
                 )
-        else:
-
-            # open the template files and perform the conversions
-            for sysctlfile, prefix in get_files_for_id(sysctl_var_id).items():
-                file_from_template(
-                    sysctlfile,
+            else:
+                self.file_from_template(
+                    "./template_BASH_sysctl",
                     {
                         "SYSCTLID":  sysctl_var_id,
                         "SYSCTLVAR": sysctl_var,
                         "SYSCTLVAL": sysctl_val
                     },
-                    "./oval/{0}.xml", prefix + sysctl_var_id
-                )
-    else:
+                    "./bash/sysctl_{0}.sh", sysctl_var_id
+            )
 
-        raise UnknownTargetError(target)
+        elif target == "oval":
+            # if the sysctl value is not present, use the variable template
+            if not sysctl_val.strip():
 
-def csv_format():
-    return("CSV should contains lines of the format: " +
-               "sysctlvariable,sysctlvalue")
+                # open the template files and perform the conversions
+                for sysctlfile, prefix in self.get_files_var_for_id(sysctl_var_id).items():
+                    self.file_from_template(
+                        sysctlfile,
+                        {
+                            "SYSCTLID":  sysctl_var_id,
+                            "SYSCTLVAR": sysctl_var,
+                        },
+                        "./oval/{0}.xml", prefix + sysctl_var_id
+                    )
+            else:
+
+                # open the template files and perform the conversions
+                for sysctlfile, prefix in self.get_files_for_id(sysctl_var_id).items():
+                    self.file_from_template(
+                        sysctlfile,
+                        {
+                            "SYSCTLID":  sysctl_var_id,
+                            "SYSCTLVAR": sysctl_var,
+                            "SYSCTLVAL": sysctl_val
+                        },
+                        "./oval/{0}.xml", prefix + sysctl_var_id
+                    )
+        else:
+
+            raise UnknownTargetError(target)
+
+    def csv_format(self):
+        return("CSV should contains lines of the format: " +
+                   "sysctlvariable,sysctlvalue")
 
 if __name__ == "__main__":
-    main(sys.argv, csv_format(), output_checkfile)
+    SysctlGenerator().main()

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -7,6 +7,7 @@ import sys
 import os
 import re
 import argparse
+from abc import abstractmethod
 
 class ExitCodes:
     OK = 0
@@ -19,196 +20,195 @@ class ActionType:
     OUTPUT = 2
     BUILD = 3
 
-product_input_dir = None
-output_dir = None
-action = None
-shared_dir = None
-
 class UnknownTargetError(ValueError):
     def __init__(self, msg):
         ValueError.__init__(self, "Unknown target language: \"{0}\"".format(msg))
 
-def get_template_filename(filename):
+class FilesGenerator(object):
 
-    template_filename = os.path.join(product_input_dir, filename)
+    def get_template_filename(self, filename):
 
-    if os.path.isfile(template_filename):
-        return template_filename
+        template_filename = os.path.join(self.product_input_dir, filename)
 
-    shared_template = os.path.join(shared_dir, "templates", filename)
-    if os.path.isfile(shared_template):
-        return shared_template
+        if os.path.isfile(template_filename):
+            return template_filename
 
-    sys.stderr.write(
-        "No specialized or shared template found for {0}\n".format(filename)
-    )
-    sys.exit(ExitCodes.NO_TEMPLATE)
+        shared_template = os.path.join(self.shared_dir, "templates", filename)
+        if os.path.isfile(shared_template):
+            return shared_template
 
-
-def load_modified(filename, constants_dict, regex_replace=[]):
-    """
-    Load file and replace constants according to constants_dict and regex_replace
-
-    constants_dict: dict of constants - replace ( key -> value)
-    regex_dict: dict of regex substitutions - sub ( key -> value)
-    """
-
-    template_filename = get_template_filename(filename)
-
-    if action == ActionType.OUTPUT:
-        return ""
-
-    if action == ActionType.INPUT:
-        print(template_filename)
-        return ""
-
-    with open(template_filename, "r") as template_file:
-        filestring = template_file.read()
-
-    for key, value in constants_dict.iteritems():
-        filestring = filestring.replace(key, value)
-
-    for pattern, replacement in regex_replace:
-        filestring = re.sub(pattern, replacement, filestring)
-
-    return filestring
-
-def save_modified(filename_format, filename_value, string):
-    """
-    Save string to file
-    """
-    filename = filename_format.format(filename_value)
-
-    filename = os.path.join(output_dir, filename)
-
-    if action == ActionType.INPUT:
-        return
-
-    if action == ActionType.OUTPUT:
-        print(filename)
-        return
-
-    with open(filename, 'w+') as outputfile:
-        outputfile.write(string)
-
-def file_from_template(template_filename, constants,
-                       filename_format, filename_value, regex_replace=[]):
-    """
-    Load template, fill constant and create new file
-    @param regex_replace: array of tuples (pattern, replacement)
-    """
-
-    filled_template = load_modified(template_filename, constants, regex_replace)
-
-    save_modified(filename_format, filename_value, filled_template)
-
-
-def process_line(line, target):
-    """
-    Remove comments
-    Remove line if target is unsupported
-    """
-
-    if target is not None:
-        regex = re.compile(r"#\s*only-for:([\s\w,]*)")
-
-        match = regex.search(line)
-
-        if match:
-            # if line contains restriction to target, check it
-            supported_targets = [x.strip() for x in match.group(1).split(",")]
-            if target not in supported_targets:
-                return None
-
-    # get part before comment
-    return (line.split("#")[0]).strip()
-
-
-def filter_out_csv_lines(csv_file, language):
-    """
-    Filter out not applicable lines
-    """
-
-    for line in csv_file:
-        processed_line = process_line(line, language)
-
-        if not processed_line:
-             continue
-
-        yield processed_line
-
-
-def csv_map(filename, method, language):
-    """
-    Call specified function on every line of file
-    CSV lines can look like:
-        col1, col2 # comment
-        col3, col4 # only-for: bash, oval
-
-    todo: remove skip_comments parameter - should be always True
-    """
-
-    with open(filename, 'r') as csv_file:
-        filtered_file = filter_out_csv_lines(csv_file, language)
-
-        csv_lines_content = csv.reader(filtered_file)
-
-        try:
-            for csv_line in csv_lines_content:
-                method(language, csv_line)
-        except UnknownTargetError as e:
-            sys.stderr.write(str(e) + "\n")
-            sys.exit(ExitCodes.UNKNOWN_TARGET)
-
-def parse_args(csv_format):
-    p = argparse.ArgumentParser()
-
-    sp = p.add_subparsers(help="actions")
-
-    make_sp = sp.add_parser('build', help="Build scripts")
-    make_sp.set_defaults(action=ActionType.BUILD)
-
-    input_sp = sp.add_parser('list-inputs', help="Generate input list")
-    input_sp.set_defaults(action=ActionType.INPUT)
-
-    output_sp = sp.add_parser('list-outputs', help="Generate output list")
-    output_sp.set_defaults(action=ActionType.OUTPUT)
-
-    p.add_argument('-s','--shared_dir', action="store", help="Shared directory")
-    p.add_argument('--language', action="store", default=None, required=True,
-                   help="Scripts of which language should we generate?")
-    p.add_argument('-c',"--csv", action="store", required=True,
-                   help="csv filename.\n" + csv_format)
-    p.add_argument('-o','--output_dir', action="store", required=True,
-                   help="output dir")
-    p.add_argument('-i','--input_dir', action="store", required=True,
-                   help="templates dir")
-
-    args, unknown = p.parse_known_args()
-
-    return (args,unknown)
-
-
-
-def main(argv, csv_format, process_line_callback):
-
-    parsed, unknown = parse_args(csv_format)
-
-    if unknown:
         sys.stderr.write(
-            "Unknown positional arguments " + ",".join(unknown) + ".\n"
+            "No specialized or shared template found for {0}\n".format(filename)
         )
-        sys.exit(ExitCodes.ERROR)
+        sys.exit(ExitCodes.NO_TEMPLATE)
 
-    global output_dir
-    global action
-    global product_input_dir
-    global shared_dir
 
-    output_dir = parsed.output_dir
-    action = parsed.action
-    product_input_dir = parsed.input_dir
-    shared_dir = parsed.shared_dir
+    def load_modified(self, filename, constants_dict, regex_replace=[]):
+        """
+        Load file and replace constants according to constants_dict and regex_replace
 
-    csv_map(parsed.csv, process_line_callback, language=parsed.language)
-    sys.exit(ExitCodes.OK)
+        constants_dict: dict of constants - replace ( key -> value)
+        regex_dict: dict of regex substitutions - sub ( key -> value)
+        """
+
+        template_filename = self.get_template_filename(filename)
+
+        if self.action == ActionType.OUTPUT:
+            return ""
+
+        if self.action == ActionType.INPUT:
+            print(template_filename)
+            return ""
+
+        with open(template_filename, "r") as template_file:
+            filestring = template_file.read()
+
+        for key, value in constants_dict.iteritems():
+            filestring = filestring.replace(key, value)
+
+        for pattern, replacement in regex_replace:
+            filestring = re.sub(pattern, replacement, filestring)
+
+        return filestring
+
+    def save_modified(self, filename_format, filename_value, string):
+        """
+        Save string to file
+        """
+        filename = filename_format.format(filename_value)
+
+        filename = os.path.join(self.output_dir, filename)
+
+        if self.action == ActionType.INPUT:
+            return
+
+        if self.action == ActionType.OUTPUT:
+            print(filename)
+            return
+
+        with open(filename, 'w+') as outputfile:
+            outputfile.write(string)
+
+    def file_from_template(self, template_filename, constants,
+                           filename_format, filename_value, regex_replace=[]):
+        """
+        Load template, fill constant and create new file
+        @param regex_replace: array of tuples (pattern, replacement)
+        """
+
+        filled_template = self.load_modified(template_filename, constants, regex_replace)
+
+        self.save_modified(filename_format, filename_value, filled_template)
+
+
+    def process_line(self, line, target):
+        """
+        Remove comments
+        Remove line if target is unsupported
+        """
+
+        if target is not None:
+            regex = re.compile(r"#\s*only-for:([\s\w,]*)")
+
+            match = regex.search(line)
+
+            if match:
+                # if line contains restriction to target, check it
+                supported_targets = [x.strip() for x in match.group(1).split(",")]
+                if target not in supported_targets:
+                    return None
+
+        # get part before comment
+        return (line.split("#")[0]).strip()
+
+
+    def filter_out_csv_lines(self, csv_file, language):
+        """
+        Filter out not applicable lines
+        """
+
+        for line in csv_file:
+            
+            processed_line = self.process_line(line, language)
+
+            if not processed_line:
+                 continue
+
+            yield processed_line
+
+
+    def csv_map(self, filename, language):
+        """
+        Call specified function on every line of file
+        CSV lines can look like:
+            col1, col2 # comment
+            col3, col4 # only-for: bash, oval
+
+        todo: remove skip_comments parameter - should be always True
+        """
+
+        with open(filename, 'r') as csv_file:
+            filtered_file = self.filter_out_csv_lines(csv_file, language)
+
+            csv_lines_content = csv.reader(filtered_file)
+
+            try:
+                for csv_line in csv_lines_content:
+                    self.generate(language, csv_line)
+            except UnknownTargetError as e:
+                sys.stderr.write(str(e) + "\n")
+                sys.exit(ExitCodes.UNKNOWN_TARGET)
+
+    def parse_args(self):
+        p = argparse.ArgumentParser()
+
+        sp = p.add_subparsers(help="actions")
+
+        make_sp = sp.add_parser('build', help="Build scripts")
+        make_sp.set_defaults(action=ActionType.BUILD)
+
+        input_sp = sp.add_parser('list-inputs', help="Generate input list")
+        input_sp.set_defaults(action=ActionType.INPUT)
+
+        output_sp = sp.add_parser('list-outputs', help="Generate output list")
+        output_sp.set_defaults(action=ActionType.OUTPUT)
+
+        p.add_argument('-s','--shared_dir', action="store", help="Shared directory")
+        p.add_argument('--language', action="store", default=None, required=True,
+                       help="Scripts of which language should we generate?")
+        p.add_argument('-c',"--csv", action="store", required=True,
+                       help="csv filename.\n" + self.csv_format())
+        p.add_argument('-o','--output_dir', action="store", required=True,
+                       help="output dir")
+        p.add_argument('-i','--input_dir', action="store", required=True,
+                       help="templates dir")
+
+        args, unknown = p.parse_known_args()
+
+        return (args,unknown)
+
+    @abstractmethod
+    def csv_format(self):
+        raise NotImplementedError("Please Implement this method")
+
+    @abstractmethod
+    def generate_from_line(self, target, line):
+        raise NotImplementedError("Please Implement this method")
+
+    def main(self):
+
+        parsed, unknown = self.parse_args()
+
+        if unknown:
+            sys.stderr.write(
+                "Unknown positional arguments " + ",".join(unknown) + ".\n"
+            )
+            sys.exit(ExitCodes.ERROR)
+
+        self.output_dir = parsed.output_dir
+        self.action = parsed.action
+        self.product_input_dir = parsed.input_dir
+        self.shared_dir = parsed.shared_dir
+
+        self.csv_map(parsed.csv, language=parsed.language)
+        sys.exit(ExitCodes.OK)

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -143,8 +143,6 @@ class FilesGenerator(object):
         CSV lines can look like:
             col1, col2 # comment
             col3, col4 # only-for: bash, oval
-
-        todo: remove skip_comments parameter - should be always True
         """
 
         with open(filename, 'r') as csv_file:


### PR DESCRIPTION
Use classes in templates to not use global variables. Differences between files should be caused mainly by indentation changes.
https://github.com/OpenSCAP/scap-security-guide/pull/1730

