### PR TITLE
update ntpd maxpoll to align with DISA

### DIFF
--- a/shared/xccdf/services/ntp.xml
+++ b/shared/xccdf/services/ntp.xml
@@ -66,7 +66,7 @@ information on the capabilities and configuration of each of the NTP daemons.
 <description>The maximum NTP or Chrony poll interval number in seconds.</description>
 <value selector="">10</value>
 <value selector="system_default">10</value>
-<value selector="disa">17</value>
+<value selector="17_seconds">17</value>
 </Value>
 
 <Rule id="service_chronyd_or_ntpd_enabled" severity="medium" prodtype="rhel7">

--- a/shared/xccdf/services/ntp.xml
+++ b/shared/xccdf/services/ntp.xml
@@ -64,7 +64,7 @@ information on the capabilities and configuration of each of the NTP daemons.
 <Value id="var_time_service_set_maxpoll" type="number" >
 <title>Maximum NTP or Chrony Poll</title>
 <description>The maximum NTP or Chrony poll interval number in seconds.</description>
-<value selector="">17</value>
+<value selector="">10</value>
 <value selector="system_default">10</value>
 <value selector="disa">17</value>
 </Value>


### PR DESCRIPTION
Original DISA drafts lowered the system default setting from 10 to 17. Apparently DISA quietly updated their value to align with system defaults. This PR adjusts  SSG to match.

`````
<fixtext fixref="F-78623r3_fix">Edit the "/etc/ntp.conf" file and add or update an entry to define "maxpoll" to "10" as follows:^M
^M
maxpoll 10^M
^M
If NTP was running and "maxpoll" was updated, the NTP service must be restarted:^M
^M
# systemctl restart ntpd^M
^M
If NTP was not running, it must be started:^M
^M
# systemctl start ntpd</fixtext>
`````