### PR TITLE
Ansible tags improvements

### DIFF
--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -56,13 +56,15 @@
   <xsl:param name="fix"/>
   <xsl:variable name="rep0" select="."/>
 
+  <xsl:variable name="ref_nist800_53" select="$rule/xccdf:reference[@href='http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf']/text()"/>
   <xsl:variable name="ident_cce" select="$rule/xccdf:ident[@system='https://nvd.nist.gov/cce/index.cfm']/text()"/>
   <xsl:variable name="ansible_tags">- <xsl:value-of select="$rule/@id"/>
     - <xsl:value-of select="$rule/@severity"/>_severity<xsl:if test="$fix/@strategy">
     - <xsl:value-of select="$fix/@strategy"/>_strategy</xsl:if><xsl:if test="$fix/@complexity">
     - <xsl:value-of select="$fix/@complexity"/>_complexity</xsl:if><xsl:if test="$fix/@disruption">
     - <xsl:value-of select="$fix/@disruption"/>_disruption</xsl:if><xsl:if test="$ident_cce">
-    - <xsl:value-of select="$ident_cce"/></xsl:if></xsl:variable>
+    - <xsl:value-of select="$ident_cce"/></xsl:if><xsl:for-each select="$ref_nist800_53">
+    - NIST-800-53-<xsl:value-of select="."/></xsl:for-each></xsl:variable>
 
   <xsl:variable name="rep1">
     <xsl:call-template name="find-and-replace">

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -62,8 +62,8 @@
     - <xsl:value-of select="$rule/@severity"/>_severity<xsl:if test="$fix/@strategy">
     - <xsl:value-of select="$fix/@strategy"/>_strategy</xsl:if><xsl:if test="$fix/@complexity">
     - <xsl:value-of select="$fix/@complexity"/>_complexity</xsl:if><xsl:if test="$fix/@disruption">
-    - <xsl:value-of select="$fix/@disruption"/>_disruption</xsl:if><xsl:if test="$ident_cce">
-    - <xsl:value-of select="$ident_cce"/></xsl:if><xsl:for-each select="$ref_nist800_53">
+    - <xsl:value-of select="$fix/@disruption"/>_disruption</xsl:if><xsl:for-each select="$ident_cce">
+    - <xsl:value-of select="."/></xsl:for-each><xsl:for-each select="$ref_nist800_53">
     - NIST-800-53-<xsl:value-of select="."/></xsl:for-each></xsl:variable>
 
   <xsl:variable name="rep1">

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -58,7 +58,8 @@
 
   <xsl:variable name="ident_cce" select="$rule/xccdf:ident[@system='https://nvd.nist.gov/cce/index.cfm']/text()"/>
   <xsl:variable name="ansible_tags">- <xsl:value-of select="$rule/@id"/>
-    - <xsl:value-of select="$rule/@severity"/>_severity<xsl:if test="$fix/@disruption">
+    - <xsl:value-of select="$rule/@severity"/>_severity<xsl:if test="$fix/@strategy">
+    - <xsl:value-of select="$fix/@strategy"/>_strategy</xsl:if><xsl:if test="$fix/@disruption">
     - <xsl:value-of select="$fix/@disruption"/>_disruption</xsl:if><xsl:if test="$ident_cce">
     - <xsl:value-of select="$ident_cce"/></xsl:if></xsl:variable>
 

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -57,7 +57,7 @@
 
   <xsl:variable name="ident_cce" select="$rule/xccdf:ident[@system='https://nvd.nist.gov/cce/index.cfm']/text()"/>
   <xsl:variable name="ansible_tags">- <xsl:value-of select="$rule/@id"/>
-    - <xsl:value-of select="$rule/@severity"/><xsl:if test="$ident_cce">
+    - <xsl:value-of select="$rule/@severity"/>_severity<xsl:if test="$ident_cce">
     - <xsl:value-of select="$ident_cce"/></xsl:if></xsl:variable>
 
   <xsl:variable name="rep1">

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -53,11 +53,13 @@
 
 <xsl:template match="text()" mode="fix_contents">
   <xsl:param name="rule"/>
+  <xsl:param name="fix"/>
   <xsl:variable name="rep0" select="."/>
 
   <xsl:variable name="ident_cce" select="$rule/xccdf:ident[@system='https://nvd.nist.gov/cce/index.cfm']/text()"/>
   <xsl:variable name="ansible_tags">- <xsl:value-of select="$rule/@id"/>
-    - <xsl:value-of select="$rule/@severity"/>_severity<xsl:if test="$ident_cce">
+    - <xsl:value-of select="$rule/@severity"/>_severity<xsl:if test="$fix/@disruption">
+    - <xsl:value-of select="$fix/@disruption"/>_disruption</xsl:if><xsl:if test="$ident_cce">
     - <xsl:value-of select="$ident_cce"/></xsl:if></xsl:variable>
 
   <xsl:variable name="rep1">
@@ -81,9 +83,11 @@
 
 <xsl:template match="@* | node()" mode="fix_contents">
   <xsl:param name="rule"/>
+  <xsl:param name="fix"/>
   <xsl:copy>
     <xsl:apply-templates select="@* | node()" mode="fix_contents">
       <xsl:with-param name="rule" select="$rule"/>
+      <xsl:with-param name="fix" select="$fix"/>
     </xsl:apply-templates>
   </xsl:copy>
 </xsl:template>
@@ -97,6 +101,7 @@
     <xsl:variable name="rule_id" select="$rule/@id"/>
 
     <xsl:for-each select="$fixgroups/xccdf:fix[@rule=$rule_id]">
+      <xsl:variable name="fix" select="."/>
       <xsl:element name="fix" namespace="http://checklists.nist.gov/xccdf/1.1">
         <xsl:attribute name="system"><xsl:value-of select="../@system"/></xsl:attribute>
         <xsl:attribute name="id"><xsl:value-of select="$rule_id"/></xsl:attribute>
@@ -117,6 +122,7 @@
         </xsl:if>
         <xsl:apply-templates select="node()" mode="fix_contents">
           <xsl:with-param name="rule" select="$rule"/>
+          <xsl:with-param name="fix" select="$fix"/>
         </xsl:apply-templates>
       </xsl:element>
     </xsl:for-each>

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -59,7 +59,8 @@
   <xsl:variable name="ident_cce" select="$rule/xccdf:ident[@system='https://nvd.nist.gov/cce/index.cfm']/text()"/>
   <xsl:variable name="ansible_tags">- <xsl:value-of select="$rule/@id"/>
     - <xsl:value-of select="$rule/@severity"/>_severity<xsl:if test="$fix/@strategy">
-    - <xsl:value-of select="$fix/@strategy"/>_strategy</xsl:if><xsl:if test="$fix/@disruption">
+    - <xsl:value-of select="$fix/@strategy"/>_strategy</xsl:if><xsl:if test="$fix/@complexity">
+    - <xsl:value-of select="$fix/@complexity"/>_complexity</xsl:if><xsl:if test="$fix/@disruption">
     - <xsl:value-of select="$fix/@disruption"/>_disruption</xsl:if><xsl:if test="$ident_cce">
     - <xsl:value-of select="$ident_cce"/></xsl:if></xsl:variable>
 


### PR DESCRIPTION
Include a bunch more in ansible tags.

Example:
```
    - name: Ensure sysctl net.ipv4.ip_forward is set to 0
      sysctl:
        name: net.ipv4.ip_forward
        value: 0
        state: present
        reload: yes
      tags:
        - sysctl_net_ipv4_ip_forward
        - medium_severity
        - disable_strategy
        - low_complexity
        - medium_disruption
        - CCE-80157-1
        - NIST-800-53-CM-7
        - NIST-800-53-SC-5
        - NIST-800-53-SC-32
```

Allows users to skip high_disruption items, example:
`ansible-playbook --skip-tags=high_disruption ssg-rhel7-role-ospp-rhel7.yml`

Or only remediate high severity unless it's high disruption:
`ansible-playbook --tags=high_severity --skip-tags=high_disruption ssg-rhel7-role-ospp-rhel7.yml`