### PR TITLE
update sshd xccdf/oval rules

### DIFF
--- a/RHEL/6/input/profiles/C2S.xml
+++ b/RHEL/6/input/profiles/C2S.xml
@@ -512,7 +512,7 @@ baseline.
 <select idref="sshd_allow_only_protocol2" selected="true" />
 
 <!-- CIS 6.2.2 Set LogLevel to INFO (Scored) -->
-<!-- Default, non-configurable system behavior, will audit user login/logout events -->
+<select idref="sshd_set_loglevel_info" selected="true" />
 
 <!-- CIS 6.2.3 Set Permissions on /etc/ssh/sshd_config (Scored) -->
 <!-- Met via RPM Verify rule -->

--- a/RHEL/6/input/profiles/C2S.xml
+++ b/RHEL/6/input/profiles/C2S.xml
@@ -512,7 +512,7 @@ baseline.
 <select idref="sshd_allow_only_protocol2" selected="true" />
 
 <!-- CIS 6.2.2 Set LogLevel to INFO (Scored) -->
-<select idref="sshd_set_loglevel_info" selected="true" />
+<!-- TO DO -->
 
 <!-- CIS 6.2.3 Set Permissions on /etc/ssh/sshd_config (Scored) -->
 <!-- Met via RPM Verify rule -->

--- a/RHEL/7/input/auxiliary/stig_overlay.xml
+++ b/RHEL/7/input/auxiliary/stig_overlay.xml
@@ -886,7 +886,7 @@ These audit records must also identify individual identities of group account us
     <VMSinfo SVKey="86925" VKey="72301" VRelease="1"/>
     <title>The Trivial File Transfer Protocol (TFTP) server package must not be installed if not required for operational support.</title>
   </overlay>
-  <overlay disa="366" owner="disastig" ownerid="RHEL-07-040710" ruleid="enable_x11_forwarding" severity="high">
+  <overlay disa="366" owner="disastig" ownerid="RHEL-07-040710" ruleid="sshd_enable_x11_forwarding" severity="high">
     <VMSinfo SVKey="86927" VKey="72303" VRelease="2"/>
     <title>Remote X connections for interactive users must be encrypted.</title>
   </overlay>

--- a/RHEL/7/input/profiles/C2S.xml
+++ b/RHEL/7/input/profiles/C2S.xml
@@ -509,7 +509,7 @@ baseline.
 <select idref="sshd_allow_only_protocol2" selected="true" />
 
 <!-- 6.2.2 Set LogLevel to INFO (Scored) -->
-<!-- TO DO: NEED XCCDF AND OVAL -->
+<select idref="sshd_set_loglevel_info" selected="true" />
 
 <!-- 6.2.3 Set Permissions on /etc/ssh/sshd_config (Scored) -->
 <!--    File permissions are managed through rpm_verify_permissions,

--- a/RHEL/7/input/profiles/ospp-rhel7.xml
+++ b/RHEL/7/input/profiles/ospp-rhel7.xml
@@ -449,7 +449,7 @@ the consensus process.
 <select idref="dconf_gnome_screensaver_user_info" selected="true" />
 <select idref="dconf_gnome_session_user_locks" selected="true" />
 <select idref="enable_dconf_user_profile" selected="true" />
-<select idref="enable_x11_forwarding" selected="true" />
+<select idref="sshd_enable_x11_forwarding" selected="true" />
 <select idref="gnome_gdm_disable_automatic_login" selected="true" />
 <select idref="gnome_gdm_disable_guest_login" selected="true" />
 <!--	END ASSIGNMENTS: DESKTOP MANAGERS -->

--- a/RHEL/7/input/profiles/stig-rhel7-disa.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-disa.xml
@@ -694,7 +694,7 @@ Storage deployments.
 <select idref="package_tftp-server_removed" selected="true" />
 
 <!-- SRG-OS-000480-GPOS-00227, SV-86927r2_rule, RHEL-07-040710 -->
-<select idref="enable_x11_forwarding" selected="true" />
+<select idref="sshd_enable_x11_forwarding" selected="true" />
 
 <!-- SRG-OS-000480-GPOS-00227, SV-86929r1_rule, RHEL-07-040720 -->
 <select idref="tftpd_uses_secure_mode" selected="true" />

--- a/SUSE/12/input/xccdf/services/ssh.xml
+++ b/SUSE/12/input/xccdf/services/ssh.xml
@@ -442,7 +442,7 @@ can allow an attacker to move trivially to other hosts.
 <ref nist="AC-3,CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00229"  />
 </Rule>
 
-<Rule id="enable_x11_forwarding" severity="high">
+<Rule id="sshd_enable_x11_forwarding" severity="high">
 <title>Enable Encrypted X11 Fordwarding</title>
 <description>By default, remote X11 connections are not encrypted when initiated
 by users. SSH has the capability to encrypt remote X11 connections when SSH's
@@ -459,7 +459,7 @@ following line in <tt>/etc/ssh/sshd_config</tt>:
 Open X displays allow an attacker to capture keystrokes and to execute commands
 remotely.
 </rationale>
-<oval id="enable_x11_forwarding" />
+<oval id="sshd_enable_x11_forwarding" />
 <ref nist="CM-2(1)(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00227"
  />
 </Rule>

--- a/shared/oval/sshd_enable_x11_forwarding.xml
+++ b/shared/oval/sshd_enable_x11_forwarding.xml
@@ -1,9 +1,9 @@
 <def-group>
-  <definition class="compliance" id="enable_x11_forwarding" version="1">
+  <definition class="compliance" id="sshd_enable_x11_forwarding" version="1">
     <metadata>
       <title>Enable X11 Forwarding</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>Enable X11Forwarding to encrypt X11 remote connections over SSH.</description>
     </metadata>

--- a/shared/oval/sshd_set_loglevel_info.xml
+++ b/shared/oval/sshd_set_loglevel_info.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="sshd_set_loglevel_info" version="1">
+    <metadata>
+      <title>Set OpenSSH LogLevel to INFO</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>The SSH LogLevel should be set to INFO.</description>
+    </metadata>
+    <criteria comment="SSH is not being used or conditions are met"
+    operator="OR">
+      <extend_definition comment="sshd service is disabled"
+      definition_ref="service_sshd_disabled" />
+      <criterion comment="Check LogLevel in /etc/ssh/sshd_config"
+      test_ref="test_sshd_set_loglevel_info" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="loglevel is set" id="test_sshd_set_loglevel_info" version="1">
+    <ind:object object_ref="obj_sshd_set_loglevel_info" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_sshd_set_loglevel_info"
+  version="2">
+    <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*(?i)LogLevel(?-i)[\s]+INFO[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/shared/oval/sshd_set_max_auth_tries.xml
+++ b/shared/oval/sshd_set_max_auth_tries.xml
@@ -1,15 +1,14 @@
 <def-group>
   <definition class="compliance" id="sshd_set_max_auth_tries" version="1">
     <metadata>
-      <title>Set OpenSSH authentication attempt limit</title>
+      <title>Set OpenSSH authentication attempt limit (MaxAuthTries)</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
       <description>The SSH MaxAuthTries should be set to an
       appropriate value.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
-    operator="OR">
+    <criteria comment="SSH is not being used or conditions are met" operator="OR">
       <extend_definition comment="sshd service is disabled"
       definition_ref="service_sshd_disabled" />
       <criterion comment="Check MaxAuthTries in /etc/ssh/sshd_config"

--- a/shared/oval/sshd_set_max_auth_tries.xml
+++ b/shared/oval/sshd_set_max_auth_tries.xml
@@ -1,0 +1,47 @@
+<def-group>
+  <definition class="compliance" id="sshd_set_max_auth_tries" version="1">
+    <metadata>
+      <title>Set OpenSSH authentication attempt limit</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>The SSH MaxAuthTries should be set to an
+      appropriate value.</description>
+    </metadata>
+    <criteria comment="SSH is not being used or conditions are met"
+    operator="OR">
+      <extend_definition comment="sshd service is disabled"
+      definition_ref="service_sshd_disabled" />
+      <criterion comment="Check MaxAuthTries in /etc/ssh/sshd_config"
+      test_ref="test_sshd_max_auth_tries" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="maxauthtries is configured" id="test_sshd_max_auth_tries" version="1">
+    <ind:object object_ref="object_sshd_max_auth_tries" />
+    <ind:state state_ref="state_maxauthtries_value_upper_bound" />
+    <ind:state state_ref="state_maxauthtries_value_lower_bound" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_sshd_max_auth_tries" version="2">
+    <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*(?i)MaxAuthTries[\s]+(\d+)[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state comment="upper bound of MaxAuthTries"
+  id="state_maxauthtries_value_upper_bound" version="1">
+    <ind:subexpression datatype="int" operation="less than or equal" var_check="all"
+    var_ref="sshd_max_auth_tries_value" />
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state comment="lower bound of MaxAuthTries"
+  id="state_maxauthtries_value_lower_bound" version="1">
+    <ind:subexpression datatype="int" operation="greater than">0</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="maxauthtries value" datatype="int"
+  id="sshd_max_auth_tries_value" version="1" />
+
+</def-group>

--- a/shared/oval/sshd_use_approved_ciphers.xml
+++ b/shared/oval/sshd_use_approved_ciphers.xml
@@ -5,8 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
       </affected>
-      <description>Limit the ciphers to those which are FIPS-approved and only
-      use ciphers in counter (CTR) mode.</description>
+      <description>Limit the ciphers to those which are FIPS-approved.</description>
     </metadata>
     <criteria operator="AND">
       <extend_definition comment="Installed OS is certified" definition_ref="installed_OS_is_certified" />
@@ -26,7 +25,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sshd_use_approved_ciphers" version="2">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)Ciphers(?-i)[\s]+((aes128-ctr|aes192-ctr|aes256-ctr),?)+[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)Ciphers(?-i)[\s]+((aes128-ctr|aes192-ctr|aes256-ctr|aes128-cbc|3des-cbc|aes192-cbc|aes256-cbc),?)+[\s]*(?:|(?:#.*))?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/shared/oval/sshd_use_approved_ciphers.xml
+++ b/shared/oval/sshd_use_approved_ciphers.xml
@@ -26,7 +26,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sshd_use_approved_ciphers" version="2">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)Ciphers(?-i)[\s]+((aes128-ctr|aes192-ctr|aes256-ctr|aes128-cbc|3des-cbc|aes192-cbc|aes256-cbc),?)+[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)Ciphers(?-i)[\s]+((aes128-ctr|aes192-ctr|aes256-ctr),?)+[\s]*(?:|(?:#.*))?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/shared/oval/sshd_use_strong_ciphers.xml
+++ b/shared/oval/sshd_use_strong_ciphers.xml
@@ -3,13 +3,11 @@
     <metadata>
       <title>Use Only Strong Ciphers</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_debian</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>Only use strong ciphers.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
-      operator="OR">
+    <criteria comment="SSH is not being used or conditions are met" operator="OR">
       <extend_definition comment="sshd service is disabled" definition_ref="service_sshd_disabled" />
       <criterion comment="Check the Ciphers list in /etc/ssh/sshd_config" test_ref="test_sshd_use_strong_ciphers" />
     </criteria>

--- a/shared/oval/sshd_use_strong_ciphers.xml
+++ b/shared/oval/sshd_use_strong_ciphers.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="sshd_use_strong_ciphers" version="1">
+    <metadata>
+      <title>Use Only Approved Ciphers</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_debian</platform>
+      </affected>
+      <description>Limit the ciphers.</description>
+    </metadata>
+    <criteria comment="SSH is not being used or conditions are met"
+      operator="OR">
+      <extend_definition comment="sshd service is disabled" definition_ref="service_sshd_disabled" />
+      <criterion comment="Check the Ciphers list in /etc/ssh/sshd_config" test_ref="test_sshd_use_strong_ciphers" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="tests the value of Ciphers setting in the /etc/ssh/sshd_config file"
+  id="test_sshd_use_strong_ciphers" version="1">
+    <ind:object object_ref="obj_sshd_use_strong_ciphers" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_sshd_use_strong_ciphers" version="2">
+    <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*(?i)Ciphers(?-i)[\s]+((chacha20-poly1305@openssh\.com|aes256-gcm@openssh\.com|aes128-gcm@openssh\.com|aes256-ctr|aes128-ctr),?)+[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/shared/oval/sshd_use_strong_ciphers.xml
+++ b/shared/oval/sshd_use_strong_ciphers.xml
@@ -1,12 +1,12 @@
 <def-group>
   <definition class="compliance" id="sshd_use_strong_ciphers" version="1">
     <metadata>
-      <title>Use Only Approved Ciphers</title>
+      <title>Use Only Strong Ciphers</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_debian</platform>
       </affected>
-      <description>Limit the ciphers.</description>
+      <description>Only use strong ciphers.</description>
     </metadata>
     <criteria comment="SSH is not being used or conditions are met"
       operator="OR">

--- a/shared/oval/sshd_use_strong_macs.xml
+++ b/shared/oval/sshd_use_strong_macs.xml
@@ -3,8 +3,7 @@
     <metadata>
       <title>Use Only Strong MACs</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_debian</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>Only use strong MACs.</description>
     </metadata>

--- a/shared/oval/sshd_use_strong_macs.xml
+++ b/shared/oval/sshd_use_strong_macs.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="sshd_use_strong_macs" version="1">
+    <metadata>
+      <title>Use Only MACs</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_debian</platform>
+      </affected>
+      <description>Limit the Message Authentication Codes (MACs).</description>
+    </metadata>
+    <criteria comment="SSH is not being used or conditions are met"
+      operator="OR">
+      <extend_definition comment="sshd service is disabled" definition_ref="service_sshd_disabled" />
+      <criterion comment="Check MACs in /etc/ssh/sshd_config" test_ref="test_sshd_use_strong_macs" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="tests the value of MACs setting in the /etc/ssh/sshd_config file"
+  id="test_sshd_use_strong_macs" version="1">
+    <ind:object object_ref="obj_sshd_use_strong_macs" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_sshd_use_strong_macs" version="1">
+    <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*(?i)MACs(?-i)[\s]+((hmac-sha2-512-etm@openssh\.com|hmac-sha2-256-etm@openssh\.com|umac-128-etm@openssh\.com|hmac-sha2-512|hmac-sha2-256|hmac-ripemd160),?)+[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/shared/oval/sshd_use_strong_macs.xml
+++ b/shared/oval/sshd_use_strong_macs.xml
@@ -1,12 +1,12 @@
 <def-group>
   <definition class="compliance" id="sshd_use_strong_macs" version="1">
     <metadata>
-      <title>Use Only MACs</title>
+      <title>Use Only Strong MACs</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_debian</platform>
       </affected>
-      <description>Limit the Message Authentication Codes (MACs).</description>
+      <description>Only use strong MACs.</description>
     </metadata>
     <criteria comment="SSH is not being used or conditions are met"
       operator="OR">

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -108,7 +108,7 @@ remote access.
 <oval id="service_sshd_disabled" />
 </Rule>
 
-<Rule id="file_permissions_sshd_pub_key" severity="medium" prodtype="rhel7">
+<Rule id="file_permissions_sshd_pub_key" severity="medium">
 <title>Verify Permissions on SSH Server Public <tt>*.pub</tt> Key Files</title>
 <description><fileperms-desc-macro file="/etc/ssh/*.pub" perms="0644"/></description>
 <ocil><fileperms-check-macro file="/etc/ssh/*.pub" perms="-rw-r--r--"/></ocil>
@@ -122,7 +122,7 @@ ossrg="SRG-OS-000480-GPOS-00227" stigid="040410" cui="3.1.13,3.13.10" />
 <oval id="file_permissions_sshd_pub_key" />
 </Rule>
 
-<Rule id="file_permissions_sshd_private_key" severity="medium" prodtype="rhel7">
+<Rule id="file_permissions_sshd_private_key" severity="medium">
 <title>Verify Permissions on SSH Server Private <tt>*_key</tt> Key Files</title>
 <description><fileperms-desc-macro file="/etc/ssh/*_key" perms="0640"/></description>
 <ocil><fileperms-check-macro file="/etc/ssh/*_key" perms="-rw-r-----"/></ocil>
@@ -181,7 +181,7 @@ will allow remote access through the SSH port.
 <oval id="firewalld_sshd_port_enabled" value="sshd_listening_port" />
 </Rule>
 
-<Rule id="sshd_allow_only_protocol2" severity="high" prodtype="rhel7">
+<Rule id="sshd_allow_only_protocol2" severity="high">
 <title>Allow Only SSH Protocol 2</title>
 <description>Only SSH protocol version 2 connections should be
 permitted. The default setting in
@@ -207,7 +207,7 @@ ossrg="SRG-OS-000074-GPOS-00042,SRG-OS-000480-GPOS-00227" stigid="040390" cjis="
 cui="3.1.13,3.5.4" />
 </Rule>
 
-<Rule id="sshd_limit_user_access" prodtype="rhel7">
+<Rule id="sshd_limit_user_access">
 <title>Limit Users' SSH Access</title>
 <description>By default, the SSH configuration allows any user with an account
 to access the system. In order to specify the users that are allowed to login
@@ -225,7 +225,7 @@ possibility of unauthorized access to the system.
 <ref prodtype="rhel7" nist="AC-3" cui="3.1.12" />
 </Rule>
 
-<Rule id="sshd_disable_gssapi_auth" severity="medium" prodtype="rhel7">
+<Rule id="sshd_disable_gssapi_auth" severity="medium">
 <title>Disable GSSAPI Authentication</title>
 <description>Unless needed, SSH should not permit extraneous or unnecessary
 authentication mechanisms like GSSAPI. To disable GSSAPI authentication, add or
@@ -249,7 +249,7 @@ GSSAPI to remote hosts, increasing the attack surface of the system.
 ossrg="SRG-OS-000364-GPOS-00151" stigid="040430" cui="3.1.12" />
 </Rule>
 
-<Rule id="sshd_disable_kerb_auth" severity="medium" prodtype="rhel7">
+<Rule id="sshd_disable_kerb_auth" severity="medium">
 <title>Disable Kerberos Authentication</title>
 <description>Unless needed, SSH should not permit extraneous or unnecessary
 authentication mechanisms like Kerberos. To disable Kerberos authentication, add
@@ -274,7 +274,7 @@ implementations may be subject to exploitation.
 ossrg="SRG-OS-000364-GPOS-00151" stigid="040440" cui="3.1.12" />
 </Rule>
 
-<Rule id="sshd_enable_strictmodes" severity="medium" prodtype="rhel7">
+<Rule id="sshd_enable_strictmodes" severity="medium">
 <title>Enable Use of Strict Mode Checking</title>
 <description>SSHs StrictModes option checks file and ownership permissions in
 the user's home directory <tt>.ssh</tt> folder before accepting login. If world-
@@ -298,7 +298,7 @@ may be able to log into the system as another user.
 cui="3.1.12" />
 </Rule>
 
-<Rule id="sshd_use_priv_separation" severity="medium" prodtype="rhel7">
+<Rule id="sshd_use_priv_separation" severity="medium">
 <title>Enable Use of Privilege Separation</title>
 <description>When enabled, SSH will create an unprivileged child process that
 has the privilege of the authenticated user. To enable privilege separation in
@@ -322,7 +322,7 @@ the unprivileged section.
 cui="3.1.12" />
 </Rule>
 
-<Rule id="sshd_disable_compression" severity="medium" prodtype="rhel7">
+<Rule id="sshd_disable_compression" severity="medium">
 <title>Disable Compression Or Set Compression to <tt>delayed</tt></title>
 <description>Compression is useful for slow network connections over long
 distances but can cause performance issues on local LANs. If use of compression
@@ -349,7 +349,7 @@ system from an unauthenticated connection, potentially wih root privileges.
 cui="3.1.12" />
 </Rule>
 
-<Rule id="sshd_print_last_log" severity="low" prodtype="rhel7">
+<Rule id="sshd_print_last_log" severity="low">
 <title>Print Last Log</title>
 <description>When enabled, SSH will display the date and time of the last
 successful account logon. To enable LastLog in
@@ -434,7 +434,7 @@ disable it:
 -->
 
 
-<Rule id="sshd_set_idle_timeout" prodtype="rhel7">
+<Rule id="sshd_set_idle_timeout">
 <title>Set SSH Idle Timeout Interval</title>
 <description>SSH allows administrators to set an idle timeout
 interval.
@@ -469,7 +469,7 @@ ossrg="SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109" stigid="040320"
 pcidss="Req-8.1.8" cis="6.2.12" cjis="5.5.6" cui="3.1.11" />
 </Rule>
 
-<Rule id="sshd_set_keepalive" severity="medium" prodtype="rhel7">
+<Rule id="sshd_set_keepalive" severity="medium">
 <title>Set SSH Client Alive Count</title>
 <description>To ensure the SSH idle timeout occurs precisely when the <tt>ClientAliveCountMax</tt> is set,
 edit <tt>/etc/ssh/sshd_config</tt> as follows:
@@ -492,7 +492,7 @@ ossrg="SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109" stigid="040340"
 cis="6.2.12" cjis="5.5.6" cui="3.1.11" />
 </Rule>
 
-<Rule id="sshd_set_max_auth_tries" severity="medium" prodtype="rhel7,debian8">
+<Rule id="sshd_set_max_auth_tries" severity="medium">
 <title>Set SSH authentication attempt limit</title>
 <description>The <tt>MaxAuthTries</tt> parameter specifies the maximum number of authentication attempts
 permitted per connection. Once the number of failures reaches half this value, additional failures are logged.
@@ -513,7 +513,7 @@ brute force attacks to the SSH server.
 <ref prodtype="debian8" cis="9.3.5" />
 </Rule>
 
-<Rule id="sshd_disable_rhosts" severity="medium" prodtype="rhel7,debian8">
+<Rule id="sshd_disable_rhosts" severity="medium">
 <title>Disable SSH Support for .rhosts Files</title>
 <description>SSH can emulate the behavior of the obsolete rsh
 command in allowing users to enable insecure access to their
@@ -536,7 +536,7 @@ can allow an attacker to move trivially to other hosts.
 ossrg="SRG-OS-000480-GPOS-00227" cjis="5.5.6" cui="3.1.12" />
 </Rule>
 
-<Rule id="sshd_disable_user_known_hosts" severity="medium" prodtype="rhel7">
+<Rule id="sshd_disable_user_known_hosts" severity="medium">
 <title>Disable SSH Support for User Known Hosts</title>
 <description>SSH can allow system users user host-based authentication to connect
 to systems if a cache of the remote systems public keys are available.
@@ -560,7 +560,7 @@ in the event of misconfiguration elsewhere.
 ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
 
-<Rule id="sshd_disable_rhosts_rsa" severity="medium" prodtype="rhel7">
+<Rule id="sshd_disable_rhosts_rsa" severity="medium">
 <title>Disable SSH Support for Rhosts RSA Authentication</title>
 <description>SSH can allow authentication through the obsolete rsh
 command through the use of the authenticating user's SSH keys. This should be disabled.
@@ -583,7 +583,7 @@ in the event of misconfiguration elsewhere.
 ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
 
-<Rule id="disable_host_auth" severity="medium" prodtype="rhel7">
+<Rule id="disable_host_auth" severity="medium">
 <title>Disable Host-Based Authentication</title>
 <description>SSH's cryptographic host-based authentication is
 more secure than <tt>.rhosts</tt> authentication. However, it is
@@ -607,7 +607,7 @@ can allow an attacker to move trivially to other hosts.
 stigid="010470" cis="6.2.7" cjis="5.5.6" cui="3.1.12" />
 </Rule>
 
-<Rule id="sshd_enable_x11_forwarding" severity="high" prodtype="rhel7">
+<Rule id="sshd_enable_x11_forwarding" severity="high">
 <title>Enable Encrypted X11 Fordwarding</title>
 <description>By default, remote X11 connections are not encrypted when initiated
 by users. SSH has the capability to encrypt remote X11 connections when SSH's
@@ -630,7 +630,7 @@ remotely.
 stigid="040710" cui="3.1.13" />
 </Rule>
 
-<Rule id="sshd_disable_root_login" severity="medium" prodtype="rhel7">
+<Rule id="sshd_disable_root_login" severity="medium">
 <title>Disable SSH Root Login</title>
 <description>The root user should never be allowed to login to a
 system directly over a network.
@@ -654,7 +654,7 @@ direct attack attempts on root's password.
 ossrg="SRG-OS-000480-GPOS-00227" stigid="040370" cis="6.2.8" cjis="5.5.6" cui="3.1.1, 3.1.5" />
 </Rule>
 
-<Rule id="sshd_disable_empty_passwords" severity="high" prodtype="rhel7">
+<Rule id="sshd_disable_empty_passwords" severity="high">
 <title>Disable SSH Access via Empty Passwords</title>
 <description>To explicitly disallow SSH login from accounts with
 empty passwords, add or correct the following line in <tt>/etc/ssh/sshd_config</tt>:
@@ -677,7 +677,7 @@ misconfiguration elsewhere.
 <ref prodtype="rhel7" nist="AC-3,AC-6,CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00229" stigid="010300" cjis="5.5.6" cui="3.1.1, 3.1.5" />
 </Rule>
 
-<Rule id="sshd_enable_warning_banner" severity="medium" prodtype="rhel7">
+<Rule id="sshd_enable_warning_banner" severity="medium">
 <title>Enable SSH Warning Banner</title>
 <description>
 To enable the warning banner and ensure it is consistent
@@ -702,7 +702,7 @@ ossrg="SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-0008
 cis="6.2.14" stigid="040170" cjis="5.5.6" cui="3.1.9" />
 </Rule>
 
-<Rule id="sshd_do_not_permit_user_env" severity="medium" prodtype="rhel7">
+<Rule id="sshd_do_not_permit_user_env" severity="medium">
 <title>Do Not Allow SSH Environment Options</title>
 <description>To ensure users are not able to override environment
 options to the SSH daemon, add or correct the following line
@@ -725,17 +725,17 @@ access restriction in some configurations.
 cis="6.2.10" cjis="5.5.6" cui="3.1.12" />
 </Rule>
 
-<Rule id="sshd_use_approved_ciphers" severity="medium" prodtype="rhel7">
-<title>Use Only Approved Ciphers</title>
+<Rule id="sshd_use_approved_ciphers" severity="medium">
+<title>Use Only FIPS 140-2 Validated Ciphers</title>
 <description>Limit the ciphers to those algorithms which are FIPS-approved.
 Counter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.
-The following line in <tt>/etc/ssh/sshd_config</tt>
-demonstrates use of FIPS-approved ciphers:
+The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use of 
+FIPS-approved ciphers:
 <pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr</pre>
 The man page <tt>sshd_config(5)</tt> contains a list of supported ciphers.
 </description>
 <ocil clause="FIPS ciphers are not configured or the enabled ciphers are not FIPS-approved">
-Only FIPS-approved ciphers should be used.  To verify that only FIPS-approved
+Only FIPS ciphers should be used.  To verify that only FIPS-approved
 ciphers are in use, run the following command:
 <pre>$ sudo grep Ciphers /etc/ssh/sshd_config</pre>
 The output should contain only those ciphers which are FIPS-approved, namely,
@@ -759,8 +759,8 @@ ossrg="SRG-OS-000033-GPOS-00014,SRG-OS-000120-GPOS-00061,SRG-OS-000125-GPOS-0006
 stigid="040110" cis="6.2.11" cjis="5.5.6" cui="3.1.13,3.13.11,3.13.8" />
 </Rule>
 
-<Rule id="sshd_use_approved_macs" severity="medium" prodtype="rhel7">
-<title>Use Only FIPS Approved MACs</title>
+<Rule id="sshd_use_approved_macs" severity="medium">
+<title>Use Only FIPS 140-2 Validated MACs</title>
 <description>Limit the MACs to those hash algorithms which are FIPS-approved.
 The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use 
 of FIPS-approved MACs:
@@ -785,7 +785,7 @@ ossrg="SRG-OS-000250-GPOS-00093" stigid="040400" cui="3.1.13,3.13.11,3.13.8" />
 </Rule>
 
 <!-- similar to sshd_use_approved_ciphers, but without FIPS certification -->
-<Rule id="sshd_use_strong_ciphers" severity="medium" prodtype="rhel7,debian8">
+<Rule id="sshd_use_strong_ciphers" severity="medium">
 <title>Use Only Strong Ciphers</title>
 <description>Limit the ciphers to strong algorithms.
 Counter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.
@@ -815,7 +815,7 @@ types of attacks and these algorithms are now recommended for standard use.
 </Rule>
 
 <!-- similar to sshd_use_approved_macs, but without FIPS certification -->
-<Rule id="sshd_use_strong_macs" severity="medium" prodtype="rhel7,debian8">
+<Rule id="sshd_use_strong_macs" severity="medium">
 <title>Use Only Strong MACs</title>
 <description>Limit the MACs to strong hash algorithms.
 The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -393,6 +393,7 @@ Response, it is important to determine when a particular user was active on a sy
 logout record can eliminate those users who disconnected, which helps narrow the field.
 </rationale>
 <oval id="sshd_set_loglevel_info" />
+<ref prodtype="rhel7" cis="5.2.9"/>
 <ref prodtype="debian8" cis="9.3.2"/>
 </Rule>
 

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -28,6 +28,7 @@ operator="equals" interactive="0">
 <description>Specify the maximum number of authentication attempts per connection.</description>
 <value selector="">4</value>
 <value selector="3">3</value>
+<value selector="4">4</value>
 <value selector="5">5</value>
 <value selector="10">10</value>
 </Value>

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -691,7 +691,7 @@ appropriate system-wide warning banner.
 </ocil>
 <rationale>
 The warning message reinforces policy awareness during the logon process and
-facilitates possible legal action against attackers.  Alternatively, systems
+facilitates possible legal action against attackers. Alternatively, systems
 whose ownership should not be obvious should ensure usage of a banner that does
 not provide easy attribution.
 </rationale>
@@ -735,7 +735,7 @@ FIPS-approved ciphers:
 The man page <tt>sshd_config(5)</tt> contains a list of supported ciphers.
 </description>
 <ocil clause="FIPS ciphers are not configured or the enabled ciphers are not FIPS-approved">
-Only FIPS ciphers should be used.  To verify that only FIPS-approved
+Only FIPS ciphers should be used. To verify that only FIPS-approved
 ciphers are in use, run the following command:
 <pre>$ sudo grep Ciphers /etc/ssh/sshd_config</pre>
 The output should contain only those ciphers which are FIPS-approved, namely,
@@ -767,7 +767,7 @@ of FIPS-approved MACs:
 <pre>MACs hmac-sha2-512,hmac-sha2-256</pre>
 </description>
 <ocil clause="MACs option is commented out or not using FIPS-approved hash algorithms">
-Only FIPS-approved MACs should be used.  To verify that only FIPS-approved
+Only FIPS-approved MACs should be used. To verify that only FIPS-approved
 MACs are in use, run the following command:
 <pre>$ sudo grep -i macs /etc/ssh/sshd_config</pre>
 The output should contain only those MACs which are FIPS-approved, namely,
@@ -796,7 +796,7 @@ demonstrates use of those ciphers:
 The man page <tt>sshd_config(5)</tt> contains a list of supported ciphers.
 </description>
 <ocil clause="ciphers are not configured or not using strong ciphers">
-Only strong ciphers should be used.  To verify that only strong
+Only strong ciphers should be used. To verify that only strong
 ciphers are in use, run the following command:
 <pre>$ sudo grep Ciphers /etc/ssh/sshd_config</pre>
 The output should contain only those ciphers which are considered strong, namely,
@@ -823,7 +823,7 @@ of those MACs:
 <pre>MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160</pre>
 </description>
 <ocil clause="MACs option is commented out or not using strong hash algorithms">
-Only strong MACs should be used.  To verify that only strong
+Only strong MACs should be used. To verify that only strong
 MACs are in use, run the following command:
 <pre>$ sudo grep -i macs /etc/ssh/sshd_config</pre>
 The output should contain only those MACs which are strong, namely,

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -22,6 +22,16 @@ operator="equals" interactive="0">
 <value selector="120_minutes">7200</value>
 </Value>
 
+<Value id="sshd_max_auth_tries_value" type="number"
+operator="equals" interactive="0">
+<title>SSH Max authentication attempts</title>
+<description>Specify the maximum number of authentication attempts per connection.</description>
+<value selector="">4</value>
+<value selector="3">3</value>
+<value selector="5">5</value>
+<value selector="10">10</value>
+</Value>
+
 <Value id="sshd_listening_port" type="number"
 operator="equals" interactive="0">
 <title>SSH Server Listening Port</title>
@@ -360,6 +370,31 @@ recognition and reporting of unauthorized account use.
 <ref prodtype="rhel7" nist="AC-9" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="040360"/>
 </Rule>
 
+<Rule id="sshd_set_loglevel_info" severity="low" prodtype="debian8">
+<title>Set LogLevel to INFO</title>
+<description>The INFO parameter specifices that record login and logout activity will be logged.
+To specify the log level in
+SSH, add or correct the following line in the <tt>/etc/ssh/sshd_config</tt> file:
+<pre>LogLevel INFO</pre>
+</description>
+<ocil clause="it is commented out or is not enabled">
+To check if PrintLastLog is enabled or set correctly, run the
+following command:
+<pre>$ sudo grep "^LogLevel" /etc/ssh/sshd_config</pre>
+If configured properly, output should be <pre>LogLevel INFO</pre>
+</ocil>
+<rationale>
+SSH provides several logging levels with varying amounts of verbosity. <tt>DEBUG</tt> is specifically
+not recommended other than strictly for debugging SSH communications since it provides
+so much data that it is difficult to identify important security information. <tt>INFO</tt> level is the
+basic level that only records login activity of SSH users. In many situations, such as Incident
+Response, it is important to determine when a particular user was active on a system. The
+logout record can eliminate those users who disconnected, which helps narrow the field.
+</rationale>
+<oval id="sshd_set_loglevel_info" />
+<ref prodtype="debian8" cis="9.3.2"/>
+</Rule>
+
 <!-- FIXME: figure out whether/how to say something discrete here -->
 <!--
 <Group id="sshd_disable_extraneous_authentication">
@@ -455,7 +490,28 @@ ossrg="SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109" stigid="040340"
 cis="6.2.12" cjis="5.5.6" cui="3.1.11" />
 </Rule>
 
-<Rule id="sshd_disable_rhosts" severity="medium" prodtype="rhel7">
+<Rule id="sshd_set_max_auth_tries" severity="medium" prodtype="rhel7,debian8">
+<title>Set SSH authentication attempt limit</title>
+<description>The <tt>MaxAuthTries</tt> parameter specifies the maximum number of authentication attempts
+permitted per connection. Once the number of failures reaches half this value, additional failures are logged.
+to set MaxAUthTries edit <tt>/etc/ssh/sshd_config</tt> as follows:
+<pre>MaxAuthTries <b>tries</b></pre>
+</description>
+<ocil clause="it is commented out or not configured properly">
+To ensure the <tt>MaxAuthTries</tt> parameter is set, run the following command:
+<pre>$ sudo grep MaxAuthTries /etc/ssh/sshd_config</pre>
+If properly configured, output should be:
+<pre>MaxAuthTries <b>tries</b></pre>
+</ocil>
+<rationale>
+Setting the MaxAuthTries parameter to a low number will minimize the risk of successful
+brute force attacks to the SSH server.
+</rationale>
+<oval id="sshd_set_max_auth_tries" value="sshd_max_auth_tries_value"/>
+<ref prodtype="debian8" cis="9.3.5" />
+</Rule>
+
+<Rule id="sshd_disable_rhosts" severity="medium" prodtype="rhel7,debian8">
 <title>Disable SSH Support for .rhosts Files</title>
 <description>SSH can emulate the behavior of the obsolete rsh
 command in allowing users to enable insecure access to their
@@ -549,7 +605,7 @@ can allow an attacker to move trivially to other hosts.
 stigid="010470" cis="6.2.7" cjis="5.5.6" cui="3.1.12" />
 </Rule>
 
-<Rule id="enable_x11_forwarding" severity="high" prodtype="rhel7">
+<Rule id="sshd_enable_x11_forwarding" severity="high" prodtype="rhel7">
 <title>Enable Encrypted X11 Fordwarding</title>
 <description>By default, remote X11 connections are not encrypted when initiated
 by users. SSH has the capability to encrypt remote X11 connections when SSH's
@@ -567,7 +623,7 @@ Open X displays allow an attacker to capture keystrokes and to execute commands
 remotely.
 </rationale>
 <ident prodtype="rhel7" cce="80226-4" />
-<oval id="enable_x11_forwarding" />
+<oval id="sshd_enable_x11_forwarding" />
 <ref prodtype="rhel7" nist="CM-2(1)(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00227"
 stigid="040710" cui="3.1.13" />
 </Rule>
@@ -724,6 +780,61 @@ functions. The only SSHv2 hash algorithms meeting this requirement is SHA2.
 <oval id="sshd_use_approved_macs" value="sshd_approved_macs" />
 <ref prodtype="rhel7" nist="AC-17(2),IA-7,SC-13" disa="1453"
 ossrg="SRG-OS-000250-GPOS-00093" stigid="040400" cui="3.1.13,3.13.11,3.13.8" />
+</Rule>
+
+<!-- similar to sshd_use_approved_ciphers, but without FIPS certification -->
+<Rule id="sshd_use_strong_ciphers" severity="medium" prodtype="rhel7,debian8">
+<title>Use Only Strong Ciphers</title>
+<description>Limit the ciphers to strong algorithms.
+Counter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.
+The following line in <tt>/etc/ssh/sshd_config</tt>
+demonstrates use of those ciphers:
+<pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr</pre>
+<pre>chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr</pre>
+The man page <tt>sshd_config(5)</tt> contains a list of supported ciphers.
+</description>
+<ocil clause="ciphers are not configured or not using strong ciphers">
+Only approved ciphers should be used.  To verify that only approved
+ciphers are in use, run the following command:
+<pre>$ sudo grep Ciphers /etc/ssh/sshd_config</pre>
+The output should contain only those ciphers which are considered strong, namely,
+chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr
+</ocil>
+<rationale>
+Based on research conducted at various institutions, it was determined that the symmetric
+portion of the SSH Transport Protocol (as described in RFC 4253) has security weaknesses
+that allowed recovery of up to 32 bits of plaintext from a block of ciphertext that was
+encrypted with the Cipher Block Chaining (CBD) method. From that research, new Counter
+mode algorithms (as described in RFC4344) were designed that are not vulnerable to these
+types of attacks and these algorithms are now recommended for standard use.
+</rationale>
+<oval id="sshd_use_strong_ciphers" />
+<ref prodtype="debian" cis="9.3.11" />
+</Rule>
+
+<!-- similar to sshd_use_approved_macs, but without FIPS certification -->
+<Rule id="sshd_use_strong_macs" severity="medium" prodtype="rhel7,debian8">
+<title>Use Only Strong MACs</title>
+<description>Limit the MACs to strong hash algorithms.
+The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use
+of those MACs:
+<pre>MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160</pre>
+</description>
+<ocil clause="MACs option is commented out or not using strong hash algorithms">
+Only approved MACs should be used.  To verify that only approved
+MACs are in use, run the following command:
+<pre>$ sudo grep -i macs /etc/ssh/sshd_config</pre>
+The output should contain only those MACs which are approved, namely,
+hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160 hash functions.
+</ocil>
+<rationale>
+MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase
+exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of
+attention as a weak spot that can be exploited with expanded computing power. An
+attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the
+SSH tunnel and capture credentials and information
+</rationale>
+<oval id="sshd_use_strong_macs" />
 </Rule>
 
 <Group id="sshd_strengthen_firewall">

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -371,7 +371,7 @@ recognition and reporting of unauthorized account use.
 <ref prodtype="rhel7" nist="AC-9" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="040360"/>
 </Rule>
 
-<Rule id="sshd_set_loglevel_info" severity="low" prodtype="debian8">
+<Rule id="sshd_set_loglevel_info" severity="low">
 <title>Set LogLevel to INFO</title>
 <description>The INFO parameter specifices that record login and logout activity will be logged.
 To specify the log level in

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -794,7 +794,7 @@ demonstrates use of those ciphers:
 The man page <tt>sshd_config(5)</tt> contains a list of supported ciphers.
 </description>
 <ocil clause="ciphers are not configured or not using strong ciphers">
-Only approved ciphers should be used.  To verify that only approved
+Only strong ciphers should be used.  To verify that only strong
 ciphers are in use, run the following command:
 <pre>$ sudo grep Ciphers /etc/ssh/sshd_config</pre>
 The output should contain only those ciphers which are considered strong, namely,
@@ -821,10 +821,10 @@ of those MACs:
 <pre>MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160</pre>
 </description>
 <ocil clause="MACs option is commented out or not using strong hash algorithms">
-Only approved MACs should be used.  To verify that only approved
+Only strong MACs should be used.  To verify that only strong
 MACs are in use, run the following command:
 <pre>$ sudo grep -i macs /etc/ssh/sshd_config</pre>
-The output should contain only those MACs which are approved, namely,
+The output should contain only those MACs which are strong, namely,
 hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160 hash functions.
 </ocil>
 <rationale>

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -379,7 +379,7 @@ SSH, add or correct the following line in the <tt>/etc/ssh/sshd_config</tt> file
 <pre>LogLevel INFO</pre>
 </description>
 <ocil clause="it is commented out or is not enabled">
-To check if PrintLastLog is enabled or set correctly, run the
+To check if LogLevel is enabled or set correctly, run the
 following command:
 <pre>$ sudo grep "^LogLevel" /etc/ssh/sshd_config</pre>
 If configured properly, output should be <pre>LogLevel INFO</pre>


### PR DESCRIPTION
rename OVAL/xccdf enable_x11_forwarding to sshd_enable_x11_forwarding
move sshd_enable_x11_forwarding oval to shared
added OVAL: sshd_set_max_auth_tries
added OVAL: sshd_set_loglevel_info.xml

changed Cipher pattern in sshd_use_approved_ciphers to reflect description (only
CTR mode)
remove criterion "installed_OS_is_certified" from sshd_use_approved_ciphers, so
the check can be used by a non-certified OS