### PR TITLE
Include AIDE installed in the STIG profile for RHEL7

### DIFF
--- a/RHEL/7/input/profiles/stig-rhel7-disa.xml
+++ b/RHEL/7/input/profiles/stig-rhel7-disa.xml
@@ -200,6 +200,7 @@ Storage deployments.
 <!-- TO DO -->
 
 <!-- SRG-OS-000363-GPOS-00150, SV-86597r1_rule, RHEL-07-020030 -->
+<select idref="package_aide_installed" selected="true" />
 <select idref="aide_periodic_cron_checking" selected="true" />
 
 <!-- SRG-OS-000363-GPOS-00150, SV-86599r1_rule, RHEL-07-020040 -->


### PR DESCRIPTION
Otherwise the remediations might fail if AIDE is not installed.

Related to #2122 

Checked all other RHEL7 profiles for the same issue:

```
$ grep "aide" -r .
./ospp-rhel7.xml:<select idref="aide_build_database" selected="true" />
./ospp-rhel7.xml:<select idref="aide_periodic_cron_checking" selected="true" />
./ospp-rhel7.xml:<select idref="aide_scan_notification" selected="true" />
./ospp-rhel7.xml:<select idref="aide_use_fips_hashes" selected="true" />
./ospp-rhel7.xml:<select idref="aide_verify_acls" selected="true" />
./ospp-rhel7.xml:<select idref="aide_verify_ext_attributes" selected="true" />
./ospp-rhel7.xml:<select idref="package_aide_installed" selected="true" />
./cjis-rhel7-server.xml:<select idref="package_aide_installed" selected="true"/>
./cjis-rhel7-server.xml:<select idref="aide_build_database" selected="true"/>
./cjis-rhel7-server.xml:<select idref="aide_periodic_cron_checking" selected="true"/>
./stig-rhel7-disa.xml:<select idref="package_aide_installed" selected="true" />
./stig-rhel7-disa.xml:<select idref="aide_periodic_cron_checking" selected="true" />
./stig-rhel7-disa.xml:<select idref="aide_scan_notification" selected="true" />
./stig-rhel7-disa.xml:<select idref="aide_verify_acls" selected="true" />
./stig-rhel7-disa.xml:<select idref="aide_verify_ext_attributes" selected="true" />
./stig-rhel7-disa.xml:<select idref="aide_use_fips_hashes" selected="true" />
./rht-ccp.xml:<select idref="package_aide_installed" selected="true"/>
./C2S.xml:<select idref="package_aide_installed" selected="true" />
./C2S.xml:<select idref="aide_periodic_cron_checking" selected="true" />
./pci-dss.xml:<select idref="package_aide_installed" selected="true"/>
./pci-dss.xml:<select idref="aide_build_database" selected="true"/>
./pci-dss.xml:<select idref="aide_periodic_cron_checking" selected="true"/>
```