### PR TITLE
Check that a trimmed key is not part of the result string after template sub

### DIFF
--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -95,13 +95,17 @@ class FilesGenerator(object):
 
             trimmed_key = key[1:-1]  # the key without the % padding chars
             if trimmed_key in filestring:
+                highlighted_filestring = filestring.replace(
+                    trimmed_key, "--->%s<---" % (trimmed_key)
+                )
                 raise RuntimeError(
                     "Trimmed key '%s' was found in the filestring after the "
                     "substitution was performed. This is usually a typo or a "
                     "mistake in the template, the python generator or both. "
                     "In the rare case where this is expected please rename the "
-                    "key to something unambiguous. Class name: %s"
-                    % (trimmed_key, self.__class__))
+                    "key to something unambiguous. Class name: %s. Filestring "
+                    "with the trimmed key highlighted:\n%s"
+                    % (trimmed_key, self.__class__, highlighted_filestring))
 
         for pattern, replacement in regex_replace:
             filestring = re.sub(pattern, replacement, filestring)

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -93,6 +93,16 @@ class FilesGenerator(object):
 
             filestring = filestring.replace(key, value)
 
+            trimmed_key = key[1:-1]  # the key without the % padding chars
+            if trimmed_key in filestring:
+                raise RuntimeError(
+                    "Trimmed key '%s' was found in the filestring after the "
+                    "substitution was performed. This is usually a typo or a "
+                    "mistake in the template, the python generator or both. "
+                    "In the rare case where this is expected please rename the "
+                    "key to something unambiguous. Class name: %s"
+                    % (trimmed_key, self.__class__))
+
         for pattern, replacement in regex_replace:
             filestring = re.sub(pattern, replacement, filestring)
 


### PR DESCRIPTION
This prevents typos where user will forget the padding %% around one
substitution key, these are hard to find and break the content.

It may be a little too aggressive but you can always make the key name
longer to avoid ambiguities.

Prevents issues such as #2198