### PR TITLE
Import template generators (build time optimization)

### DIFF
--- a/shared/templates/create_accounts_password.py
+++ b/shared/templates/create_accounts_password.py
@@ -36,6 +36,3 @@ class AccountsPasswordGenerator(FilesGenerator):
     def csv_format(self):
         return("CSV should contains lines of the format: " +
                "VARIABLE")
-
-if __name__ == "__main__":
-    AccountsPasswordGenerator().main()

--- a/shared/templates/create_audit_rules_dac_modification.py
+++ b/shared/templates/create_audit_rules_dac_modification.py
@@ -5,8 +5,6 @@
 #        generate template-based checks for audit rules dac modifications
 
 
-import re
-
 from template_common import FilesGenerator, UnknownTargetError
 
 
@@ -33,6 +31,3 @@ class AuditRulesDacModificationGenerator(FilesGenerator):
     def csv_format(self):
         return("CSV should contains lines of the format: "
                "attr")
-
-if __name__ == "__main__":
-    AuditRulesDacModificationGenerator().main()

--- a/shared/templates/create_kernel_modules_disabled.py
+++ b/shared/templates/create_kernel_modules_disabled.py
@@ -46,6 +46,3 @@ class KernelModulesDisabledGenerator(FilesGenerator):
         return (
             "CSV file should contains lines of the format: kernmod"
         )
-
-if __name__ == "__main__":
-    KernelModulesDisabledGenerator().main()

--- a/shared/templates/create_mount_options.py
+++ b/shared/templates/create_mount_options.py
@@ -9,8 +9,8 @@ import re
 
 from template_common import FilesGenerator, UnknownTargetError
 
-class MountOptionsGenerator(FilesGenerator):
 
+class MountOptionsGenerator(FilesGenerator):
     def generate(self, target, path_info):
         mount_point, mount_option = path_info
         point_id = re.sub('[-\./]', '_', mount_point)
@@ -48,10 +48,6 @@ class MountOptionsGenerator(FilesGenerator):
             else:
                 raise UnknownTargetError(target)
 
-
     def csv_format(self):
         return("CSV should contains lines of the format: "
-              "mount_point,mount_option,[mount_option]+")
-
-if __name__ == "__main__":
-    MountOptionsGenerator().main()
+               "mount_point,mount_option,[mount_option]+")

--- a/shared/templates/create_package_installed.py
+++ b/shared/templates/create_package_installed.py
@@ -11,12 +11,10 @@
 # PKGNAME - the name of the package that should be installed
 #
 
-import sys
-
 from template_common import FilesGenerator, UnknownTargetError
 
-class PackageInstalledGenerator(FilesGenerator):
 
+class PackageInstalledGenerator(FilesGenerator):
     def generate(self, target, package_info):
         pkgname = package_info[0]
         if pkgname:
@@ -63,7 +61,4 @@ class PackageInstalledGenerator(FilesGenerator):
 
     def csv_format(self):
         return("CSV should contains lines of the format: " +
-                   "PACKAGE_NAME")
-
-if __name__ == "__main__":
-    PackageInstalledGenerator().main()
+               "PACKAGE_NAME")

--- a/shared/templates/create_package_removed.py
+++ b/shared/templates/create_package_removed.py
@@ -4,12 +4,10 @@
 # create_package_removed.py
 #   automatically generate checks for removed packages
 
-import sys
-
 from template_common import FilesGenerator, UnknownTargetError
 
-class PackageRemovedGenerator(FilesGenerator):
 
+class PackageRemovedGenerator(FilesGenerator):
     def generate(self, target, package_info):
         pkgname = package_info[0]
         if pkgname:
@@ -56,7 +54,4 @@ class PackageRemovedGenerator(FilesGenerator):
 
     def csv_format(self):
         return("CSV should contains lines of the format: " +
-                   "PACKAGE_NAME")
-
-if __name__ == "__main__":
-    PackageRemovedGenerator().main()
+               "PACKAGE_NAME")

--- a/shared/templates/create_permission.py
+++ b/shared/templates/create_permission.py
@@ -5,13 +5,12 @@
 #        generate template-based checks for file permissions/ownership
 
 
-import sys
 import re
 
 from template_common import FilesGenerator, UnknownTargetError
 
-class PermissionGenerator(FilesGenerator):
 
+class PermissionGenerator(FilesGenerator):
     def generate(self, target, path_info):
         # the csv file contains lines that match the following layout:
         #    directory,file_name,uid,gid,mode
@@ -22,7 +21,7 @@ class PermissionGenerator(FilesGenerator):
         # path_id maps to FILEID in the template
         if file_name == '[NULL]':
             path_id = re.sub('[-\./]', '_', dir_path)
-        elif re.match( r'\^.*\$', file_name, 0):
+        elif re.match(r'\^.*\$', file_name, 0):
             path_id = re.sub('[-\./]', '_', dir_path) + '_' + re.sub('[-\\\./^$*(){}|]',
                                                                      '_', file_name)
             # cleaning trailing end multiple underscores, make sure id is lowercase
@@ -42,7 +41,7 @@ class PermissionGenerator(FilesGenerator):
             full_path = dir_path + '/' + file_name
 
         if target == "bash":
-            if not re.match( r'\^.*\$', file_name, 0):
+            if not re.match(r'\^.*\$', file_name, 0):
                 self.file_from_template(
                     "./template_BASH_permissions",
                     {
@@ -52,7 +51,7 @@ class PermissionGenerator(FilesGenerator):
                     "./bash/file_permissions{0}.sh", path_id
                 )
             else:
-                file_name = re.sub('^\^','', file_name)
+                file_name = re.sub('^\^', '', file_name)
                 self.file_from_template(
                     "./template_BASH_regex_permissions",
                     {
@@ -63,7 +62,7 @@ class PermissionGenerator(FilesGenerator):
                     "./bash/file_permissions{0}.sh", path_id
                 )
 
-        elif target == "ansible" and not re.match( r'\^.*\$', file_name, 0):
+        elif target == "ansible" and not re.match(r'\^.*\$', file_name, 0):
             self.file_from_template(
                 "./template_ANSIBLE_permissions",
                 {
@@ -118,8 +117,5 @@ class PermissionGenerator(FilesGenerator):
 
     def csv_format(self):
         return("CSV should contains lines of the format: "
-              "directory path,file name,owner uid (numeric),group "
-              "owner gid (numeric),mode")
-
-if __name__ == "__main__":
-    PermissionGenerator().main()
+               "directory path,file name,owner uid (numeric),group "
+               "owner gid (numeric),mode")

--- a/shared/templates/create_selinux_booleans.py
+++ b/shared/templates/create_selinux_booleans.py
@@ -12,7 +12,6 @@ from template_common import FilesGenerator, UnknownTargetError
 
 
 class SEBoolGenerator(FilesGenerator):
-
     def generate(self, target, sebool_info):
         sebool_name, sebool_state = sebool_info
         # convert variable name to a format suitable for 'id' tags
@@ -26,15 +25,15 @@ class SEBoolGenerator(FilesGenerator):
                     self.file_from_template(
                         "./template_OVAL_sebool",
                         {
-                            "SEBOOLID" : sebool_id,
-                            "SEBOOL_BOOL" : sebool_bool
+                            "SEBOOLID": sebool_id,
+                            "SEBOOL_BOOL": sebool_bool
                         },
                         "./oval/sebool_{0}.xml", sebool_id)
                 else:
                     self.file_from_template(
                         "./template_OVAL_sebool_var",
                         {
-                            "SEBOOLID" : sebool_id
+                            "SEBOOLID": sebool_id
                         },
                         "./oval/sebool_{0}.xml", sebool_id
                     )
@@ -102,6 +101,3 @@ class SEBoolGenerator(FilesGenerator):
             sebool = "false"
 
         return sebool_state, sebool
-
-if __name__ == "__main__":
-    SEBoolGenerator().main()

--- a/shared/templates/create_services_disabled.py
+++ b/shared/templates/create_services_disabled.py
@@ -93,7 +93,3 @@ class ServiceDisabledGenerator(FilesGenerator):
     def csv_format(self):
         return("CSV should contains lines of the format: " +
                "servicename,packagename")
-
-
-if __name__ == "__main__":
-    ServiceDisabledGenerator().main()

--- a/shared/templates/create_services_enabled.py
+++ b/shared/templates/create_services_enabled.py
@@ -96,7 +96,3 @@ class ServiceEnabledGenerator(FilesGenerator):
     def csv_format(self):
         return("CSV should contains lines of the format: " +
                "servicename,packagename")
-
-
-if __name__ == "__main__":
-    ServiceEnabledGenerator().main()

--- a/shared/templates/create_sysctl.py
+++ b/shared/templates/create_sysctl.py
@@ -120,6 +120,3 @@ class SysctlGenerator(FilesGenerator):
     def csv_format(self):
         return("CSV should contains lines of the format: " +
                "sysctlvariable,sysctlvalue")
-
-if __name__ == "__main__":
-    SysctlGenerator().main()

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -126,7 +126,8 @@ class FilesGenerator(object):
             self.save_modified(filename_format, filename_value, filled_template)
 
         except TemplateNotFoundError as e:
-            sys.stderr.write(str(e) + "\n")
+            if self.action == ActionType.BUILD:
+                sys.stderr.write(str(e) + "\n")
 
     def process_csv_line(self, line, target):
         """
@@ -179,7 +180,8 @@ class FilesGenerator(object):
                     self.generate(language, csv_line)
 
             except UnknownTargetError as e:
-                sys.stderr.write(str(e) + "\n")
+                if self.action == ActionType.BUILD:
+                    sys.stderr.write(str(e) + "\n")
 
     @abstractmethod
     def csv_format(self):

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -6,15 +6,7 @@ import csv
 import sys
 import os
 import re
-import argparse
 from abc import abstractmethod
-
-
-class ExitCodes:
-    OK = 0
-    ERROR = 1
-    NO_TEMPLATE = 128 + 1
-    UNKNOWN_TARGET = 128 + 2
 
 
 class ActionType:
@@ -185,7 +177,6 @@ class FilesGenerator(object):
 
             except UnknownTargetError as e:
                 sys.stderr.write(str(e) + "\n")
-                #sys.exit(ExitCodes.UNKNOWN_TARGET)
 
     @abstractmethod
     def csv_format(self):

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -114,7 +114,7 @@ class FilesGenerator(object):
 
         self.save_modified(filename_format, filename_value, filled_template)
 
-    def process_line(self, line, target):
+    def process_csv_line(self, line, target):
         """
         Remove comments
         Remove line if target is unsupported
@@ -140,7 +140,7 @@ class FilesGenerator(object):
         """
 
         for line in csv_file:
-            processed_line = self.process_line(line, language)
+            processed_line = self.process_csv_line(line, language)
 
             if not processed_line:
                 continue

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -71,10 +71,10 @@ class FilesGenerator(object):
         regex_dict: dict of regex substitutions - sub ( key -> value)
         """
 
+        template_filename = self.get_template_filename(filename)
+
         if self.action == ActionType.OUTPUT:
             return ""
-
-        template_filename = self.get_template_filename(filename)
 
         if self.action == ActionType.INPUT:
             self.files.append(

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -164,6 +164,7 @@ class FilesGenerator(object):
             try:
                 for csv_line in csv_lines_content:
                     self.generate(language, csv_line)
+
             except UnknownTargetError as e:
                 sys.stderr.write(str(e) + "\n")
                 sys.exit(ExitCodes.UNKNOWN_TARGET)
@@ -199,10 +200,6 @@ class FilesGenerator(object):
 
     @abstractmethod
     def csv_format(self):
-        raise NotImplementedError("Please Implement this method")
-
-    @abstractmethod
-    def generate_from_line(self, target, line):
         raise NotImplementedError("Please Implement this method")
 
     def main(self):

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -166,7 +166,8 @@ class FilesGenerator(object):
         """
 
         with open(filename, "r") as csv_file:
-            filtered_file = self.filter_out_csv_lines(csv_file, language)
+            filtered_file = self.filter_out_csv_lines(
+                csv_file.readlines(), language)
             csv_lines_content = csv.reader(filtered_file,
                                            delimiter=self.delimiter)
 

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -7,6 +7,7 @@ import sys
 import os
 import re
 from abc import abstractmethod
+import inspect
 
 
 class ActionType:
@@ -76,6 +77,8 @@ class FilesGenerator(object):
         template_filename = self.get_template_filename(filename)
 
         if self.action == ActionType.INPUT:
+            self.files.append(
+                os.path.abspath(inspect.getsourcefile(self.__class__)))
             self.files.append(template_filename)
             return ""
 

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -70,10 +70,10 @@ class FilesGenerator(object):
         regex_dict: dict of regex substitutions - sub ( key -> value)
         """
 
-        template_filename = self.get_template_filename(filename)
-
         if self.action == ActionType.OUTPUT:
             return ""
+
+        template_filename = self.get_template_filename(filename)
 
         if self.action == ActionType.INPUT:
             self.files.append(template_filename)
@@ -94,19 +94,20 @@ class FilesGenerator(object):
         """
         Save string to file
         """
-        filename = filename_format.format(filename_value)
-
-        filename = os.path.join(self.output_dir, filename)
 
         if self.action == ActionType.INPUT:
             return
+
+        filename = os.path.join(
+            self.output_dir, filename_format.format(filename_value)
+        )
 
         if self.action == ActionType.OUTPUT:
             self.files.append(filename)
             return
 
-        with open(filename, 'w+') as outputfile:
-            outputfile.write(string)
+        with open(filename, "w") as f:
+            f.write(string)
 
     def file_from_template(self, template_filename, constants,
                            filename_format, filename_value, regex_replace=[]):
@@ -132,7 +133,6 @@ class FilesGenerator(object):
 
         if target is not None:
             regex = re.compile(r"#\s*only-for:([\s\w,]*)")
-
             match = regex.search(line)
 
             if match:
@@ -165,9 +165,8 @@ class FilesGenerator(object):
             col3, col4 # only-for: bash, oval
         """
 
-        with open(filename, 'r') as csv_file:
+        with open(filename, "r") as csv_file:
             filtered_file = self.filter_out_csv_lines(csv_file, language)
-
             csv_lines_content = csv.reader(filtered_file,
                                            delimiter=self.delimiter)
 

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -124,9 +124,10 @@ class Builder(object):
         for oval in self.supported_ovals:
             self._set_current_oval(oval)
 
+            csv_dir = self._get_csv_dir()
             for csv_filename in self._get_csv_list():
                 generator = self._get_generator_for_csv(csv_filename)
-                csv_filepath = os.path.join(self._get_csv_dir(), csv_filename)
+                csv_filepath = os.path.join(csv_dir, csv_filename)
 
                 generator.reset()
                 generator.output_dir = self.output_dir

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -64,12 +64,6 @@ class Builder(object):
             "oval_5.11": os.path.join(self.input_dir, "csv", "oval_5.11"),
         }
 
-    def set_ssg_shared(self, shared):
-        self.ssg_shared = shared
-
-    def set_output_dir(self, output_dir):
-        self.output_dir = output_dir
-
     def _set_current_oval(self, oval):
         self.current_oval = oval
 
@@ -114,15 +108,12 @@ class Builder(object):
             )
             #sys.exit(1)
 
-    def _output_dir_for_lang(self, lang):
-        return os.path.join(self.output_dir, lang)
-
     def _deduplicate(self, files):
         return set(os.path.realpath(file_) for file_ in files)
 
     def build(self):
         for lang in self.langs:
-            dir_ = self._output_dir_for_lang(lang)
+            dir_ = os.path.join(self.output_dir, lang)
             if not os.path.exists(dir_):
                 os.makedirs(dir_)
 
@@ -185,7 +176,6 @@ class Builder(object):
 
 
 if __name__ == "__main__":
-    builder = Builder()
     p = argparse.ArgumentParser()
 
     sp = p.add_subparsers(help="actions")
@@ -218,12 +208,13 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
+    builder = Builder()
     if args.language is not None:
         builder.set_langs([args.language])
 
     builder.set_input_dir(args.input)
-    builder.set_output_dir(args.output)
-    builder.set_ssg_shared(args.shared)
+    builder.output_dir = args.output
+    builder.ssg_shared = args.shared
 
     if args.oval_version == "oval_5.10":
         builder.supported_ovals = ["oval_5.10"]

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -7,7 +7,7 @@ import argparse
 
 templates_dir = os.path.join(os.path.dirname(__file__), "..", "templates")
 sys.path.append(templates_dir)
-from template_common import ExitCodes, ActionType
+from template_common import ActionType
 
 from create_accounts_password import AccountsPasswordGenerator
 from create_kernel_modules_disabled import KernelModulesDisabledGenerator

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -67,90 +67,6 @@ class Builder(object):
     def set_ssg_shared(self, shared):
         self.ssg_shared = shared
 
-    def build(self):
-        for lang in self.langs:
-            dir_ = self._output_dir_for_lang(lang)
-            if not os.path.exists(dir_):
-                os.makedirs(dir_)
-
-        # Build scripts for multiple OVAL versions.
-        # At first for the oldest OVAL, then newer and newer
-        # this will allow to override older implementation
-        # with a never one.
-        for oval in self.supported_ovals:
-            self._set_current_oval(oval)
-
-            for csv_filename in self._get_csv_list():
-                generator = self._get_generator_for_csv(csv_filename)
-                csv_filepath = os.path.join(self._get_csv_dir(), csv_filename)
-
-                generator.reset()
-                generator.output_dir = self.output_dir
-                generator.action = ActionType.BUILD
-                generator.product_input_dir = self._get_template_dir()
-                generator.shared_dir = self.ssg_shared
-
-                for lang in self.langs:
-                    generator.csv_map(csv_filepath, language=lang)
-
-    def list_inputs(self):
-        for file_ in self.get_input_list():
-            print(file_)
-
-    def list_outputs(self):
-        for file_ in self.get_output_list():
-            print(file_)
-
-    def get_input_list(self):
-        list_ = []
-
-        for oval in self.supported_ovals:
-            self._set_current_oval(oval)
-
-            csv_dir = self._get_csv_dir()
-            for csv in self._get_csv_list():
-                csv_filepath = os.path.join(csv_dir, csv)
-                generator = self._get_generator_for_csv(csv)
-
-                list_.append(csv_filepath)
-
-                generator.reset()
-                generator.output_dir = self.output_dir
-                generator.action = ActionType.INPUT
-                generator.product_input_dir = self._get_template_dir()
-                generator.shared_dir = self.ssg_shared
-
-                for lang in self.langs:
-                    generator.csv_map(csv_filepath, language=lang)
-
-                list_.extend(generator.files)
-
-        return self._deduplicate(list_)
-
-    def get_output_list(self):
-        list_ = []
-
-        for oval in self.supported_ovals:
-            self._set_current_oval(oval)
-
-            csv_dir = self._get_csv_dir()
-            for csv in self._get_csv_list():
-                csv_filepath = os.path.join(csv_dir, csv)
-                generator = self._get_generator_for_csv(csv)
-
-                generator.reset()
-                generator.output_dir = self.output_dir
-                generator.action = ActionType.OUTPUT
-                generator.product_input_dir = self._get_template_dir()
-                generator.shared_dir = self.ssg_shared
-
-                for lang in self.langs:
-                    generator.csv_map(csv_filepath, language=lang)
-
-                list_.extend(generator.files)
-
-        return self._deduplicate(list_)
-
     def set_output_dir(self, output_dir):
         self.output_dir = output_dir
 
@@ -203,6 +119,90 @@ class Builder(object):
 
     def _deduplicate(self, files):
         return set(os.path.realpath(file_) for file_ in files)
+
+    def build(self):
+        for lang in self.langs:
+            dir_ = self._output_dir_for_lang(lang)
+            if not os.path.exists(dir_):
+                os.makedirs(dir_)
+
+        # Build scripts for multiple OVAL versions.
+        # At first for the oldest OVAL, then newer and newer
+        # this will allow to override older implementation
+        # with a never one.
+        for oval in self.supported_ovals:
+            self._set_current_oval(oval)
+
+            for csv_filename in self._get_csv_list():
+                generator = self._get_generator_for_csv(csv_filename)
+                csv_filepath = os.path.join(self._get_csv_dir(), csv_filename)
+
+                generator.reset()
+                generator.output_dir = self.output_dir
+                generator.action = ActionType.BUILD
+                generator.product_input_dir = self._get_template_dir()
+                generator.shared_dir = self.ssg_shared
+
+                for lang in self.langs:
+                    generator.csv_map(csv_filepath, language=lang)
+
+    def get_input_list(self):
+        list_ = []
+
+        for oval in self.supported_ovals:
+            self._set_current_oval(oval)
+
+            csv_dir = self._get_csv_dir()
+            for csv in self._get_csv_list():
+                csv_filepath = os.path.join(csv_dir, csv)
+                generator = self._get_generator_for_csv(csv)
+
+                list_.append(csv_filepath)
+
+                generator.reset()
+                generator.output_dir = self.output_dir
+                generator.action = ActionType.INPUT
+                generator.product_input_dir = self._get_template_dir()
+                generator.shared_dir = self.ssg_shared
+
+                for lang in self.langs:
+                    generator.csv_map(csv_filepath, language=lang)
+
+                list_.extend(generator.files)
+
+        return self._deduplicate(list_)
+
+    def list_inputs(self):
+        for file_ in self.get_input_list():
+            print(file_)
+
+    def get_output_list(self):
+        list_ = []
+
+        for oval in self.supported_ovals:
+            self._set_current_oval(oval)
+
+            csv_dir = self._get_csv_dir()
+            for csv in self._get_csv_list():
+                csv_filepath = os.path.join(csv_dir, csv)
+                generator = self._get_generator_for_csv(csv)
+
+                generator.reset()
+                generator.output_dir = self.output_dir
+                generator.action = ActionType.OUTPUT
+                generator.product_input_dir = self._get_template_dir()
+                generator.shared_dir = self.ssg_shared
+
+                for lang in self.langs:
+                    generator.csv_map(csv_filepath, language=lang)
+
+                list_.extend(generator.files)
+
+        return self._deduplicate(list_)
+
+    def list_outputs(self):
+        for file_ in self.get_output_list():
+            print(file_)
 
 
 if __name__ == "__main__":

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import argparse
+import inspect
 
 templates_dir = os.path.join(os.path.dirname(__file__), "..", "templates")
 sys.path.append(templates_dir)
@@ -142,6 +143,9 @@ class Builder(object):
         assert(action in [ActionType.INPUT, ActionType.OUTPUT])
 
         list_ = []
+        if action == ActionType.INPUT:
+            # add template_common source file
+            list_.append(os.path.abspath(inspect.getsourcefile(ActionType)))
 
         for oval in self.supported_ovals:
             self._set_current_oval(oval)

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -146,7 +146,9 @@ class Builder(object):
                 for lang in self.langs:
                     generator.csv_map(csv_filepath, language=lang)
 
-    def get_input_list(self):
+    def get_file_list(self, action):
+        assert(action in [ActionType.INPUT, ActionType.OUTPUT])
+
         list_ = []
 
         for oval in self.supported_ovals:
@@ -157,11 +159,12 @@ class Builder(object):
                 csv_filepath = os.path.join(csv_dir, csv)
                 generator = self._get_generator_for_csv(csv)
 
-                list_.append(csv_filepath)
+                if action == ActionType.INPUT:
+                    list_.append(csv_filepath)
 
                 generator.reset()
                 generator.output_dir = self.output_dir
-                generator.action = ActionType.INPUT
+                generator.action = action
                 generator.product_input_dir = self._get_template_dir()
                 generator.shared_dir = self.ssg_shared
 
@@ -173,35 +176,11 @@ class Builder(object):
         return self._deduplicate(list_)
 
     def list_inputs(self):
-        for file_ in self.get_input_list():
+        for file_ in self.get_file_list(ActionType.INPUT):
             print(file_)
 
-    def get_output_list(self):
-        list_ = []
-
-        for oval in self.supported_ovals:
-            self._set_current_oval(oval)
-
-            csv_dir = self._get_csv_dir()
-            for csv in self._get_csv_list():
-                csv_filepath = os.path.join(csv_dir, csv)
-                generator = self._get_generator_for_csv(csv)
-
-                generator.reset()
-                generator.output_dir = self.output_dir
-                generator.action = ActionType.OUTPUT
-                generator.product_input_dir = self._get_template_dir()
-                generator.shared_dir = self.ssg_shared
-
-                for lang in self.langs:
-                    generator.csv_map(csv_filepath, language=lang)
-
-                list_.extend(generator.files)
-
-        return self._deduplicate(list_)
-
     def list_outputs(self):
-        for file_ in self.get_output_list():
+        for file_ in self.get_file_list(ActionType.OUTPUT):
             print(file_)
 
 


### PR DESCRIPTION
We run template generators separately as scripts and then parse what they output on stdout. This hides errors and warnings and is much slower than just using the classes and functions directly. I am not sure what the reason for running a script that runs more scripts was but I made a quick refactor to just use the generators as classes. This results in less code and it's much faster.

~~This PR is not finished, I want to clean it all up and write it more elegantly. But first I want consensus from the community that this is the way to go. Maybe there is a reason why we run all the scripts separately.~~

Configure time:
```
old code: 51s
new code: 26s
```

Build time:
```
old code: 3m 23s
new code: 2m 54s
```

(I am working on battery, the numbers plugged in are going to be better, just included this for a comparison)