### PR TITLE
Fix errors in audit remediation bash scripts

### DIFF
--- a/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_creat.sh
+++ b/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_creat.sh
@@ -9,9 +9,9 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S creat -F exit=-EACCESS.*"
+	PATTERN="-a always,exit -F arch=$ARCH -S creat -F exit=-EACCES.*"
 	GROUP="access"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S creat -F exit=-EACCESS -F auid>=1000 -F auid!=4294967295 -F key=access"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
@@ -21,7 +21,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
         PATTERN="-a always,exit -F arch=$ARCH -S creat -F exit=-EPERM.*" 
         GROUP="access"
-        FULL_RULE="-a always,exit -F arch=$ARCH -S creat -F exit=-EPRM -F auid>=1000 -F auid!=4294967295 -F key=access"
+        FULL_RULE="-a always,exit -F arch=$ARCH -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
         # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
         fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
         fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_ftruncate.sh
+++ b/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_ftruncate.sh
@@ -9,9 +9,9 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S ftruncate -F exit=-EACCESS.*"
+	PATTERN="-a always,exit -F arch=$ARCH -S ftruncate -F exit=-EACCES.*"
 	GROUP="access"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S ftruncate -F exit=-EACCESS -F auid>=1000 -F auid!=4294967295 -F key=access"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
@@ -21,7 +21,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
         PATTERN="-a always,exit -F arch=$ARCH -S ftruncate -F exit=-EPERM.*" 
         GROUP="access"
-        FULL_RULE="-a always,exit -F arch=$ARCH -S ftruncate -F exit=-EPRM -F auid>=1000 -F auid!=4294967295 -F key=access"
+        FULL_RULE="-a always,exit -F arch=$ARCH -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
         # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
         fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
         fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_open.sh
+++ b/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_open.sh
@@ -9,9 +9,9 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S open -F exit=-EACCESS.*"
+	PATTERN="-a always,exit -F arch=$ARCH -S open -F exit=-EACCES.*"
 	GROUP="access"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S open -F exit=-EACCESS -F auid>=1000 -F auid!=4294967295 -F key=access"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
@@ -21,7 +21,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
         PATTERN="-a always,exit -F arch=$ARCH -S open -F exit=-EPERM.*" 
         GROUP="access"
-        FULL_RULE="-a always,exit -F arch=$ARCH -S open -F exit=-EPRM -F auid>=1000 -F auid!=4294967295 -F key=access"
+        FULL_RULE="-a always,exit -F arch=$ARCH -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
         # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
         fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
         fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_open_by_handle_at.sh
+++ b/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_open_by_handle_at.sh
@@ -9,9 +9,9 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S open_by_handle_at -F exit=-EACCESS.*"
+	PATTERN="-a always,exit -F arch=$ARCH -S open_by_handle_at -F exit=-EACCES.*"
 	GROUP="access"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S open_by_handle_at -F exit=-EACCESS -F auid>=1000 -F auid!=4294967295 -F key=access"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
@@ -21,7 +21,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
         PATTERN="-a always,exit -F arch=$ARCH -S open_by_handle_at -F exit=-EPERM.*" 
         GROUP="access"
-        FULL_RULE="-a always,exit -F arch=$ARCH -S open_by_handle_at -F exit=-EPRM -F auid>=1000 -F auid!=4294967295 -F key=access"
+        FULL_RULE="-a always,exit -F arch=$ARCH -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
         # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
         fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
         fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_openat.sh
+++ b/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_openat.sh
@@ -9,9 +9,9 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S openat -F exit=-EACCESS.*"
+	PATTERN="-a always,exit -F arch=$ARCH -S openat -F exit=-EACCES.*"
 	GROUP="access"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S openat -F exit=-EACCESS -F auid>=1000 -F auid!=4294967295 -F key=access"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
@@ -21,7 +21,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
         PATTERN="-a always,exit -F arch=$ARCH -S openat -F exit=-EPERM.*" 
         GROUP="access"
-        FULL_RULE="-a always,exit -F arch=$ARCH -S openat -F exit=-EPRM -F auid>=1000 -F auid!=4294967295 -F key=access"
+        FULL_RULE="-a always,exit -F arch=$ARCH -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
         # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
         fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
         fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_truncate.sh
+++ b/shared/templates/static/bash/audit_rules_unsuccessful_file_modification_truncate.sh
@@ -9,9 +9,9 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S truncate -F exit=-EACCESS.*"
+	PATTERN="-a always,exit -F arch=$ARCH -S truncate -F exit=-EACCES.*"
 	GROUP="access"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S truncate -F exit=-EACCESS -F auid>=1000 -F auid!=4294967295 -F key=access"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
@@ -21,7 +21,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
         PATTERN="-a always,exit -F arch=$ARCH -S truncate -F exit=-EPERM.*" 
         GROUP="access"
-        FULL_RULE="-a always,exit -F arch=$ARCH -S truncate -F exit=-EPRM -F auid>=1000 -F auid!=4294967295 -F key=access"
+        FULL_RULE="-a always,exit -F arch=$ARCH -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
         # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
         fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
         fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"


### PR DESCRIPTION
The first is just a simple typo fix: "EACCES**S**" should be "EACCES" and "EPRM" should be "EP**E**RM".