### PR TITLE
Removed extra whitespace around RHEL6 STIG profile titles

### DIFF
--- a/RHEL/6/input/profiles/stig-rhel6-server-gui-upstream.xml
+++ b/RHEL/6/input/profiles/stig-rhel6-server-gui-upstream.xml
@@ -1,8 +1,6 @@
 <Profile id="stig-rhel6-server-gui-upstream" 
 extends="stig-rhel6-server-upstream">
-<title override="true">
-  Upstream STIG for Red Hat Enterprise Linux 6 Server Running GUIs
-</title>
+<title override="true">Upstream STIG for Red Hat Enterprise Linux 6 Server Running GUIs</title>
 <description override="true">This profile is developed under the DoD consensus 
 model and DISA FSO Vendor STIG process, serving as the upstream development 
 environment for the Red Hat Enterprise Linux 6 Server STIG.

--- a/RHEL/6/input/profiles/stig-rhel6-workstation-upstream.xml
+++ b/RHEL/6/input/profiles/stig-rhel6-workstation-upstream.xml
@@ -1,8 +1,6 @@
 <Profile id="stig-rhel6-workstation-upstream" 
 extends="stig-rhel6-server-gui-upstream">
-<title override="true">
-  Upstream STIG for Red Hat Enterprise Linux 6 Workstation
-</title>
+<title override="true">Upstream STIG for Red Hat Enterprise Linux 6 Workstation</title>
 <description override="true">This profile is developed under the DoD consensus
 model and DISA FSO Vendor STIG process, serving as the upstream development
 environment for the Red Hat Enterprise Linux 6 Server STIG.


### PR DESCRIPTION
Can't use nice XML formatting in text parts of elements. It does make a
difference!

See https://bugzilla.redhat.com/show_bug.cgi?id=1449302