### PR TITLE
Enable building of RPM and DEB packages with CPack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,4 +220,29 @@ set(CPACK_SOURCE_IGNORE_FILES
 
 "\\\\CMakeLists.txt.user"
 )
+# Common definitions for RPM and DEB packages
+set(CPACK_PACKAGE_FILENAME "%{name}-%{version}")
+set(CPACK_PACKAGE_VERSION ${SSG_VERSION})
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Security guidance and baselines in SCAP formats")
+set(CPACK_PACKAGE_VENDOR "scap-security-guide")
+# The package contact is needed to build the deb package
+set(CPACK_PACKAGE_CONTACT "open-scap-list@redhat.com")
+set(CPACK_PACKAGE_RELOCATABLE FALSE)
+set(CPACK_RPM_PACKAGE_GROUP "Applications/System")
+set(CPACK_RPM_PACKAGE_LICENSE "Public Domain")
+set(CPACK_RPM_PACKAGE_URL "https://www.open-scap.org/security-policies/scap-security-guide/")
+set(CPACK_RPM_PACKAGE_ARCHITECTURE "noarch")
+set(CPACK_RPM_PACKAGE_REQUIRES "xml-common, openscap-utils >= 1.0.8")
+set(CPACK_RPM_PACKAGE_PROVIDES "openscap-content")
+set(CPACK_RPM_PACKAGE_DESCRIPTION "The %{name} project provides a guide for configuration of the
+system from the final system's security point of view. The guidance is
+specified in the Security Content Automation Protocol (SCAP) format and
+constitutes a catalog of practical hardening advice, linked to government
+requirements where applicable. The project bridges the gap between generalized
+policy requirements and specific implementation guidelines. The system
+administrator can use the oscap command-line tool from the openscap-utils
+package to verify that the system conforms to provided guidelines.
+")
+
+set(CPACK_GENERATOR "RPM;DEB")
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(scap-security-guide NONE)
 
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "content")
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 # This is set to silence GNUInstallDirs warning about no language being used with cmake
 set(CMAKE_INSTALL_LIBDIR "/nowhere")
@@ -228,6 +229,8 @@ set(CPACK_PACKAGE_VENDOR "scap-security-guide")
 # The package contact is needed to build the deb package
 set(CPACK_PACKAGE_CONTACT "open-scap-list@redhat.com")
 set(CPACK_PACKAGE_RELOCATABLE FALSE)
+
+set(CPACK_RPM_COMPONENT_INSTALL TRUE)
 set(CPACK_RPM_PACKAGE_GROUP "Applications/System")
 set(CPACK_RPM_PACKAGE_LICENSE "Public Domain")
 set(CPACK_RPM_PACKAGE_URL "https://www.open-scap.org/security-policies/scap-security-guide/")
@@ -243,6 +246,14 @@ policy requirements and specific implementation guidelines. The system
 administrator can use the oscap command-line tool from the openscap-utils
 package to verify that the system conforms to provided guidelines.
 ")
+
+set(CPACK_RPM_DOC_PACKAGE_SUMMARY "HTML formatted documents containing security guides generated from XCCDF benchmarks.
+")
+set(CPACK_RPM_DOC_PACKAGE_DESCRIPTION "The %{name} package contains HTML formatted documents containing
+hardening guidances that have been generated from XCCDF benchmarks
+present in %{name} package.
+")
+
 
 set(CPACK_GENERATOR "RPM;DEB")
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,7 @@ set(CPACK_PACKAGE_CONTACT "open-scap-list@redhat.com")
 set(CPACK_PACKAGE_RELOCATABLE FALSE)
 
 set(CPACK_RPM_COMPONENT_INSTALL TRUE)
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/share/xml;/usr/share/man;/usr/share/man/man8")
 set(CPACK_RPM_PACKAGE_GROUP "Applications/System")
 set(CPACK_RPM_PACKAGE_LICENSE "Public Domain")
 set(CPACK_RPM_PACKAGE_URL "https://www.open-scap.org/security-policies/scap-security-guide/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,11 +258,14 @@ set(CPACK_RPM_CONTENT_PACKAGE_NAME "scap-security-guide")
 # This puts the component name right after package name
 # and also adds the dist after the version
 set(CPACK_RPM_FILE_NAME "%{name}-%{version}-%{release}.rpm")
+
+set(CPACK_RPM_DOC_PACKAGE_GROUP "System Environment/Base")
+set(CPACK_RPM_DOC_PACKAGE_REQUIRES "scap-security-guide = ${SSG_VERSION}")
 set(CPACK_RPM_DOC_PACKAGE_SUMMARY "HTML formatted documents containing security guides generated from XCCDF benchmarks.
 ")
 set(CPACK_RPM_DOC_PACKAGE_DESCRIPTION "The %{name} package contains HTML formatted documents containing
 hardening guidances that have been generated from XCCDF benchmarks
-present in %{name} package.
+present in scap-security-guide package.
 ")
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,10 @@ administrator can use the oscap command-line tool from the openscap-utils
 package to verify that the system conforms to provided guidelines.
 ")
 
+# Set the name of content component to be only scap-security-guide in the generated spec file
+# In other words, remove the "content" name added by CPack to default component
+set(CPACK_RPM_CONTENT_PACKAGE_NAME "scap-security-guide")
+
 # Change the default file name of the RPMs
 # This puts the component name right after package name
 # and also adds the dist after the version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,6 @@ set(CPACK_SOURCE_IGNORE_FILES
 "\\\\CMakeLists.txt.user"
 )
 # Common definitions for RPM and DEB packages
-set(CPACK_PACKAGE_FILENAME "%{name}-%{version}")
 set(CPACK_PACKAGE_VERSION ${SSG_VERSION})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Security guidance and baselines in SCAP formats")
 set(CPACK_PACKAGE_VENDOR "scap-security-guide")
@@ -248,6 +247,10 @@ administrator can use the oscap command-line tool from the openscap-utils
 package to verify that the system conforms to provided guidelines.
 ")
 
+# Change the default file name of the RPMs
+# This puts the component name right after package name
+# and also adds the dist after the version
+set(CPACK_RPM_FILE_NAME "%{name}-%{version}-%{release}.rpm")
 set(CPACK_RPM_DOC_PACKAGE_SUMMARY "HTML formatted documents containing security guides generated from XCCDF benchmarks.
 ")
 set(CPACK_RPM_DOC_PACKAGE_DESCRIPTION "The %{name} package contains HTML formatted documents containing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,9 @@ set(CPACK_PACKAGE_CONTACT "open-scap-list@redhat.com")
 set(CPACK_PACKAGE_RELOCATABLE FALSE)
 
 set(CPACK_RPM_COMPONENT_INSTALL TRUE)
+
+# This adds "${?dist} to Release field in spec file
+set(CPACK_RPM_PACKAGE_RELEASE_DIST TRUE)
 set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/share/xml;/usr/share/man;/usr/share/man/man8")
 set(CPACK_RPM_PACKAGE_GROUP "Applications/System")
 set(CPACK_RPM_PACKAGE_LICENSE "Public Domain")

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -702,9 +702,10 @@ macro(ssg_build_product PRODUCT)
     install(
        CODE "
            file(GLOB GUIDE_FILES \"${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-guide-*.html\") \n
-           file(INSTALL DESTINATION \"${CMAKE_INSTALL_PREFIX}/${SSG_GUIDE_INSTALL_DIR}\"
+           file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${SSG_GUIDE_INSTALL_DIR}\"
            TYPE FILE FILES \${GUIDE_FILES}
        )"
+       COMPONENT doc
     )
 
     # grab all the kickstarts (if any) and install them
@@ -791,9 +792,10 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
     install(
        CODE "
        file(GLOB GUIDE_FILES \"${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-guide-*.html\") \n
-           file(INSTALL DESTINATION \"${CMAKE_INSTALL_PREFIX}/${SSG_GUIDE_INSTALL_DIR}\"
+           file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${SSG_GUIDE_INSTALL_DIR}\"
            TYPE FILE FILES \${GUIDE_FILES}
        )"
+       COMPONENT doc
     )
 endmacro()
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -815,7 +815,8 @@ macro(ssg_build_html_table_by_ref PRODUCT REF)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-by-ref-${REF})
 
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/table-${PRODUCT}-${REF}refs.html"
-        DESTINATION "${SSG_TABLE_INSTALL_DIR}")
+        DESTINATION "${SSG_TABLE_INSTALL_DIR}"
+        COMPONENT doc)
 endmacro()
 
 macro(ssg_build_html_nistrefs_table PRODUCT PROFILE)
@@ -834,7 +835,8 @@ macro(ssg_build_html_nistrefs_table PRODUCT PROFILE)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-nistrefs-${PROFILE})
 
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/table-${PRODUCT}-nistrefs-${PROFILE}.html"
-        DESTINATION "${SSG_TABLE_INSTALL_DIR}")
+        DESTINATION "${SSG_TABLE_INSTALL_DIR}"
+        COMPONENT doc)
 endmacro()
 
 macro(ssg_build_html_cce_table PRODUCT)
@@ -853,7 +855,8 @@ macro(ssg_build_html_cce_table PRODUCT)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-cces)
 
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/table-${PRODUCT}-cces.html"
-        DESTINATION "${SSG_TABLE_INSTALL_DIR}")
+        DESTINATION "${SSG_TABLE_INSTALL_DIR}"
+        COMPONENT doc)
 endmacro()
 
 macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_VERSION)
@@ -887,9 +890,11 @@ macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_VERSION)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-srg)
 
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/table-${PRODUCT}-srgmap.html"
-        DESTINATION "${SSG_TABLE_INSTALL_DIR}")
+        DESTINATION "${SSG_TABLE_INSTALL_DIR}"
+        COMPONENT doc)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/table-${PRODUCT}-srgmap-flat.html"
-        DESTINATION "${SSG_TABLE_INSTALL_DIR}")
+        DESTINATION "${SSG_TABLE_INSTALL_DIR}"
+        COMPONENT doc)
 endmacro()
 
 macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
@@ -932,7 +937,9 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-stig)
 
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/table-${PRODUCT}-stig.html"
-        DESTINATION "${SSG_TABLE_INSTALL_DIR}")
+        DESTINATION "${SSG_TABLE_INSTALL_DIR}"
+        COMPONENT doc)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/table-${PRODUCT}-stig-testinfo.html"
-        DESTINATION "${SSG_TABLE_INSTALL_DIR}")
+        DESTINATION "${SSG_TABLE_INSTALL_DIR}"
+        COMPONENT doc)
 endmacro()


### PR DESCRIPTION
Build RPM and DEB packages using CPack.

Packages are not identical to the one generated using the included spec file.
I couldn't remove "Linux" from the name of the generated rpm and debs, for example.

The RPMs installs nicely, but I didn't test the DEB.