### PR TITLE
Set rsyslog_remote_loghost_address to default value "logcollector"

### DIFF
--- a/shared/templates/static/ansible/rsyslog_remote_loghost.yml
+++ b/shared/templates/static/ansible/rsyslog_remote_loghost.yml
@@ -9,7 +9,6 @@
     dest: /etc/rsyslog.conf
     regexp: "^\\*\\.\\*"
     line: "*.* @@(ansible-populate rsyslog_remote_loghost_address)"
-  when: "'(ansible-populate rsyslog_remote_loghost_address)' != 'NULL'"
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/static/bash/rsyslog_remote_loghost.sh
+++ b/shared/templates/static/bash/rsyslog_remote_loghost.sh
@@ -4,7 +4,4 @@
 
 populate rsyslog_remote_loghost_address
 
-if [ "$rsyslog_remote_loghost_address" != "NULL" ]
-then
-    replace_or_append '/etc/rsyslog.conf' '^\*\.\*' "@@$rsyslog_remote_loghost_address" '@CCENUM@' '%s %s'
-fi
+replace_or_append '/etc/rsyslog.conf' '^\*\.\*' "@@$rsyslog_remote_loghost_address" '@CCENUM@' '%s %s'

--- a/shared/xccdf/system/logging.xml
+++ b/shared/xccdf/system/logging.xml
@@ -232,10 +232,10 @@ better to store log messages both centrally and on each host, so
 that they can be correlated if necessary.</description>
 
 <Value id="rsyslog_remote_loghost_address" type="string"
-operator="equals" interactive="0">
+operator="equals" interactive="1">
 <title>Remote Log Server</title>
 <description>Specify an URI or IP address of a remote host where the log messages will be sent and stored.</description>
-<value selector="default">NULL</value>
+<value selector="default">logcollector</value>
 </Value>
 
 <Rule id="rsyslog_remote_loghost" prodtype="rhel7">
@@ -261,6 +261,8 @@ To use TCP for log message delivery:
 <br/>
 To use RELP for log message delivery:
 <pre>*.* :omrelp:<i>loghost.example.com</i></pre>
+<br/>
+There must be a resolvable DNS CNAME or Alias record set to "<sub idref="rsyslog_remote_loghost_address"/>" for logs to be sent correctly to the centralized logging utility.
 </description>
 <ocil clause="none of these are present">
 To ensure logs are sent to a remote host, examine the file


### PR DESCRIPTION
Fail remediation of Rule `rsyslog_remote_loghost` if value of `value_rsyslog_remote_loghost_address` is NULL.

Do not return `fixed` if we didn't change anything.