### PR TITLE
Add "PCI-DSS variant" suffix to every title of the PCI-DSS benchmark

### DIFF
--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -185,6 +185,10 @@ def main():
         root_element.get("id").replace("_benchmark_", "_benchmark_PCIDSS-")
     )
 
+    for title_element in \
+            root_element.findall("./{%s}title" % (XCCDF_NAMESPACE)):
+        title_element.text += " (PCI-DSS variant)"
+
     # filter out all profiles except PCI-DSS
     for profile in \
             benchmark.findall("./{%s}Profile" % (XCCDF_NAMESPACE)):

--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -187,7 +187,7 @@ def main():
 
     for title_element in \
             root_element.findall("./{%s}title" % (XCCDF_NAMESPACE)):
-        title_element.text += " (PCI-DSS variant)"
+        title_element.text += " (PCI-DSS centric)"
 
     # filter out all profiles except PCI-DSS
     for profile in \


### PR DESCRIPTION
This makes it easier to distinguish the Benchmarks in the source
datastream.

See https://bugzilla.redhat.com/show_bug.cgi?id=1457442