### PR TITLE
SubElement would cause 2 appends which is not what we want

### DIFF
--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -285,7 +285,7 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
                             # Append the contribution
                             fix.text += fixtextcontribution
                             # Define new XCCDF <sub> element for the variable
-                            xccdfvarsub = ElementTree.SubElement(fix, "sub",
+                            xccdfvarsub = ElementTree.Element("sub",
                                                            idref=varname)
                             # If second pair element is not empty, append it as
                             # tail for the subelement (prefixed with closing '"')
@@ -303,7 +303,7 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
                                                  fixparts[idx],
                                                  re.DOTALL).group(1)
                             # Define new XCCDF <sub> element for the function
-                            xccdffuncsub = ElementTree.SubElement(fix, "sub",
+                            xccdffuncsub = ElementTree.Element("sub",
                                                             idref='function_%s' % \
                                                             funcname)
                             # Append original function call into tail of the


### PR DESCRIPTION
We previously used libxml2 implementation of the ElementTree API which
didn't permit one instance of the same element appearing multiple times
in the parent. The python2 inbuilt ET allows this, so we can no longer
double append. This was all done by mistake so it's not a big deal to
just change SubElement to Element.

Before this PR:
```
<fix id="sysctl_net_ipv6_conf_all_accept_source_route" system="urn:xccdf:fix:script:sh" reboot="true" complexity="low" disruption="medium" strategy="disable">
sysctl_net_ipv6_conf_all_accept_source_route_value="<ns0:sub xmlns:ns0="http://checklists.nist.gov/xccdf/1.1" idref="sysctl_net_ipv6_conf_all_accept_source_route_value"/>"

#
# Set runtime for net.ipv6.conf.all.accept_source_route
#
/sbin/sysctl -q -n -w net.ipv6.conf.all.accept_source_route=$sysctl_net_ipv6_conf_all_accept_source_route_value

#
# If net.ipv6.conf.all.accept_source_route present in /etc/sysctl.conf, change value to appropriate value
#	else, add "net.ipv6.conf.all.accept_source_route = value" to /etc/sysctl.conf
#
<ns0:sub xmlns:ns0="http://checklists.nist.gov/xccdf/1.1" idref="sysctl_net_ipv6_conf_all_accept_source_route_value"/>"

#
# Set runtime for net.ipv6.conf.all.accept_source_route
#
/sbin/sysctl -q -n -w net.ipv6.conf.all.accept_source_route=$sysctl_net_ipv6_conf_all_accept_source_route_value

#
# If net.ipv6.conf.all.accept_source_route present in /etc/sysctl.conf, change value to appropriate value
#	else, add "net.ipv6.conf.all.accept_source_route = value" to /etc/sysctl.conf
#
<ns0:sub xmlns:ns0="http://checklists.nist.gov/xccdf/1.1" idref="function_replace_or_append"/>
replace_or_append '/etc/sysctl.conf' '^net.ipv6.conf.all.accept_source_route' "$sysctl_net_ipv6_conf_all_accept_source_route_value" 'CCE-80179-5'
<ns0:sub xmlns:ns0="http://checklists.nist.gov/xccdf/1.1" idref="function_replace_or_append"/>
replace_or_append '/etc/sysctl.conf' '^net.ipv6.conf.all.accept_source_route' "$sysctl_net_ipv6_conf_all_accept_source_route_value" 'CCE-80179-5'
</fix>
```
​```

After this PR:
```
<fix id="sysctl_net_ipv4_conf_all_accept_source_route" system="urn:xccdf:fix:script:sh" reboot="true" complexity="low" disruption="medium" strategy="disable">
sysctl_net_ipv4_conf_all_accept_source_route_value="<ns0:sub xmlns:ns0="http://checklists.nist.gov/xccdf/1.1" idref="sysctl_net_ipv4_conf_all_accept_source_route_value"/>"

#
# Set runtime for net.ipv4.conf.all.accept_source_route
#
/sbin/sysctl -q -n -w net.ipv4.conf.all.accept_source_route=$sysctl_net_ipv4_conf_all_accept_source_route_value

#
# If net.ipv4.conf.all.accept_source_route present in /etc/sysctl.conf, change value to appropriate value
#	else, add "net.ipv4.conf.all.accept_source_route = value" to /etc/sysctl.conf
#
<ns0:sub xmlns:ns0="http://checklists.nist.gov/xccdf/1.1" idref="function_replace_or_append"/>
replace_or_append '/etc/sysctl.conf' '^net.ipv4.conf.all.accept_source_route' "$sysctl_net_ipv4_conf_all_accept_source_route_value" 'CCE-27434-0'
</fix>
```

This regression was introduced in PR #1937 by myself. Thanks goes to @redhatrises for helping me diagnose this.