### PR TITLE
RHBZ #1403905: Fix rules for removable media properties

### DIFF
--- a/shared/oval/mount_option_nodev_removable_partitions.xml
+++ b/shared/oval/mount_option_nodev_removable_partitions.xml
@@ -25,10 +25,16 @@
       <criteria operator="AND">
         <extend_definition comment="Check if removable partition value represents CD/DVD drive"
         definition_ref="var_removable_partition_is_cd_dvd_drive" />
-        <criterion test_ref="test_nodev_etc_fstab_cd_dvd_drive"
-        comment="Check if at least one from CD/DVD drive alternative names is using 'nodev' mount option in /etc/fstab" />
-        <criterion test_ref="test_nodev_runtime_cd_dvd_drive"
-        comment="Check if at least one from CD/DVD drive alternative names is using 'nodev' mount option in runtime configuration" />
+        <criteria operator="OR">
+          <criteria operator="AND">
+            <criterion test_ref="test_nodev_etc_fstab_cd_dvd_drive"
+            comment="Check if at least one from CD/DVD drive alternative names is using 'nodev' mount option in /etc/fstab" />
+            <criterion test_ref="test_nodev_runtime_cd_dvd_drive"
+            comment="Check if at least one from CD/DVD drive alternative names is using 'nodev' mount option in runtime configuration" />
+          </criteria>
+          <extend_definition definition_ref="no_cd_dvd_drive_in_etc_fstab"
+          comment="Check if CD/DVD drive is not configured to automount in /etc/fstab" />
+        </criteria>
       </criteria>
       <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with 'nodev' mount option in both
            /etc/fstab & runtime configuration -->
@@ -63,7 +69,7 @@
 
   <!-- If specified removable partition represents CD / DVD drive, use all alternative
        names to check /etc/fstab & runtime settings -->
-  <ind:textfilecontent54_test id="test_nodev_etc_fstab_cd_dvd_drive" check="all" comment="'nodev' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
+  <ind:textfilecontent54_test id="test_nodev_etc_fstab_cd_dvd_drive" check_existence="any_exist" check="all" comment="'nodev' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
     <ind:object object_ref="object_nodev_etc_fstab_cd_dvd_drive" />
     <ind:state state_ref="state_nodev_etc_fstab_cd_dvd_drive" />
   </ind:textfilecontent54_test>

--- a/shared/oval/mount_option_noexec_removable_partitions.xml
+++ b/shared/oval/mount_option_noexec_removable_partitions.xml
@@ -22,10 +22,16 @@
       <criteria operator="AND">
         <extend_definition comment="Check if removable partition value represents CD/DVD drive"
         definition_ref="var_removable_partition_is_cd_dvd_drive" />
-        <criterion test_ref="test_noexec_etc_fstab_cd_dvd_drive"
-        comment="Check if at least one from CD/DVD drive alternative names is using 'noexec' mount option in /etc/fstab" />
-        <criterion test_ref="test_noexec_runtime_cd_dvd_drive"
-        comment="Check if at least one from CD/DVD drive alternative names is using 'noexec' mount option in runtime configuration" />
+        <criteria operator="OR">
+          <criteria operator="AND">
+            <criterion test_ref="test_noexec_etc_fstab_cd_dvd_drive"
+            comment="Check if at least one from CD/DVD drive alternative names is using 'noexec' mount option in /etc/fstab" />
+            <criterion test_ref="test_noexec_runtime_cd_dvd_drive"
+            comment="Check if at least one from CD/DVD drive alternative names is using 'noexec' mount option in runtime configuration" />
+          </criteria>
+          <extend_definition definition_ref="no_cd_dvd_drive_in_etc_fstab"
+          comment="Check if CD/DVD drive is not configured to automount in /etc/fstab" />
+        </criteria>
       </criteria>
       <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with 'noexec' mount option in both
            /etc/fstab & runtime configuration -->
@@ -60,7 +66,7 @@
 
   <!-- If specified removable partition represents CD / DVD drive, use all alternative
        names to check /etc/fstab & runtime settings -->
-  <ind:textfilecontent54_test id="test_noexec_etc_fstab_cd_dvd_drive" check="all" comment="'noexec' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
+  <ind:textfilecontent54_test id="test_noexec_etc_fstab_cd_dvd_drive" check_existence="any_exist" check="all" comment="'noexec' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
     <ind:object object_ref="object_noexec_etc_fstab_cd_dvd_drive" />
     <ind:state state_ref="state_noexec_etc_fstab_cd_dvd_drive" />
   </ind:textfilecontent54_test>

--- a/shared/oval/mount_option_nosuid_removable_partitions.xml
+++ b/shared/oval/mount_option_nosuid_removable_partitions.xml
@@ -26,10 +26,16 @@
       <criteria operator="AND">
         <extend_definition comment="Check if removable partition value represents CD/DVD drive"
         definition_ref="var_removable_partition_is_cd_dvd_drive" />
-        <criterion test_ref="test_nosuid_etc_fstab_cd_dvd_drive"
-        comment="Check if at least one from CD/DVD drive alternative names is using 'nosuid' mount option in /etc/fstab" />
-        <criterion test_ref="test_nosuid_runtime_cd_dvd_drive"
-        comment="Check if at least one from CD/DVD drive alternative names is using 'nosuid' mount option in runtime configuration" />
+        <criteria operator="OR">
+          <criteria operator="AND">
+            <criterion test_ref="test_nosuid_etc_fstab_cd_dvd_drive"
+            comment="Check if at least one from CD/DVD drive alternative names is using 'nosuid' mount option in /etc/fstab" />
+            <criterion test_ref="test_nosuid_runtime_cd_dvd_drive"
+            comment="Check if at least one from CD/DVD drive alternative names is using 'nosuid' mount option in runtime configuration" />
+          </criteria>
+          <extend_definition definition_ref="no_cd_dvd_drive_in_etc_fstab"
+          comment="Check if CD/DVD drive is not configured to automount in /etc/fstab" />
+        </criteria>
       </criteria>
       <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with 'nosuid' mount option in both
            /etc/fstab & runtime configuration -->
@@ -64,7 +70,7 @@
 
   <!-- If specified removable partition represents CD / DVD drive, use all alternative
        names to check /etc/fstab & runtime settings -->
-  <ind:textfilecontent54_test id="test_nosuid_etc_fstab_cd_dvd_drive" check="all" comment="'nosuid' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
+  <ind:textfilecontent54_test id="test_nosuid_etc_fstab_cd_dvd_drive" check_existence="any_exist" check="all" comment="'nosuid' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
     <ind:object object_ref="object_nosuid_etc_fstab_cd_dvd_drive" />
     <ind:state state_ref="state_nosuid_etc_fstab_cd_dvd_drive" />
   </ind:textfilecontent54_test>

--- a/shared/oval/no_cd_dvd_drive_in_etc_fstab.xml
+++ b/shared/oval/no_cd_dvd_drive_in_etc_fstab.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="compliance" id="no_cd_dvd_drive_in_etc_fstab" version="1">
+    <metadata>
+      <title>No CD/DVD drive is configured to automount in /etc/fstab</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+      </affected>
+      <description>Check the /etc/fstab and check if a CD/DVD drive
+      is not configured for automount.</description>
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_no_cd_dvd_drive_in_etc_fstab"
+      comment="Check if CD/DVD drive is not configured to automout in /etc/fstab" />
+    </criteria>
+  </definition>
+
+  <!-- If specified removable partition represents CD / DVD drive, create a variable
+       holding also alternative names for CD / DVD block special device as used by udev -->
+  <constant_variable id="variable_cd_dvd_drive_alternative_names" datatype="string" comment="CD/DVD drive alternative names whitelist" version="1">
+    <value>/dev/cdrom</value>
+    <value>/dev/dvd</value>
+    <value>/dev/scd0</value>
+    <value>/dev/sr0</value>
+  </constant_variable>
+
+  <ind:textfilecontent54_test id="test_no_cd_dvd_drive_in_etc_fstab" check_existence="none_exist" check="all" comment="'CD/DVD drive is not listed in /etc/fstab" version="1">
+    <ind:object object_ref="object_no_cd_dvd_drive_in_etc_fstab" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_no_cd_dvd_drive_in_etc_fstab" version="1">
+    <ind:filepath>/etc/fstab</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string" var_ref="variable_cd_dvd_drive_alternative_names" var_check="at least one" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>


### PR DESCRIPTION
The OVAL definitions assumed that if a machine has a CD drive,
the CD drive must have a configuration entry in /etc/fstab.
When it isn't there at all, the rules resulted in fail.
This commit fixes those false positives by allowing this situation
in mount_option_.*_removable_partition rules.