### PR TITLE
Fix variable expansion in sysctl templates

### DIFF
--- a/shared/templates/template_BASH_sysctl
+++ b/shared/templates/template_BASH_sysctl
@@ -14,4 +14,4 @@
 # If SYSCTLVAR present in /etc/sysctl.conf, change value to "SYSCTLVAL"
 #	else, add "SYSCTLVAR = SYSCTLVAL" to /etc/sysctl.conf
 #
-replace_or_append '/etc/sysctl.conf' '^SYSCTLVAR' 'SYSCTLVAL' '$CCENUM'
+replace_or_append '/etc/sysctl.conf' '^SYSCTLVAR' "SYSCTLVAL" '$CCENUM'

--- a/shared/templates/template_BASH_sysctl_var
+++ b/shared/templates/template_BASH_sysctl_var
@@ -15,4 +15,4 @@ populate sysctl_SYSCTLID_value
 # If SYSCTLVAR present in /etc/sysctl.conf, change value to appropriate value
 #	else, add "SYSCTLVAR = value" to /etc/sysctl.conf
 #
-replace_or_append '/etc/sysctl.conf' '^SYSCTLVAR' '$sysctl_SYSCTLID_value' '$CCENUM'
+replace_or_append '/etc/sysctl.conf' '^SYSCTLVAR' "$sysctl_SYSCTLID_value" '$CCENUM'


### PR DESCRIPTION
Replace single quotes by double quotes to allow variable expansion.

Fixes #1951 

Thank you @MollyJoBault for reporting this.