### PR TITLE
Improved OVAL and OCIL generator elements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,12 @@ if (SSG_OVAL_511_ENABLED AND NOT "${OSCAP_V_OUTPUT}" MATCHES "OVAL Version: 5.11
     message("Your version of OpenSCAP does not support OVAL 5.11, disabling OVAL 5.11 for the SSG build.")
 endif()
 
+if("${OSCAP_V_OUTPUT}" MATCHES "^OpenSCAP command line tool \\(oscap\\) ([0-9\\.]+)")
+    set(OSCAP_VERSION "${CMAKE_MATCH_1}")
+else()
+    set(OSCAP_VERSION "unknown")
+endif()
+
 execute_process(
     COMMAND "${SSG_SHARED_UTILS}/oscap-svg-support.py" "${OSCAP_EXECUTABLE}"
     RESULT_VARIABLE OSCAP_SVG_SUPPORT_RESULT
@@ -118,7 +124,7 @@ find_program(SHELLCHECK_EXECUTABLE NAMES shellcheck)
 configure_file("${CMAKE_SOURCE_DIR}/oval.config.in" "${CMAKE_BINARY_DIR}/oval.config")
 
 message("Tools:")
-message("oscap: ${OSCAP_EXECUTABLE}")
+message("oscap: ${OSCAP_EXECUTABLE} (version: ${OSCAP_VERSION})")
 message("xsltproc: ${XSLTPROC_EXECUTABLE}")
 message("xmllint: ${XMLLINT_EXECUTABLE}")
 message("xmlwf: ${XMLWF_EXECUTABLE}")

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -150,7 +150,7 @@ endmacro()
 macro(ssg_build_ocil_unlinked PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ocil-unlinked.xml"
-        COMMAND "${XSLTPROC_EXECUTABLE}" --output "${CMAKE_CURRENT_BINARY_DIR}/ocil-unlinked.xml" "${SSG_SHARED_TRANSFORMS}/xccdf-create-ocil.xslt" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam ssg_version "${SSG_VERSION}" --output "${CMAKE_CURRENT_BINARY_DIR}/ocil-unlinked.xml" "${SSG_SHARED_TRANSFORMS}/xccdf-create-ocil.xslt" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/ocil-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/ocil-unlinked.xml"
         DEPENDS generate-internal-${PRODUCT}-xccdf-unlinked-resolved.xml
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -343,7 +343,7 @@ macro(ssg_build_oval_unlinked PRODUCT)
             # We have to remove all old shared checks in case the user removed something from the CSV files
             COMMAND "${CMAKE_COMMAND}" -E remove_directory "${BUILD_CHECKS_DIR}/shared/oval"
             COMMAND "${SSG_SHARED_UTILS}/generate-from-templates.py" --shared "${SSG_SHARED}" --oval_version "${OSCAP_OVAL_VERSION}" --input "${SSG_SHARED}/templates" --output "${BUILD_CHECKS_DIR}/shared" --language oval build
-            COMMAND "${SSG_SHARED_UTILS}/combine-ovals.py" --product "${PRODUCT}" --oval_config "${CMAKE_BINARY_DIR}/oval.config" --oval_version "5.11" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" ${OVAL_510_COMBINE_PATHS} ${OVAL_511_COMBINE_PATHS}
+            COMMAND "${SSG_SHARED_UTILS}/combine-ovals.py" --ssg_version "${SSG_VERSION}" --product "${PRODUCT}" --oval_config "${CMAKE_BINARY_DIR}/oval.config" --oval_version "5.11" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" ${OVAL_510_COMBINE_PATHS} ${OVAL_511_COMBINE_PATHS}
             COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
             DEPENDS ${OVAL_CHECKS_DEPENDS}
             DEPENDS ${SHARED_OVAL_CHECKS_DEPENDS}
@@ -366,7 +366,7 @@ macro(ssg_build_oval_unlinked PRODUCT)
             # We have to remove all old shared checks in case the user removed something from the CSV files
             COMMAND "${CMAKE_COMMAND}" -E remove_directory "${BUILD_CHECKS_DIR}/shared/oval"
             COMMAND "${SSG_SHARED_UTILS}/generate-from-templates.py" --shared "${SSG_SHARED}" --oval_version "${OSCAP_OVAL_VERSION}" --input "${SSG_SHARED}/templates" --output "${BUILD_CHECKS_DIR}/shared" --language oval build
-            COMMAND "${SSG_SHARED_UTILS}/combine-ovals.py" --product "${PRODUCT}" --oval_config "${CMAKE_BINARY_DIR}/oval.config" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" ${OVAL_510_COMBINE_PATHS}
+            COMMAND "${SSG_SHARED_UTILS}/combine-ovals.py" --ssg_version "${SSG_VERSION}" --product "${PRODUCT}" --oval_config "${CMAKE_BINARY_DIR}/oval.config" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" ${OVAL_510_COMBINE_PATHS}
             COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
             DEPENDS ${OVAL_CHECKS_DEPENDS}
             DEPENDS ${SHARED_OVAL_CHECKS_DEPENDS}

--- a/shared/transforms/xccdf-create-ocil.xslt
+++ b/shared/transforms/xccdf-create-ocil.xslt
@@ -5,6 +5,8 @@ xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" exclude-result-prefixes="cdf"
 xmlns:xhtml="http://www.w3.org/1999/xhtml"
 xmlns:date="http://exslt.org/dates-and-times" extension-element-prefixes="date" >
 
+<xsl:param name="ssg_version" select="'unknown'"/>
+
 <!-- This transform expects checks with system "ocil-transitional" and that these contain check-content
      that can transformed into OCIL questionnaires.
      -->
@@ -12,8 +14,10 @@ xmlns:date="http://exslt.org/dates-and-times" extension-element-prefixes="date" 
   <xsl:template match="/">
   <ocil xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://scap.nist.gov/schema/ocil/2.0" >
    <generator>
-   <schema_version>2.0</schema_version>
-   <timestamp><xsl:value-of as="xs:dateTime" select="date:date-time()"/></timestamp>
+     <product_name>xccdf-create-ocil.xslt from SCAP Security Guide</product_name>
+     <product_version>ssg: <xsl:value-of select="$ssg_version"/></product_version>
+     <schema_version>2.0</schema_version>
+     <timestamp><xsl:value-of as="xs:dateTime" select="date:date-time()"/></timestamp>
    </generator>
 
 	<questionnaires>

--- a/shared/utils/combine-ovals.py
+++ b/shared/utils/combine-ovals.py
@@ -29,11 +29,11 @@ sys.path.insert(0, os.path.join(
 from map_product_module import map_product, parse_product_name, multi_product_list
 
 oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
-timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
 footer = '</oval_definitions>'
 
 
 def _header(schema_version, ssg_version):
+    timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
     header = '''<?xml version="1.0" encoding="UTF-8"?>
 <oval_definitions
     xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"

--- a/shared/utils/combine-ovals.py
+++ b/shared/utils/combine-ovals.py
@@ -17,12 +17,6 @@ except ImportError:
     import cElementTree as ElementTree
 
 try:
-    set
-except NameError:
-    # for python2
-    from sets import Set as set
-
-try:
     from configparser import SafeConfigParser
 except ImportError:
     # for python2

--- a/shared/utils/combine-ovals.py
+++ b/shared/utils/combine-ovals.py
@@ -33,7 +33,7 @@ timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
 footer = '</oval_definitions>'
 
 
-def _header(schema_version):
+def _header(schema_version, ssg_version):
     header = '''<?xml version="1.0" encoding="UTF-8"?>
 <oval_definitions
     xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
@@ -48,11 +48,12 @@ def _header(schema_version):
         http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd
         http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd">
     <generator>
-        <oval:product_name>python</oval:product_name>
-        <oval:product_version>%s</oval:product_version>
+        <oval:product_name>combine-ovals.py from SCAP Security Guide</oval:product_name>
+        <oval:product_version>ssg: %s, python: %s</oval:product_version>
         <oval:schema_version>%s</oval:schema_version>
         <oval:timestamp>%s</oval:timestamp>
-    </generator>''' % (platform.python_version(), schema_version, timestamp)
+    </generator>''' % (ssg_version, platform.python_version(),
+                       schema_version, timestamp)
 
     return header
 
@@ -337,6 +338,8 @@ def checks(product, oval_dirs):
 
 def main():
     p = argparse.ArgumentParser()
+    p.add_argument("--ssg_version", default="unknown",
+                   help="SSG version for reporting purposes. example: 0.1.34")
     p.add_argument("--product", required=True,
                    help="which product are we building for? example: rhel7")
     p.add_argument("--oval_config", required=True,
@@ -369,7 +372,7 @@ def main():
             oval_schema_version = runtime_oval_schema_version
         else:
             oval_schema_version = config_oval_schema_version
-        header = _header(oval_schema_version)
+        header = _header(oval_schema_version, args.ssg_version)
     else:
         sys.stderr.write("The directory specified does not contain the %s "
                          "file!\n" % (args.oval_config))


### PR DESCRIPTION
Now we list which script generator it and which version of SSG. Previously we just include "python" and version of python.

New OVAL generator element:
```
  <ns0:generator>
    <ns2:product_name>combine-ovals.py from SCAP Security Guide</ns2:product_name>
    <ns2:product_version>ssg: 0.1.34, python: 2.7.13</ns2:product_version>
    <ns2:schema_version>5.11</ns2:schema_version>
    <ns2:timestamp>2017-07-10T19:38:34</ns2:timestamp>
  </ns0:generator>
```

New OCIL generator element:
```
  <ns0:generator>
    <ns0:product_name>xccdf-create-ocil.xslt from SCAP Security Guide</ns0:product_name>
    <ns0:product_version>ssg: 0.1.34</ns0:product_version>
    <ns0:schema_version>2.0</ns0:schema_version>
    <ns0:timestamp>2017-07-10T15:42:53-04:00</ns0:timestamp>
  </ns0:generator>
```

I also added support for detecting OpenSCAP version at configure time. I thought I would add it to the generator elements but to be fair `oscap` is not used for OVAL and OCIL. Still, I think it will be handy in the future and it just says "unknown" if the regex fails so I kept it in the PR.