### PR TITLE
Protect variable expansion in replace_or_append

### DIFF
--- a/shared/remediations/bash/templates/remediation_functions
+++ b/shared/remediations/bash/templates/remediation_functions
@@ -778,7 +778,7 @@ function replace_or_append {
 
   # If there is no print format specified in the last arg, use the default format.
   if ! [ "x$format" = x ] ; then
-    printf -v formatted_output "$format" $stripped_key $value
+    printf -v formatted_output "$format" "$stripped_key" "$value"
   else
     formatted_output="$stripped_key = $value"
   fi

--- a/shared/xccdf/remediation_functions.xml
+++ b/shared/xccdf/remediation_functions.xml
@@ -1156,7 +1156,7 @@ function replace_or_append {
 
   # If there is no print format specified in the last arg, use the default format.
   if ! [ "x$format" = x ] ; then
-    printf -v formatted_output "$format" $stripped_key $value
+    printf -v formatted_output "$format" "$stripped_key" "$value"
   else
     formatted_output="$stripped_key = $value"
   fi


### PR DESCRIPTION
A bug in replace_or_append function caused it to append the list of
local files with extension as the "key" when key is "*.*"

This happen while remediating rsyslog_remote_loghost.

Protect the expansion of stripped_key to avoid strange behaviour, like listing files.