### PR TITLE
RHBZ #1413494: Fix the regular expression for SSHD Ciphers

### DIFF
--- a/shared/oval/sshd_use_approved_ciphers.xml
+++ b/shared/oval/sshd_use_approved_ciphers.xml
@@ -26,7 +26,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sshd_use_approved_ciphers" version="2">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)Ciphers(?-i)[\s]+aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)Ciphers(?-i)[\s]+((aes128-ctr|aes192-ctr|aes256-ctr|aes128-cbc|3des-cbc|aes192-cbc|aes256-cbc),?)+[\s]*(?:|(?:#.*))?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>


### PR DESCRIPTION
The rule allowed only exact list of the ciphers, in a required order.
If user removes some of the ciphers from /etc/ssh/sshd_config.
the configuration still fulfils the rule,
but a fail was reported, because the regular expression required
all of them listed.