### PR TITLE
Correct file_permissions_grub2_cfg permission check

### DIFF
--- a/RHEL/7/templates/static/bash/file_permissions_grub2_cfg.sh
+++ b/RHEL/7/templates/static/bash/file_permissions_grub2_cfg.sh
@@ -1,2 +1,2 @@
 # platform = Red Hat Enterprise Linux 7
-chmod 600 /boot/grub2/grub.cfg
+chmod go= /boot/grub2/grub.cfg

--- a/shared/templates/static/oval/file_permissions_grub2_cfg.xml
+++ b/shared/templates/static/oval/file_permissions_grub2_cfg.xml
@@ -6,7 +6,7 @@
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
       </affected>
-      <description>File permissions for grub.cfg should be set to 0600 (or stronger). By default, this file is located at /boot/grub2/grub.cfg or, for EFI systems, at /boot/efi/EFI/redhat/grub.cfg</description>
+      <description>File permissions for grub.cfg should be set to exclude access to all but root. By default, this file is located at /boot/grub2/grub.cfg or, for EFI systems, at /boot/efi/EFI/redhat/grub.cfg</description>
     </metadata>
     <criteria operator="OR">
       <criterion test_ref="test_file_permissions_grub2_cfg" />
@@ -33,7 +33,6 @@
   </unix:file_object>
 
   <unix:file_state id="state_file_permissions_grub2_cfg" version="1">
-    <unix:uexec datatype="boolean">false</unix:uexec>
     <unix:gread datatype="boolean">false</unix:gread>
     <unix:gwrite datatype="boolean">false</unix:gwrite>
     <unix:gexec datatype="boolean">false</unix:gexec>

--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -61,14 +61,14 @@ cui="3.4.5" />
 
 <Rule id="file_permissions_grub2_cfg" severity="medium" prodtype="rhel7">
 <title>Verify /boot/grub2/grub.cfg Permissions</title>
-<description>File permissions for <tt>/boot/grub2/grub.cfg</tt> should be set to 600.
-<fileperms-desc-macro file="/boot/grub2/grub.cfg" perms="600"/>
+<description>File permissions for <tt>/boot/grub2/grub.cfg</tt> should be set to exclude access to all except root.
+<fileperms-desc-macro file="/boot/grub2/grub.cfg" perms="go="/>
 </description>
 <ocil clause ="it does not">
 To check the permissions of /boot/grub2/grub.cfg, run the command:
 <pre>$ sudo ls -lL /boot/grub2/grub.cfg</pre>
 If properly configured, the output should indicate the following
-permissions: <tt>-rw-------</tt>
+permissions: <tt>-rw-------</tt> (or <tt>-rwx------</tt> on a system with an EFI partition).
 </ocil>
 <rationale>
 Proper permissions ensure that only the root user can modify important boot


### PR DESCRIPTION
EFI-resident grub.cfg permissions always show executable bit.

(This is my first pull request, so I hope I've set it up correctly. 
NB: ```Fedora/input/xccdf/system/accounts/physical.xml``` not altered. I'm unsure if it should be.)

This should close issue #2229 .