### PR TITLE
update severity of RHEL-07-021350 (fips=1) to HIGH to align w/DISA

### DIFF
--- a/shared/xccdf/system/software/integrity.xml
+++ b/shared/xccdf/system/software/integrity.xml
@@ -642,7 +642,7 @@ ossrg="SRG-OS-000033-GPOS-00014,SRG-OS-000396-GPOS-00176,SRG-OS-000478-GPOS-0022
 cui="3.13.11,3.13.8" />
 </Rule>
 
-<Rule id="grub2_enable_fips_mode" severity="medium" prodtype="rhel7">
+<Rule id="grub2_enable_fips_mode" severity="high" prodtype="rhel7">
 <title>Enable FIPS Mode in GRUB2</title>
 <description>
 To ensure FIPS mode is enabled, rebuild <tt>initramfs</tt> by running the following command:


### PR DESCRIPTION
from DISA:
`````<Rule id="SV-86691r2_rule" severity="high" weight="10.0"><version>RHEL-07-021350</version><title>The operating system must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect data requiring data-at-rest protections in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.</title>`````