### PR TITLE
Minor speedups in templates

### DIFF
--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -30,6 +30,8 @@ class TemplateNotFoundError(RuntimeError):
             % (template, ", ".join(paths))
         )
 
+TARGET_REGEX = re.compile(r"#\s*only-for:([\s\w,]*)")
+
 
 class FilesGenerator(object):
     def __init__(self):
@@ -136,8 +138,7 @@ class FilesGenerator(object):
         """
 
         if target is not None:
-            regex = re.compile(r"#\s*only-for:([\s\w,]*)")
-            match = regex.search(line)
+            match = TARGET_REGEX.search(line)
 
             if match:
                 # if line contains restriction to target, check it

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -7,7 +7,6 @@ import sys
 import os
 import re
 from abc import abstractmethod
-import inspect
 
 
 class ActionType:
@@ -79,8 +78,6 @@ class FilesGenerator(object):
             return ""
 
         if self.action == ActionType.INPUT:
-            self.files.append(
-                os.path.abspath(inspect.getsourcefile(self.__class__)))
             self.files.append(template_filename)
             return ""
 

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -279,66 +279,66 @@ def main():
 
         queue.join()
 
-        index_source = "<!DOCTYPE html>\n"
-        index_source += "<html lang=\"en\">\n"
-        index_source += "\t<head>\n"
-        index_source += "\t\t<meta charset=\"utf-8\">\n"
-        index_source += "\t\t<title>%s</title>\n" % \
-                        (benchmarks.itervalues().next())
-        index_source += "\t\t<script>\n"
-        index_source += "\t\t\tfunction change_profile(option_element)\n"
-        index_source += "\t\t\t{\n"
-        index_source += "\t\t\t\tvar benchmark_id=option_element.getAttribute('data-benchmark-id');\n"
-        index_source += "\t\t\t\tvar profile_id=option_element.getAttribute('data-profile-id');\n"
-        index_source += "\t\t\t\tvar eval_snippet=document.getElementById('eval_snippet');\n"
-        index_source += "\t\t\t\tvar input_path='/usr/share/xml/scap/ssg/content/%s';\n" % (input_basename)
-        index_source += "\t\t\t\tif (profile_id == '')\n"
-        index_source += "\t\t\t\t{\n"
-        index_source += "\t\t\t\t\tif (benchmark_id == '')\n"
-        index_source += "\t\t\t\t\t\teval_snippet.innerHTML='# oscap xccdf eval ' + input_path;\n"
-        index_source += "\t\t\t\t\telse\n"
-        index_source += "\t\t\t\t\t\teval_snippet.innerHTML='# oscap xccdf eval --benchmark-id ' + benchmark_id + ' ' + input_path;\n"
-        index_source += "\t\t\t\t}\n"
-        index_source += "\t\t\t\telse\n"
-        index_source += "\t\t\t\t{\n"
-        index_source += "\t\t\t\t\tif (benchmark_id == '')\n"
-        index_source += "\t\t\t\t\t\teval_snippet.innerHTML='# oscap xccdf eval --profile ' + profile_id + ' ' + input_path;\n"
-        index_source += "\t\t\t\t\telse\n"
-        index_source += "\t\t\t\t\t\teval_snippet.innerHTML='# oscap xccdf eval --benchmark-id ' + benchmark_id + ' --profile ' + profile_id + ' ' + input_path;\n"
-        index_source += "\t\t\t\t}\n"
-        index_source += "\t\t\t\twindow.open(option_element.value, 'guide');\n"
-        index_source += "\t\t\t}\n"
-        index_source += "\t\t</script>\n"
-        index_source += "\t\t<style>\n"
-        index_source += "\t\t\thtml, body { margin: 0; height: 100% }\n"
-        index_source += "\t\t\t#js_switcher { position: fixed; right: 30px; top: 10px; padding: 2px; background: #ddd; border: 1px solid #999 }\n"
-        index_source += "\t\t\t#guide_div { margin: auto; width: 99%; height: 99% }\n"
-        index_source += "\t\t</style>\n"
-        index_source += "\t</head>\n"
-        index_source += "\t<body onload=\"document.getElementById('js_switcher').style.display = 'block'\">\n"
-        index_source += "\t\t<noscript>\n"
-        index_source += "Profiles: "
-        index_source += ", ".join(index_links) + "\n"
-        index_source += "\t\t</noscript>\n"
-        index_source += "\t\t<div id=\"js_switcher\" style=\"display: none\">\n"
-        index_source += "\t\t\tProfile: \n"
-        index_source += "\t\t\t<select style=\"margin-bottom: 5px\" "
-        index_source += "onchange=\"change_profile(this.options[this.selectedIndex]);\""
-        index_source += ">\n"
-        index_source += "\n".join(index_options) + "\n"
-        index_source += "\t\t\t</select>\n"
-        index_source += "\t\t\t<div id='eval_snippet' style='background: #eee; padding: 3px; border: 1px solid #000'>"
-        index_source += "select a profile to display its guide and a command line snippet needed to use it"
-        index_source += "</div>\n"
-        index_source += "\t\t</div>\n"
-        index_source += "\t\t<div id=\"guide_div\">\n"
-        index_source += \
-            "\t\t\t<iframe src=\"%s\" name=\"guide\" " % (index_initial_src)
-        index_source += "width=\"100%\" height=\"100%\">\n"
-        index_source += "\t\t\t</iframe>\n"
-        index_source += "\t\t</div>\n"
-        index_source += "\t</body>\n"
-        index_source += "</html>\n"
+        index_source = "".join([
+            "<!DOCTYPE html>\n",
+            "<html lang=\"en\">\n",
+            "\t<head>\n",
+            "\t\t<meta charset=\"utf-8\">\n",
+            "\t\t<title>%s</title>\n" % (benchmarks.itervalues().next()),
+            "\t\t<script>\n",
+            "\t\t\tfunction change_profile(option_element)\n",
+            "\t\t\t{\n",
+            "\t\t\t\tvar benchmark_id=option_element.getAttribute('data-benchmark-id');\n",
+            "\t\t\t\tvar profile_id=option_element.getAttribute('data-profile-id');\n",
+            "\t\t\t\tvar eval_snippet=document.getElementById('eval_snippet');\n",
+            "\t\t\t\tvar input_path='/usr/share/xml/scap/ssg/content/%s';\n" % (input_basename),
+            "\t\t\t\tif (profile_id == '')\n",
+            "\t\t\t\t{\n",
+            "\t\t\t\t\tif (benchmark_id == '')\n",
+            "\t\t\t\t\t\teval_snippet.innerHTML='# oscap xccdf eval ' + input_path;\n",
+            "\t\t\t\t\telse\n",
+            "\t\t\t\t\t\teval_snippet.innerHTML='# oscap xccdf eval --benchmark-id ' + benchmark_id + ' ' + input_path;\n",
+            "\t\t\t\t}\n",
+            "\t\t\t\telse\n",
+            "\t\t\t\t{\n",
+            "\t\t\t\t\tif (benchmark_id == '')\n",
+            "\t\t\t\t\t\teval_snippet.innerHTML='# oscap xccdf eval --profile ' + profile_id + ' ' + input_path;\n",
+            "\t\t\t\t\telse\n",
+            "\t\t\t\t\t\teval_snippet.innerHTML='# oscap xccdf eval --benchmark-id ' + benchmark_id + ' --profile ' + profile_id + ' ' + input_path;\n",
+            "\t\t\t\t}\n",
+            "\t\t\t\twindow.open(option_element.value, 'guide');\n",
+            "\t\t\t}\n",
+            "\t\t</script>\n",
+            "\t\t<style>\n",
+            "\t\t\thtml, body { margin: 0; height: 100% }\n",
+            "\t\t\t#js_switcher { position: fixed; right: 30px; top: 10px; padding: 2px; background: #ddd; border: 1px solid #999 }\n",
+            "\t\t\t#guide_div { margin: auto; width: 99%; height: 99% }\n",
+            "\t\t</style>\n",
+            "\t</head>\n",
+            "\t<body onload=\"document.getElementById('js_switcher').style.display = 'block'\">\n",
+            "\t\t<noscript>\n",
+            "Profiles: ",
+            ", ".join(index_links) + "\n",
+            "\t\t</noscript>\n",
+            "\t\t<div id=\"js_switcher\" style=\"display: none\">\n",
+            "\t\t\tProfile: \n",
+            "\t\t\t<select style=\"margin-bottom: 5px\" ",
+            "onchange=\"change_profile(this.options[this.selectedIndex]);\"",
+            ">\n",
+            "\n".join(index_options) + "\n",
+            "\t\t\t</select>\n",
+            "\t\t\t<div id='eval_snippet' style='background: #eee; padding: 3px; border: 1px solid #000'>",
+            "select a profile to display its guide and a command line snippet needed to use it",
+            "</div>\n",
+            "\t\t</div>\n",
+            "\t\t<div id=\"guide_div\">\n",
+            "\t\t\t<iframe src=\"%s\" name=\"guide\" " % (index_initial_src),
+            "width=\"100%\" height=\"100%\">\n",
+            "\t\t\t</iframe>\n",
+            "\t\t</div>\n",
+            "\t</body>\n",
+            "</html>\n"
+        ])
 
     index_path = os.path.join(output_dir, "%s-guide-index.html" % (path_base))
     if args.cmd == "list_inputs":

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -144,12 +144,6 @@ def main():
         # add the default profile
         profiles[""] = "(default)"
 
-        if not profiles:
-            raise RuntimeError(
-                "No profiles were found in '%s' in xccdf:Benchmark of id='%s'."
-                % (input_path, benchmark_id)
-            )
-
         for profile_id in profiles.keys():
             benchmark_profile_pairs.append(
                 (benchmark_id, profile_id, profiles[profile_id])

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -233,107 +233,107 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
         # Skip it without any further processing
         if 'remediation_functions' not in fix.text:
             return
+
         # This remediation script utilizes some of internal remediation functions
         # Expand shell variables and remediation functions calls with <xccdf:sub>
         # elements
-        else:
-            pattern = '\n+(\s*(?:' + '|'.join(remediation_functions) + ')[^\n]*)\n'
-            patcomp = re.compile(pattern, re.DOTALL)
-            fixparts = re.split(patcomp, fix.text)
-            if fixparts[0] is not None:
-                # Split the portion of fix.text from fix start to first call of
-                # remediation function into two parts:
-                # * head        to hold inclusion of the remediation functions
-                # * tail        to hold part of the fix.text after inclusion,
-                #               but before first call of remediation function
-                try:
-                    rfpattern = '(.*remediation_functions)(.*)'
-                    rfpatcomp = re.compile(rfpattern, re.DOTALL)
-                    _, head, tail, _ = re.split(rfpatcomp, fixparts[0], maxsplit=2)
-                except ValueError:
-                    sys.stderr.write("Processing fix.text for: %s rule\n"
-                                     % fix.get('rule'))
-                    sys.stderr.write("Unable to extract part of the fix.text "
-                                     "after inclusion of remediation functions."
-                                     " Aborting..\n")
-                    sys.exit(1)
-                # If the 'tail' is not empty, make it new fix.text.
-                # Otherwise use ''
-                fix.text = tail if tail is not None else ''
-                # Drop the first element of 'fixparts' since it has been processed
-                fixparts.pop(0)
-                # Perform sanity check on new 'fixparts' list content (to continue
-                # successfully 'fixparts' has to contain even count of elements)
-                if len(fixparts) % 2 != 0:
-                    sys.stderr.write("Error performing XCCDF expansion on "
-                                     "remediation script: %s\n"
-                                     % fix.get("rule"))
-                    sys.stderr.write("Invalid count of elements. Exiting!\n")
-                    sys.exit(1)
-                # Process remaining 'fixparts' elements in pairs
-                # First pair element is remediation function to be XCCDF expanded
-                # Second pair element (if not empty) is the portion of the original
-                # fix text to be used in newly added sublement's tail
-                for idx in range(0, len(fixparts), 2):
-                    # We previously removed enclosing newlines when creating
-                    # fixparts list. Add them back and reuse the above 'pattern'
-                    fixparts[idx] = "\n%s\n" % fixparts[idx]
-                    # Sanity check (verify the first field truly contains call of
-                    # some of the remediation functions)
-                    if re.match(pattern, fixparts[idx], re.DOTALL) is not None:
-                        # This chunk contains call of 'populate' function
-                        if "populate" in fixparts[idx]:
-                            varname, fixtextcontribution = get_populate_replacement(remediation_type, fixparts[idx])
-                            # Append the contribution
-                            fix.text += fixtextcontribution
-                            # Define new XCCDF <sub> element for the variable
-                            xccdfvarsub = ElementTree.Element("sub",
-                                                           idref=varname)
-                            # If second pair element is not empty, append it as
-                            # tail for the subelement (prefixed with closing '"')
-                            if fixparts[idx + 1] is not None:
-                                xccdfvarsub.tail = '"' + '\n' + fixparts[idx + 1]
-                            # Otherwise append just enclosing '"'
-                            else:
-                               xccdfvarsub.tail = '"' + '\n'
-                            # Append the new subelement to the fix element
-                            fix.append(xccdfvarsub)
-                        # This chunk contains call of other remediation function
+        pattern = '\n+(\s*(?:' + '|'.join(remediation_functions) + ')[^\n]*)\n'
+        patcomp = re.compile(pattern, re.DOTALL)
+        fixparts = re.split(patcomp, fix.text)
+        if fixparts[0] is not None:
+            # Split the portion of fix.text from fix start to first call of
+            # remediation function into two parts:
+            # * head        to hold inclusion of the remediation functions
+            # * tail        to hold part of the fix.text after inclusion,
+            #               but before first call of remediation function
+            try:
+                rfpattern = '(.*remediation_functions)(.*)'
+                rfpatcomp = re.compile(rfpattern, re.DOTALL)
+                _, head, tail, _ = re.split(rfpatcomp, fixparts[0], maxsplit=2)
+            except ValueError:
+                sys.stderr.write("Processing fix.text for: %s rule\n"
+                                    % fix.get('rule'))
+                sys.stderr.write("Unable to extract part of the fix.text "
+                                    "after inclusion of remediation functions."
+                                    " Aborting..\n")
+                sys.exit(1)
+            # If the 'tail' is not empty, make it new fix.text.
+            # Otherwise use ''
+            fix.text = tail if tail is not None else ''
+            # Drop the first element of 'fixparts' since it has been processed
+            fixparts.pop(0)
+            # Perform sanity check on new 'fixparts' list content (to continue
+            # successfully 'fixparts' has to contain even count of elements)
+            if len(fixparts) % 2 != 0:
+                sys.stderr.write("Error performing XCCDF expansion on "
+                                    "remediation script: %s\n"
+                                    % fix.get("rule"))
+                sys.stderr.write("Invalid count of elements. Exiting!\n")
+                sys.exit(1)
+            # Process remaining 'fixparts' elements in pairs
+            # First pair element is remediation function to be XCCDF expanded
+            # Second pair element (if not empty) is the portion of the original
+            # fix text to be used in newly added sublement's tail
+            for idx in range(0, len(fixparts), 2):
+                # We previously removed enclosing newlines when creating
+                # fixparts list. Add them back and reuse the above 'pattern'
+                fixparts[idx] = "\n%s\n" % fixparts[idx]
+                # Sanity check (verify the first field truly contains call of
+                # some of the remediation functions)
+                if re.match(pattern, fixparts[idx], re.DOTALL) is not None:
+                    # This chunk contains call of 'populate' function
+                    if "populate" in fixparts[idx]:
+                        varname, fixtextcontribution = get_populate_replacement(remediation_type, fixparts[idx])
+                        # Append the contribution
+                        fix.text += fixtextcontribution
+                        # Define new XCCDF <sub> element for the variable
+                        xccdfvarsub = ElementTree.Element("sub",
+                                                        idref=varname)
+                        # If second pair element is not empty, append it as
+                        # tail for the subelement (prefixed with closing '"')
+                        if fixparts[idx + 1] is not None:
+                            xccdfvarsub.tail = '"' + '\n' + fixparts[idx + 1]
+                        # Otherwise append just enclosing '"'
                         else:
-                            # Extract remediation function name
-                            funcname = re.search('\n\s*(\S+)(| .*)\n',
-                                                 fixparts[idx],
-                                                 re.DOTALL).group(1)
-                            # Define new XCCDF <sub> element for the function
-                            xccdffuncsub = ElementTree.Element("sub",
-                                                            idref='function_%s' % \
-                                                            funcname)
-                            # Append original function call into tail of the
-                            # subelement
-                            xccdffuncsub.tail = fixparts[idx]
-                            # If the second element of the pair is not empty,
-                            # append it to the tail of the subelement too
-                            if fixparts[idx + 1] is not None:
-                                xccdffuncsub.tail += fixparts[idx + 1]
-                            # Append the new subelement to the fix element
-                            fix.append(xccdffuncsub)
-                            # Ensure the newly added <xccdf:sub> element for the
-                            # function will be always inserted at newline
-                            # If xccdffuncsub is the first <xccdf:sub> element
-                            # being added as child of <fix> and fix.text doesn't
-                            # end up with newline character, append the newline
-                            # to the fix.text
-                            if list(fix).index(xccdffuncsub) == 0:
-                                if re.search('.*\n$', fix.text) is None:
-                                    fix.text += '\n'
-                            # If xccdffuncsub isn't the first child (first
-                            # <xccdf:sub> being added), and tail of previous
-                            # child doesn't end up with newline, append the newline
-                            # to the tail of previous child
-                            else:
-                                previouselem = fix[list(fix).index(xccdffuncsub) - 1]
-                                if re.search('.*\n$', previouselem.tail) is None:
-                                    previouselem.tail += '\n'
+                            xccdfvarsub.tail = '"' + '\n'
+                        # Append the new subelement to the fix element
+                        fix.append(xccdfvarsub)
+                    # This chunk contains call of other remediation function
+                    else:
+                        # Extract remediation function name
+                        funcname = re.search('\n\s*(\S+)(| .*)\n',
+                                                fixparts[idx],
+                                                re.DOTALL).group(1)
+                        # Define new XCCDF <sub> element for the function
+                        xccdffuncsub = ElementTree.Element("sub",
+                                                        idref='function_%s' % \
+                                                        funcname)
+                        # Append original function call into tail of the
+                        # subelement
+                        xccdffuncsub.tail = fixparts[idx]
+                        # If the second element of the pair is not empty,
+                        # append it to the tail of the subelement too
+                        if fixparts[idx + 1] is not None:
+                            xccdffuncsub.tail += fixparts[idx + 1]
+                        # Append the new subelement to the fix element
+                        fix.append(xccdffuncsub)
+                        # Ensure the newly added <xccdf:sub> element for the
+                        # function will be always inserted at newline
+                        # If xccdffuncsub is the first <xccdf:sub> element
+                        # being added as child of <fix> and fix.text doesn't
+                        # end up with newline character, append the newline
+                        # to the fix.text
+                        if list(fix).index(xccdffuncsub) == 0:
+                            if re.search('.*\n$', fix.text) is None:
+                                fix.text += '\n'
+                        # If xccdffuncsub isn't the first child (first
+                        # <xccdf:sub> being added), and tail of previous
+                        # child doesn't end up with newline, append the newline
+                        # to the tail of previous child
+                        else:
+                            previouselem = fix[list(fix).index(xccdffuncsub) - 1]
+                            if re.search('.*\n$', previouselem.tail) is None:
+                                previouselem.tail += '\n'
 
         # Perform a sanity check if all known remediation function calls have been
         # properly XCCDF substituted. Exit with failure if some wasn't

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -340,10 +340,11 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
 
         # First concat output form of modified fix text (including text appended
         # to all children of the fix)
-        modfixtext = fix.text
+        modfix = [fix.text]
         for child in fix.getchildren():
             if child is not None and child.text is not None:
-                modfixtext += child.text
+                modfix.append(child.text)
+        modfixtext = "".join(modfix)
         for f in remediation_functions:
             # Then efine expected XCCDF sub element form for this function
             funcxccdfsub = "<sub idref=\"function_%s\"" % f

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -402,7 +402,7 @@ def main():
                 # Create and populate new fix element based on shell file
                 fixname = os.path.splitext(filename)[0]
 
-                mod_file = ""
+                mod_file = []
                 config = {}
                 with open(os.path.join(fixdir, filename), 'r') as fix_file:
                     # Assignment automatically escapes shell characters for XML
@@ -416,12 +416,12 @@ def main():
                                     config[key.strip()] = value.strip()
                                 else:
                                     if not line.startswith(FILE_GENERATED):
-                                        mod_file += line
+                                        mod_file.append(line)
                             except ValueError:
                                 if not line.startswith(FILE_GENERATED):
-                                    mod_file += line
+                                    mod_file.append(line)
                         else:
-                            mod_file += line
+                            mod_file.append(line)
 
                 complexity = None
                 disruption = None
@@ -462,7 +462,7 @@ def main():
                             fixes[fixname] = fix
                             included_fixes_count += 1
 
-                        fix.text = mod_file
+                        fix.text = "".join(mod_file)
 
                         # Expand shell variables and remediation functions
                         # into corresponding XCCDF <sub> elements

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import argparse
-import inspect
 
 templates_dir = os.path.join(os.path.dirname(__file__), "..", "templates")
 sys.path.append(templates_dir)
@@ -144,8 +143,7 @@ class Builder(object):
 
         list_ = []
         if action == ActionType.INPUT:
-            # add template_common source file
-            list_.append(os.path.abspath(inspect.getsourcefile(ActionType)))
+            pass
 
         for oval in self.supported_ovals:
             self._set_current_oval(oval)


### PR DESCRIPTION
Very minor stuff, it's getting difficult to squeeze more performance out of the scripts.

https://wiki.python.org/moin/PythonSpeed/PerformanceTips

(time ninja)
```
old code: 1m11.540s
new code: 1m7.924s
```

(time cmake -G Ninja ..)
```
old code: 0m18.295s
new code: 0m14.758s
```

Not impressive but every little bit helps. The next frontier is replacing for loops with `map` and `filter`, etc... We still have a bunch of tools that are CPU-bound and it would help there.