### PR TITLE
fix audit syscall rule sed needs an escape character to properly run

### DIFF
--- a/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
@@ -83,7 +83,7 @@ then
 	# Extract audit $key from audit rule so we can use it later
 	key=$(expr "$full_rule" : '.*-k[[:space:]]\([^[:space:]]\+\)')
 	# Check if particular audit rule is already defined
-	IFS=$'\n' matches=($(sed -s -n -e ";${pattern};!d" -e "/${arch}/!d" -e "/${group}/!d;F" /etc/audit/rules.d/*.rules))
+	IFS=$'\n' matches=($(sed -s -n -e "\;${pattern};!d" -e "/${arch}/!d" -e "/${group}/!d;F" /etc/audit/rules.d/*.rules))
 	if [ $? -ne 0 ]
 	then
 		retval=1
@@ -117,7 +117,7 @@ do
 	# * follow the rule pattern, and
 	# * meet the hardware architecture requirement, and
 	# * are current syscall group specific
-	IFS=$'\n' existing_rules=($(sed -e ";${pattern};!d" -e "/${arch}/!d" -e "/${group}/!d"  "$audit_file"))
+	IFS=$'\n' existing_rules=($(sed -e "\;${pattern};!d" -e "/${arch}/!d" -e "/${group}/!d"  "$audit_file"))
 	if [ $? -ne 0 ]
 	then
 		retval=1
@@ -140,7 +140,7 @@ do
 				# Rule is covered (i.e. the list of -S syscalls for this rule is
 				# subset of -S syscalls of $full_rule => existing rule can be deleted
 				# Thus delete the rule from audit.rules & our array
-				sed -i -e ";${rule};d" "$audit_file"
+				sed -i -e "\;${rule};d" "$audit_file"
 				if [ $? -ne 0 ]
 				then
 					retval=1
@@ -161,7 +161,7 @@ do
 				# if the same rule not already present
 				#
 				# 1) Delete the original rule
-				sed -i -e ";${rule};d" "$audit_file"
+				sed -i -e "\;${rule};d" "$audit_file"
 				if [ $? -ne 0 ]
 				then
 					retval=1


### PR DESCRIPTION
Sorry, should have tested before the first commit (I thought I had, but evidently not thoroughly enough).  When using a non-standard deliminator on a "delete" in sed you have to escape the first one.  I've made the fix below and tested it. 
`
sed: -e expression #1, char 2: unknown command: `-'`