### PR TITLE
Use @CCENUM@ instead of $CCENUM for the token replacement

### DIFF
--- a/RHEL/7/templates/static/bash/sshd_disable_empty_passwords.sh
+++ b/RHEL/7/templates/static/bash/sshd_disable_empty_passwords.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^PermitEmptyPasswords' 'no' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^PermitEmptyPasswords' 'no' '@CCENUM@' '%s %s'

--- a/RHEL/7/templates/static/bash/sshd_do_not_permit_user_env.sh
+++ b/RHEL/7/templates/static/bash/sshd_do_not_permit_user_env.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^PermitUserEnvironment' 'no' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^PermitUserEnvironment' 'no' '@CCENUM@' '%s %s'

--- a/RHEL/7/templates/static/bash/sshd_enable_warning_banner.sh
+++ b/RHEL/7/templates/static/bash/sshd_enable_warning_banner.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^Banner' '/etc/issue' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^Banner' '/etc/issue' '@CCENUM@' '%s %s'

--- a/RHEL/7/templates/static/bash/sshd_set_idle_timeout.sh
+++ b/RHEL/7/templates/static/bash/sshd_set_idle_timeout.sh
@@ -2,4 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate sshd_idle_timeout_value
 
-replace_or_append '/etc/ssh/sshd_config' '^ClientAliveInterval' $sshd_idle_timeout_value '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^ClientAliveInterval' $sshd_idle_timeout_value '@CCENUM@' '%s %s'

--- a/RHEL/7/templates/static/bash/sshd_set_keepalive.sh
+++ b/RHEL/7/templates/static/bash/sshd_set_keepalive.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^ClientAliveCountMax' '0' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^ClientAliveCountMax' '0' '@CCENUM@' '%s %s'

--- a/RHEL/7/templates/static/bash/sshd_use_approved_ciphers.sh
+++ b/RHEL/7/templates/static/bash/sshd_use_approved_ciphers.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^Ciphers' 'aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^Ciphers' 'aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc' '@CCENUM@' '%s %s'

--- a/RHEL/7/templates/static/bash/sshd_use_approved_macs.sh
+++ b/RHEL/7/templates/static/bash/sshd_use_approved_macs.sh
@@ -5,4 +5,4 @@
 
 populate sshd_approved_macs
 
-replace_or_append '/etc/ssh/sshd_config' '^MACs' "$sshd_approved_macs" '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^MACs' "$sshd_approved_macs" '@CCENUM@' '%s %s'

--- a/RHEL/7/templates/static/bash/sysctl_kernel_exec_shield.sh
+++ b/RHEL/7/templates/static/bash/sysctl_kernel_exec_shield.sh
@@ -12,7 +12,7 @@ if [ $(getconf LONG_BIT) = "32" ] ; then
   # If kernel.exec-shield present in /etc/sysctl.conf, change value to "1"
   #	else, add "kernel.exec-shield = 1" to /etc/sysctl.conf
   #
-  replace_or_append '/etc/sysctl.conf' '^kernel.exec-shield' '1' '$CCENUM'
+  replace_or_append '/etc/sysctl.conf' '^kernel.exec-shield' '1' '@CCENUM@'
 fi
 
 if [ $(getconf LONG_BIT) = "64" ] ; then

--- a/RHEL/7/templates/static/bash/sysctl_kernel_randomize_va_space.sh
+++ b/RHEL/7/templates/static/bash/sysctl_kernel_randomize_va_space.sh
@@ -7,4 +7,4 @@ sysctl -q -n -w kernel.randomize_va_space=2
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/sysctl.conf' '^kernel.randomize_va_space' '2' '$CCENUM'
+replace_or_append '/etc/sysctl.conf' '^kernel.randomize_va_space' '2' '@CCENUM@'

--- a/shared/remediations/bash/templates/remediation_functions
+++ b/shared/remediations/bash/templates/remediation_functions
@@ -720,7 +720,7 @@ done
 # config_file:		Configuration file that will be modified
 # key:			Configuration option to change
 # value:		Value of the configuration option to change
-# cce:			The CCE identifier or '$CCENUM' if no CCE identifier exists
+# cce:			The CCE identifier or '@CCENUM@' if no CCE identifier exists
 #
 # Optional arugments:
 #
@@ -730,13 +730,13 @@ done
 # Example Call(s):
 #
 #     With default format of 'key = value':
-#     replace_or_append '/etc/sysctl.conf' '^kernel.randomize_va_space' '2' '$CCENUM'
+#     replace_or_append '/etc/sysctl.conf' '^kernel.randomize_va_space' '2' '@CCENUM@'
 #
 #     With custom key/value format:
-#     replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' 'disabled' '$CCENUM' '%s=%s'
+#     replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' 'disabled' '@CCENUM@' '%s=%s'
 #
 #     With a variable:
-#     replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' $var_selinux_state '$CCENUM' '%s=%s'
+#     replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' $var_selinux_state '@CCENUM@' '%s=%s'
 #
 function replace_or_append {
   local config_file=$1
@@ -764,9 +764,9 @@ function replace_or_append {
     sed_command="sed -i"
   fi
 
-  # Test that the cce arg is not empty or does not equal $CCENUM.
-  # If $CCENUM exists, it means that there is no CCE assigned.
-  if ! [ "x$cce" = x ] && [ "$cce" != '$CCENUM' ]; then
+  # Test that the cce arg is not empty or does not equal @CCENUM@.
+  # If @CCENUM@ exists, it means that there is no CCE assigned.
+  if ! [ "x$cce" = x ] && [ "$cce" != '@CCENUM@' ]; then
     cce="CCE-${cce}"
   else
     cce="CCE"

--- a/shared/templates/static/bash/accounts_logon_fail_delay.sh
+++ b/shared/templates/static/bash/accounts_logon_fail_delay.sh
@@ -6,4 +6,4 @@
 # Set variables
 populate var_accounts_fail_delay
 
-replace_or_append '/etc/login.defs' '^FAIL_DELAY' "$var_accounts_fail_delay" '$CCENUM' '%s %s'
+replace_or_append '/etc/login.defs' '^FAIL_DELAY' "$var_accounts_fail_delay" '@CCENUM@' '%s %s'

--- a/shared/templates/static/bash/ensure_gpgcheck_globally_activated.sh
+++ b/shared/templates/static/bash/ensure_gpgcheck_globally_activated.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_rhel
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/yum.conf' '^gpgcheck' '1' '$CCENUM'
+replace_or_append '/etc/yum.conf' '^gpgcheck' '1' '@CCENUM@'

--- a/shared/templates/static/bash/rsyslog_remote_loghost.sh
+++ b/shared/templates/static/bash/rsyslog_remote_loghost.sh
@@ -6,5 +6,5 @@ populate rsyslog_remote_loghost_address
 
 if [ "$rsyslog_remote_loghost_address" != "NULL" ]
 then
-    replace_or_append '/etc/rsyslog.conf' '^\*\.\*' "@@$rsyslog_remote_loghost_address" '$CCENUM' '%s %s'
+    replace_or_append '/etc/rsyslog.conf' '^\*\.\*' "@@$rsyslog_remote_loghost_address" '@CCENUM@' '%s %s'
 fi

--- a/shared/templates/static/bash/selinux_policytype.sh
+++ b/shared/templates/static/bash/selinux_policytype.sh
@@ -4,4 +4,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_selinux_policy_name
 
-replace_or_append '/etc/sysconfig/selinux' '^SELINUXTYPE=' $var_selinux_policy_name '$CCENUM' '%s=%s'
+replace_or_append '/etc/sysconfig/selinux' '^SELINUXTYPE=' $var_selinux_policy_name '@CCENUM@' '%s=%s'

--- a/shared/templates/static/bash/selinux_state.sh
+++ b/shared/templates/static/bash/selinux_state.sh
@@ -4,7 +4,7 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_selinux_state
 
-replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' $var_selinux_state '$CCENUM' '%s=%s'
+replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' $var_selinux_state '@CCENUM@' '%s=%s'
 
 fixfiles onboot
 fixfiles -f relabel

--- a/shared/templates/static/bash/sshd_allow_only_protocol2.sh
+++ b/shared/templates/static/bash/sshd_allow_only_protocol2.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^Protocol' '2' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^Protocol' '2' '@CCENUM@' '%s %s'

--- a/shared/templates/static/bash/sshd_disable_compression.sh
+++ b/shared/templates/static/bash/sshd_disable_compression.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^Compression' 'no' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^Compression' 'no' '@CCENUM@' '%s %s'

--- a/shared/templates/static/bash/sshd_disable_gssapi_auth.sh
+++ b/shared/templates/static/bash/sshd_disable_gssapi_auth.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^GSSAPIAuthentication' 'no' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^GSSAPIAuthentication' 'no' '@CCENUM@' '%s %s'

--- a/shared/templates/static/bash/sshd_disable_kerb_auth.sh
+++ b/shared/templates/static/bash/sshd_disable_kerb_auth.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^KerberosAuthentication' 'no' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^KerberosAuthentication' 'no' '@CCENUM@' '%s %s'

--- a/shared/templates/static/bash/sshd_disable_rhosts.sh
+++ b/shared/templates/static/bash/sshd_disable_rhosts.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^IgnoreRhosts' 'yes' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^IgnoreRhosts' 'yes' '@CCENUM@' '%s %s'

--- a/shared/templates/static/bash/sshd_disable_rhosts_rsa.sh
+++ b/shared/templates/static/bash/sshd_disable_rhosts_rsa.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^RhostsRSAAuthentication' 'no' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^RhostsRSAAuthentication' 'no' '@CCENUM@' '%s %s'

--- a/shared/templates/static/bash/sshd_disable_user_known_hosts.sh
+++ b/shared/templates/static/bash/sshd_disable_user_known_hosts.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^IgnoreUserKnownHosts' 'yes' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^IgnoreUserKnownHosts' 'yes' '@CCENUM@' '%s %s'

--- a/shared/templates/static/bash/sshd_enable_strictmodes.sh
+++ b/shared/templates/static/bash/sshd_enable_strictmodes.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^StrictModes' 'yes' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^StrictModes' 'yes' '@CCENUM@' '%s %s'

--- a/shared/templates/static/bash/sshd_print_last_log.sh
+++ b/shared/templates/static/bash/sshd_print_last_log.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^PrintLastLog' 'yes' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^PrintLastLog' 'yes' '@CCENUM@' '%s %s'

--- a/shared/templates/static/bash/sshd_use_approved_macs.sh
+++ b/shared/templates/static/bash/sshd_use_approved_macs.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^MACs' 'hmac-sha2-512,hmac-sha2-256,hmac-sha1' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^MACs' 'hmac-sha2-512,hmac-sha2-256,hmac-sha1' '@CCENUM@' '%s %s'

--- a/shared/templates/static/bash/sshd_use_priv_separation.sh
+++ b/shared/templates/static/bash/sshd_use_priv_separation.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^UsePrivilegeSeparation' 'yes' '$CCENUM' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^UsePrivilegeSeparation' 'yes' '@CCENUM@' '%s %s'

--- a/shared/templates/template_BASH_accounts_password
+++ b/shared/templates/template_BASH_accounts_password
@@ -2,4 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_VARIABLE
 
-replace_or_append '/etc/security/pwquality.conf' '^VARIABLE' $var_password_pam_VARIABLE '$CCENUM' '%s = %s'
+replace_or_append '/etc/security/pwquality.conf' '^VARIABLE' $var_password_pam_VARIABLE '@CCENUM@' '%s = %s'

--- a/shared/templates/template_BASH_sysctl
+++ b/shared/templates/template_BASH_sysctl
@@ -14,4 +14,4 @@
 # If SYSCTLVAR present in /etc/sysctl.conf, change value to "SYSCTLVAL"
 #	else, add "SYSCTLVAR = SYSCTLVAL" to /etc/sysctl.conf
 #
-replace_or_append '/etc/sysctl.conf' '^SYSCTLVAR' "SYSCTLVAL" '$CCENUM'
+replace_or_append '/etc/sysctl.conf' '^SYSCTLVAR' "SYSCTLVAL" '@CCENUM@'

--- a/shared/templates/template_BASH_sysctl_var
+++ b/shared/templates/template_BASH_sysctl_var
@@ -15,4 +15,4 @@ populate sysctl_SYSCTLID_value
 # If SYSCTLVAR present in /etc/sysctl.conf, change value to appropriate value
 #	else, add "SYSCTLVAR = value" to /etc/sysctl.conf
 #
-replace_or_append '/etc/sysctl.conf' '^SYSCTLVAR' "$sysctl_SYSCTLID_value" '$CCENUM'
+replace_or_append '/etc/sysctl.conf' '^SYSCTLVAR' "$sysctl_SYSCTLID_value" '@CCENUM@'

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -54,11 +54,11 @@
 <xsl:template match="text()" mode="fix_contents">
   <xsl:param name="rule"/>
   <xsl:choose>
-    <xsl:when test="contains(., '$CCENUM')">
+    <xsl:when test="contains(., '@CCENUM@')">
       <xsl:variable name="ident_cce" select="$rule/xccdf:ident[@system='https://nvd.nist.gov/cce/index.cfm']/text()"/>
       <xsl:call-template name="find-and-replace">
         <xsl:with-param name="text" select="."/>
-        <xsl:with-param name="replace" select="'$CCENUM'"/>
+        <xsl:with-param name="replace" select="'@CCENUM@'"/>
         <xsl:with-param name="with" select="$ident_cce"/>
       </xsl:call-template>
     </xsl:when>

--- a/shared/xccdf/remediation_functions.xml
+++ b/shared/xccdf/remediation_functions.xml
@@ -1097,7 +1097,7 @@ Expects four arguments:
   config_file:		Configuration file that will be modified
   key:			Configuration option to change
   value:		Value of the configuration option to change
-  cce:			The CCE identifier or '$CCENUM' if no CCE identifier exists
+  cce:			The CCE identifier or '@CCENUM@' if no CCE identifier exists
 
 Optional arguments:
 
@@ -1107,13 +1107,13 @@ Optional arguments:
 Example Call(s):
 
   With default format of 'key = value':
-  replace_or_append '/etc/sysctl.conf' '^kernel.randomize_va_space' '2' '$CCENUM'
+  replace_or_append '/etc/sysctl.conf' '^kernel.randomize_va_space' '2' '@CCENUM@'
 
   With custom key/value format:
-  replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' 'disabled' '$CCENUM' '%s=%s'
+  replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' 'disabled' '@CCENUM@' '%s=%s'
 
   With a variable:
-  replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' $var_selinux_state '$CCENUM' '%s=%s'
+  replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' $var_selinux_state '@CCENUM@' '%s=%s'
 </description>
 <value selector="">
 function replace_or_append {
@@ -1142,9 +1142,9 @@ function replace_or_append {
     sed_command="sed -i"
   fi
 
-  # Test that the cce arg is not empty or does not equal $CCENUM.
-  # If $CCENUM exists, it means that there is no CCE assigned.
-  if ! [ "x$cce" = x ] &amp;&amp; [ "$cce" != '$CCENUM' ]; then
+  # Test that the cce arg is not empty or does not equal @CCENUM@.
+  # If @CCENUM@ exists, it means that there is no CCE assigned.
+  if ! [ "x$cce" = x ] &amp;&amp; [ "$cce" != '@CCENUM@' ]; then
     cce="CCE-${cce}"
   else
     cce="CCE"


### PR DESCRIPTION
This avoids confusing ShellCheck and also prevents possible bugs with
variable substitution - sometimes devs forget that '$VAR' is different
from "$VAR".