### PR TITLE
Verify that TMOUT is set to readonly

### DIFF
--- a/RHEL/6/input/xccdf/system/accounts/session.xml
+++ b/RHEL/6/input/xccdf/system/accounts/session.xml
@@ -43,10 +43,15 @@ Terminating an idle session within a short time period reduces
 the window of opportunity for unauthorized personnel to take control of a 
 management session enabled on the console or console port that has been 
 left unattended.
+
+Setting the <tt>TMOUT</tt> option to readonly in <tt>/etc/profile</tt> ensures that 
+users will not be able to disable the option or alter its value.
+The following line should be appended to <tt>/etc/profile</tt>
+<pre>readonly TMOUT</pre>
 </description>
 <rationale>
 </rationale>
-<ocil clause="value of TMOUT is not greater than or equal to expected setting">
+<ocil clause="value of TMOUT is not greater than or equal to expected setting or TMOUT is not set to readonly">
 Run the following command to ensure the <tt>TMOUT</tt> value is configured for all users
 on the system:
 <pre>$ sudo grep TMOUT /etc/profile</pre>

--- a/RHEL/7/templates/static/bash/accounts_tmout.sh
+++ b/RHEL/7/templates/static/bash/accounts_tmout.sh
@@ -8,3 +8,12 @@ else
         echo -e "\n# Set TMOUT to $var_accounts_tmout per security requirements" >> /etc/profile
         echo "TMOUT=$var_accounts_tmout" >> /etc/profile
 fi
+
+# Check if 'readonly TMOUT' is not set in /etc/profile
+# Add it if it's missing
+if ! grep --silent '^\s*readonly\s\+TMOUT\s*$' /etc/profile; then
+    echo -e "\n# Set TMOUT to readonly per security requirements" >> /etc/profile
+    echo "readonly TMOUT" >> /etc/profile
+fi
+
+

--- a/shared/templates/static/oval/accounts_tmout.xml
+++ b/shared/templates/static/oval/accounts_tmout.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_tmout" version="2">
+  <definition class="compliance" id="accounts_tmout" version="3">
     <metadata>
       <title>Set Interactive Session Timeout</title>
       <affected family="unix">
@@ -7,9 +7,19 @@
       </affected>
       <description>Checks interactive shell timeout</description>
     </metadata>
+
     <criteria operator="OR">
-      <criterion comment="TMOUT value in /etc/profile >= var_accounts_tmout" test_ref="test_etc_profile_tmout" />
-      <criterion comment="TMOUT value in /etc/profile.d/*.sh >= var_accounts_tmout" test_ref="test_etc_profiled_tmout" />
+      <!-- Test the /etc/profile case -->
+      <criteria operator="AND">
+        <criterion comment="TMOUT value in /etc/profile >= var_accounts_tmout" test_ref="test_etc_profile_tmout" />
+        <criterion comment="TMOUT in /etc/profile is set to readonly" test_ref="test_etc_profile_tmout_readonly" />
+      </criteria>
+
+      <!-- Test the /etc/profile.d/ case -->
+      <criteria operator="AND">
+        <criterion comment="TMOUT value in /etc/profile.d/*.sh >= var_accounts_tmout" test_ref="test_etc_profiled_tmout" />
+        <criterion comment="TMOUT in /etc/profile.d/*.sh is set to readonly" test_ref="test_etc_profiled_tmout_readonly" />
+      </criteria>
     </criteria>
   </definition>
 
@@ -18,9 +28,17 @@
     <ind:state state_ref="state_etc_profile_tmout" />
   </ind:textfilecontent54_test>
 
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="TMOUT set to readonly in /etc/profile" id="test_etc_profile_tmout_readonly" version="1">
+    <ind:object object_ref="object_etc_profile_tmout_readonly" />
+  </ind:textfilecontent54_test>
+
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="TMOUT in /etc/profile.d/*.sh" id="test_etc_profiled_tmout" version="1">
     <ind:object object_ref="object_etc_profiled_tmout" />
     <ind:state state_ref="state_etc_profile_tmout" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="TMOUT set to readonly in /etc/profile.d/*.sh" id="test_etc_profiled_tmout_readonly" version="1">
+    <ind:object object_ref="object_etc_profiled_tmout_readonly" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_etc_profile_tmout" version="1">
@@ -29,11 +47,24 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  <ind:textfilecontent54_object id="object_etc_profile_tmout_readonly" version="1">
+    <ind:filepath>/etc/profile</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*readonly TMOUT*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
   <ind:textfilecontent54_object id="object_etc_profiled_tmout" version="1">
     <ind:path>/etc/profile.d</ind:path>
     <ind:filename operation="pattern match">^.*\.sh$</ind:filename>
     <ind:pattern operation="pattern match">^[\s]*TMOUT[\s]*=[\s]*(.*)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_etc_profiled_tmout_readonly" version="1">
+    <ind:path>/etc/profile.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.sh$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*readonly TMOUT*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_etc_profile_tmout" version="1">

--- a/shared/xccdf/system/accounts/session.xml
+++ b/shared/xccdf/system/accounts/session.xml
@@ -81,6 +81,11 @@ Setting the <tt>TMOUT</tt> option in <tt>/etc/profile</tt> ensures that
 all user sessions will terminate based on inactivity. The <tt>TMOUT</tt>
 setting in <tt>/etc/profile</tt> should read as follows:
 <pre>TMOUT=<sub idref="var_accounts_tmout" /></pre>
+
+Setting the <tt>TMOUT</tt> option to readonly in <tt>/etc/profile</tt> ensures that 
+users will not be able to disable the option or alter its value.
+The following line should be appended to <tt>/etc/profile</tt>
+<pre>readonly TMOUT</pre>
 </description>
 <rationale>
 Terminating an idle session within a short time period reduces
@@ -94,6 +99,7 @@ on the system:
 <pre>$ sudo grep TMOUT /etc/profile</pre>
 The output should return the following:
 <pre>TMOUT=<sub idref="var_accounts_tmout" /></pre>
+<pre>readonly TMOUT</pre>
 </ocil>
 <ident prodtype="rhel7" cce="27557-8" />
 <ref prodtype="rhel7" stigid="040160" />


### PR DESCRIPTION
Ensure that TMOUT is set to readonly per comment below from #2115 

> On 7/17/17 2:29 PM, tbrunell wrote:
 Talked with DISA today. They feel that the rule should stay, but with
 the addition of the "readonly TMOUT" line in /etc/profile.

This is my first contribution, please let me know if I'm missing anything 👍 
I questioned whether I should increment the check `version` in the oval definition.