### PR TITLE
Avoid repeatedly validating input when generating all roles (build time optimization)

### DIFF
--- a/shared/utils/build-all-remediation-roles.py
+++ b/shared/utils/build-all-remediation-roles.py
@@ -64,6 +64,8 @@ def generate_role_for_input_content(input_content, benchmark_id, profile_id, tem
     """
 
     args = [OSCAP_PATH, "xccdf", "generate", "fix"]
+    # avoid validating the input over and over again for every profile
+    args.append("--skip-valid")
     if benchmark_id != "":
         args.extend(["--benchmark-id", benchmark_id])
     if profile_id != "":


### PR DESCRIPTION
This saves *a lot* of time. We validate the datastream in the validate target anyway, so no safety is lost with this commit.

Stats for RHEL7 roles on my machine.
```
old code: 0m23.328s
new code: 0m5.075s
```

This saves a ton of time when applied to all our products:
```
old code: 3m55.443s
new code: 2m30.766s
```