### PR TITLE
Let's go back to the old path /usr/share/xml/scap/ssg/content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,7 @@ set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 # This is set to silence GNUInstallDirs warning about no language being used with cmake
 set(CMAKE_INSTALL_LIBDIR "/nowhere")
 include(GNUInstallDirs)
-# FIXME: This is different than the old location /usr/share/xml/scap/ssg/content
-set(SSG_CONTENT_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/scap/ssg")
+set(SSG_CONTENT_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/xml/scap/ssg/content")
 set(SSG_GUIDE_INSTALL_DIR "${CMAKE_INSTALL_DOCDIR}/guides")
 set(SSG_TABLE_INSTALL_DIR "${CMAKE_INSTALL_DOCDIR}/tables")
 
@@ -42,8 +41,6 @@ option(SSG_PRODUCT_WEBMIN "If enabled, the Webmin SCAP content will be built" TR
 
 option(SSG_CENTOS_DERIVATIVES_ENABLED "If enabled, CentOS derivative content will be built from the RHEL content" TRUE)
 option(SSG_SCIENTIFIC_LINUX_DERIVATIVES_ENABLED "If enabled, Scientific Linux derivative content will be built from the RHEL content" TRUE)
-
-option(SSG_COMPATIBILITY_SYMLINK "If enabled a compatibility symlink will be created in the old SCAP Security Guide location - /usr/share/xml/scap/contente (only on a UNIX derived operating system)" FALSE)
 
 set(SSG_SHARED "${CMAKE_SOURCE_DIR}/shared")
 set(SSG_SHARED_REFS "${SSG_SHARED}/references")
@@ -209,15 +206,6 @@ install(FILES "${CMAKE_SOURCE_DIR}/Contributors.md"
 
 install(FILES "docs/scap-security-guide.8"
     DESTINATION "${CMAKE_INSTALL_MANDIR}/man8")
-
-if (UNIX AND SSG_COMPATIBILITY_SYMLINK)
-    install(CODE "
-        file(MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/xml/scap/ssg/)
-    ")
-    install(CODE "
-        execute_process(COMMAND ln -sf ../../../scap/ssg ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/xml/scap/ssg/content)
-    ")
-endif()
 
 # only CPack should follow
 set(CPACK_CMAKE_GENERATOR "Unix Makefiles")

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ go through a few of them here.
 The `oscap` tool is a low-level command line interface that comes from
 the OpenSCAP project. It can be used to scan the local machine.
 ```
-# oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_usgcb-rhel6-server --results-arf arf.xml --report report.html /usr/share/scap/ssg/ssg-rhel6-ds.xml
+# oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_usgcb-rhel6-server --results-arf arf.xml --report report.html /usr/share/xml/scap/ssg/content/ssg-rhel6-ds.xml
 ```
 After evaluation, the `arf.xml` file will contain all results in a reusable
 *Result DataStream* format, `report.html` will contain a human readable
@@ -48,7 +48,7 @@ report that can be opened in a browser.
 Replace the profile with other profile of your choice, you can display
 all possible choices using:
 ```
-# oscap info /usr/share/scap/ssg/ssg-rhel6-ds.xml
+# oscap info /usr/share/xml/scap/ssg/content/ssg-rhel6-ds.xml
 ```
 
 Please see the [User Manual](http://static.open-scap.org/openscap-1.0/oscap_user_manual.html)
@@ -71,7 +71,7 @@ The following command evaluates machine with IP `192.168.1.123` with content
 stored on local machine. Keep in mind that `oscap` has to be installed on the
 remote machine but the SSG content doesn't need to be.
 ```
-# oscap-ssh root@192.168.1.123 22 xccdf eval --profile xccdf_org.ssgproject.content_profile_usgcb-rhel6-server --results-arf arf.xml --report report.html /usr/share/scap/ssg/ssg-rhel6-ds.xml
+# oscap-ssh root@192.168.1.123 22 xccdf eval --profile xccdf_org.ssgproject.content_profile_usgcb-rhel6-server --results-arf arf.xml --report report.html /usr/share/xml/scap/ssg/content/ssg-rhel6-ds.xml
 ```
 
 ## Support

--- a/docs/User_Guide/en-US/ch003-Scanning.xml
+++ b/docs/User_Guide/en-US/ch003-Scanning.xml
@@ -103,8 +103,8 @@
 			<programlisting>$ sudo oscap xccdf eval --profile stig-rhel6-server \
 --results /root/ssg-results.xml \
 --report /root/ssg-report.xml \
---cpe /usr/share/scap/ssg/ssg-rhel6-cpe-dictionary.xml \
-/usr/share/scap/ssg/ssg-rhel6-xccdf.xml </programlisting></para>
+--cpe /usr/share/xml/scap/ssg/content/ssg-rhel6-cpe-dictionary.xml \
+/usr/share/xml/scap/ssg/content/ssg-rhel6-xccdf.xml </programlisting></para>
 		<para>While the scan is running, you will see output similar to the following on your
 			screen:</para>
 		<para><programlisting>Title   Install AIDE

--- a/docs/scap-security-guide.8
+++ b/docs/scap-security-guide.8
@@ -368,15 +368,15 @@ stig-rhel6-server-upstream profile:
 oscap  xccdf eval --profile stig-rhel6-server-upstream \
 --results /tmp/`hostname`-ssg-results.xml \
 --report /tmp/`hostname`-ssg-results.html \
---cpe /usr/share/scap/ssg/ssg-rhel6-cpe-dictionary.xml \
-/usr/share/scap/ssg/ssg-rhel6-xccdf.xml
+--cpe /usr/share/xml/scap/ssg/content/ssg-rhel6-cpe-dictionary.xml \
+/usr/share/xml/scap/ssg/content/ssg-rhel6-xccdf.xml
 .PP
 Additional details can be found on the projects wiki page:
 https://www.github.com/OpenSCAP/scap-security-guide/wiki
 
 
 .SH FILES
-.I /usr/share/scap/ssg/
+.I /usr/share/xml/scap/ssg/content
 .RS
 Houses SCAP content utilizing the following naming conventions:
 

--- a/scap-security-guide.spec.in
+++ b/scap-security-guide.spec.in
@@ -51,7 +51,7 @@ present in %{name} package.
 %make_install
 
 %files
-%{_datadir}/scap/ssg
+%{_datadir}/xml/scap/ssg/content
 # TODO
 #%{_datadir}/%{name}/kickstart
 %lang(en) %{_mandir}/man8/scap-security-guide.8.*

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -385,7 +385,7 @@ def main():
         index_source += "\t\t\t\tvar benchmark_id=option_element.getAttribute('data-benchmark-id');\n"
         index_source += "\t\t\t\tvar profile_id=option_element.getAttribute('data-profile-id');\n"
         index_source += "\t\t\t\tvar eval_snippet=document.getElementById('eval_snippet');\n"
-        index_source += "\t\t\t\tvar input_path='/usr/share/scap/ssg/%s';\n" % (input_basename)
+        index_source += "\t\t\t\tvar input_path='/usr/share/xml/scap/ssg/content/%s';\n" % (input_basename)
         index_source += "\t\t\t\tif (profile_id == '')\n"
         index_source += "\t\t\t\t{\n"
         index_source += "\t\t\t\t\tif (benchmark_id == '')\n"


### PR DESCRIPTION
There are a lot of changes and this one might be a bit problematic with
the RPM symlink transitions. I think we can live with the long path a
little longer and make 0.1.32 less stressful by rolling this back.

I was not able to figure out the RPM transition in Fedora 25, see https://bodhi.fedoraproject.org/updates/FEDORA-2016-a24b84ee01

Originally introduced in https://github.com/OpenSCAP/scap-security-guide/pull/1535