### PR TITLE
Make schematron OVAL validation optional but still default it to true (build time optimization)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SSG_VERSION "${SSG_MAJOR_VERSION}.${SSG_MINOR_VERSION}.${SSG_PATCH_VERSION}"
 set(SSG_VENDOR "ssgproject" CACHE STRING "Specify the XCCDF 1.2 vendor string.")
 
 option(SSG_OVAL_511_ENABLED "If enabled, OVAL 5.11 and OVAL 5.10 checks will be used in the final content. Otherwise only 5.10 checks will be used." TRUE)
+option(SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED "If enabled, schematron validation will be performed as part of the 'validate' targets. Schematron takes a lot of time to complete but can find more issues than just plain XSD validation." TRUE)
 option(SSG_SVG_IN_XCCDF_ENABLED "If enabled, the built XCCDFs will include the SVG SCAP Security Guide logo." TRUE)
 
 option(SSG_PRODUCT_CHROMIUM "If enabled, the Chromium SCAP content will be built" TRUE)
@@ -128,6 +129,7 @@ message(" ")
 message("Build options:")
 message("SSG vendor string: ${SSG_VENDOR}")
 message("OVAL 5.11: ${SSG_OVAL_511_ENABLED}")
+message("OVAL schematron validation: ${SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED}")
 message("SVG logo in XCCDFs: ${SSG_SVG_IN_XCCDF_ENABLED}")
 message(" ")
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -58,6 +58,12 @@ else()
     set(OSCAP_OVAL_VERSION "oval_5.10")
 endif()
 
+if(SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED)
+    set(OSCAP_OVAL_SCHEMATRON_OPTION "--schematron")
+else()
+    set(OSCAP_OVAL_SCHEMATRON_OPTION "")
+endif()
+
 macro(ssg_build_bash_remediation_functions)
     file(GLOB BASH_REMEDIATION_FUNCTIONS "${CMAKE_SOURCE_DIR}/shared/bash_remediation_functions/*.sh")
 
@@ -419,7 +425,7 @@ macro(ssg_build_cpe_dictionary PRODUCT)
     )
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-cpe-oval.xml"
-        COMMAND "${OSCAP_EXECUTABLE}" oval validate --schematron "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
+        COMMAND "${OSCAP_EXECUTABLE}" oval validate ${OSCAP_OVAL_SCHEMATRON_OPTION} "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
         COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-cpe-oval.xml"
         DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
@@ -532,7 +538,7 @@ macro(ssg_build_oval_final PRODUCT)
     )
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-oval.xml"
-        COMMAND "${OSCAP_EXECUTABLE}" oval validate --schematron "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
+        COMMAND "${OSCAP_EXECUTABLE}" oval validate ${OSCAP_OVAL_SCHEMATRON_OPTION} "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
         COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-oval.xml"
         DEPENDS generate-ssg-${PRODUCT}-oval.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"


### PR DESCRIPTION
Schematron takes forever, it is by far the most time consuming part of
the jenkins run. As we try to make CI better for everyone in the
community we want to get under 5 mins for a jenkins run. Our plan is to
run schematron validations nightly but not use them for PR gating.
Schematron validation of a single big OVAL file takes ~4 minutes on very
good hardware.

See https://github.com/OpenSCAP/scap-security-guide/pull/2114#issuecomment-311764879 and https://github.com/OpenSCAP/scap-security-guide/pull/2114#issuecomment-311765637 for more background.

Time for a full jenkins run (`time ninja -j4 all validate`):
```
new code: 2m30.089s 
old code: 5m33.866s
```

This is open for discussion. I think we can afford to avoid schematron for PR gating. We should still run it for every release and probably also every night so that it's easier to figure out which PR broke any of it. Let me know what you think.