### PR TITLE
Avoid warning about being unable to open output/unlinked-*-oval.xml

### DIFF
--- a/Chromium/transforms/xccdf2table-profileccirefs.xslt
+++ b/Chromium/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-chromium-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/Debian/8/transforms/xccdf2table-profileccirefs.xslt
+++ b/Debian/8/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-debian8-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/Firefox/transforms/xccdf2table-profileccirefs.xslt
+++ b/Firefox/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-firefox-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/JBoss/EAP/5/transforms/xccdf2table-profileccirefs.xslt
+++ b/JBoss/EAP/5/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-eap5-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/JBoss/EAP/6/transforms/xccdf2table-profileccirefs.xslt
+++ b/JBoss/EAP/6/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-eap6-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/JBoss/Fuse/6/transforms/xccdf2table-profileccirefs.xslt
+++ b/JBoss/Fuse/6/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-fuse6-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/JRE/transforms/xccdf2table-profileccirefs.xslt
+++ b/JRE/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-jre-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/OpenStack/RHEL-OSP/7/transforms/xccdf2table-profileccirefs.xslt
+++ b/OpenStack/RHEL-OSP/7/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-rhel-osp7-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/RHEL/5/transforms/xccdf2table-profileccirefs.xslt
+++ b/RHEL/5/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-rhel5-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/RHEL/6/transforms/xccdf2table-profileccirefs.xslt
+++ b/RHEL/6/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-rhel6-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/RHEL/7/transforms/xccdf2table-profileccirefs.xslt
+++ b/RHEL/7/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-rhel7-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/RHEVM3/transforms/xccdf2table-profileccirefs.xslt
+++ b/RHEVM3/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-rhevm3-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/SUSE/11/transforms/xccdf2table-profileccirefs.xslt
+++ b/SUSE/11/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-sle11-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/SUSE/12/transforms/xccdf2table-profileccirefs.xslt
+++ b/SUSE/12/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-sle12-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/Ubuntu/14.04/transforms/xccdf2table-profileccirefs.xslt
+++ b/Ubuntu/14.04/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-ubuntu1404-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/Ubuntu/16.04/transforms/xccdf2table-profileccirefs.xslt
+++ b/Ubuntu/16.04/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-ubuntu1604-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/Webmin/transforms/xccdf2table-profileccirefs.xslt
+++ b/Webmin/transforms/xccdf2table-profileccirefs.xslt
@@ -5,7 +5,6 @@
 
 <xsl:variable name="cci_list" select="document('../../shared/references/disa-cci-list.xml')/cci:cci_list" />
 <xsl:variable name="os_srg" select="document('../../shared/references/disa-os-srg-v1r4.xml')/cdf:Benchmark" />
-<xsl:variable name="ovaldefs" select="document('../output/unlinked-webmin-oval.xml')/ovalns:oval_definitions" />
 
 <xsl:include href="constants.xslt"/>
 <xsl:include href="table-style.xslt"/>

--- a/shared/transforms/shared_xccdf2table-profileccirefs.xslt
+++ b/shared/transforms/shared_xccdf2table-profileccirefs.xslt
@@ -62,9 +62,6 @@
 		<xsl:param name="idreference" />
 		<xsl:param name="enabletest" />
 		<xsl:if test="@id=$idreference and $enabletest='true'">
-			<!-- get related OVAL check info -->
-			<xsl:variable name="ovalcheckid" select="cdf:check[@system=$ovaluri]/cdf:check-content-ref/@name" />
-			<xsl:variable name="ovalcheck" select="$ovaldefs/ovalns:definitions/ovalns:definition[@id=$ovalcheckid]" />
 
 		<tr>
 			<td> <xsl:value-of select="@id" /></td>


### PR DESCRIPTION
The CCI refs table transforms don't use ovaldefs and the OVAL document

The ovaldefs were using the old output/unlinked-*.xml paths and thus
were broken for quite a while. This gets rid of the warning with no
effect on the outputs.