### PR TITLE
Don't list templating file outputs as explicit deps for the targets (build time optimization)

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -224,8 +224,6 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGE)
     add_custom_target(
         generate-internal-${PRODUCT}-${LANGUAGE}-remediations.xml
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-remediations.xml"
-        DEPENDS ${LANGUAGE_REMEDIATIONS_OUTPUTS}
-        DEPENDS ${SHARED_LANGUAGE_REMEDIATIONS_OUTPUTS}
     )
 
     if (SHELLCHECK_EXECUTABLE AND "${LANGUAGE}" STREQUAL "bash")
@@ -379,8 +377,6 @@ macro(ssg_build_oval_unlinked PRODUCT)
     add_custom_target(
         generate-internal-${PRODUCT}-oval-unlinked.xml
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
-        DEPENDS ${OVAL_CHECKS_OUTPUTS}
-        DEPENDS ${SHARED_OVAL_CHECKS_OUTPUTS}
     )
 endmacro()
 


### PR DESCRIPTION
The built checks and remediations are a side effect, we keep them in the output dir for debugging but they are never used. We generate and combine in one step, so it's not necessary to list these deps explicitly. As we get more and more templating in place the dep re-scan is becoming pretty slow.

The full build speed-up is not that significant but it's essentially free and I already had it implemented, so I am submitting this anyway...

full build:
```
new: 3m29.237s
old: 3m40.750s
```

This avoids us having to check hundreds of timestamps and hashes of files that will always have the same timestamp as the combined file.