### PR TITLE
Sds move ocils optimization (build time optimization)

### DIFF
--- a/shared/utils/sds-move-ocil-to-checks.py
+++ b/shared/utils/sds-move-ocil-to-checks.py
@@ -193,8 +193,11 @@ def main():
     else:
         print("No extended-components, nothing to do...")
 
-    # Write the updated benchmark into output datastream file
-    ElementTree.ElementTree(datastreamtree).write(outdatastreamfile)
+    # if the in and out files are the same and we didn't do any changes we can
+    # skip the serialization
+    if extendedcomps is not None or outdatastreamfile != indatastreamfile:
+        # Write the updated benchmark into output datastream file
+        ElementTree.ElementTree(datastreamtree).write(outdatastreamfile)
     sys.exit(0)
 
 

--- a/shared/utils/sds-move-ocil-to-checks.py
+++ b/shared/utils/sds-move-ocil-to-checks.py
@@ -48,13 +48,6 @@ datastream_ns = "http://scap.nist.gov/schema/scap/source/1.2"
 ocil_ns = "http://scap.nist.gov/schema/ocil/2.0"
 
 
-def parse_xml_file(xmlfile):
-    with open(xmlfile, 'r') as xml_file:
-        filestring = xml_file.read()
-        tree = ElementTree.fromstring(filestring)
-    return tree
-
-
 def move_ocil_ref_from_ds_extended_components_to_ds_checks(datastreamtree, ocilcomp):
     # This routine moves reference to present OCIL component from <ds:extended-components>
     # datastream element to <ds:checks> element (as required by SCAP v1.2 standard)
@@ -172,7 +165,7 @@ def main():
     # Output datastream file
     outdatastreamfile = sys.argv[2]
     # Datastream element tree
-    datastreamtree = parse_xml_file(indatastreamfile)
+    datastreamtree = ElementTree.parse(indatastreamfile)
 
     # Locate <ds:extended-components> element in datastream
     extendedcomps = datastreamtree.find(".//{%s}extended-components" % datastream_ns)

--- a/shared/utils/sds-move-ocil-to-checks.py
+++ b/shared/utils/sds-move-ocil-to-checks.py
@@ -168,7 +168,7 @@ def main():
     datastreamtree = ElementTree.parse(indatastreamfile)
 
     # Locate <ds:extended-components> element in datastream
-    extendedcomps = datastreamtree.find(".//{%s}extended-components" % datastream_ns)
+    extendedcomps = datastreamtree.getroot().find("./{%s}extended-components" % datastream_ns)
     if extendedcomps is not None:
         # Locate OCIL components within <ds:extended-components>
         ocilcomps = extendedcomps.xpath(".//ds:component-ref[contains(@id,'-ocil')]",


### PR DESCRIPTION
This script is very unoptimized and does the same work over and over. The good news is that we don't care. Modern openscap will add OCILs correctly and this if this script detects that it will exit.

I optimized the most common case - in and out paths are the same and we do nothing in the script.

```
new code:  0m0.256s
old code: 0m2.455s
```

I didn't even want to submit this but I already had the fix so here goes...