### PR TITLE
Use str.replace instead of re.sub in create_audit_rules_..

### DIFF
--- a/shared/templates/create_audit_rules_login_events.py
+++ b/shared/templates/create_audit_rules_login_events.py
@@ -10,6 +10,7 @@ from template_common import FilesGenerator, UnknownTargetError
 import os
 import re
 
+
 class AuditRulesLoginEventsGenerator(FilesGenerator):
     def generate(self, target, args):
         path = args[0]
@@ -19,7 +20,7 @@ class AuditRulesLoginEventsGenerator(FilesGenerator):
                 "./template_OVAL_audit_rules_login_events",
                 {
                     "%NAME%":	name,
-                    "%PATH%":	re.sub("/", "\/", path)
+                    "%PATH%":	path.replace("/", "\\/")
                 },
                 "./oval/audit_rules_login_events_{0}.xml", name
             )
@@ -49,4 +50,3 @@ class AuditRulesLoginEventsGenerator(FilesGenerator):
     def csv_format(self):
         return("CSV should contains lines of the format: " +
                "PATH")
-               

--- a/shared/templates/create_audit_rules_privileged_commands.py
+++ b/shared/templates/create_audit_rules_privileged_commands.py
@@ -10,6 +10,7 @@ from template_common import FilesGenerator, UnknownTargetError
 import os
 import re
 
+
 class AuditRulesPrivilegedCommandsGenerator(FilesGenerator):
     def generate(self, target, args):
         path = args[0]
@@ -19,7 +20,7 @@ class AuditRulesPrivilegedCommandsGenerator(FilesGenerator):
                 "./template_OVAL_audit_rules_privileged_commands",
                 {
                     "%NAME%":	name,
-                    "%PATH%":	re.sub("/", "\/", path)
+                    "%PATH%":	path.replace("/", "\\/")
                 },
                 "./oval/audit_rules_privileged_commands_{0}.xml", name
             )

--- a/shared/templates/create_audit_rules_usergroup_modification.py
+++ b/shared/templates/create_audit_rules_usergroup_modification.py
@@ -10,6 +10,7 @@ from template_common import FilesGenerator, UnknownTargetError
 import os
 import re
 
+
 class AuditRulesUserGroupModificationGenerator(FilesGenerator):
     def generate(self, target, args):
         path = args[0]
@@ -19,7 +20,7 @@ class AuditRulesUserGroupModificationGenerator(FilesGenerator):
                 "./template_OVAL_audit_rules_usergroup_modification",
                 {
                     "%NAME%":	name,
-                    "%PATH%":	re.sub("/", "\\/", path)
+                    "%PATH%":	path.replace("/", "\\/")
                 },
                 "./oval/audit_rules_usergroup_modification_{0}.xml", name
             )
@@ -49,4 +50,3 @@ class AuditRulesUserGroupModificationGenerator(FilesGenerator):
     def csv_format(self):
         return("CSV should contains lines of the format: " +
                "PATH")
-               


### PR DESCRIPTION
Also fixed the escaping to do explicit \\ escape for the backslash.

Use str.replace instead of re.sub whenever we can. It's faster and more importantly easier to debug and understand. This is a minor thing but I wanted to fix it before we all copy paste it all over the place.

The files had PEP8 issues so I also fixed those.