### PR TITLE
Optimized relabel ids (build time optimization)

### DIFF
--- a/shared/utils/relabel-ids.py
+++ b/shared/utils/relabel-ids.py
@@ -129,7 +129,7 @@ def add_cce_id_refs_to_oval_checks(ovaltree, idmappingdict):
                     sys.exit(1)
 
 
-def ensure_by_xccdf_referenced_oval_def_is_defined_in_oval_file(xccdftree, ovaltree):
+def ensure_by_xccdf_referenced_oval_def_is_defined_in_oval_file(xccdftree, ovaltree, indexed_oval_defs):
     # Ensure all OVAL checks referenced by XCCDF are implemented in OVAL file
     # Drop the reference from XCCDF to OVAL definition if:
     # * Particular OVAL definition isn't present in OVAL file,
@@ -138,12 +138,6 @@ def ensure_by_xccdf_referenced_oval_def_is_defined_in_oval_file(xccdftree, ovalt
     # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1092
     # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1095
     # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1098
-
-    indexed_oval_defs = {}
-    for oval_def in ovaltree.findall(".//{%s}definition" % oval_ns):
-        oval_id = oval_def.get("id")
-        assert(oval_id is not None)
-        indexed_oval_defs[oval_id] = oval_def
 
     for rule in xccdftree.findall(".//{%s}Rule" % xccdf_ns):
         xccdfid = rule.get("id")
@@ -194,7 +188,7 @@ def ensure_by_xccdf_referenced_oval_def_is_defined_in_oval_file(xccdftree, ovalt
                          % xccdfid)
         rule.remove(check)
 
-def drop_oval_checks_extending_non_existing_checks(ovaltree):
+def drop_oval_checks_extending_non_existing_checks(ovaltree, indexed_oval_defs):
     # Incomplete OVAL checks are as useful as non existing checks
     # Here we check if all extend_definition refs from a definition exists in local OVAL file
     #
@@ -208,12 +202,7 @@ def drop_oval_checks_extending_non_existing_checks(ovaltree):
             extdefinitionref = extdefinition.get("definition_ref")
 
             # Search the OVAL tree for a definition with the referred ID
-            referreddefinition = None
-            for el in ovaltree.findall(".//{%s}definition" % (oval_ns)):
-                if el.get("id") != extdefinitionref:
-                    continue
-                referreddefinition = el
-                break
+            referreddefinition = indexed_oval_defs.get(extdefinitionref)
 
             if referreddefinition is None:
                 # There is no oval satisfying the extend_definition referal
@@ -405,7 +394,14 @@ def main():
     if ovalfile:
         ovaltree = parse_xml_file(ovalfile)
 
-        drop_oval_checks_extending_non_existing_checks(ovaltree)
+        indexed_oval_defs = {}
+        for oval_def in ovaltree.findall(".//{%s}definition" % oval_ns):
+            oval_id = oval_def.get("id")
+            assert(oval_id is not None)
+            indexed_oval_defs[oval_id] = oval_def
+
+        drop_oval_checks_extending_non_existing_checks(ovaltree,
+                                                       indexed_oval_defs)
 
         # Add new <reference source="CCE" ref_id="CCE-ID" /> element to those OVAL
         # checks having CCE ID already assigned in XCCDF for particular rule.
@@ -422,7 +418,8 @@ def main():
         # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1092
         # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1095
         # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1098
-        ensure_by_xccdf_referenced_oval_def_is_defined_in_oval_file(xccdftree, ovaltree)
+        ensure_by_xccdf_referenced_oval_def_is_defined_in_oval_file(
+            xccdftree, ovaltree, indexed_oval_defs)
 
         # Verify the XCCDF to OVAL datatype export matching constraints
         # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1089

--- a/shared/utils/relabel-ids.py
+++ b/shared/utils/relabel-ids.py
@@ -139,6 +139,12 @@ def ensure_by_xccdf_referenced_oval_def_is_defined_in_oval_file(xccdftree, ovalt
     # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1095
     # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1098
 
+    indexed_oval_defs = {}
+    for oval_def in ovaltree.findall(".//{%s}definition" % oval_ns):
+        oval_id = oval_def.get("id")
+        assert(oval_id is not None)
+        indexed_oval_defs[oval_id] = oval_def
+
     for rule in xccdftree.findall(".//{%s}Rule" % xccdf_ns):
         xccdfid = rule.get("id")
         if xccdfid is None:
@@ -146,13 +152,7 @@ def ensure_by_xccdf_referenced_oval_def_is_defined_in_oval_file(xccdftree, ovalt
             continue
 
         # Search OVAL ID in OVAL document
-        ovalid = None
-        for el in ovaltree.findall(".//{%s}definition" % oval_ns):
-            if el.get("id") != xccdfid:
-                continue
-            ovalid = el
-            break
-
+        ovalid = indexed_oval_defs.get(xccdfid)
         if ovalid is not None:
             # The OVAL check was found, we can continue
             continue

--- a/shared/utils/relabel-ids.py
+++ b/shared/utils/relabel-ids.py
@@ -246,6 +246,12 @@ def check_and_correct_xccdf_to_oval_data_export_matching_constraints(xccdftree, 
             'binary' :  'string'
         }
 
+        indexed_xccdf_values = {}
+        for xccdf_value in xccdftree.findall(".//{%s}Value" % (xccdf_ns)):
+            xccdf_id = xccdf_value.get("id")
+            assert(xccdf_id is not None)
+            indexed_xccdf_values[xccdf_id] = xccdf_value
+
         # Loop through all <external_variables> in the OVAL document
         ovalextvars = ovaltree.findall(".//{%s}external_variable" % oval_ns)
         if ovalextvars is not None:
@@ -261,12 +267,7 @@ def check_and_correct_xccdf_to_oval_data_export_matching_constraints(xccdftree, 
                     ovalvartype = ovalextvar.get('datatype')
 
                 # Locate the corresponding <xccdf:Value> with the same ID in the XCCDF
-                xccdfvar = None
-                for el in xccdftree.findall(".//{%s}Value" % (xccdf_ns)):
-                    if el.get("id") != ovalvarid:
-                        continue
-                    xccdfvar = el
-                    break
+                xccdfvar = indexed_xccdf_values.get(ovalvarid)
 
                 if xccdfvar is not None:
                     # Verify the found value has 'type' attribute set


### PR DESCRIPTION
O(n*m) and O(n^2) just suck... Probably was not a problem in the past but with linking times over 15 seconds this is becoming a problem. And it's used by every product!

I profiled the script and fixed the 3 functions that were slowing everything down. The speedup is pretty drastic. The pattern that I fixed is very common in SSG. Probably more optimization opportunities elsewhere. The general idea is to index using a dictionary which has O(log(n)) lookup. That way we go from O(n*m) to O(n*log(n) + m*log(n)).

Old code RHEL7:
```
$ time ../../../shared/utils/relabel-ids.py "xccdf-unlinked.xml" ssg

real    0m16.970s
user    0m16.903s
sys     0m0.029s
```

New code RHEL7:
```
$ time ../../../shared/utils/relabel-ids.py "xccdf-unlinked.xml" ssg

real    0m0.867s
user    0m0.830s
sys     0m0.033s
```

All products:
```
old code: 3m56.034s
new code: 3m13.698s
```

Paired with the role optimization fix this really cuts down on build time.