### PR TITLE
Fixed unterminated quotes in approved MACs ansible remediation

### DIFF
--- a/shared/templates/static/ansible/sshd_use_approved_macs.yml
+++ b/shared/templates/static/ansible/sshd_use_approved_macs.yml
@@ -8,6 +8,7 @@
     create=yes
     dest="/etc/ssh/sshd_config"
     regexp="^MACs"
-    line="MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1
+    line="MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1"
   tags:
     @ANSIBLE_TAGS@
+


### PR DESCRIPTION
Fix for:

```
 $ ansible-playbook --check ssg-rhel7-role-ospp-rhel7.yml --step
 [WARNING]: provided hosts list is empty, only localhost is available

ERROR! failed at splitting arguments, either an unbalanced jinja2 block or quotes: create=yes dest="/etc/ssh/sshd_config" regexp="^MACs" line="MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1

The error appears to have been in '/home/mpreisle/d/scap-security-guide/build/roles/ssg-rhel7-role-ospp-rhel7.yml': line 1770, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


    - name: "Use Only Approved MACs"
      ^ here

```