### PR TITLE
Issue #1889: remediation sshd_use_approved_macs

### DIFF
--- a/RHEL/7/input/oval/sshd_use_approved_macs.xml
+++ b/RHEL/7/input/oval/sshd_use_approved_macs.xml
@@ -18,14 +18,40 @@
       </criteria>
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+
+  <ind:variable_test check="at least one"
   comment="tests the value of MACs setting in the /etc/ssh/sshd_config file"
   id="test_sshd_use_approved_macs" version="1">
     <ind:object object_ref="obj_sshd_use_approved_macs" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_sshd_use_approved_macs" version="1">
+    <ind:state state_ref="ste_sshd_use_approved_macs" />
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_sshd_use_approved_macs" version="1">
+    <ind:var_ref>var_sshd_config_macs</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state comment="approved macs" id="ste_sshd_use_approved_macs" version="1">
+    <ind:value operation="equals" datatype="string" var_ref="var_sshd_approved_macs" var_check="at least one" />
+  </ind:variable_state>
+
+  <ind:textfilecontent54_object id="obj_sshd_config_macs" version="1">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)MACs(?-i)[\s]+hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)MACs(?-i)[\s]+([\w,-@]+)+[\s]*(?:|(?:#.*))?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <local_variable id="var_sshd_config_macs" datatype="string" version="1" comment="MACs values splitted on comma">
+    <split delimiter=",">
+      <object_component item_field="subexpression" object_ref="obj_sshd_config_macs" />
+    </split>
+  </local_variable>
+
+  <local_variable id="var_sshd_approved_macs" datatype="string" version="1" comment="approved MACs values splitted on comma">
+    <split delimiter=",">
+      <variable_component var_ref="sshd_approved_macs" />
+    </split>
+  </local_variable>
+
+  <external_variable comment="SSH Approved MACs by FIPS" datatype="string" id="sshd_approved_macs" version="1" />
+
 </def-group>

--- a/RHEL/7/templates/static/bash/sshd_use_approved_macs.sh
+++ b/RHEL/7/templates/static/bash/sshd_use_approved_macs.sh
@@ -1,0 +1,8 @@
+# platform = Red Hat Enterprise Linux 7
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+populate sshd_approved_macs
+
+replace_or_append '/etc/ssh/sshd_config' '^MACs' "$sshd_approved_macs" '$CCENUM' '%s %s'

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -30,6 +30,14 @@ operator="equals" interactive="0">
 <value selector="default">22</value>
 </Value>
 
+<Value id="sshd_approved_macs" type="string"
+operator="equals" interactive="0">
+<title>SSH Approved MACs by FIPS</title>
+<description>Specify the FIPS approved MACs (message authentication code) algorithms
+	that are used for data integrity protection by the SSH server.</description>
+<value selector="default">hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com</value>
+</Value>
+
 <Rule id="package_openssh-server_installed" severity="medium" prodtype="rhel7">
 <title>Install the OpenSSH Server Package</title>
 <description>
@@ -713,7 +721,7 @@ DoD Information Systems are required to use FIPS-approved cryptographic hash
 functions. The only SSHv2 hash algorithms meeting this requirement is SHA2.
 </rationale>
 <ident prodtype="rhel7" cce="27455-5" />
-<oval id="sshd_use_approved_macs" />
+<oval id="sshd_use_approved_macs" value="sshd_approved_macs" />
 <ref prodtype="rhel7" nist="AC-17(2),IA-7,SC-13" disa="1453"
 ossrg="SRG-OS-000250-GPOS-00093" stigid="040400" cui="3.1.13,3.13.11,3.13.8" />
 </Rule>


### PR DESCRIPTION
This pull request provides a remediation specific for RHEL7 and fixes the OVAL definition in rule `sshd_use_approved_macs`