### PR TITLE
Fix more redhat guide links

### DIFF
--- a/RHEL/5/input/xccdf/system/accounts/physical.xml
+++ b/RHEL/5/input/xccdf/system/accounts/physical.xml
@@ -378,7 +378,7 @@ is not enabled by default and must be enabled in the system settings.
 <description>
 To enable smart card authentication, consult the documentation at:
 <ul>
-<li><weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Managing_Smart_Cards/enabling-smart-card-login.html"/></li>
+<li><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Managing_Smart_Cards/enabling-smart-card-login.html"/></li>
 </ul>
 </description>
 <ocil clause="non-exempt accounts are not using CAC authentication">

--- a/SUSE/12/input/xccdf/services/ldap.xml
+++ b/SUSE/12/input/xccdf/services/ldap.xml
@@ -17,7 +17,7 @@ much control over configuration as manual editing of configuration files. The
 authconfig tools do not allow you to specify locations of SSL certificate
 files, which is useful when trying to use SSL cleanly across several protocols.
 Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at
-https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Directory_Servers.html.
+https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html.
 </description>
 <warning category="general">Before configuring any system to be an
 LDAP client, ensure that a working LDAP server is present on the
@@ -77,7 +77,7 @@ site CA.</rationale>
 <title>Configure OpenLDAP Server</title>
 <description>This section details some security-relevant settings
 for an OpenLDAP server.  Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at:
-https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Directory_Servers.html.
+https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html.
 </description>
 
 <Rule id="package_openldap-servers_removed">

--- a/SUSE/12/input/xccdf/services/ldap.xml
+++ b/SUSE/12/input/xccdf/services/ldap.xml
@@ -17,7 +17,7 @@ much control over configuration as manual editing of configuration files. The
 authconfig tools do not allow you to specify locations of SSL certificate
 files, which is useful when trying to use SSL cleanly across several protocols.
 Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at
-https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html.
+https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html.
 </description>
 <warning category="general">Before configuring any system to be an
 LDAP client, ensure that a working LDAP server is present on the
@@ -77,7 +77,7 @@ site CA.</rationale>
 <title>Configure OpenLDAP Server</title>
 <description>This section details some security-relevant settings
 for an OpenLDAP server.  Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at:
-https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html.
+https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html.
 </description>
 
 <Rule id="package_openldap-servers_removed">

--- a/SUSE/12/input/xccdf/system/network/ssl.xml
+++ b/SUSE/12/input/xccdf/system/network/ssl.xml
@@ -12,6 +12,6 @@ For information on how to use OpenSSL, see
 of OpenSSL is available at <b>http://www.openssl.org/docs/fips/fipsvalidation.html</b>
 and <b>http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm</b>.
 For information on how to use and implement OpenSSL on Red Hat Enterprise Linux, see
-<b>https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Using_OpenSSL.html</b>
+<b>https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Using_OpenSSL.html</b>
 </description>
 </Group>

--- a/SUSE/12/input/xccdf/system/software/disk_partitioning.xml
+++ b/SUSE/12/input/xccdf/system/software/disk_partitioning.xml
@@ -142,7 +142,7 @@ installer to pause and interactively ask for the passphrase during installation.
 <br /><br />
 Detailed information on encrypting partitions using LUKS can be found on
 the Red Hat Documentation web site:<br />
-https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html
+https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html
 </description>
 <ocil clause="partitions do not have a type of crypto_LUKS">
 Check the system partitions to determine if they are encrypted with the following command:

--- a/shared/xccdf/services/ldap.xml
+++ b/shared/xccdf/services/ldap.xml
@@ -17,7 +17,7 @@ much control over configuration as manual editing of configuration files. The
 authconfig tools do not allow you to specify locations of SSL certificate
 files, which is useful when trying to use SSL cleanly across several protocols.
 Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at
-<weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html"/>.
+<weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html"/>.
 </description>
 <warning category="general">Before configuring any system to be an
 LDAP client, ensure that a working LDAP server is present on the
@@ -79,7 +79,7 @@ site CA.</rationale>
 <title>Configure OpenLDAP Server</title>
 <description>This section details some security-relevant settings
 for an OpenLDAP server.  Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at:
-<weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html"/>.
+<weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html"/>.
 </description>
 
 <Rule id="package_openldap-servers_removed" prodtype="rhel7">

--- a/shared/xccdf/services/ldap.xml
+++ b/shared/xccdf/services/ldap.xml
@@ -17,7 +17,7 @@ much control over configuration as manual editing of configuration files. The
 authconfig tools do not allow you to specify locations of SSL certificate
 files, which is useful when trying to use SSL cleanly across several protocols.
 Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at
-<weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Directory_Servers.html"/>.
+<weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html"/>.
 </description>
 <warning category="general">Before configuring any system to be an
 LDAP client, ensure that a working LDAP server is present on the
@@ -79,7 +79,7 @@ site CA.</rationale>
 <title>Configure OpenLDAP Server</title>
 <description>This section details some security-relevant settings
 for an OpenLDAP server.  Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at:
-<weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Directory_Servers.html"/>.
+<weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html"/>.
 </description>
 
 <Rule id="package_openldap-servers_removed" prodtype="rhel7">

--- a/shared/xccdf/system/network/ssl.xml
+++ b/shared/xccdf/system/network/ssl.xml
@@ -12,6 +12,6 @@ For information on how to use OpenSSL, see
 of OpenSSL is available at <b><weblink-macro link="http://www.openssl.org/docs/fips/fipsvalidation.html"/></b>
 and <b><weblink-macro link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm"/></b>.
 For information on how to use and implement OpenSSL on Red Hat Enterprise Linux, see
-<b><weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Using_OpenSSL.html"/></b>
+<b><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Using_OpenSSL.html"/></b>
 </description>
 </Group>

--- a/shared/xccdf/system/software/disk_partitioning.xml
+++ b/shared/xccdf/system/software/disk_partitioning.xml
@@ -152,7 +152,7 @@ installer to pause and interactively ask for the passphrase during installation.
 <br /><br />
 Detailed information on encrypting partitions using LUKS can be found on
 the Red Hat Documentation web site:<br />
-<weblink-macro link="https://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html"/>
+<weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html"/>
 </description>
 <ocil clause="partitions do not have a type of crypto_LUKS">
 Check the system partitions to determine if they are encrypted with the following command:


### PR DESCRIPTION
Link to OpenLDAP was dead, also removed rest of docs.redhat.com links.