### PR TITLE
Fix user login in RHEL7-OSPP kickstart

### DIFF
--- a/RHEL/7/kickstart/ssg-rhel7-ospp-ks.cfg
+++ b/RHEL/7/kickstart/ssg-rhel7-ospp-ks.cfg
@@ -62,6 +62,11 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
 # Configure firewall settings for the system (optional)
 # --enabled	reject incoming connections that are not in response to outbound requests
 # --ssh		allow sshd service through the firewall


### PR DESCRIPTION
The RHEL7 OSPP profile kickstart is so strict that root login is not
allowed.

Add a user that can login and escalate privileges.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1378581