### PR TITLE
Functions use return, "exit" exits whole script

### DIFF
--- a/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
@@ -69,7 +69,7 @@ if [ "$tool" != 'auditctl' ] && [ "$tool" != 'augenrules' ]
 then
 	echo "Unknown audit rules loading tool: $1. Aborting."
 	echo "Use either 'auditctl' or 'augenrules'!"
-	exit 1
+	return 1
 # If audit tool is 'auditctl', then add '/etc/audit/audit.rules'
 # file to the list of files to be inspected
 elif [ "$tool" == 'auditctl' ]
@@ -215,6 +215,6 @@ do
 	fi
 done
 
-exit $retval
+return $retval
 
 }


### PR DESCRIPTION
Found another issue.  This one I made worse.  "exit" in functions exits whole script.  returns push you back to caller.  Audit rules were not working since only auditctl was being called (which was being blasted over by the augenrules generation).