### PR TITLE
RHBZ #1420038: Identify Red Hat Enterprise Virtualization Host as RHEL7

### DIFF
--- a/shared/oval/installed_OS_is_rhel7.xml
+++ b/shared/oval/installed_OS_is_rhel7.xml
@@ -19,6 +19,10 @@
         <criterion comment="RHEL 7 Workstation is installed" test_ref="test_rhel7_workstation" />
         <criterion comment="RHEL 7 Server is installed" test_ref="test_rhel7_server" />
         <criterion comment="RHEL 7 Compute Node is installed" test_ref="test_rhel7_computenode" />
+        <criteria operator="AND" comment="Red Hat Enterpise Virtualization Host is installed">
+          <criterion comment="redhat-release-virtualization-host RPM package is installed" test_ref="test_redhat_release_virtualization_host_rpm" />
+          <criterion comment="Red Hat Enterpise Virtualization Host is based on RHEL 7" test_ref="test_rhev_rhel_version" />
+        </criteria>
       </criteria>
     </criteria>
   </definition>
@@ -75,4 +79,25 @@
   <linux:rpminfo_object id="obj_rhel7_computenode" version="1">
     <linux:name>redhat-release-computenode</linux:name>
   </linux:rpminfo_object>
+
+  <linux:rpminfo_test check="all" check_existence="only_one_exists" comment="redhat-release-virtualization-host RPM package is installed" id="test_redhat_release_virtualization_host_rpm" version="1">
+    <linux:object object_ref="obj_redhat_release_virtualization_host_rpm" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_redhat_release_virtualization_host_rpm" version="1">
+    <linux:name>redhat-release-virtualization-host</linux:name>
+  </linux:rpminfo_object>
+
+  <ind:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 7" id="test_rhev_rhel_version" version="1">
+    <ind:object object_ref="obj_rhevh_rhel_version" />
+    <ind:state state_ref="state_rhevh_rhel_version" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_rhevh_rhel_version" version="1">
+    <ind:filepath>/etc/redhat-release</ind:filepath>
+    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_rhevh_rhel_version" version="1">
+    <ind:subexpression operation="pattern match">7</ind:subexpression>
+  </ind:textfilecontent54_state>
+
 </def-group>


### PR DESCRIPTION
RHEVH is based on RHEL7, therefore RHEL7 profiles should be applicable
on this system. This commit enables evaluating RHEL7 profiles on RHEVH.
However the underlying RHEL version cannot be determined from
redhat-release RPM package version, because RHEVH obsoletes
the redhat-release RPM package. Instead we should check for presence
of redhat-release-virtualization-host and then we will parse the
RHEL version from /etc/redhat-release file. Note that
redhat-release-virtualization-host RPM version represents RHEVH
version (currently 4.0.6), not RHEL version, so it's not possible
to rely only on rpminfo tests.