### PR TITLE
Standard profile container

### DIFF
--- a/RHEL/7/input/profiles/standard.xml
+++ b/RHEL/7/input/profiles/standard.xml
@@ -17,8 +17,15 @@ Regardless of your system's workload all of these checks should pass.</descripti
 
 <!-- The following rules currently returns 'notapplicable' on RHEL-7 container -->
 <!-- Investigate why, fix the issues, and re-enable back once fixed -->
-<!-- <select idref="accounts_password_all_shadowed" selected="true"/> -->
+
+<!-- The OVAL check for root_path_no_dot uses environmentvariable58_test -->
+<!-- which may be the cause of 'notapplicable' results for offline scanning -->
 <!-- <select idref="root_path_no_dot" selected="true"/> -->
+
+<!-- Password and shadow probes are disabled for offline scanning. -->
+<!-- See https://github.com/OpenSCAP/openscap/pull/327 and -->
+<!-- https://github.com/OpenSCAP/openscap/pull/344 -->
+<!-- <select idref="accounts_password_all_shadowed" selected="true"/> -->
 
 <select idref="mount_option_dev_shm_nodev" selected="true" />
 <select idref="mount_option_dev_shm_nosuid" selected="true" />

--- a/RHEL/7/input/profiles/standard.xml
+++ b/RHEL/7/input/profiles/standard.xml
@@ -7,6 +7,7 @@ Regardless of your system's workload all of these checks should pass.</descripti
 <select idref="ensure_gpgcheck_globally_activated" selected="true" />
 <select idref="rpm_verify_permissions" selected="true" />
 <select idref="rpm_verify_hashes" selected="true" />
+<select idref="security_patches_up_to_date" selected="true"/>
 <select idref="no_empty_passwords" selected="true"/>
 <select idref="file_permissions_unauthorized_sgid" selected="true"/>
 <select idref="file_permissions_unauthorized_suid" selected="true"/>
@@ -18,7 +19,8 @@ Regardless of your system's workload all of these checks should pass.</descripti
 <!-- Investigate why, fix the issues, and re-enable back once fixed -->
 <!-- <select idref="accounts_password_all_shadowed" selected="true"/> -->
 <!-- <select idref="root_path_no_dot" selected="true"/> -->
-<!-- <select idref="mount_option_dev_shm_nodev" selected="true" /> -->
-<!-- <select idref="mount_option_dev_shm_nosuid" selected="true" /> -->
+
+<select idref="mount_option_dev_shm_nodev" selected="true" />
+<select idref="mount_option_dev_shm_nosuid" selected="true" />
 
 </Profile>

--- a/shared/xccdf/system/software/updating.xml
+++ b/shared/xccdf/system/software/updating.xml
@@ -153,6 +153,7 @@ recent security patches and updates are not installed, unauthorized
 users may take advantage of weaknesses in the unpatched software. The
 lack of prompt attention to patching could result in a system compromise.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="26895-3" />
 <!-- Particular OVAL check is defined directly via <check> element above -->
 <!-- DO NOT REFERENCE an OVAL id here !!! -->

--- a/shared/xccdf/system/software/updating.xml
+++ b/shared/xccdf/system/software/updating.xml
@@ -153,7 +153,6 @@ recent security patches and updates are not installed, unauthorized
 users may take advantage of weaknesses in the unpatched software. The
 lack of prompt attention to patching could result in a system compromise.
 </rationale>
-<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="26895-3" />
 <!-- Particular OVAL check is defined directly via <check> element above -->
 <!-- DO NOT REFERENCE an OVAL id here !!! -->


### PR DESCRIPTION
Rules 'mount_option_dev_shm_nodev' and 'mount_option_dev_shm_nosuid'
are marked as 'machine' only, so they will return 'notapplicable'
anyway. Enable them so that machines can take benefit of it.

Enable 'security_patches_up_to_date' rule in standard profile, it
removed in #1303 because it doesn't make sense for containers,
but it does for RHEL7 bare-metal and virtual machines.
So adding it back, and marking the rule as 'machine' only.

And document why some rules are returning 'notapplicable' for offline scanning.

Improves standard RHEL7 profile from #589.