### PR TITLE
Make the aide_periodic_cron_checking bash remediation idempotent

### DIFF
--- a/shared/templates/static/bash/aide_periodic_cron_checking.sh
+++ b/shared/templates/static/bash/aide_periodic_cron_checking.sh
@@ -1,2 +1,4 @@
 # platform = multi_platform_rhel
-echo "05 4 * * * root /usr/sbin/aide --check" >> /etc/crontab
+if ! grep -q "/usr/sbin/aide --check"; then
+    echo "05 4 * * * root /usr/sbin/aide --check" >> /etc/crontab
+fi


### PR DESCRIPTION
Otherwise it will keep adding more and more aide check commands in crontab which DDoSes the machine eventually.