### PR TITLE
Support pam faillock with sssd enabled

### DIFF
--- a/shared/oval/accounts_passwords_pam_faillock_deny.xml
+++ b/shared/oval/accounts_passwords_pam_faillock_deny.xml
@@ -48,7 +48,7 @@
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so preauth silent in auth section is listed before
          pam_unix.so module in auth section -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*deny=([0-9]+)[\s]*(?s).*[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+[^\n]*silent[\s]+[^\n]*deny=([0-9]+)[\s]*(?s).*[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -103,7 +103,7 @@
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so preauth silent in auth section is listed before
          pam_unix.so module in auth section -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+silent[\s]+[^\n]*deny=([0-9]+)[\s]*(?s).*[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+required[\s]+pam_faillock\.so[\s]+preauth[\s]+[^\n]*silent[\s]+[^\n]*deny=([0-9]+)[\s]*(?s).*[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/templates/static/bash/accounts_passwords_pam_faillock_deny.sh
+++ b/shared/templates/static/bash/accounts_passwords_pam_faillock_deny.sh
@@ -30,8 +30,8 @@ do
 	else
 
 		# insert pam_faillock.so preauth & authfail rows with proper value of the 'deny' option
-		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
-		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
+		sed -i --follow-symlinks "/^auth.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
+		sed -i --follow-symlinks "/^auth.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
 	fi
 
 	# add pam_faillock.so into account phase

--- a/shared/templates/static/bash/accounts_passwords_pam_faillock_deny.sh
+++ b/shared/templates/static/bash/accounts_passwords_pam_faillock_deny.sh
@@ -5,6 +5,15 @@ populate var_accounts_passwords_pam_faillock_deny
 AUTH_FILES[0]="/etc/pam.d/system-auth"
 AUTH_FILES[1]="/etc/pam.d/password-auth"
 
+# This script fixes absence of pam_faillock.so in PAM stack or the
+# absense of deny=[0-9]+ in pam_faillock.so arguments
+# When inserting auth pam_faillock.so entries,
+# the entry with preauth argument will be added before pam_unix.so module
+# and entry with authfail argument will be added before pam_deny.so module.
+
+# The placement of pam_faillock.so entries will not be changed
+# if they are already present
+
 for pamFile in "${AUTH_FILES[@]}"
 do
 	

--- a/shared/templates/static/bash/accounts_passwords_pam_faillock_deny.sh
+++ b/shared/templates/static/bash/accounts_passwords_pam_faillock_deny.sh
@@ -29,9 +29,10 @@ do
 	# pam_faillock.so not present yet
 	else
 
-		# insert pam_faillock.so preauth & authfail rows with proper value of the 'deny' option
+		# insert pam_faillock.so preauth row with proper value of the 'deny' option before pam_unix.so
 		sed -i --follow-symlinks "/^auth.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
-		sed -i --follow-symlinks "/^auth.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
+		# insert pam_faillock.so authfail row with proper value of the 'deny' option before pam_deny.so, after all modules which determine authentication outcome.
+		sed -i --follow-symlinks "/^auth.*pam_deny.so.*/i auth        [default=die] pam_faillock.so authfail deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
 	fi
 
 	# add pam_faillock.so into account phase

--- a/shared/templates/static/bash/accounts_passwords_pam_faillock_deny.sh
+++ b/shared/templates/static/bash/accounts_passwords_pam_faillock_deny.sh
@@ -32,6 +32,10 @@ do
 		# insert pam_faillock.so preauth & authfail rows with proper value of the 'deny' option
 		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
 		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
+	fi
+
+	# add pam_faillock.so into account phase
+	if ! grep -q "^account.*required.*pam_faillock.so" $pamFile; then
 		sed -i --follow-symlinks "/^account.*required.*pam_unix.so/i account     required      pam_faillock.so" $pamFile
 	fi
 done


### PR DESCRIPTION
- Flexibilize check for preauth, allowing other arguments to be present.
- Flexibilize remediation so that it applies on configuration created by `authconfig`.

This fixes issues rised in https://bugzilla.redhat.com/show_bug.cgi?id=1344581#c6.