### PR TITLE
RHBZ#1461330: Add Anaconda remediation for rule "smartcard_auth"

### DIFF
--- a/shared/templates/static/anaconda/smartcard_auth.anaconda
+++ b/shared/templates/static/anaconda/smartcard_auth.anaconda
@@ -1,0 +1,3 @@
+# platform = multi_platform_rhel
+
+package --add=pam_pkcs11 --add=esc


### PR DESCRIPTION
Packages pam_pkcs11 and esc weren't installed by Anaconda during
installing, which caused that users can't log in.