### PR TITLE
Build zip archive and update usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,23 @@ rpmroot:
 	mkdir -p $(RPMBUILD)/ZIPS
 	mkdir -p $(RPMBUILD)/BUILDROOT
 
+zipfile:
+	@# ZIP only contains source datastreams and kickstarts, people who
+	@# want sources to build from should get the tarball instead.
+	rm -rf zipfile/$(PKG)
+	mkdir -p zipfile/$(PKG)
+	cp README.md zipfile/$(PKG)/
+	cp Contributors.md zipfile/$(PKG)/
+	cp LICENSE zipfile/$(PKG)/
+	rm -rf zipfile/build
+	mkdir -p zipfile/build
+	(cd zipfile/build && cmake ../../ && make -j 4)
+	cp zipfile/build/*-ds.xml zipfile/$(PKG)/
+	mkdir zipfile/$(PKG)/kickstart
+	cp RHEL/{6,7}/kickstart/*-ks.cfg zipfile/$(PKG)/kickstart/
+	(cd zipfile && zip -r $(PKG).zip $(PKG)/)
+	@echo "ZIP file is ready at zipfile/$(PKG).zip"
+
 version-update:
 	@echo -e "\nUpdating $(RPM_SPEC) version, release, and changelog..."
 	sed -e s/__NAME__/$(PKGNAME)/ \
@@ -96,5 +113,5 @@ rpm: srpm
 	@echo -e "\nBuilding $(PKGNAME) RPM..."
 	cd $(RPMBUILD)/SRPMS && rpmbuild --rebuild --target=$(ARCH) $(RPMBUILD_ARGS) --buildroot $(RPMBUILD)/BUILDROOT -bb $(PKG)-$(SSG_RELEASE_VERSION)$(OS_DIST).src.rpm
 
-.PHONY: tarball srpm rpm
+.PHONY: tarball srpm rpm zipfile
 	rm -f scap-security-guide.spec

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ version that is packaged is too old, you need to build the content yourself
 and install it via `make install`. Please see the [BUILD.md](BUILD.md)
 document for more info.
 
+Or you can download pre-built SSG zip archive from [latest release](https://github.com/OpenSCAP/scap-security-guide/releases/latest).
+
 ## Usage
 We assume you have installed SCAP Security Guide system-wide into a
 standard location as instructed in the previous section.


### PR DESCRIPTION
Until cmake is updated to generate zip archives we will use the global Makefile to build it.

Since #622 was reported README.md has improved and already contains usage of data streams.

Fixes: #622
