### PR TITLE
Fix file_owner_cron_allow and file_groupowner_cron_allow checks 

### DIFF
--- a/RHEL/7/input/oval/file_groupowner_cron_allow.xml
+++ b/RHEL/7/input/oval/file_groupowner_cron_allow.xml
@@ -12,7 +12,7 @@
       <criterion test_ref="test_groupowner_etc_cron_allow" />
     </criteria>
   </definition>
-  <unix:file_test check="all" check_existence="all_exist"
+  <unix:file_test check="all" check_existence="any_exist"
   comment="Testing group ownership /etc/cron.allow" id="test_groupowner_etc_cron_allow"
   version="1">
     <unix:object object_ref="object_groupowner_cron_allow_file" />

--- a/RHEL/7/input/oval/file_owner_cron_allow.xml
+++ b/RHEL/7/input/oval/file_owner_cron_allow.xml
@@ -14,7 +14,7 @@
       test_ref="test_userowner_cron_allow_file" />
     </criteria>
   </definition>
-  <unix:file_test check="all" check_existence="all_exist"
+  <unix:file_test check="all" check_existence="any_exist"
   comment="Testing user ownership of /etc/cron.allow"
   id="test_userowner_cron_allow_file" version="1">
     <unix:object object_ref="object_file_etc_cron_allow" />


### PR DESCRIPTION
Checks file_owner_cron_allow and file_groupowner_cron_allow to return 
true even if /etc/cron.allow doesn't exist

Change existance check of checks file_owner_cron_allow and
file_groupowner_cron_allow to any_exist.
This will make the check return true if the file doesn't exist, but
will still check its state if it exists.

Fixes #1927 
Fixes #1926 