### PR TITLE
Reset parsed remediation attributes in combine-remediations.py correctly

### DIFF
--- a/RHEL/5/templates/static/bash/accounts_cracklib_present.sh
+++ b/RHEL/5/templates/static/bash/accounts_cracklib_present.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 authconfig --updateall
 if [ -e /etc/pam.d/system-auth-ac ]; then
 	sed -i '/password.*include.*system-auth-ac/ipassword    required     pam_cracklib.so' /etc/pam.d/system-auth

--- a/RHEL/5/templates/static/bash/accounts_disable_expired.sh
+++ b/RHEL/5/templates/static/bash/accounts_disable_expired.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_account_disable_post_pw_expiration
 

--- a/RHEL/5/templates/static/bash/accounts_disable_post_pw_expiration.sh
+++ b/RHEL/5/templates/static/bash/accounts_disable_post_pw_expiration.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_account_disable_post_pw_expiration
 

--- a/RHEL/5/templates/static/bash/accounts_fail_delay.sh
+++ b/RHEL/5/templates/static/bash/accounts_fail_delay.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(grep -c ^FAIL_DELAY /etc/login.defs) != 0 ]; then
 	sed -i 's/^FAIL_DELAY.*[0-9]*/FAIL_DELAY 4/' /etc/login.defs
 else

--- a/RHEL/5/templates/static/bash/accounts_global_setting.sh
+++ b/RHEL/5/templates/static/bash/accounts_global_setting.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 cat > /etc/pam.d/system-auth-local <<'STOP_HERE'
 auth        include      system-auth-ac
 account     include      system-auth-ac

--- a/RHEL/5/templates/static/bash/accounts_logins_logged.sh
+++ b/RHEL/5/templates/static/bash/accounts_logins_logged.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ ! -e /var/log/btmp ]; then
 	>/var/log/btmp
 	chmod 600 /var/log/btmp

--- a/RHEL/5/templates/static/bash/accounts_max_concurrent_login_sessions.sh
+++ b/RHEL/5/templates/static/bash/accounts_max_concurrent_login_sessions.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate max_concurrent_login_sessions_value
 

--- a/RHEL/5/templates/static/bash/accounts_maximum_age_login_defs.sh
+++ b/RHEL/5/templates/static/bash/accounts_maximum_age_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_maximum_age_login_defs
 

--- a/RHEL/5/templates/static/bash/accounts_minimum_age_login_defs.sh
+++ b/RHEL/5/templates/static/bash/accounts_minimum_age_login_defs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_minimum_age_login_defs
 

--- a/RHEL/5/templates/static/bash/accounts_no_uid_except_zero.sh
+++ b/RHEL/5/templates/static/bash/accounts_no_uid_except_zero.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 for UID0_USER in `cat /etc/passwd | cut -d: -f1,3 | grep :0$ | grep -v ^root: | cut -d: -f1`; do
 	userdel -rf ${UID0_USER}
 done

--- a/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_dcredit.sh
+++ b/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_dcredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_cracklib_dcredit
 

--- a/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_difok.sh
+++ b/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_difok.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_cracklib_difok
 

--- a/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_lcredit.sh
+++ b/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_lcredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_cracklib_lcredit
 

--- a/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_maxrepeat.sh
+++ b/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_maxrepeat.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_cracklib_maxrepeat
 

--- a/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_minlen.sh
+++ b/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_minlen.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_cracklib_minlen
 

--- a/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_ocredit.sh
+++ b/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_ocredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_cracklib_ocredit
 

--- a/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_ucredit.sh
+++ b/RHEL/5/templates/static/bash/accounts_password_pam_cracklib_ucredit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_cracklib_ucredit
 

--- a/RHEL/5/templates/static/bash/accounts_password_pam_tally_deny.sh
+++ b/RHEL/5/templates/static/bash/accounts_password_pam_tally_deny.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_password_pam_tally_deny
 

--- a/RHEL/5/templates/static/bash/accounts_password_reuse_limit.sh
+++ b/RHEL/5/templates/static/bash/accounts_password_reuse_limit.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate password_history_retain_number
 

--- a/RHEL/5/templates/static/bash/accounts_umask.sh
+++ b/RHEL/5/templates/static/bash/accounts_umask.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_user_umask
 

--- a/RHEL/5/templates/static/bash/aide_periodic_cron_checking.sh
+++ b/RHEL/5/templates/static/bash/aide_periodic_cron_checking.sh
@@ -1,2 +1,3 @@
+# platform = Red Hat Enterprise Linux 5
 echo "/usr/sbin/aide --config=/etc/aide.conf --check" > /etc/cron.weekly/aide
 chmod 700 /etc/cron.weekly/aide

--- a/RHEL/5/templates/static/bash/at_access_controlled.sh
+++ b/RHEL/5/templates/static/bash/at_access_controlled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ ! -e [/etc/at.allow ]; then
 	> /etc/at.allow
 	chown root:root /etc/at.allow

--- a/RHEL/5/templates/static/bash/at_deny_nonempty.sh
+++ b/RHEL/5/templates/static/bash/at_deny_nonempty.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 SYS_USER=$(cat /etc/passwd | while read entry; do if [ "$(echo ${entry} | cut -d: -f3)" -lt "500" ]; then echo ${entry} | cut -d: -f1 ; fi; done)
 for USER in `echo $SYS_USER`; do
 	if [ $(grep -c "^${USER}$" /etc/at.deny) = 0 ]; then

--- a/RHEL/5/templates/static/bash/at_system_accounts.sh
+++ b/RHEL/5/templates/static/bash/at_system_accounts.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 SYS_USER=$(cat /etc/passwd | while read entry; do if [ "$(echo ${entry} | cut -d: -f3)" -lt "500" ]; then echo ${entry} | cut -d: -f1 ; fi; done)
 for USER in `echo $SYS_USER`; do
 	if [ $(grep -c "^${USER}$" /etc/at.deny) = 0 ]; then

--- a/RHEL/5/templates/static/bash/audit_rules_audit_rules.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_audit_rules.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 elif [ -e /etc/audit.rules ]; then

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_chmod.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_chmod.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_chown.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_chown.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_fchmod.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_fchmod.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_fchmodat.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_fchmodat.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_fchown.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_fchown.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_fchownat.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_fchownat.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_fremovexattr.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_fremovexattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_fsetxattr.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_fsetxattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_lchown.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_lchown.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_lremovexattr.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_lremovexattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_lsetxattr.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_lsetxattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_removexattr.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_removexattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_dac_modification_setxattr.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_dac_modification_setxattr.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k perm_mod"

--- a/RHEL/5/templates/static/bash/audit_rules_file_deletion_events.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_file_deletion_events.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k delete"

--- a/RHEL/5/templates/static/bash/audit_rules_file_deletion_events_rmdir.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_file_deletion_events_rmdir.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k delete"

--- a/RHEL/5/templates/static/bash/audit_rules_kernel_module_loading.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_kernel_module_loading.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k modules"

--- a/RHEL/5/templates/static/bash/audit_rules_login_events.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_login_events.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 elif [ -e /etc/audit.rules ]; then

--- a/RHEL/5/templates/static/bash/audit_rules_sched_setparam.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_sched_setparam.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k set_scheduler_parameters"

--- a/RHEL/5/templates/static/bash/audit_rules_sched_setscheduler.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_sched_setscheduler.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k set_scheduler_setting"

--- a/RHEL/5/templates/static/bash/audit_rules_setdomainname.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_setdomainname.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k set_domainname"

--- a/RHEL/5/templates/static/bash/audit_rules_sethostname.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_sethostname.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k set_hostname"

--- a/RHEL/5/templates/static/bash/audit_rules_time_adjtimex.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_time_adjtimex.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k audit_time_rules"

--- a/RHEL/5/templates/static/bash/audit_rules_time_settimeofday.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_time_settimeofday.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k audit_time_rules"

--- a/RHEL/5/templates/static/bash/audit_rules_time_stime.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_time_stime.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 	AUDIT_TAG="-k audit_time_rules"

--- a/RHEL/5/templates/static/bash/audit_rules_unsuccessful_file_creat.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_unsuccessful_file_creat.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	if [ "`grep " -S creat " /etc/audit/audit.rules | grep -v '#' | grep -c '\-F exit=-EACCES'`" = "0" ]; then
 		if [ "`uname -p`" != "x86_64" ]; then

--- a/RHEL/5/templates/static/bash/audit_rules_unsuccessful_file_ftruncate.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_unsuccessful_file_ftruncate.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	if [ "`grep " -S ftruncate " /etc/audit/audit.rules | grep -v '#' | grep -c '\-F exit=-EACCES'`" = "0" ]; then
 		if [ "`uname -p`" != "x86_64" ]; then

--- a/RHEL/5/templates/static/bash/audit_rules_unsuccessful_file_open.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_unsuccessful_file_open.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	if [ "`grep " -S open " /etc/audit/audit.rules | grep -v '#' | grep -c '\-F exit=-EACCES'`" = "0" ]; then
 		if [ "`uname -p`" != "x86_64" ]; then

--- a/RHEL/5/templates/static/bash/audit_rules_unsuccessful_file_openat.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_unsuccessful_file_openat.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	if [ "`grep " -S openat " /etc/audit/audit.rules | grep -v '#' | grep -c '\-F exit=-EACCES'`" = "0" ]; then
 		if [ "`uname -p`" != "x86_64" ]; then

--- a/RHEL/5/templates/static/bash/audit_rules_unsuccessful_file_truncate.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_unsuccessful_file_truncate.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	if [ "`grep " -S truncate " /etc/audit/audit.rules | grep -v '#' | grep -c '\-F exit=-EACCES'`" = "0" ]; then
 		if [ "`uname -p`" != "x86_64" ]; then

--- a/RHEL/5/templates/static/bash/audit_rules_usergroup_creation.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_usergroup_creation.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 elif [ -e /etc/audit.rules ]; then

--- a/RHEL/5/templates/static/bash/audit_rules_usergroup_disabling.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_usergroup_disabling.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 elif [ -e /etc/audit.rules ]; then

--- a/RHEL/5/templates/static/bash/audit_rules_usergroup_modification.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_usergroup_modification.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 elif [ -e /etc/audit.rules ]; then

--- a/RHEL/5/templates/static/bash/audit_rules_usergroup_termination.sh
+++ b/RHEL/5/templates/static/bash/audit_rules_usergroup_termination.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/audit.rules ]; then
 	AUDIT_RULES_FILE="/etc/audit/audit.rules"
 elif [ -e /etc/audit.rules ]; then

--- a/RHEL/5/templates/static/bash/auditd_data_retention_audit_processing_failure.sh
+++ b/RHEL/5/templates/static/bash/auditd_data_retention_audit_processing_failure.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_disk_error_action
 

--- a/RHEL/5/templates/static/bash/auditd_data_retention_audit_storage_failure.sh
+++ b/RHEL/5/templates/static/bash/auditd_data_retention_audit_storage_failure.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/auditd.conf ]; then
 	AUDITD_CONF_FILE="/etc/audit/auditd.conf"
 elif [ -e /etc/auditd.conf ]; then

--- a/RHEL/5/templates/static/bash/banner_etc_issue.sh
+++ b/RHEL/5/templates/static/bash/banner_etc_issue.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate system_login_banner_text
 

--- a/RHEL/5/templates/static/bash/banner_gui_enabled.sh
+++ b/RHEL/5/templates/static/bash/banner_gui_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate gui_login_banner_text
 

--- a/RHEL/5/templates/static/bash/baseline_device_files.sh
+++ b/RHEL/5/templates/static/bash/baseline_device_files.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 # Generate a device file baseline
 find / -type b -o -type c 2>/dev/null | sort  > /var/log/device-file-list
 chmod 640 /var/log/device-file-list

--- a/RHEL/5/templates/static/bash/baseline_sgid_files.sh
+++ b/RHEL/5/templates/static/bash/baseline_sgid_files.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 # Generate a sgid file baseline
 find / -perm -2000 -type f  2>/dev/null | sort > /var/log/sgid-file-list
 chmod 640 /var/log/sgid-file-list

--- a/RHEL/5/templates/static/bash/baseline_suid_files.sh
+++ b/RHEL/5/templates/static/bash/baseline_suid_files.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 # Generate a suid file baseline
 find / -perm -4000 -type f 2>/dev/null | sort > /var/log/suid-file-list
 chmod 640 /var/log/suid-file-list

--- a/RHEL/5/templates/static/bash/bootloader_audit_argument.sh
+++ b/RHEL/5/templates/static/bash/bootloader_audit_argument.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(grep -v '#' /boot/grub/grub.conf | grep kernel | grep -c audit=) = 0 ]; then
 	sed -i '/^[ |\t]*kernel/s/$/ audit=1/' /boot/grub/grub.conf
 else

--- a/RHEL/5/templates/static/bash/bootloader_nousb_argument.sh
+++ b/RHEL/5/templates/static/bash/bootloader_nousb_argument.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 USB_KEYBOARD=$(grep 'Product=' /proc/bus/usb/devices 2>/dev/null| egrep -ic '(ps2 to usb adapter|keyboard|kvm|sc reader)')
 if [ "${USB_KEYBOARD}" = "0" ]; then
 	sed -i '/^[ |\t]*kernel/s/$/ nousb/' /boot/grub/grub.conf

--- a/RHEL/5/templates/static/bash/bootloader_password.sh
+++ b/RHEL/5/templates/static/bash/bootloader_password.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /tmp/GRUB.TMP ]; then
 	/sbin/grub-md5-crypt < /tmp/GRUB.TMP &> /tmp/GRUB.TMP.out
 	md5crypt=`tail -n1 /tmp/GRUB.TMP.out`

--- a/RHEL/5/templates/static/bash/bootloader_password_hash.sh
+++ b/RHEL/5/templates/static/bash/bootloader_password_hash.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /tmp/GRUB.TMP ]; then
 	/sbin/grub-md5-crypt < /tmp/GRUB.TMP &> /tmp/GRUB.TMP.out
 	md5crypt=`tail -n1 /tmp/GRUB.TMP.out`

--- a/RHEL/5/templates/static/bash/cron_access_controlled.sh
+++ b/RHEL/5/templates/static/bash/cron_access_controlled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ ! -e [/etc/cron.allow ]; then
 	> /etc/cron.allow
 	chown root:root /etc/cron.allow

--- a/RHEL/5/templates/static/bash/cron_system_accounts.sh
+++ b/RHEL/5/templates/static/bash/cron_system_accounts.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 SYS_USER=$(cat /etc/passwd | while read entry; do if [ "$(echo ${entry} | cut -d: -f3)" -lt "500" ]; then echo ${entry} | cut -d: -f1 ; fi; done)
 for USER in `echo $SYS_USER`; do
 	if [ $(grep -c "^${USER}$" /etc/cron.deny) = 0 ]; then

--- a/RHEL/5/templates/static/bash/dhcp_client_disable_ddns.sh
+++ b/RHEL/5/templates/static/bash/dhcp_client_disable_ddns.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/dhclient.conf ]; then
 	if [ $(grep -c "do-forward-updates false;" /etc/dhclient.conf) = 0 ]; then
 		echo "do-forward-updates false;" | tee -a /etc/dhclient.conf &>/dev/null

--- a/RHEL/5/templates/static/bash/dir_perms_world_writable_sticky_bits.sh
+++ b/RHEL/5/templates/static/bash/dir_perms_world_writable_sticky_bits.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find / /home /var /var/log /var/log/audit -xdev -perm -2 ! -perm -1000 -type d 2>/dev/null | xargs chmod o-w

--- a/RHEL/5/templates/static/bash/disable_ctrlaltdel_reboot.sh
+++ b/RHEL/5/templates/static/bash/disable_ctrlaltdel_reboot.sh
@@ -1,2 +1,3 @@
+# platform = Red Hat Enterprise Linux 5
 sed -i 's/^.*:ctrlaltdel:.*\(shutdown\|reboot\).*/ca:nil:ctrlaltdel:\/usr\/bin\/logger -p security.info "Ctrl-Alt-Del was pressed"/' /etc/inittab
 	

--- a/RHEL/5/templates/static/bash/disable_users_coredumps.sh
+++ b/RHEL/5/templates/static/bash/disable_users_coredumps.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 echo "*     hard   core    0" >> /etc/security/limits.conf

--- a/RHEL/5/templates/static/bash/ensure_gpgcheck_never_disabled.sh
+++ b/RHEL/5/templates/static/bash/ensure_gpgcheck_never_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 grep -R gpgcheck /etc/yum.repos.d/* /etc/yum.conf /root/rpmrc /usr/lib/rpm/redhat/rpmrc /usr/lib/rpm/rpmrc /etc/rpmrc 2>/dev/null | grep -v 'gpgcheck=1' | cut -d: -f1 | sort -u | while read YUM_FILE; do
 	sed -i 's/gpgcheck=.*/gpgcheck=1/g' ${YUM_FILE}
 done

--- a/RHEL/5/templates/static/bash/file_group_owner_grub_conf.sh
+++ b/RHEL/5/templates/static/bash/file_group_owner_grub_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chgrp root /etc/grub.conf /boot/grub/grub.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_aliases.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_aliases.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/postfix/aliases /etc/postfix/aliases.db /etc/aliases /etc/aliases.db 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_groupowner_aliases_files.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_aliases_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep "/" /etc/aliases /etc/aliases.db | grep -v "#" | grep ^/ | sed 's/.*[\s|\t]\//\//' | xargs chown :root

--- a/RHEL/5/templates/static/bash/file_groupowner_audio_devices.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_audio_devices.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /dev/audio* /dev/snd/*
 if [[ "`uname -r`" = "2.6.9"* ]]; then
 	sed -i 's/\(^audio\*:[a-z]*:\)[a-z]*:/\1sys:/' /etc/udev/permissions.d/50-udev.permissions

--- a/RHEL/5/templates/static/bash/file_groupowner_audit_log.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_audit_log.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/auditd.conf ]; then
 	grep ^log_file /etc/audit/auditd.conf | awk '{ print $3 }' | xargs chown :root
 if [ -e /etc/auditd.conf ]; then

--- a/RHEL/5/templates/static/bash/file_groupowner_audit_tools.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_audit_tools.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /sbin/auditctl /sbin/auditd /sbin/ausearch /sbin/aureport /sbin/autrace /sbin/audispd

--- a/RHEL/5/templates/static/bash/file_groupowner_bin_traceroute.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_bin_traceroute.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /bin/traceroute

--- a/RHEL/5/templates/static/bash/file_groupowner_binary_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_binary_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find /etc /bin /usr/bin /usr/lbin /usr/usb /sbin /usr/sbin -follow -gid +499 2>/dev/null | xargs chown :root

--- a/RHEL/5/templates/static/bash/file_groupowner_core_dump_dir.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_core_dump_dir.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep path.*/ /etc/kdump.conf | awk '{ print $2 }' | xargs chown :root

--- a/RHEL/5/templates/static/bash/file_groupowner_crontab_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_crontab_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/cron.d /etc/cron.daily /etc/cron.hourly /etc/cron.monthly /etc/cron.weekly /var/spool/cron 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_groupowner_crontab_files.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_crontab_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/crontab /etc/cron.d/* /var/spool/cron/* 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_at_allow.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_at_allow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/at.allow

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_at_deny.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_at_deny.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/at.deny

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_cron_allow.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_cron_allow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/cron.allow

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_cron_deny.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_cron_deny.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/cron.deny

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_cups_printers_conf.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_cups_printers_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/cups/printers.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_exports.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_exports.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/exports

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_hosts.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_hosts.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/hosts

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_ldap_conf.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_ldap_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/ldap.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_nsswitch_conf.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_nsswitch_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/nsswitch.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_ntp_conf.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_ntp_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/ntp.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_resolv_conf.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_resolv_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/resolv.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_samba_smb_conf.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_samba_smb_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/samba/smb.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_samba_tdb.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_samba_tdb.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/samba/passdb.tdb /etc/samba/secrets.tdb

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_securetty.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_securetty.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/securetty

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_security_access_conf.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_security_access_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/security/access.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_services.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_services.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/services

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_shadow.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_shadow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chgrp root /etc/shadow

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_skel.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_skel.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/skel/*

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_sysctl_conf.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_sysctl_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/sysctl.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_syslog_conf.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_syslog_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/syslog.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_etc_xinetd_conf.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_etc_xinetd_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/xinetd.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_exports_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_exports_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 cat /etc/exports | awk '{ print $1 }' | xargs chown :root

--- a/RHEL/5/templates/static/bash/file_groupowner_grub_conf.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_grub_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown :root /etc/grub.conf

--- a/RHEL/5/templates/static/bash/file_groupowner_ldap_cacerts.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_ldap_cacerts.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep -i '^tls_cacert' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }' | xargs chown -R :root

--- a/RHEL/5/templates/static/bash/file_groupowner_ldap_certs.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_ldap_certs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep -i '^tls_cert' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }' | xargs chown -R :root

--- a/RHEL/5/templates/static/bash/file_groupowner_ldap_keys.sh
+++ b/RHEL/5/templates/static/bash/file_groupowner_ldap_keys.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep -i '^tls_key' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }' | xargs chown -R :root

--- a/RHEL/5/templates/static/bash/file_owner_aliases.sh
+++ b/RHEL/5/templates/static/bash/file_owner_aliases.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/postfix/aliases /etc/postfix/aliases.db /etc/aliases /etc/aliases.db 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_owner_aliases_files.sh
+++ b/RHEL/5/templates/static/bash/file_owner_aliases_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep "/" /etc/aliases /etc/aliases.db | grep -v "#" | grep ^/ | sed 's/.*[\s|\t]\//\//' | xargs chown root

--- a/RHEL/5/templates/static/bash/file_owner_audio_devices.sh
+++ b/RHEL/5/templates/static/bash/file_owner_audio_devices.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /dev/audio* /dev/snd/*

--- a/RHEL/5/templates/static/bash/file_owner_audit_log.sh
+++ b/RHEL/5/templates/static/bash/file_owner_audit_log.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/auditd.conf ]; then
 	grep ^log_file /etc/audit/auditd.conf | awk '{ print $3 }' | xargs chown root
 if [ -e /etc/auditd.conf ]; then

--- a/RHEL/5/templates/static/bash/file_owner_audit_tools.sh
+++ b/RHEL/5/templates/static/bash/file_owner_audit_tools.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /sbin/auditctl /sbin/auditd /sbin/ausearch /sbin/aureport /sbin/autrace /sbin/audispd

--- a/RHEL/5/templates/static/bash/file_owner_bin_traceroute.sh
+++ b/RHEL/5/templates/static/bash/file_owner_bin_traceroute.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /bin/traceroute

--- a/RHEL/5/templates/static/bash/file_owner_binary_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_owner_binary_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find /etc /bin /usr/bin /usr/lbin /usr/usb /sbin /usr/sbin -follow -uid +499 2>/dev/null | xargs chown root

--- a/RHEL/5/templates/static/bash/file_owner_core_dump_dir.sh
+++ b/RHEL/5/templates/static/bash/file_owner_core_dump_dir.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep path.*/ /etc/kdump.conf | awk '{ print $2 }' | chown root

--- a/RHEL/5/templates/static/bash/file_owner_crontab_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_owner_crontab_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/cron.d /etc/cron.daily /etc/cron.hourly /etc/cron.monthly /etc/cron.weekly /var/spool/cron 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_owner_crontab_files.sh
+++ b/RHEL/5/templates/static/bash/file_owner_crontab_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/crontab /etc/cron.d/* /var/spool/cron/* 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_owner_etc_at_allow.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_at_allow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/at.allow

--- a/RHEL/5/templates/static/bash/file_owner_etc_at_deny.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_at_deny.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/at.deny

--- a/RHEL/5/templates/static/bash/file_owner_etc_cron_allow.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_cron_allow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/cron.allow

--- a/RHEL/5/templates/static/bash/file_owner_etc_cron_deny.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_cron_deny.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/cron.deny

--- a/RHEL/5/templates/static/bash/file_owner_etc_cups_printers_conf.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_cups_printers_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/cups/printers.conf

--- a/RHEL/5/templates/static/bash/file_owner_etc_exports.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_exports.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/exports

--- a/RHEL/5/templates/static/bash/file_owner_etc_hosts.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_hosts.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/hosts

--- a/RHEL/5/templates/static/bash/file_owner_etc_ldap_conf.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_ldap_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/ldap.conf

--- a/RHEL/5/templates/static/bash/file_owner_etc_nsswitch_conf.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_nsswitch_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/nsswitch.conf

--- a/RHEL/5/templates/static/bash/file_owner_etc_ntp_conf.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_ntp_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/ntp.conf

--- a/RHEL/5/templates/static/bash/file_owner_etc_resolv_conf.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_resolv_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/resolv.conf

--- a/RHEL/5/templates/static/bash/file_owner_etc_samba_smb_conf.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_samba_smb_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/samba/smb.conf

--- a/RHEL/5/templates/static/bash/file_owner_etc_samba_tdb.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_samba_tdb.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/samba/passdb.tdb /etc/samba/secrets.tdb

--- a/RHEL/5/templates/static/bash/file_owner_etc_securetty.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_securetty.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/securetty

--- a/RHEL/5/templates/static/bash/file_owner_etc_security_access_conf.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_security_access_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/security/access.conf

--- a/RHEL/5/templates/static/bash/file_owner_etc_services.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_services.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/services

--- a/RHEL/5/templates/static/bash/file_owner_etc_shadow.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_shadow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/shadow

--- a/RHEL/5/templates/static/bash/file_owner_etc_skel.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_skel.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/skel/*

--- a/RHEL/5/templates/static/bash/file_owner_etc_sysctl_conf.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_sysctl_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/sysctl.conf

--- a/RHEL/5/templates/static/bash/file_owner_etc_syslog_conf.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_syslog_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/syslog.conf

--- a/RHEL/5/templates/static/bash/file_owner_etc_xinetd_conf.sh
+++ b/RHEL/5/templates/static/bash/file_owner_etc_xinetd_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/xinetd.conf

--- a/RHEL/5/templates/static/bash/file_owner_exports_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_owner_exports_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 cat /etc/exports | awk '{ print $1 }' | xargs chown root

--- a/RHEL/5/templates/static/bash/file_owner_grub_conf.sh
+++ b/RHEL/5/templates/static/bash/file_owner_grub_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chown root /etc/grub.conf /boot/grub/grub.conf

--- a/RHEL/5/templates/static/bash/file_owner_ldap_cacerts.sh
+++ b/RHEL/5/templates/static/bash/file_owner_ldap_cacerts.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep -i '^tls_cacert' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }' | xargs chown -R root

--- a/RHEL/5/templates/static/bash/file_owner_ldap_certs.sh
+++ b/RHEL/5/templates/static/bash/file_owner_ldap_certs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep -i '^tls_cert' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }' | xargs chown -R root

--- a/RHEL/5/templates/static/bash/file_owner_ldap_keys.sh
+++ b/RHEL/5/templates/static/bash/file_owner_ldap_keys.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep -i '^tls_key' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }' | xargs chown -R root

--- a/RHEL/5/templates/static/bash/file_permissions_aliases.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_aliases.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 644 /etc/postfix/aliases /etc/postfix/aliases.db /etc/aliases /etc/aliases.db 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_permissions_aliases_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_aliases_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep "/" /etc/aliases /etc/aliases.db | grep -v "#" | grep ^/ | sed 's/.*[\s|\t]\//\//' | xargs chmod 755

--- a/RHEL/5/templates/static/bash/file_permissions_audio_devices.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_audio_devices.sh
@@ -1,2 +1,3 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 660 /dev/audio* /dev/snd/*
 sed -i '/[audio|snd]/s/MODE="[0-9]*"/MODE="660"/' /etc/udev/rules.d/50-udev.rules

--- a/RHEL/5/templates/static/bash/file_permissions_audit_log.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_audit_log.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/auditd.conf ]; then
 	grep ^log_file /etc/audit/auditd.conf | awk '{ print $3 }' | xargs chmod 640
 elif [ -e /etc/auditd.conf ]; then

--- a/RHEL/5/templates/static/bash/file_permissions_audit_tools.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_audit_tools.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 750 /sbin/auditctl /sbin/auditd /sbin/ausearch /sbin/aureport /sbin/autrace /sbin/audispd

--- a/RHEL/5/templates/static/bash/file_permissions_binary_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_binary_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find /etc /bin /usr/bin /usr/lbin /usr/usb /sbin /usr/sbin -follow -perm -20 -o -perm -2 2>/dev/null | xargs chmod go-w

--- a/RHEL/5/templates/static/bash/file_permissions_core_dump_dir.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_core_dump_dir.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep path.*/ /etc/kdump.conf | awk '{ print $2 }' | xargs chmod 700

--- a/RHEL/5/templates/static/bash/file_permissions_cron_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_cron_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 0700 /etc/cron.daily/* /etc/cron.hourly/* /etc/cron.monthly/* /etc/cron.weekly/* 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_permissions_cron_log_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_cron_log_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep ^cron /etc/syslog.conf | awk '{ print $2 }' | xargs chmod 0600

--- a/RHEL/5/templates/static/bash/file_permissions_crontab_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_crontab_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 755 /etc/cron.d /etc/cron.daily /etc/cron.hourly /etc/cron.monthly /etc/cron.weekly /var/spool/cron 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_permissions_crontab_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_crontab_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 600 /etc/crontab /etc/cron.d/* /var/spool/cron/* 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_permissions_etc_samba_smb_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_etc_samba_smb_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 0644 /etc/samba/smb.conf

--- a/RHEL/5/templates/static/bash/file_permissions_etc_samba_tdb.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_etc_samba_tdb.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 0600 /etc/samba/passdb.tdb /etc/samba/secrets.tdb

--- a/RHEL/5/templates/static/bash/file_permissions_etc_skel.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_etc_skel.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 0644 /etc/skel/*

--- a/RHEL/5/templates/static/bash/file_permissions_etc_sysctl_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_etc_sysctl_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 0600 /etc/sysctl.conf

--- a/RHEL/5/templates/static/bash/file_permissions_etc_xinetd_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_etc_xinetd_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 0640 /etc/xinetd.conf /etc/xinetd.d/*

--- a/RHEL/5/templates/static/bash/file_permissions_etc_xinetd_dir.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_etc_xinetd_dir.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 0755 /etc/xinet.d/*

--- a/RHEL/5/templates/static/bash/file_permissions_extended_aliases.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_aliases.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/aliases /etc/aliases.db /etc/postfix/aliases /etc/postfix/aliases.db 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_permissions_extended_aliases_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_aliases_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep / /etc/aliases | grep -v "#" | sed s/^[^\/]*// | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_audio_devices.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_audio_devices.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /dev/audio* /dev/snd/* 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_permissions_extended_audit_log.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_audit_log.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/audit/auditd.conf ]; then
 	grep "^log_file" /etc/audit/auditd.conf | sed s/^[^\/]*// | xargs setfacl --remove-all
 elif [ -e /etc/auditd.conf ]; then

--- a/RHEL/5/templates/static/bash/file_permissions_extended_audit_tools.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_audit_tools.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /sbin/auditctl /sbin/auditd /sbin/ausearch /sbin/aureport /sbin/autrace /sbin/audispd

--- a/RHEL/5/templates/static/bash/file_permissions_extended_bin_traceroute.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_bin_traceroute.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /bin/traceroute

--- a/RHEL/5/templates/static/bash/file_permissions_extended_binary_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_binary_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl -RLb /etc /bin /usr/bin /usr/lbin /usr/usb /sbin /usr/sbin 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_permissions_extended_core_dump_dir.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_core_dump_dir.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep path /etc/kdump.conf | grep -v "#" | awk '{ print $2 }' | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_cron_log_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_cron_log_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep cron /etc/syslog.conf | grep -v "#" | awk '{ print $2 }' | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_crontab_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_crontab_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/cron.d /etc/crontab /etc/cron.daily /etc/cron.hourly /etc/cron.monthly /etc/cron.weekly /var/spool/cron 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_permissions_extended_crontab_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_crontab_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find /etc/cron.d /etc/crontab /etc/cron.daily /etc/cron.hourly /etc/cron.monthly /etc/cron.weekly /var/spool/cron  -type f 2>/dev/null | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_at_allow.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_at_allow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/at.allow

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_at_deny.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_at_deny.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/at.deny

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_cron_allow.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_cron_allow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/cron.allow

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_cron_deny.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_cron_deny.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/cron.deny

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_cups_printers_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_cups_printers_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/cups/printers.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_exports.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_exports.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/exports

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_group.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_group.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/group

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_gshadow.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_gshadow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/gshadow

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_hosts.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_hosts.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/hosts

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_ldap_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_ldap_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/ldap.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_news_hosts_nntp_nolimit.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_news_hosts_nntp_nolimit.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/news/hosts.nntp.nolimit

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_news_incoming_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_news_incoming_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/news/incoming.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_news_infeed_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_news_infeed_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/news/infeed.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_news_nnrp_access.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_news_nnrp_access.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/news/nnrp.access

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_news_passwd_nntp.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_news_passwd_nntp.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/news/passwd.nntp

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_nsswitch_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_nsswitch_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/nsswitch.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_ntp_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_ntp_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/ntp.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_passwd.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_passwd.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/passwd

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_resolv_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_resolv_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/resolv.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_samba_smb_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_samba_smb_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/samba/smb.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_samba_tdb.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_samba_tdb.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/samba/passdb.tdb /etc/samba/secrets.tdb

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_security_access_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_security_access_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/security/access.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_services.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_services.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/services

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_shadow.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_shadow.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/shadow

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_skel.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_skel.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find /etc/skel 2>/dev/null | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_sysctl_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_sysctl_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/sysctl.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_syslog_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_syslog_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/syslog.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_xinetd_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_xinetd_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/xinetd.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_etc_xinetd_dir.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_etc_xinetd_dir.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find /etc/xinetd.d -type f 2>/dev/null | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_ftpusers.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_ftpusers.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/ftpusers /etc/vsftpd.ftpusers /etc/vsftpd/ftpusers

--- a/RHEL/5/templates/static/bash/file_permissions_extended_global_initialization_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_global_initialization_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/bashrc /etc/csh.cshrc /etc/csh.login /etc/csh.logout /etc/environment /etc/ksh.kshrc /etc/profile /etc/suid_profile /etc/profile.d/*

--- a/RHEL/5/templates/static/bash/file_permissions_extended_grub_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_grub_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /etc/grub.conf /boot/grub/grub.conf

--- a/RHEL/5/templates/static/bash/file_permissions_extended_home_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_home_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 cut -d: -f6 /etc/passwd | sort -u | xargs setfacl --remove-all 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_permissions_extended_home_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_home_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find /home -type f 2>/dev/null | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_ldap_cacerts.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_ldap_cacerts.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep -i '^tls_cacert' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }' | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_ldap_certs.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_ldap_certs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep -i '^tls_cert' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }' | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_ldap_keys.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_ldap_keys.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep -i '^tls_key' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }' | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_library_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_library_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl -RLb --remove-all /usr/lib/* /lib/*

--- a/RHEL/5/templates/static/bash/file_permissions_extended_local_initialization_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_local_initialization_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 cut -d: -f6 /etc/passwd | sort -u | xargs -n1 -IDIR find DIR -maxdepth 1 -name .bashrc -o -name .bash_login -o -name .bash_logout -o -name .bash_profile -o -name .cshrc -o -name .kshrc -o -name .login -o -name .logout -o -name .profile -o -name .env -o -name .dtprofile -o -name .dispatch -o -name .emacs -o -name .exrc 2>/dev/null | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_man_pages.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_man_pages.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl -RLb /usr/share/man/* /usr/share/info/* /usr/share/infopage/*

--- a/RHEL/5/templates/static/bash/file_permissions_extended_mib_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_mib_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find / -name *.mib 2>/dev/null | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_root_dir.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_root_dir.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl -RLb /root/*

--- a/RHEL/5/templates/static/bash/file_permissions_extended_run_control_scripts.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_run_control_scripts.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find /etc/rc* /etc/init.d -type f 2>/dev/null | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_shell_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_shell_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 cat /etc/shells | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_smtp_logs.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_smtp_logs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 egrep "(\*.crit|mail\.[^n][^/]*)" /etc/syslog.conf | sed 's/^[^/]*//' | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_snmpd_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_snmpd_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find / -name snmpd.conf 2>/dev/null | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_extended_usr_sbin_dir.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_usr_sbin_dir.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl -RLb /usr/sbin/*

--- a/RHEL/5/templates/static/bash/file_permissions_extended_var_log.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_var_log.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl -RLb /var/log/*

--- a/RHEL/5/templates/static/bash/file_permissions_extended_var_spool_at.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_var_spool_at.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl --remove-all /var/spool/at

--- a/RHEL/5/templates/static/bash/file_permissions_extended_var_yp.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_var_yp.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 setfacl -RLb /var/yp/*

--- a/RHEL/5/templates/static/bash/file_permissions_extended_xauthority_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_extended_xauthority_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 cut -d: -f6 /etc/passwd | sort -u | xargs -n1 -IDIR find DIR -maxdepth 1 -name .Xauthority -o -name .xauth 2>/dev/null | xargs setfacl --remove-all

--- a/RHEL/5/templates/static/bash/file_permissions_ftpusers.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_ftpusers.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 0640 /etc/ftpusers /etc/vsftpd.ftpusers /etc/vsftpd/ftpusers 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_permissions_global_initialization_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_global_initialization_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod -R 0644 /etc/bashrc /etc/csh.cshrc /etc/csh.login /etc/csh.logout /etc/environment /etc/ksh.kshrc /etc/profile /etc/suid_profile /etc/profile.d 2>/dev/null

--- a/RHEL/5/templates/static/bash/file_permissions_grub_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_grub_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod 0600 /etc/grub.conf /boot/grub/grub.conf

--- a/RHEL/5/templates/static/bash/file_permissions_home_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_home_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find /root /home/* -perm -1 -o -perm -2 -o -perm -4 -o -perm -20 2>/dev/null | xargs -I entry chmod o-rwx,g-w "entry"

--- a/RHEL/5/templates/static/bash/file_permissions_ldap_cacerts.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_ldap_cacerts.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 KEY_PATH="`grep -i '^tls_cacert' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }'`"
 if [ -d "${KEY_PATH}" ]; then
 	chmod 755 "${KEY_PATH}"

--- a/RHEL/5/templates/static/bash/file_permissions_ldap_certs.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_ldap_certs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep -i '^tls_cert' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }' | xargs chmod -R 644

--- a/RHEL/5/templates/static/bash/file_permissions_ldap_keys.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_ldap_keys.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep -i '^tls_key' /etc/ldap.conf | grep -v "#" | awk '{ print $2 }' | xargs chmod -R 600	

--- a/RHEL/5/templates/static/bash/file_permissions_library_dirs.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_library_dirs.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find /lib /usr/lib -follow -perm -20 -o -perm -2 2>/dev/null | xargs chmod go-w

--- a/RHEL/5/templates/static/bash/file_permissions_local_initialization_files.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_local_initialization_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find /root /home -maxdepth 2 -type f \( -perm -o+r -o -perm -o+w  -o -perm -o+x -o -perm -g+w -o -perm -g+x \) -a \( -name \.bashrc -o -name \.bash_login -o -name \.bash_logout -o -name \.bash_profile -o -name \.cshrc -o -name \.kshrc -o -name \.login -o -name \.logout -o -name \.profile -o -name \.env -o -name \.dtprofile -o -name \.dispatch -o -name \.emacs -o -name \.exrc \) 2>/dev/null | xargs chmod o-rwx,g-wx

--- a/RHEL/5/templates/static/bash/file_permissions_root_dir.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_root_dir.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 grep ^root: /etc/passwd | awk -F: ' { print $6 }' | xargs -I entry chmod g-rwx,o-rwx "entry"

--- a/RHEL/5/templates/static/bash/file_permissions_snmpd_conf.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_snmpd_conf.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find / -name snmpd.conf 2>/dev/null | xargs chmod ugo-x,go-wr

--- a/RHEL/5/templates/static/bash/file_permissions_unauthorized_world_writable.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_unauthorized_world_writable.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find / /var /home -xdev -follow -type f -perm -002 2>/dev/null | xargs chmod o-w

--- a/RHEL/5/templates/static/bash/file_permissions_ungroupowned.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_ungroupowned.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find / /home /var /var/log /var/log/audit -xdev -nogroup 2>/dev/null | xargs chown :root

--- a/RHEL/5/templates/static/bash/file_permissions_usr_bin_ldd.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_usr_bin_ldd.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 chmod a-x /usr/bin/ldd

--- a/RHEL/5/templates/static/bash/file_permissions_var_log.sh
+++ b/RHEL/5/templates/static/bash/file_permissions_var_log.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 find /var/log -follow -type f ! -name wtmp 2>/dev/null | xargs chmod o-rwx,g-wx,u-x
 
 # The following corrects the permission mask set for /var/log/rpmpkgs.

--- a/RHEL/5/templates/static/bash/ftp_default_umask.sh
+++ b/RHEL/5/templates/static/bash/ftp_default_umask.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ "$(rpm -q krb5-workstation &>/dev/null; echo $?)" = "0" ]; then
 	if [ "$(grep server_args /etc/xinetd.d/gssftp | grep -v "#" | grep -c "\-u 077")" = "0" ]; then
 		sed -i '/server_args/s/$/ -u 077/' /etc/xinetd.d/gssftp

--- a/RHEL/5/templates/static/bash/ftp_enable_warning_banner.sh
+++ b/RHEL/5/templates/static/bash/ftp_enable_warning_banner.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate ftp_login_banner_text
 

--- a/RHEL/5/templates/static/bash/ftp_ftpusers_file_empty.sh
+++ b/RHEL/5/templates/static/bash/ftp_ftpusers_file_empty.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 SYS_USER=$(cat /etc/passwd | while read entry; do if [ "$(echo ${entry} | cut -d: -f3)" -lt "500" ]; then echo ${entry} | cut -d: -f1 ; fi; done)
 if [ "$(rpm -q krb5-workstation &>/dev/null; echo $?)" = "0" ]; then
 	if [ ! -e /etc/ftpusers ]; then

--- a/RHEL/5/templates/static/bash/ftp_ftpusers_file_exists.sh
+++ b/RHEL/5/templates/static/bash/ftp_ftpusers_file_exists.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 SYS_USER=$(cat /etc/passwd | while read entry; do if [ "$(echo ${entry} | cut -d: -f3)" -lt "500" ]; then echo ${entry} | cut -d: -f1 ; fi; done)
 if [ "$(rpm -q krb5-workstation &>/dev/null; echo $?)" = "0" ]; then
 	if [ ! -e /etc/ftpusers ]; then

--- a/RHEL/5/templates/static/bash/ftp_log_transactions.sh
+++ b/RHEL/5/templates/static/bash/ftp_log_transactions.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -e /etc/xinetd.d/gssftp ]; then
 	if [ "$(grep server_args /etc/xinetd.d/gssftp | grep -c " -l")" = "0" ]; then
 		sed -i "/server_args/s/$/ -l/" /etc/xinetd.d/gssftp

--- a/RHEL/5/templates/static/bash/gconf_gnome_screensaver_idle_activation_enabled.sh
+++ b/RHEL/5/templates/static/bash/gconf_gnome_screensaver_idle_activation_enabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 gconftool-2 --direct --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory --type bool --set /apps/gnome-screensaver/idle_activation_enabled true &>/dev/null

--- a/RHEL/5/templates/static/bash/gconf_gnome_screensaver_idle_delay.sh
+++ b/RHEL/5/templates/static/bash/gconf_gnome_screensaver_idle_delay.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 gconftool-2 --direct --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory --type int --set /apps/gnome-screensaver/idle_delay 15 &>/dev/null

--- a/RHEL/5/templates/static/bash/gconf_gnome_screensaver_lock_enabled.sh
+++ b/RHEL/5/templates/static/bash/gconf_gnome_screensaver_lock_enabled.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 gconftool-2 --direct --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory --type bool --set /apps/gnome-screensaver/lock_enabled true &>/dev/null

--- a/RHEL/5/templates/static/bash/global_initialization_files_mesg.sh
+++ b/RHEL/5/templates/static/bash/global_initialization_files_mesg.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 echo mesg n | tee -a /etc/profile &>/dev/null

--- a/RHEL/5/templates/static/bash/ip6tables_input_icmpv6_broadcast.sh
+++ b/RHEL/5/templates/static/bash/ip6tables_input_icmpv6_broadcast.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ ! -e /etc/sysconfig/ip6tables ] || [ "$(grep -c ^ /etc/sysconfig/ip6tables)" -lt "5" ]; then
 	echo -e "*filter\n:INPUT DROP [0:0]\n:FORWARD DROP [0:0]\n:OUTPUT ACCEPT [0:0]\nCOMMIT" | tee /etc/sysconfig/ip6tables &>/dev/null
 	echo "-A INPUT -p icmpv6 -d ff02::1 --icmpv6-type 128 -j DROP" | tee -a /etc/sysconfig/ip6tables &>/dev/null 

--- a/RHEL/5/templates/static/bash/ip_6to4_tunnels.sh
+++ b/RHEL/5/templates/static/bash/ip_6to4_tunnels.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 ip tunnel list | cut -d: -f1 | while read TUNNEL_INTERFACE; do ip tunnel del $TUNNEL_INTERFACE 2>/dev/null; done

--- a/RHEL/5/templates/static/bash/ip_teredo.sh
+++ b/RHEL/5/templates/static/bash/ip_teredo.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 ps ax | grep -i miredo | grep -v grep | awk ' { print $1 }' | xargs kill

--- a/RHEL/5/templates/static/bash/ip_tunnels.sh
+++ b/RHEL/5/templates/static/bash/ip_tunnels.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 ip tunnel list | cut -d: -f1 | while read TUNNEL_INTERFACE; do ip tunnel del $TUNNEL_INTERFACE 2>/dev/null; done

--- a/RHEL/5/templates/static/bash/iptables_input_reject_rule.sh
+++ b/RHEL/5/templates/static/bash/iptables_input_reject_rule.sh
@@ -1,2 +1,3 @@
+# platform = Red Hat Enterprise Linux 5
 /sbin/iptables -A INPUT -j REJECT --reject-with icmp-host-prohibited
 /sbin/iptables-save > /etc/sysconfig/iptables

--- a/RHEL/5/templates/static/bash/iptables_timestamp_reject_rule.sh
+++ b/RHEL/5/templates/static/bash/iptables_timestamp_reject_rule.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ "$(egrep -c '(--icmp-type 14|timestamp-reply) -j DROP')" = "0" ]; then
 	/sbin/iptables -I INPUT -p ICMP --icmp-type timestamp-reply -j DROP
 fi

--- a/RHEL/5/templates/static/bash/kernel_module_dccp_disabled.sh
+++ b/RHEL/5/templates/static/bash/kernel_module_dccp_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -d /etc/modprobe.d/ ]; then
 	echo "install dccp /bin/true" >> /etc/modprobe.d/disabled_modules.conf
 	echo "install dccp_ipv4 /bin/true" >> /etc/modprobe.d/disabled_modules.conf

--- a/RHEL/5/templates/static/bash/kernel_module_ipv6_option_disabled.sh
+++ b/RHEL/5/templates/static/bash/kernel_module_ipv6_option_disabled.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -d /etc/modprobe.d/ ]; then
 	echo "install ipv6 /bin/true" >> /etc/modprobe.d/disabled_modules.conf
 else

--- a/RHEL/5/templates/static/bash/ldap_client_bindpw.sh
+++ b/RHEL/5/templates/static/bash/ldap_client_bindpw.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 sed -i '/bindpw/d' /etc/ldap.conf

--- a/RHEL/5/templates/static/bash/ldap_client_start_tls.sh
+++ b/RHEL/5/templates/static/bash/ldap_client_start_tls.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ "$(cat /etc/ldap.conf | grep -c '^ssl ')" = "0" ]; then
 	echo "ssl start_tls" | tee -a /etc/ldap.conf &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/ldap_client_tls_cert.sh
+++ b/RHEL/5/templates/static/bash/ldap_client_tls_cert.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 sed -i 's/ ldap//g' /etc/nsswitch.conf

--- a/RHEL/5/templates/static/bash/ldap_client_tls_checkpeer.sh
+++ b/RHEL/5/templates/static/bash/ldap_client_tls_checkpeer.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ldap.conf | grep -c "^tls_checkpeer") = "0" ]; then
 	echo "tls_checkpeer yes" | tee -a /etc/ldap.conf &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/ldap_client_tls_crlcheck.sh
+++ b/RHEL/5/templates/static/bash/ldap_client_tls_crlcheck.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ldap.conf | grep -c "^tls_crlcheck") = "0" ]; then
 	echo "tls_crlcheck all" | tee -a /etc/ldap.conf &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/mail_forward_files.sh
+++ b/RHEL/5/templates/static/bash/mail_forward_files.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 SENDMAIL_CONFIG=$(rpm -ql sendmail | grep sendmail.cf)
 SENDMAIL_MAINCONF=$(rpm -ql sendmail | grep sendmail.mc)
 if [ "$(rpm -q sendmail-cf &>/dev/null; echo $?)" = "0" ]; then

--- a/RHEL/5/templates/static/bash/mail_help_command.sh
+++ b/RHEL/5/templates/static/bash/mail_help_command.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 >/etc/mail/helpfile

--- a/RHEL/5/templates/static/bash/mail_version_info.sh
+++ b/RHEL/5/templates/static/bash/mail_version_info.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 SENDMAIL_CONFIG=$(rpm -ql sendmail | grep sendmail.cf)
 SENDMAIL_MAINCONF=$(rpm -ql sendmail | grep sendmail.mc)
 if [ "$(rpm -q sendmail-cf &>/dev/null; echo $?)" = "0" ]; then

--- a/RHEL/5/templates/static/bash/network_ipv6_disable_interfaces.sh
+++ b/RHEL/5/templates/static/bash/network_ipv6_disable_interfaces.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(grep -c "^NETWORKING_IPV6" /etc/sysconfig/network) = 0 ]; then
 	echo "NETWORKING_IPV6=no" | tee -a /etc/sysconfig/network &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/no_files_unowned_by_user.sh
+++ b/RHEL/5/templates/static/bash/no_files_unowned_by_user.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find / /home /var /var/log /var/log/audit -xdev -nouser 2>/dev/null | xargs chown root

--- a/RHEL/5/templates/static/bash/no_root_webbrowsing.sh
+++ b/RHEL/5/templates/static/bash/no_root_webbrowsing.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 rm -rf `grep ^root: /etc/passwd | awk -F: '{ print $6 }'`/.mozilla

--- a/RHEL/5/templates/static/bash/package_rpc_removed.sh
+++ b/RHEL/5/templates/static/bash/package_rpc_removed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 yum -y remove portmap rpcbind --disablerepo=* 1>/dev/null

--- a/RHEL/5/templates/static/bash/package_samba_removed.sh
+++ b/RHEL/5/templates/static/bash/package_samba_removed.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 yum -y remove samba-common --disablerepo=* 1>/dev/null

--- a/RHEL/5/templates/static/bash/require_singleuser_auth.sh
+++ b/RHEL/5/templates/static/bash/require_singleuser_auth.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 grep -q :S: /etc/inittab && \
   sed -i "s/.*:S:.*/~:S:wait:\/sbin\/sulogin/g" /etc/inittab
 if ! [ $? -eq 0 ]; then

--- a/RHEL/5/templates/static/bash/restricted_accounts.sh
+++ b/RHEL/5/templates/static/bash/restricted_accounts.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 /usr/bin/id shutdown &>/dev/null && /usr/sbin/userdel shutdown
 /usr/bin/id halt &>/dev/null && /usr/sbin/userdel halt
 /usr/bin/id reboot &>/dev/null && /usr/sbin/userdel reboot

--- a/RHEL/5/templates/static/bash/restricted_accounts_ftp.sh
+++ b/RHEL/5/templates/static/bash/restricted_accounts_ftp.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 /usr/bin/id ftp &>/dev/null && /usr/sbin/userdel ftp

--- a/RHEL/5/templates/static/bash/restricted_accounts_games.sh
+++ b/RHEL/5/templates/static/bash/restricted_accounts_games.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 /usr/bin/id games &>/dev/null && /usr/sbin/userdel games

--- a/RHEL/5/templates/static/bash/restricted_accounts_gopher.sh
+++ b/RHEL/5/templates/static/bash/restricted_accounts_gopher.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 /usr/bin/id gopher &>/dev/null && /usr/sbin/userdel gopher

--- a/RHEL/5/templates/static/bash/restricted_accounts_news.sh
+++ b/RHEL/5/templates/static/bash/restricted_accounts_news.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 /usr/bin/id news &>/dev/null && /usr/sbin/userdel news

--- a/RHEL/5/templates/static/bash/rhosts_auth_pam_files.sh
+++ b/RHEL/5/templates/static/bash/rhosts_auth_pam_files.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 sed -i '/.*rhosts_auth.*/d' /etc/pam.d/*

--- a/RHEL/5/templates/static/bash/rpm_nosignature.sh
+++ b/RHEL/5/templates/static/bash/rpm_nosignature.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 grep nosignature /etc/rpmrc /usr/lib/rpm/rpmrc /usr/lib/rpm/redhat/rpmrc ~root/.rpmrc 2>/dev/null | cut -d: -f1 | sort -u | while read RPM_FILE; do
 	sed -i 's/nosignature//g' ${RPM_FILE}
 done

--- a/RHEL/5/templates/static/bash/samba_encrypt_passwords_option.sh
+++ b/RHEL/5/templates/static/bash/samba_encrypt_passwords_option.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ "$(grep -c '^[ |\t]*encrypt passwords' /etc/samba/smb.conf)" = "0" ]; then
 	sed -i 's/\(^\[global\]$\)/\1\n\n\tencrypt passwords = yes/' /etc/samba/smb.conf
 else

--- a/RHEL/5/templates/static/bash/samba_guest_ok_option.sh
+++ b/RHEL/5/templates/static/bash/samba_guest_ok_option.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 sed -i '/^[#|;]/!s/\(guest ok =\).*/\1 no/g' /etc/samba/smb.conf

--- a/RHEL/5/templates/static/bash/samba_hosts_option.sh
+++ b/RHEL/5/templates/static/bash/samba_hosts_option.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 sed -i 's/\(^\[global\]$\)/\1\n\n\thosts allow = 127./' /etc/samba/smb.conf

--- a/RHEL/5/templates/static/bash/samba_security_option.sh
+++ b/RHEL/5/templates/static/bash/samba_security_option.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 sed -i '/^[#|;]/!s/\([ |\t]*security =\).*/\1 user/' /etc/samba/smb.conf

--- a/RHEL/5/templates/static/bash/securetty_root_login_console_only.sh
+++ b/RHEL/5/templates/static/bash/securetty_root_login_console_only.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 echo tty1 > /etc/securetty

--- a/RHEL/5/templates/static/bash/selinux_enforcing.sh
+++ b/RHEL/5/templates/static/bash/selinux_enforcing.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 . /usr/share/scap-security-guide/remediation_functions
 populate var_selinux_policy_name
 

--- a/RHEL/5/templates/static/bash/set_password_hashing_algorithm_systemauth.sh
+++ b/RHEL/5/templates/static/bash/set_password_hashing_algorithm_systemauth.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(grep "password.*pam_unix.so" /etc/pam.d/system-auth | egrep -c '(descrypt|bigcrypt|md5|sha256)') != 0 ]; then
 	sed -i '/password.*pam_unix.so/s/\(descrypt\|bigcrypt\|md5\|sha256\)/sha512/' /etc/pam.d/system-auth
 else

--- a/RHEL/5/templates/static/bash/shells_file_references.sh
+++ b/RHEL/5/templates/static/bash/shells_file_references.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 for USHELL in `cut -d: -f7 /etc/passwd | egrep -v '(/usr/bin/false|/bin/false|/dev/null|/sbin/nologin|/bin/sync|/sbin/halt|/sbin/shutdown)' | uniq`; do
 	if [ "$(grep -c "${USHELL}" /etc/shells)" = "0" ]; then
 		echo "${USHELL}" >> /etc/shells

--- a/RHEL/5/templates/static/bash/snmpd_use_newer_protocol.sh
+++ b/RHEL/5/templates/static/bash/snmpd_use_newer_protocol.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 find / -xdev -name snmpd.conf 2>/dev/null | xargs sed -i '/.*\(v1\|v2c\|community\|com2sec\).*/s/^/#/'

--- a/RHEL/5/templates/static/bash/ssh_gssapiauthentication.sh
+++ b/RHEL/5/templates/static/bash/ssh_gssapiauthentication.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ssh/ssh_config | grep -c "^GSSAPIAuthentication") = "0" ]; then
 	echo "GSSAPIAuthentication no" | tee -a /etc/ssh/ssh_config &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/ssh_no_cbc.sh
+++ b/RHEL/5/templates/static/bash/ssh_no_cbc.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 grep -q ^Ciphers /etc/ssh/ssh_config && \
   sed -i "s/Ciphers.*/Ciphers aes128-ctr,aes192-ctr,aes256-ctr/g" /etc/ssh/ssh_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/5/templates/static/bash/ssh_protocol_2.sh
+++ b/RHEL/5/templates/static/bash/ssh_protocol_2.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ssh/ssh_config | grep -c "^Protocol") != "0" ]; then
 	sed -i 's/^Protocol.*/Protocol 2/' /etc/ssh/ssh_config
 else

--- a/RHEL/5/templates/static/bash/ssh_use_approved_ciphers.sh
+++ b/RHEL/5/templates/static/bash/ssh_use_approved_ciphers.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 grep -q ^Ciphers /etc/ssh/ssh_config && \
   sed -i "s/Ciphers.*/Ciphers aes128-ctr,aes192-ctr,aes256-ctr/g" /etc/ssh/ssh_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/5/templates/static/bash/ssh_use_approved_macs.sh
+++ b/RHEL/5/templates/static/bash/ssh_use_approved_macs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ssh/ssh_config | grep -c "^MACs") = "0" ]; then
 	echo "MACs hmac-sha1" | tee -a /etc/ssh/ssh_config &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/sshd_compression.sh
+++ b/RHEL/5/templates/static/bash/sshd_compression.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ssh/sshd_config | grep -ic "^Compression") = "0" ]; then
 	echo "Compression delayed" | tee -a /etc/ssh/sshd_config &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/sshd_disable_root_login.sh
+++ b/RHEL/5/templates/static/bash/sshd_disable_root_login.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 grep -q ^PermitRootLogin /etc/ssh/sshd_config && \
   sed -i "s/PermitRootLogin.*/PermitRootLogin no/g" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/5/templates/static/bash/sshd_enable_warning_banner.sh
+++ b/RHEL/5/templates/static/bash/sshd_enable_warning_banner.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 grep -q ^Banner /etc/ssh/sshd_config && \
   sed -i "s/Banner.*/Banner \/etc\/issue/g" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/5/templates/static/bash/sshd_gssapiauthentication.sh
+++ b/RHEL/5/templates/static/bash/sshd_gssapiauthentication.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ssh/sshd_config | grep -c "^GSSAPIAuthentication") = "0" ]; then
 	echo "GSSAPIAuthentication no" | tee -a /etc/ssh/sshd_config &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/sshd_ipfiltering.sh
+++ b/RHEL/5/templates/static/bash/sshd_ipfiltering.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 MANAGEMENT_IP=$(/sbin/ifconfig | grep inet | grep -v 127.0.0.1 | cut -d: -f2 | awk '{ print $1}' | head -1 | cut -d. -f1-2)
 sed -i '/sshd/d' /etc/hosts.allow
 echo "sshd: ${MANAGEMENT_IP}.: spawn /bin/echo SSHD accessed on \$(/bin/date) from %h>>/var/log/host.access" | tee -a /etc/hosts.allow &>/dev/null

--- a/RHEL/5/templates/static/bash/sshd_kerberosauthentication.sh
+++ b/RHEL/5/templates/static/bash/sshd_kerberosauthentication.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ssh/sshd_config | grep -ic "^KerberosAuthentication") = "0" ]; then
 	echo "KerberosAuthentication no" | tee -a /etc/ssh/sshd_config &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/sshd_listen_addresses.sh
+++ b/RHEL/5/templates/static/bash/sshd_listen_addresses.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 MANAGEMENT_IP=$(/sbin/ifconfig | grep inet | grep -v 127.0.0.1 | cut -d: -f2 | awk '{ print $1}' | head -1)
 if [ $(cat /etc/ssh/sshd_config | grep -ic "^ListenAddress") = "0" ]; then
 	echo "ListenAddress ${MANAGEMENT_IP}" | tee -a /etc/ssh/sshd_config &>/dev/null

--- a/RHEL/5/templates/static/bash/sshd_no_cbc.sh
+++ b/RHEL/5/templates/static/bash/sshd_no_cbc.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 grep -q ^Ciphers /etc/ssh/sshd_config && \
   sed -i "s/Ciphers.*/Ciphers aes128-ctr,aes192-ctr,aes256-ctr/g" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/5/templates/static/bash/sshd_printlastlog.sh
+++ b/RHEL/5/templates/static/bash/sshd_printlastlog.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ "$(grep -c '^session.*required.*pam_lastlog.so$' /etc/pam.d/sshd)" = "0" ]; then
 	echo -e "session    required\tpam_lastlog.so" | tee -a /etc/pam.d/sshd &>/dev/null
 elif [ "$(grep pam_lastlog /etc/pam.d/sshd | grep -c silent)" != "0" ]; then

--- a/RHEL/5/templates/static/bash/sshd_privilegeseparation.sh
+++ b/RHEL/5/templates/static/bash/sshd_privilegeseparation.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ssh/sshd_config | grep -ic "^UsePrivilegeSeparation") = "0" ]; then
 	echo "UsePrivilegeSeparation yes" | tee -a /etc/ssh/sshd_config &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/sshd_protocol_2.sh
+++ b/RHEL/5/templates/static/bash/sshd_protocol_2.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ssh/sshd_config | grep -c "^Protocol") != "0" ]; then
 	sed -i 's/^Protocol.*/Protocol 2/' /etc/ssh/sshd_config
 else

--- a/RHEL/5/templates/static/bash/sshd_rhostsrsaauthentication.sh
+++ b/RHEL/5/templates/static/bash/sshd_rhostsrsaauthentication.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ssh/sshd_config | grep -ic "^RhostsRSAAuthentication") = "0" ]; then
 	echo "RhostsRSAAuthentication no" | tee -a /etc/ssh/sshd_config &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/sshd_strictmodes.sh
+++ b/RHEL/5/templates/static/bash/sshd_strictmodes.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ssh/sshd_config | grep -c "^StrictModes") = "0" ]; then
 	echo "StrictModes yes" | tee -a /etc/ssh/sshd_config &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/sshd_use_approved_ciphers.sh
+++ b/RHEL/5/templates/static/bash/sshd_use_approved_ciphers.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 grep -q ^Ciphers /etc/ssh/sshd_config && \
   sed -i "s/Ciphers.*/Ciphers aes128-ctr,aes192-ctr,aes256-ctr/g" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/RHEL/5/templates/static/bash/sshd_use_approved_macs.sh
+++ b/RHEL/5/templates/static/bash/sshd_use_approved_macs.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ $(cat /etc/ssh/sshd_config | grep -c "^MACs") = "0" ]; then
 	echo "MACs hmac-sha1" | tee -a /etc/ssh/sshd_config &>/dev/null
 else

--- a/RHEL/5/templates/static/bash/sshd_users_groups.sh
+++ b/RHEL/5/templates/static/bash/sshd_users_groups.sh
@@ -1,2 +1,3 @@
+# platform = Red Hat Enterprise Linux 5
 echo "AllowGroups wheel" | tee -a /etc/ssh/sshd_config &>/dev/null
 service sshd restart 1>/dev/null

--- a/RHEL/5/templates/static/bash/sudo_wheel.sh
+++ b/RHEL/5/templates/static/bash/sudo_wheel.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ "$(grep -c '#.*auth.*required.*pam_wheel.so' /etc/pam.d/su)" != "0" ]; then
 	sed -i '/auth.*required.*pam_wheel.so/s/#//g' /etc/pam.d/su
 else

--- a/RHEL/5/templates/static/bash/sysconfig_networking_bootproto_ifcfg.sh
+++ b/RHEL/5/templates/static/bash/sysconfig_networking_bootproto_ifcfg.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 sed -i 's/^BOOTPROTO=.*/BOOTPROTO="static"/' /etc/sysconfig/network-scripts/ifcfg-*

--- a/RHEL/5/templates/static/bash/sysconfig_networking_userctl_ifcfg.sh
+++ b/RHEL/5/templates/static/bash/sysconfig_networking_userctl_ifcfg.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 find /etc/sysconfig/network-scripts/ -name ifcfg-* | while read FILE; do
 	sed -i 's/^USERCTL=.*/USERCTL=no/' "${FILE}"
 done

--- a/RHEL/5/templates/static/bash/sysctl_kernel_execshield.sh
+++ b/RHEL/5/templates/static/bash/sysctl_kernel_execshield.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 /sbin/sysctl -q -n -w kernel.exec-shield=1
 if grep --silent ^kernel.exec-shield /etc/sysctl.conf ; then
 	sed -i 's/^kernel.exec-shield.*/kernel.exec-shield = 1/g' /etc/sysctl.conf

--- a/RHEL/5/templates/static/bash/sysctl_kernel_nonexec_stack.sh
+++ b/RHEL/5/templates/static/bash/sysctl_kernel_nonexec_stack.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [[ "`uname -r`" != "2.6.9"* ]]; then
 	/sbin/sysctl -q -n -w kernel.randomize_va_space=1
 	if grep --silent ^kernel.randomize_va_space /etc/sysctl.conf ; then

--- a/RHEL/5/templates/static/bash/sysctl_net_ipv4_conf_accept_redirects.sh
+++ b/RHEL/5/templates/static/bash/sysctl_net_ipv4_conf_accept_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 /sbin/sysctl -q -n -w net.ipv4.conf.all.accept_redirects=0
 /sbin/sysctl -q -n -w net.ipv4.conf.default.accept_redirects=0
 

--- a/RHEL/5/templates/static/bash/sysctl_net_ipv4_conf_accept_source_route.sh
+++ b/RHEL/5/templates/static/bash/sysctl_net_ipv4_conf_accept_source_route.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 /sbin/sysctl -q -n -w net.ipv4.conf.all.accept_source_route=0
 /sbin/sysctl -q -n -w net.ipv4.conf.default.accept_source_route=0
 

--- a/RHEL/5/templates/static/bash/sysctl_net_ipv4_conf_log_martians.sh
+++ b/RHEL/5/templates/static/bash/sysctl_net_ipv4_conf_log_martians.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 /sbin/sysctl -q -n -w net.ipv4.conf.all.log_martians=1
 /sbin/sysctl -q -n -w net.ipv4.conf.default.log_martians=1
 

--- a/RHEL/5/templates/static/bash/sysctl_net_ipv4_conf_send_redirects.sh
+++ b/RHEL/5/templates/static/bash/sysctl_net_ipv4_conf_send_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 /sbin/sysctl -q -n -w net.ipv4.conf.all.send_redirects=0
 /sbin/sysctl -q -n -w net.ipv4.conf.default.send_redirects=0
 

--- a/RHEL/5/templates/static/bash/sysctl_net_ipv6_conf_all_accept_redirects.sh
+++ b/RHEL/5/templates/static/bash/sysctl_net_ipv6_conf_all_accept_redirects.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 #
 # Set runtime for net.ipv6.conf.all.accept_redirects
 #

--- a/RHEL/5/templates/static/bash/sysctl_net_ipv6_conf_forwarding.sh
+++ b/RHEL/5/templates/static/bash/sysctl_net_ipv6_conf_forwarding.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 #
 # Set runtime for net.ipv6.conf.all.forwarding
 #

--- a/RHEL/5/templates/static/bash/system_access_control.sh
+++ b/RHEL/5/templates/static/bash/system_access_control.sh
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ ! -e /etc/hosts.allow ]; then
 	>/etc/hosts.allow
 	chmod 644 /etc/hosts.allow

--- a/RHEL/5/templates/static/bash/xwindows_runlevel_setting.sh
+++ b/RHEL/5/templates/static/bash/xwindows_runlevel_setting.sh
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 sed -i 's/.*:initdefault:.*/id:3:initdefault:/' /etc/inittab

--- a/RHEL/5/templates/template_BASH_kernel_module_disabled
+++ b/RHEL/5/templates/template_BASH_kernel_module_disabled
@@ -1,3 +1,4 @@
+# platform = Red Hat Enterprise Linux 5
 if [ -d /etc/modprobe.d/ ]; then
 	echo "install KERNMODULE /bin/true" >> /etc/modprobe.d/disabled_modules.conf
 else

--- a/RHEL/5/templates/template_BASH_package_installed
+++ b/RHEL/5/templates/template_BASH_package_installed
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 yum -y install PKGNAME

--- a/RHEL/5/templates/template_BASH_package_removed
+++ b/RHEL/5/templates/template_BASH_package_removed
@@ -1,1 +1,2 @@
+# platform = Red Hat Enterprise Linux 5
 yum -y remove PKGNAME --disablerepo=* 1>/dev/null

--- a/RHEL/5/templates/template_BASH_service_disabled
+++ b/RHEL/5/templates/template_BASH_service_disabled
@@ -1,3 +1,5 @@
+# platform = Red Hat Enterprise Linux 5
+
 #
 # Disable SERVICENAME for all run levels
 #

--- a/RHEL/5/templates/template_BASH_service_enabled
+++ b/RHEL/5/templates/template_BASH_service_enabled
@@ -1,3 +1,5 @@
+# platform = Red Hat Enterprise Linux 5
+
 #
 # Enable SERVICENAME for all run levels
 #

--- a/Webmin/templates/static/bash/accounts_passwd_cmd.sh
+++ b/Webmin/templates/static/bash/accounts_passwd_cmd.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^passwd_cmd=' /etc/webmin/config)" = "0" ]; then
 	echo "passwd_cmd=/usr/bin/passwd" >> /etc/webmin/config
 else

--- a/Webmin/templates/static/bash/accounts_passwd_mode.sh
+++ b/Webmin/templates/static/bash/accounts_passwd_mode.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^passwd_mode=' /etc/webmin/miniserv.conf)" = "0" ]; then
 	echo "passwd_mode=2" >> /etc/webmin/miniserv.conf
 else

--- a/Webmin/templates/static/bash/accounts_use_pam.sh
+++ b/Webmin/templates/static/bash/accounts_use_pam.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^no_pam=' /etc/webmin/miniserv.conf)" = "0" ]; then
 	echo "no_pam=0" >> /etc/webmin/miniserv.conf
 else

--- a/Webmin/templates/static/bash/logs_webmin_actions_cleared.sh
+++ b/Webmin/templates/static/bash/logs_webmin_actions_cleared.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^logclear=' /etc/webmin/config)" = "0" ]; then
 	echo "logclear=0" >> /etc/webmin/config
 else

--- a/Webmin/templates/static/bash/logs_webmin_actions_enabled.sh
+++ b/Webmin/templates/static/bash/logs_webmin_actions_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^log=' /etc/webmin/config)" = "0" ]; then
 	echo "log=1" >> /etc/webmin/config
 else

--- a/Webmin/templates/static/bash/logs_webmin_actions_perms.sh
+++ b/Webmin/templates/static/bash/logs_webmin_actions_perms.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^logperms=' /etc/webmin/config)" = "0" ]; then
 	echo "logperms=640" >> /etc/webmin/config
 else

--- a/Webmin/templates/static/bash/logs_webmin_requests_cleared.sh
+++ b/Webmin/templates/static/bash/logs_webmin_requests_cleared.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^logclear=' /etc/webmin/miniserv.conf)" = "0" ]; then
 	echo "logclear=0" >> /etc/webmin/miniserv.conf
 else

--- a/Webmin/templates/static/bash/logs_webmin_requests_enabled.sh
+++ b/Webmin/templates/static/bash/logs_webmin_requests_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^log=' /etc/webmin/miniserv.conf)" = "0" ]; then
 	echo "log=1" >> /etc/webmin/miniserv.conf
 else

--- a/Webmin/templates/static/bash/logs_webmin_requests_perms.sh
+++ b/Webmin/templates/static/bash/logs_webmin_requests_perms.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^logperms=' /etc/webmin/miniserv.conf)" = "0" ]; then
 	echo "logperms=640" >> /etc/webmin/miniserv.conf
 else

--- a/Webmin/templates/static/bash/module_useradmin_accounts_char_types.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_char_types.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^passwd_re=' /etc/webmin/useradmin/config)" = "0" ]; then
 	echo "passwd_re=^.*(?=.*[a-z])(?=.*[A-Z])(?=.*[\d])(?=.*[\W]).*$" >> /etc/webmin/useradmin/config
 else

--- a/Webmin/templates/static/bash/module_useradmin_accounts_home_perms.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_home_perms.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^homedir_perms=' /etc/webmin/useradmin/config)" = "0" ]; then
 	echo "homedir_perms=0750" >> /etc/webmin/useradmin/config
 else

--- a/Webmin/templates/static/bash/module_useradmin_accounts_inactive.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_inactive.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 . /usr/share/scap-security-guide/remediation_functions
 populate var_webmin_module_useradmin_accounts_inactive
 

--- a/Webmin/templates/static/bash/module_useradmin_accounts_last_login.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_last_login.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^last_show=' /etc/webmin/useradmin/config)" = "0" ]; then
 	echo "last_show=1" >> /etc/webmin/useradmin/config
 else

--- a/Webmin/templates/static/bash/module_useradmin_accounts_max.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_max.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 . /usr/share/scap-security-guide/remediation_functions
 populate var_webmin_module_useradmin_accounts_max
 

--- a/Webmin/templates/static/bash/module_useradmin_accounts_min.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_min.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 . /usr/share/scap-security-guide/remediation_functions
 populate var_webmin_module_useradmin_accounts_min
 

--- a/Webmin/templates/static/bash/module_useradmin_accounts_min_length.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_min_length.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 . /usr/share/scap-security-guide/remediation_functions
 populate var_webmin_module_useradmin_accounts_min_length
 

--- a/Webmin/templates/static/bash/module_useradmin_accounts_password_dictionary.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_password_dictionary.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^passwd_dict=' /etc/webmin/useradmin/config)" = "0" ]; then
 	echo "passwd_dict=1" >> /etc/webmin/useradmin/config
 else

--- a/Webmin/templates/static/bash/module_useradmin_accounts_password_hash.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_password_hash.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 . /usr/share/scap-security-guide/remediation_functions
 populate var_webmin_module_useradmin_accounts_password_hash
 

--- a/Webmin/templates/static/bash/module_useradmin_accounts_password_masked.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_password_masked.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^passwd_stars=' /etc/webmin/useradmin/config)" = "0" ]; then
 	echo "passwd_stars=1" >> /etc/webmin/useradmin/config
 else

--- a/Webmin/templates/static/bash/module_useradmin_accounts_password_same.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_password_same.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^passwd_same=' /etc/webmin/useradmin/config)" = "0" ]; then
 	echo "passwd_same=1" >> /etc/webmin/useradmin/config
 else

--- a/Webmin/templates/static/bash/module_useradmin_accounts_warn.sh
+++ b/Webmin/templates/static/bash/module_useradmin_accounts_warn.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 . /usr/share/scap-security-guide/remediation_functions
 populate var_webmin_module_useradmin_accounts_warn
 

--- a/Webmin/templates/static/bash/sessions_login_banner.sh
+++ b/Webmin/templates/static/bash/sessions_login_banner.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 . /usr/share/scap-security-guide/remediation_functions
 populate var_webmin_sessions_login_banner_text
 

--- a/Webmin/templates/static/bash/sessions_port.sh
+++ b/Webmin/templates/static/bash/sessions_port.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 . /usr/share/scap-security-guide/remediation_functions
 populate var_webmin_sessions_port
 

--- a/Webmin/templates/static/bash/sessions_save_password.sh
+++ b/Webmin/templates/static/bash/sessions_save_password.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^noremember=' /etc/webmin/config)" = "0" ]; then
 	echo "noremember=1" >> /etc/webmin/config
 else

--- a/Webmin/templates/static/bash/sessions_ssl_cipher.sh
+++ b/Webmin/templates/static/bash/sessions_ssl_cipher.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c no_ssl3 /usr/libexec/webmin/miniserv.pl)" = "0" ]; then
 	if [ "$(grep -c '^ssl_cipher_list=' /etc/webmin/miniserv.conf)" = "0" ]; then
 		echo 'ssl_cipher_list=ECDHE-RSA-AES256-SHA384:AES256-SHA256:RC4:HIGH:+TLSv1.2:+TLSv1:!MD5:!SSLv2:!SSLv3:!ADH:!aNULL:!eNULL:!NULL:!DH:!EDH:!AESGCM' >> /etc/webmin/miniserv.conf

--- a/Webmin/templates/static/bash/sessions_ssl_enabled.sh
+++ b/Webmin/templates/static/bash/sessions_ssl_enabled.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 if [ "$(grep -c '^ssl=' /etc/webmin/miniserv.conf)" = "0" ]; then
 	echo "ssl=1" >> /etc/webmin/miniserv.conf
 else

--- a/Webmin/templates/static/bash/sessions_timeout.sh
+++ b/Webmin/templates/static/bash/sessions_timeout.sh
@@ -1,3 +1,4 @@
+# platform = Webmin
 . /usr/share/scap-security-guide/remediation_functions
 populate var_webmin_sessions_timeout
 

--- a/shared/templates/static/puppet/file_permissions_sshd_private_key.pp
+++ b/shared/templates/static/puppet/file_permissions_sshd_private_key.pp
@@ -1,3 +1,4 @@
+# platform = multi_platform_all
 include ssh_private_key_perms
 
 class ssh_private_key_perms {

--- a/shared/templates/static/puppet/file_permissions_sshd_pub_key.pp
+++ b/shared/templates/static/puppet/file_permissions_sshd_pub_key.pp
@@ -1,3 +1,4 @@
+# platform = multi_platform_all
 include ssh_public_key_perms
 
 class ssh_public_key_perms {

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -423,57 +423,57 @@ def main():
                         else:
                             mod_file += line
 
-                    complexity = None
-                    disruption = None
-                    reboot = None
-                    script_platform = None
-                    strategy = None
+                complexity = None
+                disruption = None
+                reboot = None
+                script_platform = None
+                strategy = None
 
-                    if 'complexity' in config:
-                        complexity = config['complexity']
-                    if 'disruption' in config:
-                        disruption = config['disruption']
-                    if 'platform' in config:
-                        script_platform = config['platform']
-                    if 'complexity' in config:
-                        reboot = config['reboot']
-                    if 'complexity' in config:
-                        strategy = config['strategy']
+                if 'complexity' in config:
+                    complexity = config['complexity']
+                if 'disruption' in config:
+                    disruption = config['disruption']
+                if 'platform' in config:
+                    script_platform = config['platform']
+                if 'complexity' in config:
+                    reboot = config['reboot']
+                if 'complexity' in config:
+                    strategy = config['strategy']
 
-                    if script_platform:
-                        product_name, result = fix_is_applicable_for_product(
-                            script_platform, args.product)
-                        if result:
-                            if fixname in fixes:
-                                fix = fixes[fixname]
-                                for child in list(fix):
-                                    fix.remove(child)
-                            else:
-                                fix = ElementTree.SubElement(fixgroup, "fix")
-                                fix.set("rule", fixname)
-                                if complexity is not None:
-                                    fix.set("complexity", complexity)
-                                if disruption is not None:
-                                    fix.set("disruption", disruption)
-                                if reboot is not None:
-                                    fix.set("reboot", reboot)
-                                if strategy is not None:
-                                    fix.set("strategy", strategy)
-                                fixes[fixname] = fix
-                                included_fixes_count += 1
+                if script_platform:
+                    product_name, result = fix_is_applicable_for_product(
+                        script_platform, args.product)
+                    if result:
+                        if fixname in fixes:
+                            fix = fixes[fixname]
+                            for child in list(fix):
+                                fix.remove(child)
+                        else:
+                            fix = ElementTree.SubElement(fixgroup, "fix")
+                            fix.set("rule", fixname)
+                            if complexity is not None:
+                                fix.set("complexity", complexity)
+                            if disruption is not None:
+                                fix.set("disruption", disruption)
+                            if reboot is not None:
+                                fix.set("reboot", reboot)
+                            if strategy is not None:
+                                fix.set("strategy", strategy)
+                            fixes[fixname] = fix
+                            included_fixes_count += 1
 
-                            fix.text = mod_file
+                        fix.text = mod_file
 
-                            # Expand shell variables and remediation functions
-                            # into corresponding XCCDF <sub> elements
-                            expand_xccdf_subs(
-                                fix, args.remediation_type,
-                                remediation_functions
-                            )
-                    else:
-                        sys.stderr.write("Skipping '%s' remediation script. "
-                                         "The platform identifier in the "
-                                         "script is missing!\n" % (filename))
+                        # Expand shell variables and remediation functions
+                        # into corresponding XCCDF <sub> elements
+                        expand_xccdf_subs(
+                            fix, args.remediation_type,
+                            remediation_functions
+                        )
+                else:
+                    sys.stderr.write("Skipping '%s' remediation script. "
+                                        "The platform identifier in the "
+                                        "script is missing!\n" % (filename))
         except OSError as e:
             if e.errno != errno.ENOENT:
                 raise

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -392,7 +392,6 @@ def main():
 
     remediation_functions = get_available_remediation_functions(args.build_dir)
 
-    config = {}
     included_fixes_count = 0
     for fixdir in args.fixdirs:
         try:
@@ -404,6 +403,7 @@ def main():
                 fixname = os.path.splitext(filename)[0]
 
                 mod_file = ""
+                config = {}
                 with open(os.path.join(fixdir, filename), 'r') as fix_file:
                     # Assignment automatically escapes shell characters for XML
                     for line in fix_file.readlines():


### PR DESCRIPTION
@dahaic found a strange issue that adding one remediation changes remediation attributes for a lot of other remediations. We found out that the combine remediations code doesn't reset the parsed in attributes so one fix can basically change the defaults for every other script.

This PR fixes that.

I had to add platform tags to a whole bunch of files. Previously something templated would be combined in first and that templated fix was very often multi_platform_all. That way the bug stayed hidden until now.

Kudos to @dahaic for finding this issue and investigating it.