### PR TITLE
Use double dash instead of a single dash in ANACONDA remediation temp…

### DIFF
--- a/shared/templates/template_ANACONDA_package_installed
+++ b/shared/templates/template_ANACONDA_package_installed
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-package -add=PKGNAME
+package --add=PKGNAME

--- a/shared/templates/template_ANACONDA_package_removed
+++ b/shared/templates/template_ANACONDA_package_removed
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-package -remove=PKGNAME
+package --remove=PKGNAME


### PR DESCRIPTION
…lates

Fixes a regression introduced in https://github.com/OpenSCAP/scap-security-guide/pull/1638

See https://bugzilla.redhat.com/show_bug.cgi?id=1450731