### PR TITLE
Evaluate $sed_command

### DIFF
--- a/shared/bash_remediation_functions/replace_or_append.sh
+++ b/shared/bash_remediation_functions/replace_or_append.sh
@@ -71,7 +71,7 @@ function replace_or_append {
 
   # If the key exists, change it. Otherwise, add it to the config_file.
   if `grep -qi $key $config_file` ; then
-    $sed_command "s/$key.*/$formatted_output/g" $config_file
+    eval $sed_command "s/$key.*/$formatted_output/g" $config_file
   else
     # \n is precaution for case where file ends without trailing newline
     echo -e "\n# Per $cce: Set $formatted_output in $config_file" >> $config_file


### PR DESCRIPTION
"sed -i" is considered a whole command, we need to evaluate it.

Fixes: #1420 