### PR TITLE
update manpage to have --oval-results in example

### DIFF
--- a/docs/scap-security-guide.8
+++ b/docs/scap-security-guide.8
@@ -321,13 +321,13 @@ Regardless of your system's workload all of these checks should pass.
 
 .SH EXAMPLES
 To scan your system utilizing the OpenSCAP utility against the
-stig-rhel6-server-upstream profile:
+ospp-rhel7 profile:
 
-oscap  xccdf eval --profile stig-rhel6-server-upstream \
+oscap xccdf eval --profile ospp-rhel7 \
 --results /tmp/`hostname`-ssg-results.xml \
 --report /tmp/`hostname`-ssg-results.html \
---cpe /usr/share/xml/scap/ssg/content/ssg-rhel6-cpe-dictionary.xml \
-/usr/share/xml/scap/ssg/content/ssg-rhel6-xccdf.xml
+--oval-results \
+/usr/share/xml/scap/ssg/content/ssg-rhel7-xccdf.xml
 .PP
 Additional details can be found on the projects wiki page:
 https://www.github.com/OpenSCAP/scap-security-guide/wiki


### PR DESCRIPTION
--oval-results has been useful in a few conversations over the past few days.

Here's a patch to include --oval-results in the manpage example of oscap CLI.