### PR TITLE
Issue #1876: Add remediation script for aide_use_fips_hashes

### DIFF
--- a/shared/templates/static/bash/aide_use_fips_hashes.sh
+++ b/shared/templates/static/bash/aide_use_fips_hashes.sh
@@ -1,0 +1,27 @@
+# platform = multi_platform_rhel, multi_platform_fedora
+
+aide_conf="/etc/aide.conf"
+forbidden_hashes=(sha1 rmd160 sha256 whirlpool tiger haval gost crc32)
+
+groups=$(grep "^[A-Z]\+" $aide_conf | cut -f1 -d ' ' | tr -d ' ' | sort -u)
+
+for group in $groups
+do
+	config=$(grep "^$group\s*=" $aide_conf | cut -f2 -d '=' | tr -d ' ')
+
+	if ! [[ $config = *sha512* ]]
+	then
+		config=$config"+sha512"
+	fi
+
+	for hash in ${forbidden_hashes[@]}
+	do
+		config=$(echo $config | sed "s/$hash//")
+	done
+
+	config=$(echo $config | sed "s/^\+*//")
+	config=$(echo $config | sed "s/\+\++/+/")
+	config=$(echo $config | sed "s/\+$//")
+
+	sed -i "s/^$group\s*=.*/$group = $config/g" $aide_conf
+done


### PR DESCRIPTION
This remediation script goes through /etc/aide.conf, removes
those hashes that are not FIPS-approved and adds sha512 where
appropriate.