### PR TITLE
Self implement subprocess.check_output for python 2.6

### DIFF
--- a/shared/utils/oscap-svg-support.py
+++ b/shared/utils/oscap-svg-support.py
@@ -29,6 +29,32 @@ svg_benchmark = """<?xml version="1.0"?>
 """
 
 
+def subprocess_check_output(*popenargs, **kwargs):
+    # Backport of subprocess.check_output taken from
+    # https://gist.github.com/edufelipe/1027906
+    #
+    # Originally from Python 2.7 stdlib under PSF, compatible with LGPL2+
+    # Copyright (c) 2003-2005 by Peter Astrand <astrand@lysator.liu.se>
+    # Changes by Eduardo Felipe
+
+    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+    output, unused_err = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        error = subprocess.CalledProcessError(retcode, cmd)
+        error.output = output
+        raise error
+    return output
+
+
+if hasattr(subprocess, "check_output"):
+    # if available we just use the real function
+    subprocess_check_output = subprocess.check_output
+
+
 def main():
     oscap_executable = sys.argv[1]
 
@@ -36,7 +62,7 @@ def main():
     xccdf.write(svg_benchmark.encode("utf-8"))
     xccdf.flush()
 
-    out = subprocess.check_output(
+    out = subprocess_check_output(
         [oscap_executable, "xccdf", "generate", "guide", xccdf.name]
     ).decode("utf-8")
 


### PR DESCRIPTION
Argh... This again...

```
[build] $ cmake -G "Unix Makefiles" -D CMAKE_BUILD_TYPE=Release /home/jenkins/workspace/scap-security-guide-pull-requests/label/node-el6-openscap-new
SCAP Security Guide 0.1.32

Traceback (most recent call last):
  File "/home/jenkins/workspace/scap-security-guide-pull-requests/label/node-el6-openscap-new/shared/utils/oscap-svg-support.py", line 48, in <module>
    main()
  File "/home/jenkins/workspace/scap-security-guide-pull-requests/label/node-el6-openscap-new/shared/utils/oscap-svg-support.py", line 39, in main
    out = subprocess.check_output(
AttributeError: 'module' object has no attribute 'check_output'
Your version of OpenSCAP does not support having the SVG logo in the XCCDF, disabling SVG logo.
```

https://jenkins.open-scap.org/job/scap-security-guide-pull-requests/1351/label=node-el6-openscap-new/console