### PR TITLE
Updates python shebangs for virtualenv support.

### DIFF
--- a/Chromium/transforms/xccdf2csv-stig.py
+++ b/Chromium/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/Chromium/transforms/xccdf2csv-stig.py
+++ b/Chromium/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/Chromium/utils/verify-cce.py
+++ b/Chromium/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/Chromium/utils/verify-cce.py
+++ b/Chromium/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/Firefox/transforms/xccdf2csv-stig.py
+++ b/Firefox/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/Firefox/transforms/xccdf2csv-stig.py
+++ b/Firefox/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/Firefox/utils/verify-cce.py
+++ b/Firefox/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/Firefox/utils/verify-cce.py
+++ b/Firefox/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/JBoss/EAP/5/transforms/xccdf2csv-stig.py
+++ b/JBoss/EAP/5/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/JBoss/EAP/5/transforms/xccdf2csv-stig.py
+++ b/JBoss/EAP/5/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/JBoss/EAP/5/utils/verify-cce.py
+++ b/JBoss/EAP/5/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/JBoss/EAP/5/utils/verify-cce.py
+++ b/JBoss/EAP/5/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/JBoss/EAP/6/transforms/xccdf2csv-stig.py
+++ b/JBoss/EAP/6/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/JBoss/EAP/6/transforms/xccdf2csv-stig.py
+++ b/JBoss/EAP/6/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/JBoss/EAP/6/utils/verify-cce.py
+++ b/JBoss/EAP/6/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/JBoss/EAP/6/utils/verify-cce.py
+++ b/JBoss/EAP/6/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/JBoss/Fuse/6/transforms/xccdf2csv-stig.py
+++ b/JBoss/Fuse/6/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/JBoss/Fuse/6/transforms/xccdf2csv-stig.py
+++ b/JBoss/Fuse/6/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/JBoss/Fuse/6/utils/verify-cce.py
+++ b/JBoss/Fuse/6/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/JBoss/Fuse/6/utils/verify-cce.py
+++ b/JBoss/Fuse/6/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/JRE/transforms/xccdf2csv-stig.py
+++ b/JRE/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/JRE/transforms/xccdf2csv-stig.py
+++ b/JRE/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/JRE/utils/verify-cce.py
+++ b/JRE/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/JRE/utils/verify-cce.py
+++ b/JRE/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/OpenStack/RHEL-OSP/7/transforms/xccdf2csv-stig.py
+++ b/OpenStack/RHEL-OSP/7/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/OpenStack/RHEL-OSP/7/transforms/xccdf2csv-stig.py
+++ b/OpenStack/RHEL-OSP/7/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/OpenStack/RHEL-OSP/7/utils/verify-cce.py
+++ b/OpenStack/RHEL-OSP/7/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/OpenStack/RHEL-OSP/7/utils/verify-cce.py
+++ b/OpenStack/RHEL-OSP/7/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/OpenStack/RHEL-OSP/7/utils/verify-references.py
+++ b/OpenStack/RHEL-OSP/7/utils/verify-references.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/OpenStack/RHEL-OSP/7/utils/verify-references.py
+++ b/OpenStack/RHEL-OSP/7/utils/verify-references.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/RHEL/5/transforms/xccdf2csv-stig.py
+++ b/RHEL/5/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/RHEL/5/transforms/xccdf2csv-stig.py
+++ b/RHEL/5/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/RHEL/5/utils/verify-cce.py
+++ b/RHEL/5/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/RHEL/5/utils/verify-cce.py
+++ b/RHEL/5/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/RHEL/6/tests/oval/check_instances_test.py
+++ b/RHEL/6/tests/oval/check_instances_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import sys
 import os

--- a/RHEL/6/transforms/xccdf2csv-stig.py
+++ b/RHEL/6/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/RHEL/6/transforms/xccdf2csv-stig.py
+++ b/RHEL/6/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/RHEL/6/utils/verify-cce.py
+++ b/RHEL/6/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/RHEL/6/utils/verify-cce.py
+++ b/RHEL/6/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/RHEL/7/transforms/xccdf2csv-stig.py
+++ b/RHEL/7/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/RHEL/7/transforms/xccdf2csv-stig.py
+++ b/RHEL/7/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/RHEL/7/utils/verify-cce.py
+++ b/RHEL/7/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/RHEL/7/utils/verify-cce.py
+++ b/RHEL/7/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/RHEVM3/transforms/xccdf2csv-stig.py
+++ b/RHEVM3/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/RHEVM3/transforms/xccdf2csv-stig.py
+++ b/RHEVM3/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/SUSE/11/transforms/xccdf2csv-stig.py
+++ b/SUSE/11/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/SUSE/11/transforms/xccdf2csv-stig.py
+++ b/SUSE/11/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/SUSE/11/utils/verify-cce.py
+++ b/SUSE/11/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/SUSE/11/utils/verify-cce.py
+++ b/SUSE/11/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/SUSE/12/transforms/xccdf2csv-stig.py
+++ b/SUSE/12/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/SUSE/12/transforms/xccdf2csv-stig.py
+++ b/SUSE/12/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/SUSE/12/utils/verify-cce.py
+++ b/SUSE/12/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/SUSE/12/utils/verify-cce.py
+++ b/SUSE/12/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/Webmin/transforms/xccdf2csv-stig.py
+++ b/Webmin/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/Webmin/transforms/xccdf2csv-stig.py
+++ b/Webmin/transforms/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/Webmin/utils/verify-cce.py
+++ b/Webmin/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/Webmin/utils/verify-cce.py
+++ b/Webmin/utils/verify-cce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/shared/misc/cce_extract.py
+++ b/shared/misc/cce_extract.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import sys
 import lxml.etree as ET

--- a/shared/misc/count_oval_objects.py
+++ b/shared/misc/count_oval_objects.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 '''
 count_oval_objects.py

--- a/shared/misc/find_duplicates.py
+++ b/shared/misc/find_duplicates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
     This script should find duplicates e.g. specific template is same as shared one
 """

--- a/shared/misc/find_duplicates.py
+++ b/shared/misc/find_duplicates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
     This script should find duplicates e.g. specific template is same as shared one
 """

--- a/shared/misc/find_orphans.py
+++ b/shared/misc/find_orphans.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 """
 This script lists all oval files made for all platforms (set as

--- a/shared/misc/generate-contributors.py
+++ b/shared/misc/generate-contributors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import subprocess
 import re

--- a/shared/misc/generate-contributors.py
+++ b/shared/misc/generate-contributors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import subprocess
 import re

--- a/shared/modules/verify_cce_module.py
+++ b/shared/modules/verify_cce_module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import sys
 import platform

--- a/shared/modules/xccdf2csv_stig_module.py
+++ b/shared/modules/xccdf2csv_stig_module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import sys
 import csv

--- a/shared/modules/xccdf_utils.py
+++ b/shared/modules/xccdf_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 """
 A couple generic XCCDF utilities used by build-all-guides.py and

--- a/shared/templates/create_accounts_password.py
+++ b/shared/templates/create_accounts_password.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_accounts_password.py

--- a/shared/templates/create_audit_rules_dac_modification.py
+++ b/shared/templates/create_audit_rules_dac_modification.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_audit_rules_dac_modification.py

--- a/shared/templates/create_kernel_modules_disabled.py
+++ b/shared/templates/create_kernel_modules_disabled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_kernel_modules_disabled.py

--- a/shared/templates/create_mount_options.py
+++ b/shared/templates/create_mount_options.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_mount_options.py

--- a/shared/templates/create_package_installed.py
+++ b/shared/templates/create_package_installed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_package_installed.py

--- a/shared/templates/create_package_removed.py
+++ b/shared/templates/create_package_removed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_package_removed.py

--- a/shared/templates/create_permission.py
+++ b/shared/templates/create_permission.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_permission.py

--- a/shared/templates/create_selinux_booleans.py
+++ b/shared/templates/create_selinux_booleans.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_selinux_booleans.py

--- a/shared/templates/create_services_disabled.py
+++ b/shared/templates/create_services_disabled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_services_disabled.py

--- a/shared/templates/create_services_enabled.py
+++ b/shared/templates/create_services_enabled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_services_enabled.py

--- a/shared/templates/create_sockets_disabled.py
+++ b/shared/templates/create_sockets_disabled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_sockets_disabled.py

--- a/shared/templates/create_sysctl.py
+++ b/shared/templates/create_sysctl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import re
 

--- a/shared/templates/create_umask_checks.py
+++ b/shared/templates/create_umask_checks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # create_umask_checks.py

--- a/shared/templates/find_untemplated.py
+++ b/shared/templates/find_untemplated.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import sys
 import os

--- a/shared/transforms/pcidss/generate_pcidss_json.py
+++ b/shared/transforms/pcidss/generate_pcidss_json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2016 Red Hat Inc., Durham, North Carolina.
 #

--- a/shared/transforms/pcidss/generate_pcidss_json.py
+++ b/shared/transforms/pcidss/generate_pcidss_json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright 2016 Red Hat Inc., Durham, North Carolina.
 #

--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2016 Red Hat Inc., Durham, North Carolina.
 #

--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright 2016 Red Hat Inc., Durham, North Carolina.
 #

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 """
 Takes given XCCDF or DataStream and for every profile in it it generates one

--- a/shared/utils/build-all-remediation-roles.py
+++ b/shared/utils/build-all-remediation-roles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 """
 Takes given XCCDF or DataStream and for every profile in it it generates one

--- a/shared/utils/combine-ovals.py
+++ b/shared/utils/combine-ovals.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import datetime
 import os

--- a/shared/utils/combine-ovals.py
+++ b/shared/utils/combine-ovals.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import datetime
 import os

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import os

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os

--- a/shared/utils/cpe-generate.py
+++ b/shared/utils/cpe-generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import fnmatch
 import sys

--- a/shared/utils/create-stig-overlay.py
+++ b/shared/utils/create-stig-overlay.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import re
 import sys

--- a/shared/utils/enable-derivatives.py
+++ b/shared/utils/enable-derivatives.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 """
 Takes given XCCDF or DataStream and adds RHEL derivative operating system(s) CPE name next

--- a/shared/utils/generate-bash-remediation-functions.py
+++ b/shared/utils/generate-bash-remediation-functions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import sys
 import os

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import sys

--- a/shared/utils/generate-from-templates.py
+++ b/shared/utils/generate-from-templates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/shared/utils/oscap-svg-support.py
+++ b/shared/utils/oscap-svg-support.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import subprocess
 import tempfile

--- a/shared/utils/oscap-svg-support.py
+++ b/shared/utils/oscap-svg-support.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import subprocess
 import tempfile

--- a/shared/utils/profile-stats.py
+++ b/shared/utils/profile-stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import json
 import argparse

--- a/shared/utils/profile-stats.py
+++ b/shared/utils/profile-stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import json
 import argparse

--- a/shared/utils/relabel-ids.py
+++ b/shared/utils/relabel-ids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import re
 import sys

--- a/shared/utils/relabel-ids.py
+++ b/shared/utils/relabel-ids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import re
 import sys

--- a/shared/utils/sds-move-ocil-to-checks.py
+++ b/shared/utils/sds-move-ocil-to-checks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 # OpenSCAP as of version 1.2.8 doesn't support OCIL check system yet. For
 # example attempt to build RHEL/6 SSG benchmark produces the following error:

--- a/shared/utils/testoval.py
+++ b/shared/utils/testoval.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import os

--- a/shared/utils/testoval.py
+++ b/shared/utils/testoval.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os

--- a/shared/utils/unselect-empty-xccdf-groups.py
+++ b/shared/utils/unselect-empty-xccdf-groups.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 """
 Takes given *resolved* XCCDF, goes through every profile. For every profile,

--- a/shared/utils/verify-input-sanity.py
+++ b/shared/utils/verify-input-sanity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 #
 # verify-input-sanity.py

--- a/shared/utils/verify-references.py
+++ b/shared/utils/verify-references.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 import sys
 import optparse


### PR DESCRIPTION
Per the documented best practice:
 - https://docs.python.org/3.6/using/unix.html#miscellaneous
 - https://docs.python.org/2/using/unix.html#miscellaneous

When using strictly /usr/bin/python this may invoke a default system
python3 when a virtualenv is established to bind `python2.7` to `python`.