### PR TITLE
Escape the CMAKE_INSTALL_PREFIX again

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -754,7 +754,7 @@ macro(ssg_build_product PRODUCT)
         CODE "
         file(GLOB GUIDE_FILES \"${CMAKE_BINARY_DIR}/guides/ssg-${PRODUCT}-guide-*.html\") \n
         if(NOT IS_ABSOLUTE ${SSG_GUIDE_INSTALL_DIR})
-            file(INSTALL DESTINATION \"${CMAKE_INSTALL_PREFIX}/${SSG_GUIDE_INSTALL_DIR}\"
+            file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${SSG_GUIDE_INSTALL_DIR}\"
                 TYPE FILE FILES \${GUIDE_FILES})
         else()
             file(INSTALL DESTINATION \"${SSG_GUIDE_INSTALL_DIR}\"
@@ -767,7 +767,7 @@ macro(ssg_build_product PRODUCT)
         CODE "
         file(GLOB ROLE_FILES \"${CMAKE_BINARY_DIR}/roles/ssg-${PRODUCT}-role-*.yml\") \n
         if(NOT IS_ABSOLUTE ${SSG_ROLE_INSTALL_DIR})
-            file(INSTALL DESTINATION \"${CMAKE_INSTALL_PREFIX}/${SSG_ROLE_INSTALL_DIR}\"
+            file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${SSG_ROLE_INSTALL_DIR}\"
                 TYPE FILE FILES \${ROLE_FILES})
         else()
             file(INSTALL DESTINATION \"${SSG_ROLE_INSTALL_DIR}\"
@@ -779,7 +779,7 @@ macro(ssg_build_product PRODUCT)
         CODE "
         file(GLOB ROLE_FILES \"${CMAKE_BINARY_DIR}/roles/ssg-${PRODUCT}-role-*.sh\") \n
         if(NOT IS_ABSOLUTE ${SSG_ROLE_INSTALL_DIR})
-            file(INSTALL DESTINATION \"${CMAKE_INSTALL_PREFIX}/${SSG_ROLE_INSTALL_DIR}\"
+            file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${SSG_ROLE_INSTALL_DIR}\"
                 TYPE FILE FILES \${ROLE_FILES})
         else()
             file(INSTALL DESTINATION \"${SSG_ROLE_INSTALL_DIR}\"
@@ -894,7 +894,7 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
         CODE "
         file(GLOB GUIDE_FILES \"${CMAKE_BINARY_DIR}/guides/ssg-${DERIVATIVE}-guide-*.html\") \n
         if(NOT IS_ABSOLUTE ${SSG_GUIDE_INSTALL_DIR})
-            file(INSTALL DESTINATION \"${CMAKE_INSTALL_PREFIX}/${SSG_GUIDE_INSTALL_DIR}\"
+            file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${SSG_GUIDE_INSTALL_DIR}\"
                 TYPE FILE FILES \${GUIDE_FILES})
         else()
             file(INSTALL DESTINATION \"${SSG_GUIDE_INSTALL_DIR}\"
@@ -907,7 +907,7 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
         CODE "
         file(GLOB ROLE_FILES \"${CMAKE_BINARY_DIR}/roles/ssg-${DERIVATIVE}-role-*.yml\") \n
         if(NOT IS_ABSOLUTE ${SSG_ROLE_INSTALL_DIR})
-            file(INSTALL DESTINATION \"${CMAKE_INSTALL_PREFIX}/${SSG_ROLE_INSTALL_DIR}\"
+            file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${SSG_ROLE_INSTALL_DIR}\"
                 TYPE FILE FILES \${ROLE_FILES})
         else()
             file(INSTALL DESTINATION \"${SSG_ROLE_INSTALL_DIR}\"
@@ -919,7 +919,7 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
         CODE "
         file(GLOB ROLE_FILES \"${CMAKE_BINARY_DIR}/roles/ssg-${DERIVATIVE}-role-*.sh\") \n
         if(NOT IS_ABSOLUTE ${SSG_ROLE_INSTALL_DIR})
-            file(INSTALL DESTINATION \"${CMAKE_INSTALL_PREFIX}/${SSG_ROLE_INSTALL_DIR}\"
+            file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${SSG_ROLE_INSTALL_DIR}\"
                 TYPE FILE FILES \${ROLE_FILES})
         else()
             file(INSTALL DESTINATION \"${SSG_ROLE_INSTALL_DIR}\"


### PR DESCRIPTION
Resolve the install prefix during install time.
This was fixed once, reintroduced, and fixing now again.

Fixes #2004 