### PR TITLE
Use @override for NIST 800 171 CUI profile

### DIFF
--- a/RHEL/7/input/profiles/nist-800-171-cui.xml
+++ b/RHEL/7/input/profiles/nist-800-171-cui.xml
@@ -1,6 +1,5 @@
 <Profile id="nist-800-171-cui" extends="ospp-rhel7">
-<title>Unclassified Information in Non-federal Information Systems and
-Organizations (NIST 800-171)</title>
+<title override="true">Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)</title>
 <description>From NIST 800-171, Section 2.2:
 Security requirements for protecting the confidentiality of CUI in nonfederal 
 information systems and organizations have a well-defined structure that 


### PR DESCRIPTION
Otherwise the name of the profile gets concatenated with the name of the
profile it extends.

See https://bugzilla.redhat.com/show_bug.cgi?id=1449211