### PR TITLE
Fixed the variable substitution in template_OVAL_permissions

### DIFF
--- a/shared/templates/template_OVAL_permissions
+++ b/shared/templates/template_OVAL_permissions
@@ -23,10 +23,10 @@
     %UNIX_FILENAME%
   </unix:file_object>
   <unix:file_state id="%FILEID%_state_uid_%FILEUID%" version="1">
-    <unix:user_id datatype="int" operation="equals">FILEUID</unix:user_id>
+    <unix:user_id datatype="int" operation="equals">%FILEUID%</unix:user_id>
   </unix:file_state>
   <unix:file_state id="%FILEID%_state_gid_%FILEGID%" version="1">
-    <unix:group_id datatype="int" operation="equals">FILEGID</unix:group_id>
+    <unix:group_id datatype="int" operation="equals">%FILEGID%</unix:group_id>
   </unix:file_state>
   <unix:file_state id="%FILEID%_state_mode_%FILEMODE%" version="1">
 %STATEMODE%


### PR DESCRIPTION
This fixes the NIST testsuite but also fixes the logic of those OVAL
checks.

See https://jenkins.open-scap.org/job/scap-security-guide-nist-testsuite/10/console