### PR TITLE
Removes `silent` from the pam.d deny_root search/replace pattern

### DIFF
--- a/shared/templates/static/bash/accounts_passwords_pam_faillock_deny_root.sh
+++ b/shared/templates/static/bash/accounts_passwords_pam_faillock_deny_root.sh
@@ -26,7 +26,7 @@ do
 		# pam_faillock.so present, authfail even_deny_root directive present?
 		if ! grep -q "^auth.*\[default=die\].*pam_faillock.so.*authfail.*even_deny_root" $pamFile; then
 			# even_deny_root is not present
-			sed -i --follow-symlinks "s/\(^auth.*\[default=die\].*pam_faillock.so.*authfail.*silent.*\).*/\1 even_deny_root/" $pamFile
+			sed -i --follow-symlinks "s/\(^auth.*\[default=die\].*pam_faillock.so.*authfail.*\).*/\1 even_deny_root/" $pamFile
 		fi
 
 	# pam_faillock.so not present yet


### PR DESCRIPTION
The prior pattern required that the "silent" token be present, but
that token is not necessarily present. For example, after remediating
a fresh build of RHEL 7.4, the corresponding line looks like this:

```
auth        [default=die] pam_faillock.so authfail deny=3 unlock_time=never fail_interval=900
```

As a result, the corresponding OVAL check was continuing to report
failure (accounts_passwords_pam_faillock_deny_root).

After removing the "silent" token from the search/replace pattern,
the script successfully remediates the system and the OVAL check
passes.