### PR TITLE
Fixed a typo in title of the FISMA profile for RHEL6

### DIFF
--- a/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
+++ b/RHEL/6/input/profiles/fisma-medium-rhel6-server.xml
@@ -1,5 +1,5 @@
 <Profile id="fisma-medium-rhel6-server">
-<title>FISAMA Medium for Red Hat Enterprise Linux 6</title>
+<title>FISMA Medium for Red Hat Enterprise Linux 6</title>
 <description>FISMA Medium for Red Hat Enterprise Linux 6</description>
 
 <!-- ACCESS CONTROL (AC) -->


### PR DESCRIPTION
Just noticed this while browsing the HTML guides.