### PR TITLE
Fixing sed confusion for auditd remediation template 

### DIFF
--- a/shared/remediations/bash/templates/remediation_functions
+++ b/shared/remediations/bash/templates/remediation_functions
@@ -146,7 +146,7 @@ do
 				# Rule is covered (i.e. the list of -S syscalls for this rule is
 				# subset of -S syscalls of $full_rule => existing rule can be deleted
 				# Thus delete the rule from audit.rules & our array
-				sed -i -e "/$rule/d" "$audit_file"
+				sed -i -e "/${rule}/d" "$audit_file"
 				existing_rules=("${existing_rules[@]//$rule/}")
 			else
 				# Rule isn't covered by $full_rule - it besides -S syscall arguments
@@ -163,7 +163,7 @@ do
 				# if the same rule not already present
 				#
 				# 1) Delete the original rule
-				sed -i -e "/$rule/d" "$audit_file"
+				sed -i -e "/${rule}/d" "$audit_file"
 				# 2) Delete syscalls for this group, but keep those from other groups
 				# Convert current rule syscall's string into array splitting by '-S' delimiter
 				IFS=$'-S' read -a rule_syscalls_as_array <<< "$rule_syscalls"

--- a/shared/xccdf/remediation_functions.xml
+++ b/shared/xccdf/remediation_functions.xml
@@ -143,7 +143,7 @@ do
                                 # Rule is covered (i.e. the list of -S syscalls for this rule is
                                 # subset of -S syscalls of $full_rule => existing rule can be deleted
                                 # Thus delete the rule from audit.rules &amp; our array
-                                sed -i -e "/$rule/d" "$audit_file"
+                                sed -i -e "/${rule}/d" "$audit_file"
                                 existing_rules=("${existing_rules[@]//$rule/}")
                         else
                                 # Rule isn't covered by $full_rule - it besides -S syscall arguments
@@ -160,7 +160,7 @@ do
                                 # if the same rule not already present
                                 #
                                 # 1) Delete the original rule
-                                sed -i -e "/$rule/d" "$audit_file"
+                                sed -i -e "/${rule}/d" "$audit_file"
                                 # 2) Delete syscalls for this group, but keep those from other groups
                                 # Convert current rule syscall's string into array splitting by '-S' delimiter
                                 IFS=$'-S' read -a rule_syscalls_as_array &lt;&lt;&lt; "$rule_syscalls"


### PR DESCRIPTION
sed confusion causes the substitution to fail for audit template.

sed: -e expression #1, char 26: unknown command: `u'
sed: -e expression #1, char 26: unknown command: `u'
sed: -e expression #1, char 26: unknown command: `u'