### PR TITLE
Do not use jinja separators in when statements in ansible

### DIFF
--- a/shared/templates/static/ansible/ensure_redhat_gpgkey_installed.yml
+++ b/shared/templates/static/ansible/ensure_redhat_gpgkey_installed.yml
@@ -33,7 +33,7 @@
     key: /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
   when:
     (gpg_key_directory_permission.stat.mode <= '0755')
-    and ({{ gpg_fingerprints.stdout_lines | difference(gpg_valid_fingerprints) }} | length == 0)
+    and (( gpg_fingerprints.stdout_lines | difference(gpg_valid_fingerprints)) | length == 0)
     and (gpg_fingerprints.stdout_lines | length > 0)
     and (ansible_distribution == "RedHat")
   tags:


### PR DESCRIPTION
Gets rid of:
```
TASK [Import RedHat GPG key] ******************************************************************************************************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: (gpg_key_directory_permission.stat.mode <= '0755') and ({{
gpg_fingerprints.stdout_lines | difference(gpg_valid_fingerprints) }} | length == 0) and (gpg_fingerprints.stdout_lines | length > 0) and (ansible_distribution == "RedHat")
```