### PR TITLE
Build table for ospp-rhel7, not ospp-rhel7-server

### DIFF
--- a/RHEL/7/CMakeLists.txt
+++ b/RHEL/7/CMakeLists.txt
@@ -10,7 +10,7 @@ ssg_build_html_table_by_ref(${PRODUCT} "cui")
 ssg_build_html_table_by_ref(${PRODUCT} "pcidss")
 
 ssg_build_html_nistrefs_table(${PRODUCT} "common")
-ssg_build_html_nistrefs_table(${PRODUCT} "ospp-${PRODUCT}-server")
+ssg_build_html_nistrefs_table(${PRODUCT} "ospp-${PRODUCT}")
 ssg_build_html_nistrefs_table(${PRODUCT} "C2S")
 ssg_build_html_nistrefs_table(${PRODUCT} "stig-${PRODUCT}-disa")
 


### PR DESCRIPTION
The profile has been renamed from ospp-rhel7-server to ospp-rhel7.