### PR TITLE
Bring shellcheck back

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ if (NOT SED_EXECUTABLE)
     message(FATAL_ERROR "sed is required!")
 endif()
 
+find_program(SHELLCHECK_EXECUTABLE NAMES shellcheck)
+
 configure_file("${CMAKE_SOURCE_DIR}/oval.config.in" "${CMAKE_BINARY_DIR}/oval.config")
 
 message("Tools:")
@@ -105,6 +107,7 @@ message("xsltproc: ${XSLTPROC_EXECUTABLE}")
 message("xmllint: ${XMLLINT_EXECUTABLE}")
 message("xmlwf: ${XMLWF_EXECUTABLE}")
 message("sed: ${SED_EXECUTABLE}")
+message("shellcheck (optional): ${SHELLCHECK_EXECUTABLE}")
 message(" ")
 
 message("Build options:")

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -203,6 +203,25 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGE)
         DEPENDS ${LANGUAGE_REMEDIATIONS_OUTPUTS}
         DEPENDS ${SHARED_LANGUAGE_REMEDIATIONS_OUTPUTS}
     )
+
+    if (SHELLCHECK_EXECUTABLE AND "${LANGUAGE}" STREQUAL "bash")
+        add_custom_command(
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shellcheck-validation-bash-remediations"
+            # SC1071: ShellCheck only supports sh/bash/ksh scripts
+            # SC1091: Not following: /usr/share/scap-security-guide/remediation_functions
+            # TODO: Stop ignoring the exit code as we fix the bash issues
+            COMMAND "${SHELLCHECK_EXECUTABLE}" --shell bash --exclude SC1071,SC1091 ${LANGUAGE_REMEDIATIONS_DEPENDS} ${SHARED_LANGUAGE_REMEDIATIONS_DEPENDS} ${EXTRA_LANGUAGE_DEPENDS} ${EXTRA_SHARED_LANGUAGE_DEPENDS} || "true"
+            COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/shellcheck-validation-bash-remediations"
+            VERBATIM
+            COMMENT "[${PRODUCT}-validate] validating inputs for bash remediations"
+        )
+        add_custom_target(
+            validate-ssg-${PRODUCT}-bash-remediation-inputs
+            DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/shellcheck-validation-bash-remediations"
+        )
+        add_dependencies(${PRODUCT}-validate validate-ssg-${PRODUCT}-bash-remediation-inputs)
+    endif()
+
 endmacro()
 
 macro(ssg_build_remediations PRODUCT)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -629,6 +629,9 @@ macro(ssg_build_html_guides PRODUCT)
 endmacro()
 
 macro(ssg_build_product PRODUCT)
+    add_custom_target(${PRODUCT}-content)
+    add_custom_target(${PRODUCT}-validate)
+
     ssg_build_guide_xml(${PRODUCT})
     ssg_build_shorthand_xml(${PRODUCT})
     ssg_build_xccdf_unlinked(${PRODUCT})
@@ -647,27 +650,27 @@ macro(ssg_build_product PRODUCT)
     ssg_build_sds(${PRODUCT})
 
     add_custom_target(${PRODUCT} ALL)
-
-    add_custom_target(
-        ${PRODUCT}-content
-        DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
-        DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
-        DEPENDS generate-ssg-${PRODUCT}-oval.xml
-        DEPENDS generate-ssg-${PRODUCT}-ocil.xml
-        DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml
-        DEPENDS generate-ssg-${PRODUCT}-ds.xml
-    )
     add_dependencies(${PRODUCT} ${PRODUCT}-content)
 
-    add_custom_target(
+    add_dependencies(
+        ${PRODUCT}-content
+        generate-ssg-${PRODUCT}-xccdf.xml
+        generate-ssg-${PRODUCT}-xccdf-1.2.xml
+        generate-ssg-${PRODUCT}-oval.xml
+        generate-ssg-${PRODUCT}-ocil.xml
+        generate-ssg-${PRODUCT}-cpe-dictionary.xml
+        generate-ssg-${PRODUCT}-ds.xml
+    )
+
+    add_dependencies(
         ${PRODUCT}-validate
-        DEPENDS validate-ssg-${PRODUCT}-xccdf.xml
-        #DEPENDS validate-ssg-${PRODUCT}-xccdf-1.2.xml
-        DEPENDS validate-ssg-${PRODUCT}-oval.xml
-        #DEPENDS validate-ssg-${PRODUCT}-ocil.xml
-        DEPENDS validate-ssg-${PRODUCT}-cpe-dictionary.xml
-        DEPENDS validate-ssg-${PRODUCT}-cpe-oval.xml
-        DEPENDS validate-ssg-${PRODUCT}-ds.xml
+        validate-ssg-${PRODUCT}-xccdf.xml
+        #validate-ssg-${PRODUCT}-xccdf-1.2.xml
+        validate-ssg-${PRODUCT}-oval.xml
+        #validate-ssg-${PRODUCT}-ocil.xml
+        validate-ssg-${PRODUCT}-cpe-dictionary.xml
+        validate-ssg-${PRODUCT}-cpe-oval.xml
+        validate-ssg-${PRODUCT}-ds.xml
     )
     add_dependencies(validate ${PRODUCT}-validate)
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -207,10 +207,11 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGE)
     if (SHELLCHECK_EXECUTABLE AND "${LANGUAGE}" STREQUAL "bash")
         add_custom_command(
             OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shellcheck-validation-bash-remediations"
+            # format gcc so that people using IDEs can click on errors to get to the problematic lines
             # SC1071: ShellCheck only supports sh/bash/ksh scripts
             # SC1091: Not following: /usr/share/scap-security-guide/remediation_functions
             # TODO: Stop ignoring the exit code as we fix the bash issues
-            COMMAND "${SHELLCHECK_EXECUTABLE}" --shell bash --exclude SC1071,SC1091 ${LANGUAGE_REMEDIATIONS_DEPENDS} ${SHARED_LANGUAGE_REMEDIATIONS_DEPENDS} ${EXTRA_LANGUAGE_DEPENDS} ${EXTRA_SHARED_LANGUAGE_DEPENDS} || "true"
+            COMMAND "${SHELLCHECK_EXECUTABLE}" --format gcc --shell bash --exclude SC1071,SC1091 ${LANGUAGE_REMEDIATIONS_DEPENDS} ${SHARED_LANGUAGE_REMEDIATIONS_DEPENDS} ${EXTRA_LANGUAGE_DEPENDS} ${EXTRA_SHARED_LANGUAGE_DEPENDS} || "true"
             COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/shellcheck-validation-bash-remediations"
             VERBATIM
             COMMENT "[${PRODUCT}-validate] validating inputs for bash remediations"

--- a/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
+++ b/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
@@ -4,7 +4,7 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate sshd_listening_port
 
-if [ $sshd_listening_port -ne 22] ; then
+if [ $sshd_listening_port -ne 22 ] ; then
   firewall-cmd --permanent --add-port=$sshd_listening_port/tcp
 else
   firewall-cmd --permanent --add-service=ssh


### PR DESCRIPTION
We used to run `shellcheck` on bash remediation inputs but we stopped doing that with the move to cmake. This PR brings shell checking back. Since we stopped running shellcheck we have introduced quite a few new errors, mostly word splitting. For now the build will not fail with shellcheck issues, I am hoping we will be able to fix the issues and start failing validation again when new issues are introduced.

There are some false positives, for example $CCENUM. We tend to use bash-like syntax for template replacement. We should probably change that to something else to avoid confusing shellcheck and developers.

Example of output:
```
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/auditd_data_retention_max_log_file.sh:8:46: warning: var_auditd_max_log_file is referenced but not assigned. [SC2154]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/auditd_data_retention_max_log_file.sh:9:8: note: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?. [SC2181]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sshd_allow_only_protocol2.sh:6:58: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/auditd_data_retention_max_log_file_action.sh:8:60: warning: var_auditd_max_log_file_action is referenced but not assigned. [SC2154]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/auditd_data_retention_max_log_file_action.sh:9:8: note: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?. [SC2181]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sshd_disable_compression.sh:6:62: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/auditd_data_retention_num_logs.sh:8:38: warning: var_auditd_num_logs is referenced but not assigned. [SC2154]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/auditd_data_retention_num_logs.sh:9:8: note: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?. [SC2181]
[  3%] Built target generate-internal-opensuse-shorthand.xml
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/auditd_data_retention_space_left_action.sh:12:62: warning: var_auditd_space_left_action is referenced but not assigned. [SC2154]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sshd_disable_gssapi_auth.sh:6:71: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/bootloader_nousb_argument.sh:4:14: warning: Quote the grep pattern so the shell won't interpret it. [SC2062]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/disable_host_auth.sh:4:8: note: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?. [SC2181]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sshd_disable_kerb_auth.sh:6:73: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sshd_disable_rhosts.sh:6:64: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sshd_disable_rhosts_rsa.sh:6:74: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/display_login_attempts.sh:3:6: warning: Remove backticks to avoid executing output. [SC2092]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/display_login_attempts.sh:3:6: note: Use $(..) instead of legacy `..`. [SC2006]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/display_login_attempts.sh:3:15: warning: Quote the grep pattern so the shell won't interpret it. [SC2062]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/display_login_attempts.sh:4:13: warning: Quote this to prevent word splitting. [SC2046]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/display_login_attempts.sh:4:13: note: Use $(..) instead of legacy `..`. [SC2006]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/ensure_gpgcheck_globally_activated.sh:4:51: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sshd_disable_user_known_hosts.sh:6:72: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sshd_enable_strictmodes.sh:6:63: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sshd_print_last_log.sh:6:64: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/ensure_redhat_gpgkey_installed.sh:15:13: warning: GPG_OUT appears unused. Verify it or export it. [SC2034]
[  3%] Built target generate-ssg-opensuse-cpe-dictionary.xml
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/file_ownership_var_log_audit.sh:3:4: warning: Remove backticks to avoid executing output. [SC2092]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/file_ownership_var_log_audit.sh:3:4: note: Use $(..) instead of legacy `..`. [SC2006]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/file_ownership_var_log_audit.sh:6:16: note: Double quote to prevent globbing and word splitting. [SC2086]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/file_ownership_var_log_audit.sh:7:16: note: Double quote to prevent globbing and word splitting. [SC2086]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sshd_use_approved_macs.sh:6:90: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sshd_use_priv_separation.sh:6:74: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sticky_world_writable_dirs.sh:2:21: warning: This { is literal. Check expression (missing ;/\n?) or quote it. [SC1083]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/sticky_world_writable_dirs.sh:2:43: warning: This } is literal. Check expression (missing ;/\n?) or quote it. [SC1083]
[  3%] Built target generate-internal-rhel-osp7-shorthand.xml
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/file_permissions_var_log_audit.sh:3:4: warning: Remove backticks to avoid executing output. [SC2092]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/file_permissions_var_log_audit.sh:3:4: note: Use $(..) instead of legacy `..`. [SC2006]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/firewalld_sshd_port_enabled.sh:7:6: warning: sshd_listening_port is referenced but not assigned. [SC2154]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/firewalld_sshd_port_enabled.sh:7:6: note: Double quote to prevent globbing and word splitting. [SC2086]
/home/mpreisle/d/scap-security-guide/shared/templates/static/bash/firewalld_sshd_port_enabled.sh:8:39: note: Double quote to prevent globbing and word splitting. [SC2086]
```