### PR TITLE
Fix svg detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if (SSG_OVAL_511_ENABLED AND NOT "${OSCAP_V_OUTPUT}" MATCHES "OVAL Version: 5.11
 endif()
 
 execute_process(
-    COMMAND "${SSG_SHARED_UTILS}/oscap-svg-support.py"
+    COMMAND "${SSG_SHARED_UTILS}/oscap-svg-support.py" "${OSCAP_EXECUTABLE}"
     RESULT_VARIABLE OSCAP_SVG_SUPPORT_RESULT
 )
 # OSCAP_SVG_SUPPORT_RESULT == 0 means SVG is supported

--- a/shared/utils/oscap-svg-support.py
+++ b/shared/utils/oscap-svg-support.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from subprocess import Popen, PIPE
+import subprocess
 import tempfile
 import sys
 
@@ -38,16 +38,9 @@ def main():
     xccdf.flush()
 
     # Call oscap process to generate guide
-    command = "oscap xccdf generate guide %s" % (xccdf.name)
-    child = Popen(command.split(), stdout=PIPE, stderr=PIPE)
-    out, err = child.communicate()
-    out = out.decode("utf-8")
-    print(out)
-
-    # Child run sanity check
-    if child.returncode != 0:
-        # Set exit value to failure
-        EXIT_CODE = 1
+    out = subprocess.check_output(
+        ["oscap", "xccdf", "generate", "guide", xccdf.name]
+    ).decode("utf-8")
 
     # Check if generated guide contains desired SVG element
     if "circle" in out:

--- a/shared/utils/oscap-svg-support.py
+++ b/shared/utils/oscap-svg-support.py
@@ -34,11 +34,11 @@ def main():
     xccdf.write(svg_benchmark.encode("utf-8"))
     xccdf.flush()
 
-    # Call oscap process to generate guide
     out = subprocess.check_output(
         ["oscap", "xccdf", "generate", "guide", xccdf.name]
     ).decode("utf-8")
 
+    # check whether oscap threw away the SVG elements
     sys.exit(0 if "circle" in out else 1)
 
 

--- a/shared/utils/oscap-svg-support.py
+++ b/shared/utils/oscap-svg-support.py
@@ -30,12 +30,14 @@ svg_benchmark = """<?xml version="1.0"?>
 
 
 def main():
+    oscap_executable = sys.argv[1]
+
     xccdf = tempfile.NamedTemporaryFile()
     xccdf.write(svg_benchmark.encode("utf-8"))
     xccdf.flush()
 
     out = subprocess.check_output(
-        ["oscap", "xccdf", "generate", "guide", xccdf.name]
+        [oscap_executable, "xccdf", "generate", "guide", xccdf.name]
     ).decode("utf-8")
 
     # check whether oscap threw away the SVG elements

--- a/shared/utils/oscap-svg-support.py
+++ b/shared/utils/oscap-svg-support.py
@@ -5,8 +5,6 @@ from tempfile import mkstemp
 import os
 import sys
 
-# Default exit with failure
-EXIT_CODE = 1
 
 svg_benchmark = """<?xml version="1.0"?>
 <Benchmark xmlns="http://checklists.nist.gov/xccdf/1.1"
@@ -31,38 +29,46 @@ svg_benchmark = """<?xml version="1.0"?>
 </Benchmark>
 """
 
-# Create temporary file with the content of svg_benchmark variable above
-fd, filename = mkstemp(prefix='svg_', suffix='.xml')
-xccdf = os.fdopen(fd, 'wt')
-xccdf.write(svg_benchmark)
-xccdf.close()
 
-# Call oscap process to generate guide
-command = "oscap xccdf generate guide %s" % filename
-child = Popen(command.split(), stdout=PIPE, stderr=PIPE)
-out, err = child.communicate()
-out = out.decode("utf-8")
-
-# Child run sanity check
-if child.returncode != 0:
-    # Set exit value to failure
+def main():
+    # Default exit with failure
     EXIT_CODE = 1
 
-# Delete the temporary file
-try:
-    os.remove(filename)
-except OSError as e:
-    sys.stderr.write(
-        "Error removing file: %s - %s\n" % (e.filename, e.strerror)
-    )
+    # Create temporary file with the content of svg_benchmark variable above
+    fd, filename = mkstemp(prefix='svg_', suffix='.xml')
+    xccdf = os.fdopen(fd, 'wt')
+    xccdf.write(svg_benchmark)
+    xccdf.close()
 
-# Check if generated guide contains desired SVG element
-if "circle" in out:
-    # If so, set exit value to success
-    EXIT_CODE = 0
-else:
-    # Otherwise to failure
-    EXIT_CODE = 1
+    # Call oscap process to generate guide
+    command = "oscap xccdf generate guide %s" % filename
+    child = Popen(command.split(), stdout=PIPE, stderr=PIPE)
+    out, err = child.communicate()
+    out = out.decode("utf-8")
 
-# Call exit with appropriate value
-sys.exit(EXIT_CODE)
+    # Child run sanity check
+    if child.returncode != 0:
+        # Set exit value to failure
+        EXIT_CODE = 1
+
+    # Delete the temporary file
+    try:
+        os.remove(filename)
+    except OSError as e:
+        sys.stderr.write(
+            "Error removing file: %s - %s\n" % (e.filename, e.strerror)
+        )
+
+    # Check if generated guide contains desired SVG element
+    if "circle" in out:
+        # If so, set exit value to success
+        EXIT_CODE = 0
+    else:
+        # Otherwise to failure
+        EXIT_CODE = 1
+
+    # Call exit with appropriate value
+    sys.exit(EXIT_CODE)
+
+if __name__ == "__main__":
+    main()

--- a/shared/utils/oscap-svg-support.py
+++ b/shared/utils/oscap-svg-support.py
@@ -38,7 +38,7 @@ xccdf.write(svg_benchmark)
 xccdf.close()
 
 # Call oscap process to generate guide
-command = "oscap xccdf generate guide --profile allrules %s" % filename
+command = "oscap xccdf generate guide %s" % filename
 child = Popen(command.split(), stdout=PIPE, stderr=PIPE)
 out, err = child.communicate()
 out = out.decode("utf-8")

--- a/shared/utils/oscap-svg-support.py
+++ b/shared/utils/oscap-svg-support.py
@@ -30,9 +30,6 @@ svg_benchmark = """<?xml version="1.0"?>
 
 
 def main():
-    # Default exit with failure
-    EXIT_CODE = 1
-
     xccdf = tempfile.NamedTemporaryFile()
     xccdf.write(svg_benchmark.encode("utf-8"))
     xccdf.flush()
@@ -42,16 +39,8 @@ def main():
         ["oscap", "xccdf", "generate", "guide", xccdf.name]
     ).decode("utf-8")
 
-    # Check if generated guide contains desired SVG element
-    if "circle" in out:
-        # If so, set exit value to success
-        EXIT_CODE = 0
-    else:
-        # Otherwise to failure
-        EXIT_CODE = 1
+    sys.exit(0 if "circle" in out else 1)
 
-    # Call exit with appropriate value
-    sys.exit(EXIT_CODE)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The SVG detection got broken with fixes in oscap XSLT for HTML guides. We now terminate HTML guide generation when profile doesn't exist. See https://github.com/OpenSCAP/openscap/pull/671

This PR fixes it and refactors the oscap-svg-support.py script to be way simpler and easier to understand.