### PR TITLE
Fix drop of OVAL checks extending non-existing definitions

### DIFF
--- a/shared/utils/relabel-ids.py
+++ b/shared/utils/relabel-ids.py
@@ -201,6 +201,7 @@ def drop_oval_checks_extending_non_existing_checks(ovaltree):
     # TODO: handle multiple levels of referrals.
     # OVAL checks that go beyond one level of extend_definition won't be completely removed
     definitions = ovaltree.find(".//{%s}definitions" % oval_ns)
+    defstoremove = []
     for definition in definitions:
         for extdefinition in definition.findall(".//{%s}extend_definition" % oval_ns):
             # Verify each extend_definition in the definition
@@ -216,11 +217,13 @@ def drop_oval_checks_extending_non_existing_checks(ovaltree):
 
             if referreddefinition is None:
                 # There is no oval satisfying the extend_definition referal
+                defstoremove.append((definition, extdefinitionref))
 
-                sys.stderr.write("WARNING: OVAL check '%s' extends non-existing '%s' "
-                                 "OVAL definition, removing check from OVAL definitions.\n"
-                                 % (definition.get("id"), extdefinitionref))
-                definitions.remove(definition)
+    for definition in defstoremove:
+        sys.stderr.write("WARNING: OVAL check '%s' extends non-existing '%s' "
+                "OVAL definition, removing check from OVAL definitions.\n"
+                % (definition[0].get("id"), definition[1]))
+        definitions.remove(definition[0])
 
 
 def check_and_correct_xccdf_to_oval_data_export_matching_constraints(xccdftree, ovaltree):


### PR DESCRIPTION
Do not remove checks while iterating over them

With inbuilt python element tree it is not safe to remove itens from the
list you are iterating on.