### PR TITLE
Benchmark stats and CSV output in profile_stats.py

### DIFF
--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -443,10 +443,9 @@ def main():
         args.missing_cces = True
 
     benchmark = XCCDFBenchmark(args.benchmark)
+    ret = []
     if args.profile:
-        ret = benchmark.show_profile_stats(args.profile, args)
-        if args.format == "json":
-            print(json.dumps(ret, indent=4))
+        ret.append(benchmark.show_profile_stats(args.profile, args))
     else:
         all_profile_elems = benchmark.tree.findall("./{%s}Profile" % (xccdf_ns))
         ret = []
@@ -455,8 +454,8 @@ def main():
             if profile is not None:
                 ret.append(benchmark.show_profile_stats(profile, args))
 
-        if args.format == "json":
-            print(json.dumps(ret, indent=4))
+    if args.format == "json":
+        print(json.dumps(ret, indent=4))
 
 if __name__ == '__main__':
     main()

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -207,7 +207,7 @@ class XCCDFBenchmark(object):
         impl_anaconda_fixes_count = len(profile_stats['implemented_anaconda_fixes'])
         impl_cces_count = len(profile_stats['assigned_cces'])
 
-        if not options.json:
+        if options.format == "plain":
             print("\nProfile %s:" % profile)
             print("* rules:            %d" % rules_count)
             print("* checks (OVAL):    %d\t[%d%% complete]" %
@@ -417,9 +417,9 @@ def main():
     parser.add_argument("--all", default=False,
                         action="store_true", dest="all",
                         help="Show all available statistics.")
-    parser.add_argument("--json", default=False,
-                        action="store_true", dest="json",
-                        help="Show statistics in json file format.")
+    parser.add_argument("--format", default="plain",
+                        choices=["plain", "json"],
+                        help="Which format to use for output.")
 
     args, unknown = parser.parse_known_args()
     if unknown:
@@ -445,7 +445,7 @@ def main():
     benchmark = XCCDFBenchmark(args.benchmark)
     if args.profile:
         ret = benchmark.show_profile_stats(args.profile, args)
-        if args.json:
+        if args.format == "json":
             print(json.dumps(ret, indent=4))
     else:
         all_profile_elems = benchmark.tree.findall("./{%s}Profile" % (xccdf_ns))
@@ -455,7 +455,7 @@ def main():
             if profile is not None:
                 ret.append(benchmark.show_profile_stats(profile, args))
 
-        if args.json:
+        if args.format == "json":
             print(json.dumps(ret, indent=4))
 
 if __name__ == '__main__':

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -96,6 +96,9 @@ class XCCDFBenchmark(object):
                 print("** %s" % profile.get('id'))
             sys.exit(1)
 
+        # This will only work with SSG where the (default) profile has zero
+        # selected rule. If you want to reuse this for custom content, you need
+        # to change this to look into Rule/@selected
         rules = xccdf_profile.findall("./{%s}select[@selected=\"true\"]" %
                                       xccdf_ns)
         for rule in rules:

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -418,7 +418,7 @@ def main():
                         action="store_true", dest="all",
                         help="Show all available statistics.")
     parser.add_argument("--format", default="plain",
-                        choices=["plain", "json"],
+                        choices=["plain", "json", "csv"],
                         help="Which format to use for output.")
 
     args, unknown = parser.parse_known_args()
@@ -456,6 +456,13 @@ def main():
 
     if args.format == "json":
         print(json.dumps(ret, indent=4))
+    elif args.format == "csv":
+        # we can assume ret has at least one element
+        # CSV header
+        print(",".join(ret[0].keys()))
+        for line in ret:
+            print(",".join([str(value) for value in line.values()]))
+
 
 if __name__ == '__main__':
     main()

--- a/shared/misc/profile_stats.py
+++ b/shared/misc/profile_stats.py
@@ -55,7 +55,7 @@ class XCCDFBenchmark(object):
             print("%s" % ioerr)
             sys.exit(1)
 
-    def get_profile_stats(self, profile=None):
+    def get_profile_stats(self, profile):
         """Obtain statistics for the profile"""
 
         # Holds the intermediary statistics for profile
@@ -86,40 +86,52 @@ class XCCDFBenchmark(object):
         rule_stats = []
         ssg_version_elem = self.tree.find("./{%s}version[@update=\"%s\"]" %
                                           (xccdf_ns, ssg_version_uri))
-        xccdf_profile = self.tree.find("./{%s}Profile[@id=\"%s\"]" %
-                                       (xccdf_ns, profile))
-        if xccdf_profile is None:
-            print("No such profile \"%s\" found in the benchmark!" % profile)
-            print("* Available profiles:")
-            profiles_avail = self.tree.findall("./{%s}Profile" % (xccdf_ns))
-            for profile in profiles_avail:
-                print("** %s" % profile.get('id'))
-            sys.exit(1)
 
-        # This will only work with SSG where the (default) profile has zero
-        # selected rule. If you want to reuse this for custom content, you need
-        # to change this to look into Rule/@selected
-        rules = xccdf_profile.findall("./{%s}select[@selected=\"true\"]" %
-                                      xccdf_ns)
+        rules = []
+
+        if profile == "all":
+            # "all" is a virtual profile that selects all rules
+            rules = self.tree.findall(".//{%s}Rule" % (xccdf_ns))
+        else:
+            xccdf_profile = self.tree.find("./{%s}Profile[@id=\"%s\"]" %
+                                           (xccdf_ns, profile))
+            if xccdf_profile is None:
+                print("No such profile \"%s\" found in the benchmark!"
+                      % profile)
+                print("* Available profiles:")
+                profiles_avail = self.tree.findall("./{%s}Profile" % (xccdf_ns))
+                for profile in profiles_avail:
+                    print("** %s" % profile.get('id'))
+                sys.exit(1)
+
+            # This will only work with SSG where the (default) profile has zero
+            # selected rule. If you want to reuse this for custom content, you
+            # need to change this to look into Rule/@selected
+            selects = xccdf_profile.findall("./{%s}select[@selected=\"true\"]" %
+                                            xccdf_ns)
+
+            for select in selects:
+                rule_id = select.get('idref')
+                xccdf_rule = self.tree.find(".//{%s}Rule[@id=\"%s\"]" %
+                                            (xccdf_ns, rule_id))
+                rules.append(xccdf_rule)
+
         for rule in rules:
-            rule_id = rule.get('idref')
-            xccdf_rule = self.tree.find(".//{%s}Rule[@id=\"%s\"]" %
-                                        (xccdf_ns, rule_id))
-            if xccdf_rule is not None:
-                oval = xccdf_rule.find("./{%s}check[@system=\"%s\"]" %
-                                       (xccdf_ns, oval_ns))
-                bash_fix = xccdf_rule.find("./{%s}fix[@system=\"%s\"]" %
-                                           (xccdf_ns, bash_rem_system))
-                ansible_fix = xccdf_rule.find("./{%s}fix[@system=\"%s\"]" %
-                                              (xccdf_ns, ansible_rem_system))
-                puppet_fix = xccdf_rule.find("./{%s}fix[@system=\"%s\"]" %
-                                             (xccdf_ns, puppet_rem_system))
-                anaconda_fix = xccdf_rule.find("./{%s}fix[@system=\"%s\"]" %
-                                               (xccdf_ns, anaconda_rem_system))
-                cce = xccdf_rule.find("./{%s}ident[@system=\"%s\"]" %
-                                      (xccdf_ns, cce_system))
+            if rule is not None:
+                oval = rule.find("./{%s}check[@system=\"%s\"]" %
+                                 (xccdf_ns, oval_ns))
+                bash_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
+                                     (xccdf_ns, bash_rem_system))
+                ansible_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
+                                        (xccdf_ns, ansible_rem_system))
+                puppet_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
+                                       (xccdf_ns, puppet_rem_system))
+                anaconda_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
+                                         (xccdf_ns, anaconda_rem_system))
+                cce = rule.find("./{%s}ident[@system=\"%s\"]" %
+                                (xccdf_ns, cce_system))
                 rule_stats.append(
-                    RuleStats(rule_id, oval,
+                    RuleStats(rule.get("id"), oval,
                               bash_fix, ansible_fix, puppet_fix, anaconda_fix,
                               cce)
                 )


### PR DESCRIPTION
Adds two new features to profile_stats.py

1) virtual "all" profile that will output stats for all Rules in the benchmark, regardless of their selection

Example:
```
$ ../shared/misc/profile_stats.py -b ssg-rhel7-xccdf.xml --profile all

Profile all:
* rules:            837
* checks (OVAL):    771 [92% complete]
* fixes (bash):     338 [40% complete]
* fixes (ansible):  167 [19% complete]
* fixes (puppet):   32  [3% complete]
* fixes (anaconda): 31  [3% complete]
* CCEs:             828 [98% complete]
```

2) CSV output format for everything in profile_stats.py

```
$ ../shared/misc/profile_stats.py -b ssg-rhel7-xccdf.xml --format csv
ssg_version,rules_count,profile_id,implemented_anaconda_fixes_pct,implemented_ansible_fixes_pct,assigned_cces_pct,implemented_puppet_fixes_pct,implemented_ovals_pct,implemented_bash_fixes_pct
SCAP Security Guide 0.1.33,13,standard,0.0,46.1538461538,100.0,0.0,100.0,38.4615384615
SCAP Security Guide 0.1.33,94,pci-dss,2.12765957447,15.9574468085,100.0,2.12765957447,100.0,90.4255319149
SCAP Security Guide 0.1.33,168,C2S,13.0952380952,48.2142857143,99.4047619048,12.5,98.2142857143,85.7142857143
SCAP Security Guide 0.1.33,69,rht-ccp,4.34782608696,43.4782608696,100.0,4.34782608696,100.0,88.4057971014
SCAP Security Guide 0.1.33,38,common,2.63157894737,23.6842105263,100.0,2.63157894737,100.0,94.7368421053
SCAP Security Guide 0.1.33,199,stig-rhel7-disa,3.5175879397,27.135678392,100.0,4.52261306533,98.9949748744,76.8844221106
SCAP Security Guide 0.1.33,199,stig-rhevh-upstream,3.5175879397,27.135678392,100.0,4.52261306533,98.9949748744,76.8844221106
SCAP Security Guide 0.1.33,357,ospp-rhel7,3.36134453782,26.8907563025,100.0,3.92156862745,99.4397759104,66.3865546218
SCAP Security Guide 0.1.33,96,cjis-rhel7-server,1.04166666667,29.1666666667,100.0,1.04166666667,100.0,94.7916666667
SCAP Security Guide 0.1.33,6,docker-host,0.0,16.6666666667,100.0,0.0,100.0,66.6666666667
SCAP Security Guide 0.1.33,357,nist-800-171-cui,3.36134453782,26.8907563025,100.0,3.92156862745,99.4397759104,66.3865546218
```