### PR TITLE
Generate roles from xccdf

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -673,11 +673,11 @@ macro(ssg_build_remediation_roles PRODUCT TEMPLATE EXTENSION)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/roles/all-roles-${PRODUCT}-${EXTENSION}"
         COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/roles"
-        COMMAND "${SSG_SHARED_UTILS}/build-all-remediation-roles.py" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/roles" --template "${TEMPLATE}" --extension "${EXTENSION}" build
+        COMMAND "${SSG_SHARED_UTILS}/build-all-remediation-roles.py" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --output "${CMAKE_BINARY_DIR}/roles" --template "${TEMPLATE}" --extension "${EXTENSION}" build
         COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_BINARY_DIR}/roles/all-roles-${PRODUCT}-${EXTENSION}"
-        DEPENDS generate-ssg-${PRODUCT}-ds.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-        COMMENT "[${PRODUCT}-roles] generating ${TEMPLATE} remediation roles for all profiles in ssg-${PRODUCT}-ds.xml"
+        DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        COMMENT "[${PRODUCT}-roles] generating ${TEMPLATE} remediation roles for all profiles in ssg-${PRODUCT}-xccdf.xml"
     )
     add_custom_target(
         generate-all-roles-${PRODUCT}-${EXTENSION}

--- a/shared/modules/xccdf_utils.py
+++ b/shared/modules/xccdf_utils.py
@@ -62,9 +62,12 @@ def get_profile_choices_for_input(input_tree, benchmark_id, tailoring_tree):
     ret = {}
 
     def scrape_profiles(root_element, namespace, dest):
-        for benchmark in root_element.findall(
-            ".//{%s}Benchmark" % (namespace)
-        ):
+        candidates = \
+            list(root_element.findall(".//{%s}Benchmark" % (namespace)))
+        if root_element.tag == "{%s}Benchmark" % (namespace):
+            candidates.append(root_element)
+
+        for benchmark in candidates:
             if benchmark.get("id") != benchmark_id:
                 continue
 


### PR DESCRIPTION
We used to generate roles from SDS which may or may not contain 2 benchmarks. If it does contain the extra PCI-DSS benchmark it will have exactly 2 profiles that select exactly the same set of rules. Thus the roles will be duplicated. This PR avoids that.

(Also optimized ~2 seconds off the RHEL7 build time but that was not the motivation for this PR)