### PR TITLE
Change external_variable accounts_umask_etc_login_defs

### DIFF
--- a/shared/oval/accounts_umask_etc_bashrc.xml
+++ b/shared/oval/accounts_umask_etc_bashrc.xml
@@ -65,12 +65,6 @@
     </arithmetic>
   </local_variable>
 
-  <!-- The 'var_accounts_user_umask_umask_as_number' variable is created by evaluation of
-       the referenced 'var_accounts_user_umask_as_number' OVAL definition -->
-  <external_variable id="var_accounts_user_umask_umask_as_number"
-  comment="Required umask converted from string to octal number"
-  datatype="int" version="1"/>
-
   <ind:variable_test id="tst_accounts_umask_etc_bashrc" version="1" check="all"
   comment="Test the retrieved /etc/bashrc umask value(s) match the var_accounts_user_umask requirement">
     <ind:object object_ref="obj_accounts_umask_etc_bashrc" />
@@ -81,6 +75,8 @@
     <ind:var_ref>var_etc_bashrc_umask_as_number</ind:var_ref>
   </ind:variable_object>
 
+  <!-- The 'var_accounts_user_umask_umask_as_number' variable is created by evaluation of
+       the referenced 'var_accounts_user_umask_as_number' OVAL definition -->
   <ind:variable_state id="ste_accounts_umask_etc_bashrc" version="1">
     <ind:value datatype="int" operation="bitwise and" var_ref="var_accounts_user_umask_umask_as_number" />
   </ind:variable_state>

--- a/shared/oval/accounts_umask_etc_csh_cshrc.xml
+++ b/shared/oval/accounts_umask_etc_csh_cshrc.xml
@@ -65,12 +65,6 @@
     </arithmetic>
   </local_variable>
 
-  <!-- The 'var_accounts_user_umask_umask_as_number' variable is created by evaluation of
-       the referenced 'var_accounts_user_umask_as_number' OVAL definition -->
-  <external_variable id="var_accounts_user_umask_umask_as_number"
-  comment="Required umask converted from string to octal number"
-  datatype="int" version="1"/>
-
   <ind:variable_test id="tst_accounts_umask_etc_csh_cshrc" version="1" check="all"
   comment="Test the retrieved /etc/csh.cshrc umask value(s) match the var_accounts_user_umask requirement">
     <ind:object object_ref="obj_accounts_umask_etc_csh_cshrc" />
@@ -81,6 +75,8 @@
     <ind:var_ref>var_etc_csh_cshrc_umask_as_number</ind:var_ref>
   </ind:variable_object>
 
+  <!-- The 'var_accounts_user_umask_umask_as_number' variable is created by evaluation of
+       the referenced 'var_accounts_user_umask_as_number' OVAL definition -->
   <ind:variable_state id="ste_accounts_umask_etc_csh_cshrc" version="1">
     <ind:value datatype="int" operation="bitwise and" var_ref="var_accounts_user_umask_umask_as_number" />
   </ind:variable_state>

--- a/shared/oval/accounts_umask_etc_login_defs.xml
+++ b/shared/oval/accounts_umask_etc_login_defs.xml
@@ -65,12 +65,6 @@
     </arithmetic>
   </local_variable>
 
-  <!-- The 'var_accounts_user_umask_umask_as_number' variable is created by evaluation of
-       the referenced 'var_accounts_user_umask_as_number' OVAL definition -->
-  <external_variable id="var_accounts_user_umask_umask_as_number"
-  comment="Required umask converted from string to octal number"
-  datatype="int" version="1"/>
-
   <ind:variable_test id="tst_accounts_umask_etc_login_defs" version="1" check="all"
   comment="Test the retrieved /etc/login.defs umask value(s) match the var_accounts_user_umask requirement">
     <ind:object object_ref="obj_accounts_umask_etc_login_defs" />
@@ -81,6 +75,8 @@
     <ind:var_ref>var_etc_login_defs_umask_as_number</ind:var_ref>
   </ind:variable_object>
 
+  <!-- The 'var_accounts_user_umask_umask_as_number' variable is created by evaluation of
+       the referenced 'var_accounts_user_umask_as_number' OVAL definition -->
   <ind:variable_state id="ste_accounts_umask_etc_login_defs" version="1">
     <ind:value datatype="int" operation="bitwise and" var_ref="var_accounts_user_umask_umask_as_number" />
   </ind:variable_state>

--- a/shared/oval/accounts_umask_etc_profile.xml
+++ b/shared/oval/accounts_umask_etc_profile.xml
@@ -65,12 +65,6 @@
     </arithmetic>
   </local_variable>
 
-  <!-- The 'var_accounts_user_umask_umask_as_number' variable is created by evaluation of
-       the referenced 'var_accounts_user_umask_as_number' OVAL definition -->
-  <external_variable id="var_accounts_user_umask_umask_as_number"
-  comment="Required umask converted from string to octal number"
-  datatype="int" version="1"/>
-
   <ind:variable_test id="tst_accounts_umask_etc_profile" version="1" check="all"
   comment="Test the retrieved /etc/profile umask value(s) match the var_accounts_user_umask requirement">
     <ind:object object_ref="obj_accounts_umask_etc_profile" />
@@ -81,6 +75,8 @@
     <ind:var_ref>var_etc_profile_umask_as_number</ind:var_ref>
   </ind:variable_object>
 
+  <!-- The 'var_accounts_user_umask_umask_as_number' variable is created by evaluation of
+       the referenced 'var_accounts_user_umask_as_number' OVAL definition -->
   <ind:variable_state id="ste_accounts_umask_etc_profile" version="1">
     <ind:value datatype="int" operation="bitwise and" var_ref="var_accounts_user_umask_umask_as_number" />
   </ind:variable_state>


### PR DESCRIPTION
By defining 'var_accounts_user_umask_umask_as_number' as an
external_variable the check expected to receive fron an external source
other then OVAL definitions, and no one defined it externaly.

The OVAL checks:
- accounts_umask_etc_bashrc
- accounts_umask_etc_csh_cshrc
- accounts_umask_etc_login_defs
- accounts_umask_etc_profile

are capable of using the variable defined in
'var_accounts_user_umask_as_number' without defining it as an
external_variable.

- Fixes #1890 