### PR TITLE
remove nullok, handle links

### DIFF
--- a/shared/templates/static/ansible/no_empty_passwords.yml
+++ b/shared/templates/static/ansible/no_empty_passwords.yml
@@ -3,11 +3,21 @@
 # strategy = configure
 # complexity = low
 # disruption = medium
-- name: "Prevent Log In to Accounts With Empty Password"
+- name: "Prevent Log In to Accounts With Empty Password - system-auth"
   replace:
     dest: /etc/pam.d/system-auth
-    regexp: 'nullok\s*'
-    replace: ''
+    follow: yes
+    regexp: 'nullok'
+  tags:
+    @ANSIBLE_TAGS@
+
+- name: "Prevent Log In to Accounts With Empty Password - password-auth"
+  become: yes
+  become_method: sudo
+  replace:
+    dest: /etc/pam.d/password-auth
+    follow: yes
+    regexp: 'nullok'
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/static/ansible/no_empty_passwords.yml
+++ b/shared/templates/static/ansible/no_empty_passwords.yml
@@ -12,8 +12,6 @@
     @ANSIBLE_TAGS@
 
 - name: "Prevent Log In to Accounts With Empty Password - password-auth"
-  become: yes
-  become_method: sudo
   replace:
     dest: /etc/pam.d/password-auth
     follow: yes

--- a/shared/templates/static/bash/no_empty_passwords.sh
+++ b/shared/templates/static/bash/no_empty_passwords.sh
@@ -1,2 +1,3 @@
 # platform = Red Hat Enterprise Linux 5, multi_platform_rhel, multi_platform_fedora
 sed --follow-symlinks -i 's/\<nullok\>//g' /etc/pam.d/system-auth
+sed --follow-symlinks -i 's/\<nullok\>//g' /etc/pam.d/password-auth


### PR DESCRIPTION
Remove `nullok` from `password-auth` and `system-auth-ac` and handle links.

```
$ grep -i nullok /etc/pam.d/* && ls -l /etc/pam.d/*auth*
/etc/pam.d/password-auth:auth        sufficient    pam_unix.so nullok try_first_pass
/etc/pam.d/password-auth:password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok
/etc/pam.d/password-auth-ac:auth        sufficient    pam_unix.so nullok try_first_pass
/etc/pam.d/password-auth-ac:password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok
/etc/pam.d/system-auth:auth        sufficient    pam_unix.so nullok try_first_pass
/etc/pam.d/system-auth:password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok
/etc/pam.d/system-auth-ac:auth        sufficient    pam_unix.so nullok try_first_pass
/etc/pam.d/system-auth-ac:password    sufficient    pam_unix.so md5 shadow nullok try_first_pass use_authtok
lrwxrwxrwx. 1 root root  19 Jul  5 11:59 /etc/pam.d/fingerprint-auth -> fingerprint-auth-ac
-rw-r--r--. 1 root root 702 Jul  5 11:59 /etc/pam.d/fingerprint-auth-ac
lrwxrwxrwx. 1 root root  16 Jul  5 11:59 /etc/pam.d/password-auth -> password-auth-ac
-rw-r--r--. 1 root root 971 Jul  5 11:59 /etc/pam.d/password-auth-ac
lrwxrwxrwx. 1 root root  17 Jul  5 11:59 /etc/pam.d/smartcard-auth -> smartcard-auth-ac
-rw-r--r--. 1 root root 752 Jul  5 11:59 /etc/pam.d/smartcard-auth-ac
lrwxrwxrwx. 1 root root  14 Jul  5 11:59 /etc/pam.d/system-auth -> system-auth-ac
-rw-r--r--. 1 root root 971 Jul  5 11:59 /etc/pam.d/system-auth-ac
```

https://github.com/konstruktoid/ansible-role-hardening/blob/master/tasks/19_password.yml

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>