### PR TITLE
Fix no rsh trust files bash remediation

### DIFF
--- a/shared/templates/static/bash/no_rsh_trust_files.sh
+++ b/shared/templates/static/bash/no_rsh_trust_files.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_rhel
 find /home -maxdepth 2 -type f -name .rhosts -exec rm -f '{}' \;
-rm /etc/hosts.equiv
+rm -f /etc/hosts.equiv

--- a/shared/templates/static/bash/no_rsh_trust_files.sh
+++ b/shared/templates/static/bash/no_rsh_trust_files.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_rhel
-find -type f -name .rhosts -exec rm -f '{}' \;
+find /home -maxdepth 2 -type f -name .rhosts -exec rm -f '{}' \;
 rm /etc/hosts.equiv


### PR DESCRIPTION
The remediation script assumed that it's being run in /

Also specified `maxdepth` to speed up remediation.

Caught by ShellCheck:
```
scap-security-guide/shared/templates/static/bash/no_rsh_trust_files.sh:2:1: note: Some finds don't have a default path. Specify '.' explicitly. [SC2185]
```