### PR TITLE
Build zipfiles through CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,11 +209,16 @@ install(FILES "${CMAKE_SOURCE_DIR}/Contributors.md"
 install(FILES "docs/scap-security-guide.8"
     DESTINATION "${CMAKE_INSTALL_MANDIR}/man8")
 
+# ZIP only contains source datastreams and kickstarts, people who
+# want sources to build from should get the tarball instead.
 if(SSG_OVAL_511_ENABLED)
     ssg_build_zipfile("scap-security-guide-${SSG_VERSION}")
 else()
     ssg_build_zipfile("scap-security-guide-${SSG_VERSION}-oval-5.10")
 endif()
+
+# We use CPack to generate the tarball with all sources and
+# packages for testing
 
 # only CPack should follow
 set(CPACK_CMAKE_GENERATOR "Unix Makefiles")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,9 +136,20 @@ message("Webmin: ${SSG_PRODUCT_WEBMIN}")
 
 message(" ")
 
+include(SSGCommon)
+
+# Targets 'validate' and 'zipfile' need to be added before any product because
+# they will receive dependencies from products added
+
 add_custom_target(validate)
 
-include(SSGCommon)
+# ZIP only contains source datastreams and kickstarts, people who
+# want sources to build from should get the tarball instead.
+if(SSG_OVAL_511_ENABLED)
+    ssg_build_zipfile("scap-security-guide-${SSG_VERSION}")
+else()
+    ssg_build_zipfile("scap-security-guide-${SSG_VERSION}-oval-5.10")
+endif()
 
 if (SSG_PRODUCT_CHROMIUM)
     add_subdirectory("Chromium")
@@ -208,14 +219,6 @@ install(FILES "${CMAKE_SOURCE_DIR}/Contributors.md"
 
 install(FILES "docs/scap-security-guide.8"
     DESTINATION "${CMAKE_INSTALL_MANDIR}/man8")
-
-# ZIP only contains source datastreams and kickstarts, people who
-# want sources to build from should get the tarball instead.
-if(SSG_OVAL_511_ENABLED)
-    ssg_build_zipfile("scap-security-guide-${SSG_VERSION}")
-else()
-    ssg_build_zipfile("scap-security-guide-${SSG_VERSION}-oval-5.10")
-endif()
 
 # We use CPack to generate the tarball with all sources and
 # packages for testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,12 @@ install(FILES "${CMAKE_SOURCE_DIR}/Contributors.md"
 install(FILES "docs/scap-security-guide.8"
     DESTINATION "${CMAKE_INSTALL_MANDIR}/man8")
 
+if(SSG_OVAL_511_ENABLED)
+    ssg_build_zipfile("scap-security-guide-${SSG_VERSION}")
+else()
+    ssg_build_zipfile("scap-security-guide-${SSG_VERSION}-oval-5.10")
+endif()
+
 # only CPack should follow
 set(CPACK_CMAKE_GENERATOR "Unix Makefiles")
 set(CPACK_SOURCE_GENERATOR "TBZ2")

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -943,3 +943,23 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
         DESTINATION "${SSG_TABLE_INSTALL_DIR}"
         COMPONENT doc)
 endmacro()
+
+macro(ssg_build_zipfile ZIPNAME)
+    add_custom_command(
+        OUTPUT "${CMAKE_BINARY_DIR}/zipfile/${ZIPNAME}.zip"
+        COMMAND ${CMAKE_COMMAND} -E remove_directory "zipfile/"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "zipfile/${ZIPNAME}/kickstart"
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/README.md" "zipfile/${ZIPNAME}"
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/Contributors.md" "zipfile/${ZIPNAME}"
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/LICENSE" "zipfile/${ZIPNAME}"
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/RHEL/{6,7}/kickstart/*-ks.cfg" "zipfile/${ZIPNAME}/kickstart"
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/ssg-*-ds.xml" "zipfile/${ZIPNAME}"
+        COMMAND ${CMAKE_COMMAND} -E chdir "zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}.zip" --format=zip "${ZIPNAME}"
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-*-ds.xml" # A change in any data stream will cause the zipfile to be rebuilt
+        COMMENT "Building zipfile at ${CMAKE_BINARY_DIR}/zipfile/${ZIPNAME}.zip"
+        )
+    add_custom_target(
+        zipfile
+        DEPENDS "${CMAKE_BINARY_DIR}/zipfile/${ZIPNAME}.zip"
+    )
+endmacro()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -670,6 +670,8 @@ macro(ssg_build_product PRODUCT)
     )
     add_dependencies(validate ${PRODUCT}-validate)
 
+    add_dependencies(zipfile "generate-ssg-${PRODUCT}-ds.xml")
+
     ssg_build_html_guides(${PRODUCT})
 
     add_custom_target(
@@ -955,7 +957,6 @@ macro(ssg_build_zipfile ZIPNAME)
         COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/RHEL/{6,7}/kickstart/*-ks.cfg" "zipfile/${ZIPNAME}/kickstart"
         COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/ssg-*-ds.xml" "zipfile/${ZIPNAME}"
         COMMAND ${CMAKE_COMMAND} -E chdir "zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}.zip" --format=zip "${ZIPNAME}"
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-*-ds.xml" # A change in any data stream will cause the zipfile to be rebuilt
         COMMENT "Building zipfile at ${CMAKE_BINARY_DIR}/zipfile/${ZIPNAME}.zip"
         )
     add_custom_target(


### PR DESCRIPTION
The zipfile is built with whatever data stream already built in
CMAKE_BINARY_DIR.
The zipfile name will vary according to configuration of OVAL version
enabled.