### PR TITLE
re-enable remediation for net.ipv6.conf.all.disable_ipv6 = 1

### DIFF
--- a/RHEL/7/templates/csv/sysctl_values.csv
+++ b/RHEL/7/templates/csv/sysctl_values.csv
@@ -24,7 +24,7 @@ net.ipv6.conf.default.accept_ra,
 net.ipv6.conf.default.accept_redirects,
 net.ipv6.conf.all.accept_ra,
 net.ipv6.conf.all.accept_redirects,
-#net.ipv6.conf.all.disable_ipv6,1
+net.ipv6.conf.all.disable_ipv6,1
 net.ipv6.conf.default.accept_source_route,
 net.ipv6.conf.all.accept_source_route,
 net.ipv6.conf.all.forwarding,


### PR DESCRIPTION
rule_sysctl_kernel_ipv6_disable is failing to remediate, wasn't sure why this was disabled in code.

I suppose one argument is we shouldn't be disabling entire IPv6 stacks. The opposite side being "then don't select it in your profile"