### PR TITLE
Fix 'small' element namespace

### DIFF
--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -475,7 +475,7 @@
   </xsl:template>
 
   <!-- put general formatting xhtml into xhtml namespace -->
-  <xsl:template match="p | code | strong | b | em | i | pre | br | hr" >
+  <xsl:template match="p | code | strong | b | em | i | pre | br | hr | small" >
     <xsl:element name="{local-name()}" namespace="http://www.w3.org/1999/xhtml">
       <xsl:apply-templates select="@*|node()"/>
     </xsl:element>


### PR DESCRIPTION
It was beign added to xccdf namespace, while it should actually be in
xhtml namespace.