### PR TITLE
Use inbuilt python element tree

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -454,6 +454,7 @@ macro(ssg_build_xccdf_final PRODUCT)
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         DEPENDS generate-ssg-${PRODUCT}-oval.xml  # because of verify-references
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
+        DEPENDS "${SSG_SHARED_UTILS}/verify-references.py"
         COMMENT "[${PRODUCT}-validate] validating ssg-${PRODUCT}-xccdf.xml"
     )
     add_custom_target(

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -1,9 +1,13 @@
 #!/usr/bin/python
 
 import json
-import lxml.etree as ET
 import optparse
 import sys
+
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    import cElementTree as ElementTree
 
 script_usage = """
 %prog -b XCCDF_file [-p XCCDF_profile] [--implemented] [--missing] [--all]
@@ -63,7 +67,7 @@ class XCCDFBenchmark(object):
         try:
             with open(filepath, 'r') as xccdf_file:
                 file_string = xccdf_file.read()
-                tree = ET.fromstring(file_string)
+                tree = ElementTree.fromstring(file_string)
                 self.tree = tree
         except IOError as ioerr:
             print("%s" % ioerr)

--- a/shared/modules/idtranslate_module.py
+++ b/shared/modules/idtranslate_module.py
@@ -3,7 +3,12 @@ names to IDs in the formats required by the SCAP checking systems, such as
 OVAL and OCIL."""
 
 import sys
-import lxml.etree as ET
+
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    import cElementTree as ElementTree
+
 
 oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
 oval_cs = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
@@ -98,8 +103,8 @@ class idtranslator(object):
                 if store_defname and element.tag == "{" + oval_ns + "}definition":
                     metadata = element.find("{" + oval_ns + "}metadata")
                     if metadata is None:
-                        metadata = ET.SubElement(element, "metadata")
-                    defnam = ET.SubElement(metadata, "reference",
+                        metadata = ElementTree.SubElement(element, "metadata")
+                    defnam = ElementTree.SubElement(metadata, "reference",
                                            ref_id=idname, source=self.content_id)
                 # set the element to the new identifier
                 element.set("id", self.generate_id(element.tag, idname))

--- a/shared/utils/combine-ovals.py
+++ b/shared/utils/combine-ovals.py
@@ -127,7 +127,10 @@ def check_is_applicable_for_product(oval_check_def, product):
 
 
 def add_platforms(xml_tree, multi_platform):
-    for affected in xml_tree.findall('.//*[@family="unix"]'):
+    for affected in xml_tree.findall(".//affected"):
+        if affected.get("family") != "unix":
+            continue
+
         for plat_elem in affected:
             try:
                 if plat_elem.text == 'multi_platform_oval':
@@ -199,7 +202,14 @@ def append(element, newchild):
     """Append new child ONLY if it's not a duplicate"""
 
     newid = newchild.get("id")
-    existing = element.find(".//*[@id='" + newid + "']")
+    existing = None
+    for child in element.findall(".//*"):
+        if child.get("id") != newid:
+            continue
+
+        existing = child
+        break
+
     if existing is not None:
         # ID is identical and OVAL entities are identical
         if oval_entities_are_identical(existing, newchild):

--- a/shared/utils/cpe-generate.py
+++ b/shared/utils/cpe-generate.py
@@ -3,7 +3,11 @@
 import fnmatch
 import sys
 import os
-import lxml.etree as ET
+
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    import cElementTree as ElementTree
 
 # Put shared python modules in path
 sys.path.insert(0, os.path.join(
@@ -24,7 +28,7 @@ cpe_ns = "http://cpe.mitre.org/dictionary/2.0"
 def parse_xml_file(xmlfile):
     with open(xmlfile, 'r') as xml_file:
         filestring = xml_file.read()
-        tree = ET.fromstring(filestring)
+        tree = ElementTree.fromstring(filestring)
     return tree
 
 
@@ -140,7 +144,7 @@ def main():
 
     newovalfile = idname + "-" + product + "-" + os.path.basename(ovalfile)
     newovalfile = newovalfile.replace("oval-unlinked", "cpe-oval")
-    ET.ElementTree(ovaltree).write(cpeoutdir + "/" + newovalfile)
+    ElementTree.ElementTree(ovaltree).write(cpeoutdir + "/" + newovalfile)
 
     # replace and sync IDs, href filenames in input cpe dictionary file
     cpedicttree = parse_xml_file(cpedictfile)
@@ -207,7 +211,7 @@ def main():
         # Referenced OVAL checks passed both of the above sanity tests
         check.text = translator.generate_id("{" + oval_ns + "}definition", check.text)
 
-    ET.ElementTree(cpedicttree).write(cpeoutdir + '/' + newcpedictfile)
+    ElementTree.ElementTree(cpedicttree).write(cpeoutdir + '/' + newcpedictfile)
 
     sys.exit(0)
 

--- a/shared/utils/cpe-generate.py
+++ b/shared/utils/cpe-generate.py
@@ -92,7 +92,7 @@ def main():
     # making (dubious) assumption that all inventory defs are CPE
     defs = ovaltree.find("./{%s}definitions" % oval_ns)
     inventory_defs = []
-    for el in defs.findall(".//{%s}definition"):
+    for el in defs.findall(".//{%s}definition" % oval_ns):
         if el.get("class") != "inventory":
             continue
         inventory_defs.append(el)

--- a/shared/utils/cpe-generate.py
+++ b/shared/utils/cpe-generate.py
@@ -91,8 +91,12 @@ def main():
     # extract inventory definitions
     # making (dubious) assumption that all inventory defs are CPE
     defs = ovaltree.find("./{%s}definitions" % oval_ns)
-    inventory_defs = defs.findall(".//{%s}definition[@class='inventory']"
-                                  % oval_ns)
+    inventory_defs = []
+    for el in defs.findall(".//{%s}definition"):
+        if el.get("class") != "inventory":
+            continue
+        inventory_defs.append(el)
+
     # Keep the list of 'id' attributes from untranslated inventory def elements
     inventory_defs_id_attrs = []
 

--- a/shared/utils/relabel-ids.py
+++ b/shared/utils/relabel-ids.py
@@ -3,7 +3,11 @@
 import re
 import sys
 import os
-import lxml.etree as ET
+
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    import cElementTree as ElementTree
 
 try:
     from configparser import SafeConfigParser
@@ -35,7 +39,7 @@ cce_uri = "http://cce.mitre.org"
 def parse_xml_file(xmlfile):
     with open(xmlfile, 'r') as xml_file:
         filestring = xml_file.read()
-        tree = ET.fromstring(filestring)
+        tree = ElementTree.fromstring(filestring)
         # print filestring
     return tree
 
@@ -109,7 +113,8 @@ def add_cce_id_refs_to_oval_checks(ovaltree, idmappingdict):
             if re.search(r'CCE-\d{4,5}-\d', xccdfcceid) is not None:
                 # Then append the <reference source="CCE" ref_id="CCE-ID" /> element right
                 # after <description> element of specific OVAL check
-                ccerefelem = ET.Element('reference', ref_id="%s" % xccdfcceid, source="CCE")
+                ccerefelem = ElementTree.Element(
+                    'reference', ref_id="%s" % xccdfcceid, source="CCE")
                 ovaldesc.addnext(ccerefelem)
                 # Sanity check if appending succeeded
                 if ccerefelem.getprevious() is not ovaldesc:
@@ -390,14 +395,14 @@ def main():
 
         ovaltree = translator.translate(ovaltree, store_defname=True)
         newovalfile = ovalfile.replace("unlinked", "linked")
-        ET.ElementTree(ovaltree).write(newovalfile)
+        ElementTree.ElementTree(ovaltree).write(newovalfile)
 
     # Rename all IDs in the ocil file
     if ocilfile:
         ociltree = parse_xml_file(ocilfile)
         ociltree = translator.translate(ociltree)
         newocilfile = ocilfile.replace("unlinked", "linked")
-        ET.ElementTree(ociltree).write(newocilfile)
+        ElementTree.ElementTree(ociltree).write(newocilfile)
 
     # Rename all IDs and file refs in the xccdf file
     for check in checks:
@@ -439,8 +444,7 @@ def main():
                 checkexport.set("export-name", newexportname)
 
     newxccdffile = xccdffile.replace("unlinked", "linked")
-    # ET.dump(xccdftree)
-    ET.ElementTree(xccdftree).write(newxccdffile)
+    ElementTree.ElementTree(xccdftree).write(newxccdffile)
     sys.exit(0)
 
 if __name__ == "__main__":

--- a/shared/utils/relabel-ids.py
+++ b/shared/utils/relabel-ids.py
@@ -202,7 +202,7 @@ def drop_oval_checks_extending_non_existing_checks(ovaltree):
     # OVAL checks that go beyond one level of extend_definition won't be completely removed
     definitions = ovaltree.find(".//{%s}definitions" % oval_ns)
     for definition in definitions:
-        for extdefinition in definition.iterfind(".//{%s}extend_definition" % oval_ns):
+        for extdefinition in definition.findall(".//{%s}extend_definition" % oval_ns):
             # Verify each extend_definition in the definition
             extdefinitionref = extdefinition.get("definition_ref")
 

--- a/shared/utils/sds-move-ocil-to-checks.py
+++ b/shared/utils/sds-move-ocil-to-checks.py
@@ -37,7 +37,11 @@
 #   $ ./sds-move-ocil-to-checks.py ssg-rhel6-ds.xml new-ds.xml
 
 import sys
-import lxml.etree as ET
+
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    import cElementTree as ElementTree
 
 xlink_ns = "http://www.w3.org/1999/xlink"
 datastream_ns = "http://scap.nist.gov/schema/scap/source/1.2"
@@ -47,7 +51,7 @@ ocil_ns = "http://scap.nist.gov/schema/ocil/2.0"
 def parse_xml_file(xmlfile):
     with open(xmlfile, 'r') as xml_file:
         filestring = xml_file.read()
-        tree = ET.fromstring(filestring)
+        tree = ElementTree.fromstring(filestring)
     return tree
 
 
@@ -117,9 +121,9 @@ def move_ocil_content_from_ds_extended_component_to_ds_component(datastreamtree,
         sys.exit(1)
 
     # Decode possible HTML entities present in OCIL component
-    extnohtmlents = ET.tostring(extendedcomp, method='html')
+    extnohtmlents = ElementTree.tostring(extendedcomp, method='html')
     # Create new element tree from decoded HTML
-    extcomptree = ET.fromstring(extnohtmlents)
+    extcomptree = ElementTree.fromstring(extnohtmlents)
     # Locate the OCIL subcomponent within that element tree
     ocilcomp = extcomptree.find(".//{%s}ocil" % ocil_ns)
 
@@ -128,7 +132,7 @@ def move_ocil_content_from_ds_extended_component_to_ds_component(datastreamtree,
     # * future OCIL <ds:component> timestamp --> timestamp
     # * future OCIL <ds:component> content   --> ocilcomp
     # to be ables to create new <ds:component> for OCIL content
-    ocildscomp = ET.Element('{' + datastream_ns + '}component',
+    ocildscomp = ElementTree.Element('{' + datastream_ns + '}component',
                             attrib = { 'id' : ocildscompid, 'timestamp' : timestamp },
                             nsmap = {'ds' : datastream_ns})
     # Insert the OCIL content into newly created <ds:component>
@@ -197,7 +201,7 @@ def main():
         print("No extended-components, nothing to do...")
 
     # Write the updated benchmark into output datastream file
-    ET.ElementTree(datastreamtree).write(outdatastreamfile)
+    ElementTree.ElementTree(datastreamtree).write(outdatastreamfile)
     sys.exit(0)
 
 

--- a/shared/utils/verify-references.py
+++ b/shared/utils/verify-references.py
@@ -116,8 +116,13 @@ def get_profileruleids(xccdftree, profile_name):
     ruleids = []
 
     while profile_name:
-        profile = xccdftree.find(".//{%s}Profile[@id='%s']"
-                                 % (xccdf_ns, profile_name))
+        profile = None
+        for el in xccdftree.findall(".//{%s}Profile" % xccdf_ns):
+            if el.get("id") != profile_name:
+                continue
+            profile = el
+            break
+
         if profile is None:
             sys.exit("Specified XCCDF Profile %s was not found.")
         for select in profile.findall(".//{%s}select" % xccdf_ns):
@@ -159,8 +164,13 @@ def main():
     ovaltree = ElementTree.parse(ovalfile)
     # collect all compliance checks (not inventory checks, which are
     # needed by CPE)
-    ovaldefs = ovaltree.findall(".//{%s}definition[@class='compliance']"
-                                % oval_ns)
+    ovaldefs = []
+    for el in ovaltree.findall(".//{%s}definition" % oval_ns):
+        if el.get("class") != "compliance":
+            continue
+
+        ovaldefs.append(el)
+
     ovaldef_ids = [ovaldef.get("id") for ovaldef in ovaldefs]
 
     oval_extenddefs = ovaltree.findall(".//{%s}extend_definition" % oval_ns)

--- a/shared/utils/verify-references.py
+++ b/shared/utils/verify-references.py
@@ -2,8 +2,12 @@
 
 import sys
 import optparse
-import lxml.etree as ET
 import os.path
+
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    import cElementTree as ElementTree
 
 """
 This script can verify consistency of references (linkage) between XCCDF and
@@ -129,7 +133,7 @@ def main():
     xccdffilename = args[0]
 
     # extract all of the rules within the xccdf
-    xccdftree = ET.parse(xccdffilename)
+    xccdftree = ElementTree.parse(xccdffilename)
     rules = xccdftree.findall(".//{%s}Rule" % xccdf_ns)
 
     # if a profile was specified, get rid of any Rules that aren't in it
@@ -152,7 +156,7 @@ def main():
 
     # find important elements within the XCCDF and the OVAL
     ovalfile = os.path.join(os.path.dirname(xccdffilename), ovalfiles.pop())
-    ovaltree = ET.parse(ovalfile)
+    ovaltree = ElementTree.parse(ovalfile)
     # collect all compliance checks (not inventory checks, which are
     # needed by CPE)
     ovaldefs = ovaltree.findall(".//{%s}definition[@class='compliance']"
@@ -166,13 +170,14 @@ def main():
     check_content_refs = xccdftree.findall(".//{%s}check-content-ref"
                                            % xccdf_ns)
 
+    xccdf_parent_map = dict((c, p) for p in xccdftree.getiterator() for c in p)
     # now we can actually do the verification work here
     if options.rules_with_invalid_checks or options.all_checks:
         for check_content_ref in check_content_refs:
 
             # Skip those <check-content-ref> elements using OCIL as the checksystem
             # (since we are checking just referenced OVAL definitions)
-            if check_content_ref.getparent().get("system") == ocil_cs:
+            if xccdf_parent_map[check_content_ref].get("system") == ocil_cs:
                 continue
 
             # Obtain the value of the 'href' attribute of particular
@@ -189,7 +194,9 @@ def main():
 
             refname = check_content_ref.get("name")
             if refname not in ovaldef_ids:
-                rule = check_content_ref.getparent().getparent()
+                rule = xccdf_parent_map[
+                    xccdf_parent_map[check_content_ref]
+                ]
                 print("ERROR: Invalid OVAL definition referenced by XCCDF Rule: %s"
                       % (rule.get("id")))
                 exit_value = 1


### PR DESCRIPTION
For some reason we used the libxml ElementTree python compatibility module instead of using the actual cElementTree from python2 and 3. I have no idea why. It makes the builds fail when lxml is missing and we aren't really using anything special from libxml. Let's use what's included in python.

This should help in the future when we want to enable SSG builds on Windows and MacOSX. It's not as simple to install libxml2 on these platforms as it is on Linux distributions.

I haven't replaced it in all the tools, there are some tools that we no longer use that I skipped over. I will create another PR to remove them from the repo.