### PR TITLE
Only consider PCI-DSS related rules when constructing the PCI-DSS tree

### DIFF
--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -93,6 +93,14 @@ def main():
         rules.append(rule)
     rule_usage_map = {}
 
+    # only PCI-DSS related rules in that list, to speed-up processing
+    filtered_rules = []
+    for rule in rules:
+        for ref in rule.findall("./{%s}reference" % (XCCDF_NAMESPACE)):
+            if ref.get("href") == REMOTE_URL:
+                filtered_rules.append(rule)
+                break
+
     values = []
     for value in \
             benchmark.findall(".//{%s}Value" % (XCCDF_NAMESPACE)):
@@ -112,7 +120,8 @@ def main():
     root_element = benchmark.getroot()
     for id_, desc, children in id_tree:
         element = \
-            construct_xccdf_group(id_, desc, children, rules, rule_usage_map)
+            construct_xccdf_group(id_, desc, children,
+                                  filtered_rules, rule_usage_map)
         root_element.append(element)
 
     if len(values) > 0:


### PR DESCRIPTION
Cuts down the processing time to roughly 50%

new code:
```
time ../shared/transforms/pcidss/transform_benchmark_to_pcidss.py ../shared/transforms/pcidss/PCI_DSS.json ./ssg-rhel7-xccdf-1.2.xml t.xml
ERROR:Rule 'xccdf_org.ssgproject.content_rule_service_auditd_enabled' references PCI-DSS 'Req-10' but doesn't match any Group ID in our requirement tree. Perhaps it's referencing something we don't consider applicable on the Operating System level?
WARNING:715 rules don't reference PCI-DSS!

real    0m0.849s
user    0m0.821s
sys     0m0.025s
```

old code:
```
time ../shared/transforms/pcidss/transform_benchmark_to_pcidss.py ../shared/transforms/pcidss/PCI_DSS.json ./ssg-rhel7-xccdf-1.2.xml t.xml
ERROR:Rule 'xccdf_org.ssgproject.content_rule_service_auditd_enabled' references PCI-DSS 'Req-10' but doesn't match any Group ID in our requirement tree. Perhaps it's referencing something we don't consider applicable on the Operating System level?
WARNING:715 rules don't reference PCI-DSS!

real    0m1.951s
user    0m1.920s
sys     0m0.026s
```

This could be sped-up further by pre-computing a map of all PCI-DSS ids mapping to lists of all related rules. Then just using that map to generate the tree. Not sure if that's worth it.