### PR TITLE
Updating for stats for all rules (even profileless)

### DIFF
--- a/shared/utils/profile-stats.py
+++ b/shared/utils/profile-stats.py
@@ -98,7 +98,7 @@ class XCCDFBenchmark(object):
 
         rules = []
 
-        if profile == "all":
+        if ( profile == "all" ) or ( profile == "none" ):
             # "all" is a virtual profile that selects all rules
             rules = self.indexed_rules.values()
         else:
@@ -394,7 +394,7 @@ def main():
                         action="store",
                         help="Show statistics for this XCCDF Profile only. If "
                         "not provided the script will show stats for all "
-                        "available profiles.")
+                        "available profiles. none gives stats for all rules.")
     parser.add_argument("--benchmark", "-b", required=True,
                         action="store",
                         help="Specify XCCDF file to act on. Must be a plain "


### PR DESCRIPTION
Small change to the profile-stats script.  It would not give stats for a rule unless it belonged to a profile.  Which is apt since the script is called "profile-stats".  :)  It would be useful for my purposes to know the stats on all the rules (even the ones not currently in a profile).  

Long-term, what is the plan for tagging "WIP" rules (nice term for missing) in the xccdf?  Long-term, I see this occasionally getting updated for various reasons and maybe some things are only partially there.  My first gut suggestion would be to add a [WIP] tag in the description to give someone using OSCAP Workbench a hint that the rule may not be fully implemented.  This gets messy since now, what part is WIP?