### PR TITLE
add container_build to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # Build files
 rpmbuild
 scap-security-guide.spec
+container_build/
 build/
 
 # Ignore docs tmp directories


### PR DESCRIPTION
Ignore the `container_build` directory when building with Docker.

https://github.com/OpenSCAP/scap-security-guide/commit/f646804f447bf041b4ca2c10a7422077ec044bee#diff-c21202b241d0cd40822db520c8b00770R141

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>