### PR TITLE
Fix remediation for accounts_logon_fail_delay

### DIFF
--- a/shared/templates/static/bash/accounts_logon_fail_delay.sh
+++ b/shared/templates/static/bash/accounts_logon_fail_delay.sh
@@ -4,7 +4,6 @@
 . /usr/share/scap-security-guide/remediation_functions
 
 # Set variables
-declare var_accounts_fail_delay
 populate var_accounts_fail_delay
 
-replace_or_append '/etc/login.defs' '^FAIL_DELAY' '$var_accounts_fail_delay' '$CCENUM' '%s %s'
+replace_or_append '/etc/login.defs' '^FAIL_DELAY' "$var_accounts_fail_delay" '$CCENUM' '%s %s'


### PR DESCRIPTION
Fix substition of variable in remediation script.
Remove declare statement. I don't see why it is there.

Possibly related to #1928 