### PR TITLE
Checking to see if /etc/ssh/*.pub files exist before changing

### DIFF
--- a/shared/templates/static/bash/file_permissions_sshd_private_key.sh
+++ b/shared/templates/static/bash/file_permissions_sshd_private_key.sh
@@ -1,3 +1,8 @@
 # platform = multi_platform_rhel
 
-chmod 0640 /etc/ssh/*_key
+#check if files exist before attempting 
+#to change them
+if ls /etc/ssh/*_key &> /dev/null
+then
+    chmod 0640 /etc/ssh/*_key
+fi

--- a/shared/templates/static/bash/file_permissions_sshd_pub_key.sh
+++ b/shared/templates/static/bash/file_permissions_sshd_pub_key.sh
@@ -1,3 +1,8 @@
 # platform = multi_platform_rhel
 
-chmod 0644 /etc/ssh/*.pub
+#check if files exist before attempting 
+#to change them
+if ls /etc/ssh/*.pub &> /dev/null
+then
+    chmod 0644 /etc/ssh/*.pub
+fi


### PR DESCRIPTION
Ran xccdf_org.ssgproject.content_rule_file_permissions_sshd_pub_key and got the following error:

`chmod: cannot access '/etc/ssh/*.pub': No such file or directory`

Updating remediation script to see if files exist before attempting to update.

UPDATE: Added
`chmod: cannot access '/etc/ssh/*_key': No such file or directory`