### PR TITLE
Use element id cache instead of O(n^2) in combine-ovals.py (build time optimization)

### DIFF
--- a/shared/utils/combine-ovals.py
+++ b/shared/utils/combine-ovals.py
@@ -198,17 +198,18 @@ def oval_entity_is_extvar(elem):
     return elem.tag == '{%s}external_variable' % oval_ns
 
 
+element_child_cache = {}
+
+
 def append(element, newchild):
     """Append new child ONLY if it's not a duplicate"""
 
-    newid = newchild.get("id")
-    existing = None
-    for child in element.findall(".//*"):
-        if child.get("id") != newid:
-            continue
+    if element not in element_child_cache:
+        element_child_cache[element] = dict()
 
-        existing = child
-        break
+    newid = newchild.get("id")
+
+    existing = element_child_cache[element].get(newid, None)
 
     if existing is not None:
         # ID is identical and OVAL entities are identical
@@ -256,6 +257,7 @@ def append(element, newchild):
                 sys.exit(1)
     else:
         element.append(newchild)
+        element_child_cache[element][newid] = newchild
 
 
 def check_oval_version(oval_version):


### PR DESCRIPTION
This makes the whole thing linear instead of quadratic... That's a big deal with thousands of elements.

```
new code: 0m0.300s
old code: 0m9.104s
```

Tested with:
```
time RUNTIME_OVAL_VERSION=5.11 /home/mpreisle/d/scap-security-guide/shared/utils/combine-ovals.py /home/mpreisle/d/scap-security-guide/build/oval.config rhel7 oval_5.10:/home/mpreisle/d/scap-security-guide/build/RHEL/7/checks/shared/oval oval_5.10:/home/mpreisle/d/scap-security-guide/shared/templates/static/oval oval_5.10:/home/mpreisle/d/scap-security-guide/build/RHEL/7/checks/oval oval_5.10:/home/mpreisle/d/scap-security-guide/RHEL/7/templates/static/oval oval_5.11:/home/mpreisle/d/scap-security-guide/build/RHEL/7/checks/shared/oval/oval_5.11 oval_5.11:/home/mpreisle/d/scap-security-guide/shared/templates/static/oval/oval_5.11 oval_5.11:/home/mpreisle/d/scap-security-guide/build/RHEL/7/checks/oval/oval_5.11 oval_5.11:/home/mpreisle/d/scap-security-guide/RHEL/7/templates/static/oval/oval_5.11 > /home/mpreisle/d/scap-security-guide/build/RHEL/7/oval-unlinked.xml && /usr/bin/xmllint --format --output /home/mpreisle/d/scap-security-guide/build/RHEL/7/oval-unlinked.xml /home/mpreisle/d/scap-security-guide/build/RHEL/7/oval-unlinked.xml
Not merging OVAL content from the '/home/mpreisle/d/scap-security-guide/build/RHEL/7/checks/oval/oval_5.11' directory as the directory does not exist
Not merging OVAL content from the '/home/mpreisle/d/scap-security-guide/build/RHEL/7/checks/shared/oval/oval_5.11' directory as the directory does not exist
Merged 912 OVAL checks.

real    0m0.300s
user    0m0.274s
sys     0m0.025
```