### PR TITLE
Better profile stats

### DIFF
--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -336,19 +336,13 @@ class XCCDFBenchmark(object):
                 del profile_stats['missing_cces']
             if not options.implemented_ovals:
                 del profile_stats['implemented_ovals']
-                del profile_stats['implemented_ovals_pct']
             if not options.implemented_fixes:
                 del profile_stats['implemented_bash_fixes']
-                del profile_stats['implemented_bash_fixes_pct']
                 del profile_stats['implemented_ansible_fixes']
-                del profile_stats['implemented_ansible_fixes_pct']
                 del profile_stats['implemented_puppet_fixes']
-                del profile_stats['implemented_puppet_fixes_pct']
                 del profile_stats['implemented_anaconda_fixes']
-                del profile_stats['implemented_anaconda_fixes_pct']
             if not options.assigned_cces:
                 del profile_stats['assigned_cces']
-                del profile_stats['assigned_cces_pct']
 
             return profile_stats
 

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -217,14 +217,41 @@ class XCCDFBenchmark(object):
                 self.console_print(profile_stats['implemented_ovals'],
                                    console_width)
 
-            if options.implemented_fixes and \
-               profile_stats['implemented_bash_fixes']:
-                print("*** Rules of '%s' " % profile + "profile having " +
-                      "a bash remediation script: %d of %d [%d%% complete]" %
-                      (impl_bash_fixes_count, rules_count,
-                       profile_stats['implemented_bash_fixes_pct']))
-                self.console_print(profile_stats['implemented_bash_fixes'],
-                                   console_width)
+            if options.implemented_fixes:
+                if profile_stats['implemented_bash_fixes']:
+                    print("*** Rules of '%s' profile having "
+                          "a bash fix script: %d of %d [%d%% complete]"
+                          % (profile, impl_bash_fixes_count, rules_count,
+                             profile_stats['implemented_bash_fixes_pct']))
+                    self.console_print(profile_stats['implemented_bash_fixes'],
+                                       console_width)
+
+                if profile_stats['implemented_ansible_fixes']:
+                    print("*** Rules of '%s' profile having "
+                          "a ansible fix script: %d of %d [%d%% complete]"
+                          % (profile, impl_ansible_fixes_count, rules_count,
+                             profile_stats['implemented_ansible_fixes_pct']))
+                    self.console_print(
+                        profile_stats['implemented_ansible_fixes'],
+                        console_width)
+
+                if profile_stats['implemented_puppet_fixes']:
+                    print("*** Rules of '%s' profile having "
+                          "a puppet fix script: %d of %d [%d%% complete]"
+                          % (profile, impl_puppet_fixes_count, rules_count,
+                             profile_stats['implemented_puppet_fixes_pct']))
+                    self.console_print(
+                        profile_stats['implemented_puppet_fixes'],
+                        console_width)
+
+                if profile_stats['implemented_anaconda_fixes']:
+                    print("*** Rules of '%s' profile having "
+                          "a anaconda fix script: %d of %d [%d%% complete]"
+                          % (profile, impl_anaconda_fixes_count, rules_count,
+                             profile_stats['implemented_anaconda_fixes_pct']))
+                    self.console_print(
+                        profile_stats['implemented_anaconda_fixes'],
+                        console_width)
 
             if options.assigned_cces and \
                profile_stats['assigned_cces']:
@@ -243,13 +270,42 @@ class XCCDFBenchmark(object):
                 self.console_print(profile_stats['missing_ovals'],
                                    console_width)
 
-            if options.missing_fixes and profile_stats['missing_bash_fixes']:
-                print("*** Rules of '%s' " % profile + "profile missing " +
-                      "a bash remediation script: %d of %d [%d%% complete]" %
-                      (rules_count - impl_bash_fixes_count, rules_count,
-                       profile_stats['implemented_bash_fixes_pct']))
-                self.console_print(profile_stats['missing_bash_fixes'],
-                                   console_width)
+            if options.missing_fixes:
+                if profile_stats['missing_bash_fixes']:
+                    print("*** rules of '%s' profile missing "
+                          "a bash fix script: %d of %d [%d%% complete]"
+                          % (profile, rules_count - impl_bash_fixes_count,
+                             rules_count,
+                             profile_stats['implemented_bash_fixes_pct']))
+                    self.console_print(profile_stats['missing_bash_fixes'],
+                                       console_width)
+
+                if profile_stats['missing_ansible_fixes']:
+                    print("*** rules of '%s' profile missing "
+                          "a ansible fix script: %d of %d [%d%% complete]"
+                          % (profile, rules_count - impl_ansible_fixes_count,
+                             rules_count,
+                             profile_stats['implemented_ansible_fixes_pct']))
+                    self.console_print(profile_stats['missing_ansible_fixes'],
+                                       console_width)
+
+                if profile_stats['missing_puppet_fixes']:
+                    print("*** rules of '%s' profile missing "
+                          "a puppet fix script: %d of %d [%d%% complete]"
+                          % (profile, rules_count - impl_puppet_fixes_count,
+                             rules_count,
+                             profile_stats['implemented_puppet_fixes_pct']))
+                    self.console_print(profile_stats['missing_puppet_fixes'],
+                                       console_width)
+
+                if profile_stats['missing_anaconda_fixes']:
+                    print("*** rules of '%s' profile missing "
+                          "a anaconda fix script: %d of %d [%d%% complete]"
+                          % (profile, rules_count - impl_anaconda_fixes_count,
+                             rules_count,
+                             profile_stats['implemented_anaconda_fixes_pct']))
+                    self.console_print(profile_stats['missing_anaconda_fixes'],
+                                       console_width)
 
             if options.missing_cces and profile_stats['missing_cces']:
                 print("***Rules of '%s' " % profile + "profile missing " +

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -66,9 +66,18 @@ class XCCDFBenchmark(object):
             'implemented_ovals': [],
             'implemented_ovals_pct': 0,
             'missing_ovals': [],
-            'implemented_fixes': [],
-            'implemented_fixes_pct': 0,
-            'missing_fixes': [],
+            'implemented_bash_fixes': [],
+            'implemented_bash_fixes_pct': 0,
+            'implemented_ansible_fixes': [],
+            'implemented_ansible_fixes_pct': 0,
+            'implemented_puppet_fixes': [],
+            'implemented_puppet_fixes_pct': 0,
+            'implemented_anaconda_fixes': [],
+            'implemented_anaconda_fixes_pct': 0,
+            'missing_bash_fixes': [],
+            'missing_ansible_fixes': [],
+            'missing_puppet_fixes': [],
+            'missing_anaconda_fixes': [],
             'assigned_cces': [],
             'assigned_cces_pct': 0,
             'missing_cces': []
@@ -319,15 +328,24 @@ class XCCDFBenchmark(object):
             if not options.missing_ovals:
                 del profile_stats['missing_ovals']
             if not options.missing_fixes:
-                del profile_stats['missing_fixes']
+                del profile_stats['missing_bash_fixes']
+                del profile_stats['missing_ansible_fixes']
+                del profile_stats['missing_puppet_fixes']
+                del profile_stats['missing_anaconda_fixes']
             if not options.missing_cces:
                 del profile_stats['missing_cces']
             if not options.implemented_ovals:
                 del profile_stats['implemented_ovals']
                 del profile_stats['implemented_ovals_pct']
             if not options.implemented_fixes:
-                del profile_stats['implemented_fixes']
-                del profile_stats['implemented_fixes_pct']
+                del profile_stats['implemented_bash_fixes']
+                del profile_stats['implemented_bash_fixes_pct']
+                del profile_stats['implemented_ansible_fixes']
+                del profile_stats['implemented_ansible_fixes_pct']
+                del profile_stats['implemented_puppet_fixes']
+                del profile_stats['implemented_puppet_fixes_pct']
+                del profile_stats['implemented_anaconda_fixes']
+                del profile_stats['implemented_anaconda_fixes_pct']
             if not options.assigned_cces:
                 del profile_stats['assigned_cces']
                 del profile_stats['assigned_cces_pct']

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -184,33 +184,32 @@ class XCCDFBenchmark(object):
         impl_cces_count = len(profile_stats['assigned_cces'])
 
         if not options.json:
-            print("\n* %s statistics of '%s' profile:" %
-                  (profile_stats['ssg_version'], profile))
-            print("** Count of rules: %d" % rules_count)
-            print("** Count of ovals: %d [%d%% complete]" %
+            print("\nProfile %s:" % profile)
+            print("* rules:            %d" % rules_count)
+            print("* checks (OVAL):    %d\t[%d%% complete]" %
                   (impl_ovals_count,
                    profile_stats['implemented_ovals_pct']))
 
-            print("** Count of fixes (bash): %d [%d%% complete]" %
+            print("* fixes (bash):     %d\t[%d%% complete]" %
                   (impl_bash_fixes_count,
                    profile_stats['implemented_bash_fixes_pct']))
-            print("** Count of fixes (ansible): %d [%d%% complete]" %
+            print("* fixes (ansible):  %d\t[%d%% complete]" %
                   (impl_ansible_fixes_count,
                    profile_stats['implemented_ansible_fixes_pct']))
-            print("** Count of fixes (puppet): %d [%d%% complete]" %
+            print("* fixes (puppet):   %d\t[%d%% complete]" %
                   (impl_puppet_fixes_count,
                    profile_stats['implemented_puppet_fixes_pct']))
-            print("** Count of fixes (anaconda): %d [%d%% complete]" %
+            print("* fixes (anaconda): %d\t[%d%% complete]" %
                   (impl_anaconda_fixes_count,
                    profile_stats['implemented_anaconda_fixes_pct']))
 
-            print("** Count of CCEs: %d [%d%% complete]" %
+            print("* CCEs:             %d\t[%d%% complete]" %
                   (impl_cces_count,
                    profile_stats['assigned_cces_pct']))
 
             if options.implemented_ovals and \
                profile_stats['implemented_ovals']:
-                print("*** Rules of '%s' " % profile +
+                print("** Rules of '%s' " % profile +
                       "profile having OVAL check: %d of %d [%d%% complete]" %
                       (impl_ovals_count, rules_count,
                        profile_stats['implemented_ovals_pct']))

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -9,40 +9,10 @@ try:
 except ImportError:
     import cElementTree as ElementTree
 
-script_usage = """
-profile_stats.py -b XCCDF_file [-p XCCDF_profile] [--implemented] [--missing] [--all]
-                    [--implemented-ovals] [--implemented-fixes] [--assigned-cces]
-                    [--missing-ovals] [--missing-fixes] [--missing-cces] [--json]
-
-Obtains and displays XCCDF profile statistics like:
-* Count of rules present in the <xccdf:Profile>
-* Count of rules having OVAL implemented [%% of completion]
-* Count of rules having remediation implemented [%% of completion]
-
-for the XCCDF benchmark provided as -b or --benchmark argument.
-
-Unless -p or --profile option was provided, it will display statistics
-for all profiles found in the benchmark. Use -p or --profile XCCDF_profile
-to obtain statistics solely for particular profile.
-
-If --implemented option was provided it will also display the IDs
-of implemented OVAL checks, remediation scripts, and IDs of rules
-having CCE identifier already assigned. It is a shortcut for combination
-of --implemented-ovals, --implemented-fixes, and --assigned-cces options.
-
-If --missing option was provided it will also display the IDs of
-not implemented OVAL checks, remediation scripts, and IDs of rules
-not having CCE identifier assigned yet. It is a shortcut for combination
-of --missing-ovals, --missing-fixes, and --missing-cces options.
-
-If --all option was provided, it will display all available information.
-It is a shortcut for combination of --implemented and --missing options.
-
-If --json option is provided, it will display the statistics in the form
-of json format file (rather than default text form)
-
-NOTE: Does NOT work on DataStream benchmark format (yet)!
-"""
+script_desc = \
+    "Obtains and displays XCCDF profile statistics. Namely number " + \
+    "of rules in the profile, how many of these rules have their OVAL " + \
+    "check implemented, how many have a remediation available, ..."
 
 
 xccdf_ns = "http://checklists.nist.gov/xccdf/1.1"
@@ -262,25 +232,28 @@ class XCCDFBenchmark(object):
 
 
 def main():
-    parser = argparse.ArgumentParser(usage=script_usage, version="%prog 1.0")
+    parser = argparse.ArgumentParser(description=script_desc, version="%prog 1.0")
     parser.add_argument("--profile", "-p",
                         action="store",
-                        help="Show statistics for this XCCDF Profile only.")
+                        help="Show statistics for this XCCDF Profile only. If "
+                        "not provided the script will show stats for all "
+                        "available profiles.")
     parser.add_argument("--benchmark", "-b", required=True,
                         action="store",
-                        help="Specify XCCDF benchmark to act on.")
+                        help="Specify XCCDF file to act on. Must be a plain "
+                        "XCCDF file, doesn't work on source datastreams yet!")
     parser.add_argument("--implemented-ovals", default=False,
                         action="store_true", dest="implemented_ovals",
-                        help="Show also IDs of implemented OVAL checks.")
+                        help="Show IDs of implemented OVAL checks.")
     parser.add_argument("--missing-ovals", default=False,
                         action="store_true", dest="missing_ovals",
-                        help="Show also IDs of unimplemented OVAL checks.")
+                        help="Show IDs of unimplemented OVAL checks.")
     parser.add_argument("--implemented-fixes", default=False,
                         action="store_true", dest="implemented_fixes",
-                        help="Show also IDs of implemented remediations.")
+                        help="Show IDs of implemented remediations.")
     parser.add_argument("--missing-fixes", default=False,
                         action="store_true", dest="missing_fixes",
-                        help="Show also IDs of unimplemented remediations.")
+                        help="Show IDs of unimplemented remediations.")
     parser.add_argument("--assigned-cces", default=False,
                         action="store_true", dest="assigned_cces",
                         help="Show IDs of rules having CCE assigned.")
@@ -289,19 +262,19 @@ def main():
                         help="Show IDs of rules missing CCE element.")
     parser.add_argument("--implemented", default=False,
                         action="store_true",
-                        help="Equivalent like --implemented-ovals, "
-                        "--implemented_fixes, and --assigned-cves "
-                        "would be set.")
+                        help="Equivalent of --implemented-ovals, "
+                        "--implemented_fixes and --assigned-cves "
+                        "all being set.")
     parser.add_argument("--missing", default=False,
                         action="store_true",
-                        help="Equivalent to --missing-ovals, --missing-fixes,"
+                        help="Equivalent of --missing-ovals, --missing-fixes"
                         " and --missing-cces all being set.")
     parser.add_argument("--all", default=False,
                         action="store_true", dest="all",
                         help="Show all available statistics.")
     parser.add_argument("--json", default=False,
                         action="store_true", dest="json",
-                        help="Show the statistics in json file format.")
+                        help="Show statistics in json file format.")
 
     args, unknown = parser.parse_known_args()
     if unknown:

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -263,11 +263,11 @@ class XCCDFBenchmark(object):
 
 def main():
     parser = argparse.ArgumentParser(usage=script_usage, version="%prog 1.0")
-    parser.add_argument("-p", "--profile", default=False,
-                        action="store", dest="profile",
+    parser.add_argument("--profile", "-p",
+                        action="store",
                         help="Show statistics for this XCCDF Profile only.")
-    parser.add_argument("-b", "--benchmark", required=True,
-                        action="store", dest="benchmark_file",
+    parser.add_argument("--benchmark", "-b", required=True,
+                        action="store",
                         help="Specify XCCDF benchmark to act on.")
     parser.add_argument("--implemented-ovals", default=False,
                         action="store_true", dest="implemented_ovals",
@@ -288,14 +288,14 @@ def main():
                         action="store_true", dest="missing_cces",
                         help="Show IDs of rules missing CCE element.")
     parser.add_argument("--implemented", default=False,
-                        action="store_true", dest="implemented",
+                        action="store_true",
                         help="Equivalent like --implemented-ovals, "
                         "--implemented_fixes, and --assigned-cves "
                         "would be set.")
     parser.add_argument("--missing", default=False,
-                        action="store_true", dest="missing",
-                        help="Equivalent like --missing-ovals, --missing-fixes,"
-                        " and --missing-cces would be set.")
+                        action="store_true",
+                        help="Equivalent to --missing-ovals, --missing-fixes,"
+                        " and --missing-cces all being set.")
     parser.add_argument("--all", default=False,
                         action="store_true", dest="all",
                         help="Show all available statistics.")
@@ -324,14 +324,13 @@ def main():
         args.missing_fixes = True
         args.missing_cces = True
 
-    benchmark = XCCDFBenchmark(args.benchmark_file)
+    benchmark = XCCDFBenchmark(args.benchmark)
     if args.profile:
         ret = benchmark.show_profile_stats(args.profile, args)
         if args.json:
             print(json.dumps(ret, indent=4))
     else:
-        all_profile_elems = benchmark.tree.findall("./{%s}Profile" %
-                                                   (xccdf_ns))
+        all_profile_elems = benchmark.tree.findall("./{%s}Profile" % (xccdf_ns))
         ret = []
         for elem in all_profile_elems:
             profile = elem.get('id')

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -19,7 +19,8 @@ xccdf_ns = "http://checklists.nist.gov/xccdf/1.1"
 oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
 rem_system = "urn:xccdf:fix:script:sh"
 cce_system = "https://nvd.nist.gov/cce/index.cfm"
-ssg_version_uri = "https://github.com/OpenSCAP/scap-security-guide/releases/latest"
+ssg_version_uri = \
+    "https://github.com/OpenSCAP/scap-security-guide/releases/latest"
 console_width = 80
 
 
@@ -43,23 +44,24 @@ class XCCDFBenchmark(object):
             print("%s" % ioerr)
             sys.exit(1)
 
-    def get_profile_stats(self, profile = None):
+    def get_profile_stats(self, profile=None):
         """Obtain statistics for the profile"""
 
         # Holds the intermediary statistics for profile
-        profile_stats = { 'profile_id' : None,
-                          'ssg_version' : 0,
-                          'rules_count' : 0,
-                          'implemented_ovals' : [],
-                          'implemented_ovals_pct' : 0,
-                          'missing_ovals' : [],
-                          'implemented_fixes' : [],
-                          'implemented_fixes_pct' : 0,
-                          'missing_fixes' : [],
-                          'assigned_cces' : [],
-                          'assigned_cces_pct' : 0,
-                          'missing_cces' : []
-                         }
+        profile_stats = {
+            'profile_id': None,
+            'ssg_version': 0,
+            'rules_count': 0,
+            'implemented_ovals': [],
+            'implemented_ovals_pct': 0,
+            'missing_ovals': [],
+            'implemented_fixes': [],
+            'implemented_fixes_pct': 0,
+            'missing_fixes': [],
+            'assigned_cces': [],
+            'assigned_cces_pct': 0,
+            'missing_cces': []
+        }
 
         rule_stats = []
         ssg_version_elem = self.tree.find("./{%s}version[@update=\"%s\"]" %
@@ -136,21 +138,21 @@ class XCCDFBenchmark(object):
                   (profile_stats['ssg_version'], profile))
             print("** Count of rules: %d" % rules_count)
             print("** Count of ovals: %d [%d%% complete]" %
-                  (impl_ovals_count, \
-                  profile_stats['implemented_ovals_pct']))
+                  (impl_ovals_count,
+                   profile_stats['implemented_ovals_pct']))
             print("** Count of fixes: %d [%d%% complete]" %
-                  (impl_fixes_count, \
-                  profile_stats['implemented_fixes_pct']))
+                  (impl_fixes_count,
+                   profile_stats['implemented_fixes_pct']))
             print("** Count of CCEs: %d [%d%% complete]" %
-                  (impl_cces_count, \
-                  profile_stats['assigned_cces_pct']))
+                  (impl_cces_count,
+                   profile_stats['assigned_cces_pct']))
 
             if options.implemented_ovals and \
                profile_stats['implemented_ovals']:
                 print("*** Rules of '%s' " % profile +
                       "profile having OVAL check: %d of %d [%d%% complete]" %
                       (impl_ovals_count, rules_count,
-                      profile_stats['implemented_ovals_pct']))
+                       profile_stats['implemented_ovals_pct']))
                 self.console_print(profile_stats['implemented_ovals'],
                                    console_width)
 
@@ -159,7 +161,7 @@ class XCCDFBenchmark(object):
                 print("*** Rules of '%s' " % profile + "profile having " +
                       "remediation script: %d of %d [%d%% complete]" %
                       (impl_fixes_count, rules_count,
-                      profile_stats['implemented_fixes_pct']))
+                       profile_stats['implemented_fixes_pct']))
                 self.console_print(profile_stats['implemented_fixes'],
                                    console_width)
 
@@ -168,7 +170,7 @@ class XCCDFBenchmark(object):
                 print("*** Rules of '%s' " % profile +
                       "profile having CCE assigned: %d of %d [%d%% complete]" %
                       (impl_cces_count, rules_count,
-                      profile_stats['assigned_cces_pct']))
+                       profile_stats['assigned_cces_pct']))
                 self.console_print(profile_stats['assigned_cces'],
                                    console_width)
 
@@ -176,7 +178,7 @@ class XCCDFBenchmark(object):
                 print("*** Rules of '%s' " % profile + "profile missing " +
                       "OVAL: %d of %d [%d%% complete]" %
                       (rules_count - impl_ovals_count, rules_count,
-                      profile_stats['implemented_ovals_pct']))
+                       profile_stats['implemented_ovals_pct']))
                 self.console_print(profile_stats['missing_ovals'],
                                    console_width)
 
@@ -184,7 +186,7 @@ class XCCDFBenchmark(object):
                 print("*** Rules of '%s' " % profile + "profile missing " +
                       "remediation: %d of %d [%d%% complete]" %
                       (rules_count - impl_fixes_count, rules_count,
-                      profile_stats['implemented_fixes_pct']))
+                       profile_stats['implemented_fixes_pct']))
                 self.console_print(profile_stats['missing_fixes'],
                                    console_width)
 
@@ -192,7 +194,7 @@ class XCCDFBenchmark(object):
                 print("***Rules of '%s' " % profile + "profile missing " +
                       "CCE identifier: %d of %d [%d%% complete]" %
                       (rules_count - impl_cces_count, rules_count,
-                      profile_stats['assigned_cces_pct']))
+                       profile_stats['assigned_cces_pct']))
                 self.console_print(profile_stats['missing_cces'],
                                    console_width)
 
@@ -232,7 +234,7 @@ class XCCDFBenchmark(object):
 
 
 def main():
-    parser = argparse.ArgumentParser(description=script_desc, version="%prog 1.0")
+    parser = argparse.ArgumentParser(description=script_desc)
     parser.add_argument("--profile", "-p",
                         action="store",
                         help="Show statistics for this XCCDF Profile only. If "

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -266,7 +266,7 @@ def main():
     parser.add_argument("-p", "--profile", default=False,
                         action="store", dest="profile",
                         help="Show statistics for this XCCDF Profile only.")
-    parser.add_argument("-b", "--benchmark", default=False,
+    parser.add_argument("-b", "--benchmark", required=True,
                         action="store", dest="benchmark_file",
                         help="Specify XCCDF benchmark to act on.")
     parser.add_argument("--implemented-ovals", default=False,
@@ -308,11 +308,6 @@ def main():
         sys.stderr.write(
             "Unknown positional arguments " + ",".join(unknown) + ".\n"
         )
-        sys.exit(1)
-
-    if not args.benchmark_file:
-        print("Missing XCCDF location via -b or --benchmark arguments!\n")
-        parser.print_help()
         sys.exit(1)
 
     if args.all:


### PR DESCRIPTION
I wanted to demo how many ansible fixes were added in the past few months but found out that the profile_stats.py script is not suitable for that. It only displayed bash fix stats and nothing else.

This PR fixes that.

Example of output:
```
$ ./profile_stats.py -b ../../build/ssg-rhel7-xccdf.xml --profile pci-dss

Profile pci-dss:
* rules:            94
* checks (OVAL):    94  [100% complete]
* fixes (bash):     85  [90% complete]
* fixes (ansible):  15  [15% complete]
* fixes (puppet):   2   [2% complete]
* fixes (anaconda): 2   [2% complete]
* CCEs:             94  [100% complete]
```

Example of json output:
```
$ ./profile_stats.py -b ../../build/ssg-rhel7-xccdf.xml --profile pci-dss --json
{
    "ssg_version": "SCAP Security Guide 0.1.33", 
    "rules_count": 94, 
    "profile_id": "pci-dss", 
    "implemented_anaconda_fixes_pct": 2.127659574468085, 
    "implemented_ansible_fixes_pct": 15.957446808510639, 
    "assigned_cces_pct": 100.0, 
    "implemented_puppet_fixes_pct": 2.127659574468085, 
    "implemented_ovals_pct": 100.0, 
    "implemented_bash_fixes_pct": 90.42553191489363
}
```

I have plans to run the json variant over various versions of SSG and make a table of how we are progressing with all the profiles.