### PR TITLE
Check if sshd is expected by Profiles

### DIFF
--- a/debian8/templates/csv/packages_installed.csv
+++ b/debian8/templates/csv/packages_installed.csv
@@ -12,3 +12,4 @@ cron
 ntp
 rsyslog
 syslog-ng-core
+openssh-server

--- a/fedora/templates/csv/packages_installed.csv
+++ b/fedora/templates/csv/packages_installed.csv
@@ -3,3 +3,4 @@ chrony
 cronie
 firewalld
 libreswan
+openssh-server

--- a/rhel6/templates/csv/packages_installed.csv
+++ b/rhel6/templates/csv/packages_installed.csv
@@ -10,6 +10,7 @@ iptables-ipv6
 irqbalance
 ntp
 openswan
+openssh-server
 pam_pkcs11
 pcsc-lite
 policycoreutils

--- a/rhel7/checks/oval/sshd_disable_compression.xml
+++ b/rhel7/checks/oval/sshd_disable_compression.xml
@@ -7,12 +7,16 @@
       </affected>
       <description>SSH should either have compression disabled or set to delayed.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check Compression in /etc/ssh/sshd_config"
-      test_ref="test_sshd_disable_compression" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check Compression in /etc/ssh/sshd_config"
+        test_ref="test_sshd_disable_compression" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/rhel7/checks/oval/sshd_disable_gssapi_auth.xml
+++ b/rhel7/checks/oval/sshd_disable_gssapi_auth.xml
@@ -8,12 +8,16 @@
       <description>Unless needed, disable the GSSAPI authentication option for
 the SSH Server.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check GSSAPIAuthentication in /etc/ssh/sshd_config"
-      test_ref="test_sshd_disable_gssapi_auth" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check GSSAPIAuthentication in /etc/ssh/sshd_config"
+        test_ref="test_sshd_disable_gssapi_auth" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/rhel7/checks/oval/sshd_disable_kerb_auth.xml
+++ b/rhel7/checks/oval/sshd_disable_kerb_auth.xml
@@ -8,12 +8,16 @@
       <description>Unless needed, disable the Kerberos authentication option for
 the SSH Server.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check KerberosAuthentication in /etc/ssh/sshd_config"
-      test_ref="test_sshd_disable_kerb_auth" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check KerberosAuthentication in /etc/ssh/sshd_config"
+        test_ref="test_sshd_disable_kerb_auth" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/rhel7/checks/oval/sshd_enable_strictmodes.xml
+++ b/rhel7/checks/oval/sshd_enable_strictmodes.xml
@@ -8,12 +8,16 @@
       <description>Enable StrictMode to check users home directory permissions
 and configurations.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check StrictModes in /etc/ssh/sshd_config"
-      test_ref="test_sshd_enable_strictmodes" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check StrictModes in /etc/ssh/sshd_config"
+        test_ref="test_sshd_enable_strictmodes" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/rhel7/checks/oval/sshd_print_last_log.xml
+++ b/rhel7/checks/oval/sshd_print_last_log.xml
@@ -8,12 +8,16 @@
       <description>Enable PrintLastLogStrict to display user's last login time 
 and date.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check PrintLastLog in /etc/ssh/sshd_config"
-      test_ref="test_sshd_enable_printlastlog" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check PrintLastLog in /etc/ssh/sshd_config"
+        test_ref="test_sshd_enable_printlastlog" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/rhel7/checks/oval/sshd_use_approved_macs.xml
+++ b/rhel7/checks/oval/sshd_use_approved_macs.xml
@@ -9,12 +9,16 @@
     </metadata>
     <criteria operator="AND">
       <extend_definition comment="Installed OS is certified" definition_ref="installed_OS_is_certified" />
-      <criteria comment="SSH is not being used or conditions are met"
+      <criteria comment="SSH is not installed or conditions are met"
       operator="OR">
-        <extend_definition comment="sshd service is disabled"
-        definition_ref="service_sshd_disabled" />
-        <criterion comment="Check MACs in /etc/ssh/sshd_config"
-        test_ref="test_sshd_use_approved_macs" />
+        <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+        definition_ref="sshd_not_required_or_unset" />
+        <criteria comment="sshd is installed and configured" operator="AND">
+          <extend_definition comment="sshd is required and installed, or requirement is unset"
+          definition_ref="sshd_required_or_unset" />
+          <criterion comment="Check MACs in /etc/ssh/sshd_config"
+          test_ref="test_sshd_use_approved_macs" />
+        </criteria>
       </criteria>
     </criteria>
   </definition>

--- a/rhel7/checks/oval/sshd_use_priv_separation.xml
+++ b/rhel7/checks/oval/sshd_use_priv_separation.xml
@@ -8,12 +8,16 @@
       <description>Use priviledge separation to cause the SSH process to drop
 root privileges when not needed.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check UsePrivilegeSeparation in /etc/ssh/sshd_config"
-      test_ref="test_sshd_use_priv_separation" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check UsePrivilegeSeparation in /etc/ssh/sshd_config"
+        test_ref="test_sshd_use_priv_separation" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/rhel7/profiles/ospp-rhel7.xml
+++ b/rhel7/profiles/ospp-rhel7.xml
@@ -286,6 +286,8 @@ the consensus process.
 <select idref="service_rexec_disabled" selected="true" />
 <select idref="service_rlogin_disabled" selected="true" />
 <select idref="service_rsh_disabled" selected="true" />
+<!-- Other Rules will know that SSH is required to be installed -->
+<refine-value idref="sshd_required" selector="yes" />
 <select idref="service_sshd_enabled" selected="true" />
 <select idref="service_telnet_disabled" selected="true" />
 <select idref="service_xinetd_disabled" selected="true" />

--- a/rhel7/profiles/stig-rhel7-disa.xml
+++ b/rhel7/profiles/stig-rhel7-disa.xml
@@ -594,6 +594,8 @@ Storage deployments.
 <select idref="package_openssh-server_installed" selected="true" />
 
 <!-- SRG-OS-000423-GPOS-00187, SV-86859r2_rule, RHEL-07-040310 -->
+<!-- Other Rules will know that SSH is required to be installed -->
+<refine-value idref="sshd_required" selector="yes" />
 <select idref="service_sshd_enabled" selected="true" />
 
 <!-- SRG-OS-000163-GPOS-00072, SV-86861r2_rule, RHEL-07-040320 -->

--- a/shared/checks/oval/package_openssh-server_removed.xml
+++ b/shared/checks/oval/package_openssh-server_removed.xml
@@ -7,6 +7,8 @@
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_sle</platform>
+        <platform>multi_platform_wrlinux</platform>
+        <platform>multi_platform_opensuse</platform>
       </affected>
       <description>The RPM package openssh-server should be removed.</description>
     </metadata>

--- a/shared/checks/oval/sshd_allow_only_protocol2.xml
+++ b/shared/checks/oval/sshd_allow_only_protocol2.xml
@@ -9,13 +9,15 @@
       </affected>
       <description>The OpenSSH daemon should be running protocol 2.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met" operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <extend_definition comment="rpm package openssh-server removed"
-      definition_ref="package_openssh-server_removed" />
-      <criterion comment="Check Protocol in /etc/ssh/sshd_config"
-      test_ref="test_sshd_allow_only_protocol2" />
+    <criteria comment="SSH is not installed or conditions are met" operator="OR">
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check Protocol in /etc/ssh/sshd_config"
+        test_ref="test_sshd_allow_only_protocol2" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/shared/checks/oval/sshd_disable_empty_passwords.xml
+++ b/shared/checks/oval/sshd_disable_empty_passwords.xml
@@ -8,12 +8,16 @@
       <description>Remote connections from accounts with empty passwords should
       be disabled (and dependencies are met)</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check PermitEmptyPasswords in /etc/ssh/sshd_config"
-      negate="true" test_ref="test_sshd_permitemptypasswords_no" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check PermitEmptyPasswords in /etc/ssh/sshd_config"
+        negate="true" test_ref="test_sshd_permitemptypasswords_no" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"

--- a/shared/checks/oval/sshd_disable_rhosts.xml
+++ b/shared/checks/oval/sshd_disable_rhosts.xml
@@ -8,12 +8,16 @@
       <description>Emulation of the rsh command through the ssh server should
       be disabled (and dependencies are met)</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check IgnoreRhosts in /etc/ssh/sshd_config"
-      test_ref="test_sshd_rsh_emulation_disabled" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check IgnoreRhosts in /etc/ssh/sshd_config"
+        test_ref="test_sshd_rsh_emulation_disabled" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"

--- a/shared/checks/oval/sshd_disable_rhosts_rsa.xml
+++ b/shared/checks/oval/sshd_disable_rhosts_rsa.xml
@@ -8,12 +8,16 @@
       <description>SSH can allow authentication through the obsolete rsh command
       through the use of the authenticating user's SSH keys. This should be disabled.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check RhostsRSAAuthentication in /etc/ssh/sshd_config"
-      negate="true" test_ref="test_sshd_disable_rhosts_rsa" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check RhostsRSAAuthentication in /etc/ssh/sshd_config"
+        negate="true" test_ref="test_sshd_disable_rhosts_rsa" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"

--- a/shared/checks/oval/sshd_disable_root_login.xml
+++ b/shared/checks/oval/sshd_disable_root_login.xml
@@ -8,12 +8,16 @@
       <description>Root login via SSH should be disabled (and dependencies are
       met)</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check PermitRootLogin in /etc/ssh/sshd_config"
-      negate="true" test_ref="test_sshd_permitrootlogin_no" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check PermitRootLogin in /etc/ssh/sshd_config"
+        negate="true" test_ref="test_sshd_permitrootlogin_no" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"

--- a/shared/checks/oval/sshd_disable_user_known_hosts.xml
+++ b/shared/checks/oval/sshd_disable_user_known_hosts.xml
@@ -9,9 +9,15 @@
 to connect to systems if a cache of the remote systems public keys are available.
 This should be disabled.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met" operator="OR">
-      <extend_definition comment="sshd service is disabled" definition_ref="service_sshd_disabled" />
-      <criterion comment="Check IgnoreUserKnownHosts in /etc/ssh/sshd_config" test_ref="test_sshd_disable_user_known_hosts" />
+    <criteria comment="SSH is not installed or conditions are met" operator="OR">
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check IgnoreUserKnownHosts in /etc/ssh/sshd_config"
+        test_ref="test_sshd_disable_user_known_hosts" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/shared/checks/oval/sshd_do_not_permit_user_env.xml
+++ b/shared/checks/oval/sshd_do_not_permit_user_env.xml
@@ -7,12 +7,16 @@
       </affected>
       <description>PermitUserEnvironment should be disabled</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check PermitUserEnvironment in /etc/ssh/sshd_config"
-      negate="true" test_ref="test_sshd_no_user_envset" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check PermitUserEnvironment in /etc/ssh/sshd_config"
+        negate="true" test_ref="test_sshd_no_user_envset" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"

--- a/shared/checks/oval/sshd_enable_warning_banner.xml
+++ b/shared/checks/oval/sshd_enable_warning_banner.xml
@@ -8,12 +8,16 @@
       <description>SSH warning banner should be enabled (and dependencies are
       met)</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check Banner in /etc/ssh/sshd_config"
-      test_ref="test_sshd_banner_set" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check Banner in /etc/ssh/sshd_config"
+        test_ref="test_sshd_banner_set" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/shared/checks/oval/sshd_enable_x11_forwarding.xml
+++ b/shared/checks/oval/sshd_enable_x11_forwarding.xml
@@ -7,12 +7,16 @@
       </affected>
       <description>Enable X11Forwarding to encrypt X11 remote connections over SSH.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check X11Forwarding in /etc/ssh/sshd_config"
-      test_ref="test_sshd_enable_x11_forwarding" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check X11Forwarding in /etc/ssh/sshd_config"
+        test_ref="test_sshd_enable_x11_forwarding" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/shared/checks/oval/sshd_not_required_or_unset.xml
+++ b/shared/checks/oval/sshd_not_required_or_unset.xml
@@ -1,0 +1,38 @@
+<def-group>
+
+  <definition class="compliance" id="sshd_not_required_or_unset" version="1">
+    <metadata>
+      <title>SSHD is not required to be installed or requirement not set</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>If SSHD is not required, we check it is not installed. If SSH requirement is unset, we are good.</description>
+    </metadata>
+    <criteria comment="SSH not required or not set" operator="OR">
+      <criteria comment="SSH is not required and not installed" operator="AND">
+        <criterion test_ref="test_sshd_not_required" />
+        <extend_definition comment="rpm package openssh-server removed"
+        definition_ref="package_openssh-server_removed" />
+      </criteria>
+      <extend_definition comment="SSH requirement is unset"
+      definition_ref="sshd_requirement_unset" />
+    </criteria>
+  </definition>
+
+  <ind:variable_test id="test_sshd_not_required"
+  comment="Verify if Profile set Value sshd_required as not required"
+  check="all" check_existence="at_least_one_exists" version="1">
+    <ind:object object_ref="object_sshd_not_required" />
+    <ind:state state_ref="state_sshd_not_required" />
+  </ind:variable_test>
+  <ind:variable_object id="object_sshd_not_required" version="1">
+    <ind:var_ref>sshd_required</ind:var_ref>
+  </ind:variable_object>
+  <ind:variable_state id="state_sshd_not_required" version="1">
+      <ind:value operation="equals" datatype="int" var_check="at least one" >1</ind:value >
+  </ind:variable_state>
+
+  <external_variable comment="May be defined by Profiles to explicitly say if sshd is required or not" datatype="int"
+  id="sshd_required" version="1" />
+</def-group>
+

--- a/shared/checks/oval/sshd_not_required_or_unset.xml
+++ b/shared/checks/oval/sshd_not_required_or_unset.xml
@@ -29,7 +29,7 @@
     <ind:var_ref>sshd_required</ind:var_ref>
   </ind:variable_object>
   <ind:variable_state id="state_sshd_not_required" version="1">
-      <ind:value operation="equals" datatype="int" var_check="at least one" >1</ind:value >
+      <ind:value operation="equals" datatype="int">1</ind:value>
   </ind:variable_state>
 
   <external_variable comment="May be defined by Profiles to explicitly say if sshd is required or not" datatype="int"

--- a/shared/checks/oval/sshd_required_or_unset.xml
+++ b/shared/checks/oval/sshd_required_or_unset.xml
@@ -1,0 +1,37 @@
+<def-group>
+
+  <definition class="compliance" id="sshd_required_or_unset" version="1">
+    <metadata>
+      <title>SSHD is required to be installed or requirement not set</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>If SSHD is required, we check it is installed. If SSH requirement is unset, we are good.</description>
+    </metadata>
+    <criteria comment="SSH required or not set" operator="OR">
+      <criteria comment="SSH is required and installed" operator="AND">
+        <criterion test_ref="test_sshd_required" />
+        <extend_definition comment="rpm package openssh-server installed"
+        definition_ref="package_openssh-server_installed" />
+      </criteria>
+      <extend_definition comment="SSH requirement is unset"
+      definition_ref="sshd_requirement_unset" />
+    </criteria>
+  </definition>
+
+  <ind:variable_test id="test_sshd_required"
+  comment="Verify if Profile set Value sshd_required as required"
+  check="all" check_existence="at_least_one_exists" version="1">
+    <ind:object object_ref="object_sshd_required" />
+    <ind:state state_ref="state_sshd_required" />
+  </ind:variable_test>
+  <ind:variable_object id="object_sshd_required" version="1">
+    <ind:var_ref>sshd_required</ind:var_ref>
+  </ind:variable_object>
+  <ind:variable_state id="state_sshd_required" version="1">
+      <ind:value operation="equals" datatype="int" var_check="at least one" >2</ind:value >
+  </ind:variable_state>
+
+  <external_variable comment="May be defined by Profiles to explicitly say if sshd is required or not" datatype="int"
+  id="sshd_required" version="1" />
+</def-group>

--- a/shared/checks/oval/sshd_required_or_unset.xml
+++ b/shared/checks/oval/sshd_required_or_unset.xml
@@ -29,7 +29,7 @@
     <ind:var_ref>sshd_required</ind:var_ref>
   </ind:variable_object>
   <ind:variable_state id="state_sshd_required" version="1">
-      <ind:value operation="equals" datatype="int" var_check="at least one" >2</ind:value >
+      <ind:value operation="equals" datatype="int">2</ind:value>
   </ind:variable_state>
 
   <external_variable comment="May be defined by Profiles to explicitly say if sshd is required or not" datatype="int"

--- a/shared/checks/oval/sshd_requirement_unset.xml
+++ b/shared/checks/oval/sshd_requirement_unset.xml
@@ -1,0 +1,31 @@
+<def-group>
+
+  <definition class="compliance" id="sshd_requirement_unset" version="1">
+    <metadata>
+      <title>It doesn't matter if sshd is installed or not</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Test if value sshd_required is 0.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_sshd_requirement_unset" />
+    </criteria>
+  </definition>
+  <ind:variable_test id="test_sshd_requirement_unset"
+  comment="Verify if Value of sshd_required is the default"
+  check="all" check_existence="at_least_one_exists" version="1">
+    <ind:object object_ref="object_sshd_requirement_unknown" />
+    <ind:state state_ref="state_sshd_requirement_unset" />
+  </ind:variable_test>
+  <ind:variable_object id="object_sshd_requirement_unknown" version="1">
+    <ind:var_ref>sshd_required</ind:var_ref>
+  </ind:variable_object>
+  <ind:variable_state id="state_sshd_requirement_unset" version="1">
+      <ind:value operation="equals" datatype="int" var_check="at least one" >0</ind:value >
+  </ind:variable_state>
+
+  <external_variable comment="May be defined by Profiles to explicitly say if sshd is required or not" datatype="int"
+  id="sshd_required" version="1" />
+</def-group>
+

--- a/shared/checks/oval/sshd_requirement_unset.xml
+++ b/shared/checks/oval/sshd_requirement_unset.xml
@@ -22,7 +22,7 @@
     <ind:var_ref>sshd_required</ind:var_ref>
   </ind:variable_object>
   <ind:variable_state id="state_sshd_requirement_unset" version="1">
-      <ind:value operation="equals" datatype="int" var_check="at least one" >0</ind:value >
+      <ind:value operation="equals" datatype="int">0</ind:value>
   </ind:variable_state>
 
   <external_variable comment="May be defined by Profiles to explicitly say if sshd is required or not" datatype="int"

--- a/shared/checks/oval/sshd_set_idle_timeout.xml
+++ b/shared/checks/oval/sshd_set_idle_timeout.xml
@@ -8,12 +8,16 @@
       <description>The SSH idle timeout interval should be set to an
       appropriate value.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check ClientAliveInterval in /etc/ssh/sshd_config"
-      test_ref="test_sshd_idle_timeout" />
+        <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+        definition_ref="sshd_not_required_or_unset" />
+        <criteria comment="sshd is installed and configured" operator="AND">
+          <extend_definition comment="sshd is required and installed, or requirement is unset"
+          definition_ref="sshd_required_or_unset" />
+          <criterion comment="Check ClientAliveInterval in /etc/ssh/sshd_config"
+        test_ref="test_sshd_idle_timeout" />
+      </criteria>
     </criteria>
   </definition>
 

--- a/shared/checks/oval/sshd_set_keepalive.xml
+++ b/shared/checks/oval/sshd_set_keepalive.xml
@@ -8,12 +8,16 @@
       <description>The SSH ClientAliveCountMax should be set to an appropriate
       value (and dependencies are met)</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
+    <criteria comment="SSH is not installed or conditions are met"
     operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check ClientAliveCountMax in /etc/ssh/sshd_config"
-      test_ref="test_sshd_clientalivecountmax" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check ClientAliveCountMax in /etc/ssh/sshd_config"
+        test_ref="test_sshd_clientalivecountmax" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/shared/checks/oval/sshd_use_approved_ciphers.xml
+++ b/shared/checks/oval/sshd_use_approved_ciphers.xml
@@ -9,12 +9,16 @@
     </metadata>
     <criteria operator="AND">
       <extend_definition comment="Installed OS is certified" definition_ref="installed_OS_is_certified" />
-      <criteria comment="SSH is not being used or conditions are met"
+      <criteria comment="SSH is not installed or conditions are met"
       operator="OR">
-        <extend_definition comment="sshd service is disabled"
-        definition_ref="service_sshd_disabled" />
-        <criterion comment="Check the Cipers list in /etc/ssh/sshd_config"
-        test_ref="test_sshd_use_approved_ciphers" />
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+          <criterion comment="Check the Cipers list in /etc/ssh/sshd_config"
+          test_ref="test_sshd_use_approved_ciphers" />
+        </criteria>
       </criteria>
     </criteria>
   </definition>

--- a/shared/checks/oval/sshd_use_approved_macs.xml
+++ b/shared/checks/oval/sshd_use_approved_macs.xml
@@ -9,12 +9,16 @@
     </metadata>
     <criteria operator="AND">
       <extend_definition comment="Installed OS is certified" definition_ref="installed_OS_is_certified" />
-      <criteria comment="SSH is not being used or conditions are met"
+      <criteria comment="SSH is not installed or conditions are met"
       operator="OR">
-        <extend_definition comment="sshd service is disabled"
-        definition_ref="service_sshd_disabled" />
-        <criterion comment="Check MACs in /etc/ssh/sshd_config"
-        test_ref="test_sshd_use_approved_macs" />
+        <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+        definition_ref="sshd_not_required_or_unset" />
+        <criteria comment="sshd is installed and configured" operator="AND">
+          <extend_definition comment="sshd is required and installed, or requirement is unset"
+          definition_ref="sshd_required_or_unset" />
+          <criterion comment="Check MACs in /etc/ssh/sshd_config"
+          test_ref="test_sshd_use_approved_macs" />
+        </criteria>
       </criteria>
     </criteria>
   </definition>

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -468,16 +468,20 @@
             <xsl:value-of select="$ovaluri" />
           </xsl:attribute>
 
-          <xsl:if test="@value">
+          <xsl:for-each select="@*">
+          <xsl:choose>
+          <xsl:when test="contains(name(),'value')">
             <check-export>
               <xsl:attribute name="export-name">
-                <xsl:value-of select="@value" />
+                <xsl:value-of select="." />
               </xsl:attribute>
               <xsl:attribute name="value-id">
-                <xsl:value-of select="@value" />
+                <xsl:value-of select="." />
               </xsl:attribute>
             </check-export>
-          </xsl:if>
+          </xsl:when>
+          </xsl:choose>
+          </xsl:for-each>
 
           <check-content-ref>
             <xsl:attribute name="href">

--- a/shared/utils/relabel-ids.py
+++ b/shared/utils/relabel-ids.py
@@ -467,8 +467,8 @@ def main():
                                              checkcontentref.get("name"))
             checkcontentref.set("name", checkid)
             checkcontentref.set("href", newovalfile)
-            checkexport = check.find("./{%s}check-export" % xccdf_ns)
-            if checkexport is not None:
+            checkexports = check.findall("./{%s}check-export" % xccdf_ns)
+            for checkexport in checkexports:
                 newexportname = translator.generate_id("{" + oval_ns + "}variable",
                                                        checkexport.get("export-name"))
                 checkexport.set("export-name", newexportname)

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -490,7 +490,7 @@ opportunity for unauthorized personnel to take control of a management session
 enabled on the console or console port that has been let unattended.
 </rationale>
 <ident prodtype="rhel7" cce="27433-2" />
-<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value"/>
+<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value" value2="sshd_required" />
 <ref prodtype="rhel7" stigid="040320" />
 <ref nist="AC-2(5),SA-8(i),AC-12" disa="1133,2361" srg="SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109" pcidss="Req-8.1.8" cis="6.2.12" cjis="5.5.6" cui="3.1.11" />
 </Rule>
@@ -834,7 +834,7 @@ DoD Information Systems are required to use FIPS-approved cryptographic hash
 functions. The only SSHv2 hash algorithms meeting this requirement is SHA2.
 </rationale>
 <ident prodtype="rhel7" cce="27455-5" />
-<oval id="sshd_use_approved_macs" value="sshd_approved_macs" />
+<oval id="sshd_use_approved_macs" value="sshd_approved_macs" value2="sshd_required" />
 <ref prodtype="rhel7" stigid="040400" />
 <ref nist="AC-17(2),IA-7,SC-13" disa="1453" srg="SRG-OS-000250-GPOS-00093" cui="3.1.13,3.13.11,3.13.8" />
 </Rule>

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -73,7 +73,7 @@ operator="equals" interactive="0">
 <description>Specify if the Policy requires SSH to be installed. Used by SSH Rules
 to determine if SSH should be uninstalled or configured.<br />
 A value of 0 means that the policy doesn't care if OpenSSH server is installed or not. If it is installed, scanner will check for it's configuration, if it's not installed, the check will pass.<br />
-A value of 1 indicates that OpensSH server package is not required by policy;<br />
+A value of 1 indicates that OpenSSH server package is not required by the policy;<br />
 A value of 2 indicates that OpenSSH server package is required by the policy.<br /></description>
 <value selector="">0</value>
 <value selector="no">1</value>

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -71,7 +71,10 @@ operator="equals" interactive="0">
 operator="equals" interactive="0">
 <title>SSH is required to be installed</title>
 <description>Specify if the Policy requires SSH to be installed. Used by SSH Rules
-to determine if SSH should be uninstalled or configured.</description>
+to determine if SSH should be uninstalled or configured.<br />
+A value of 0 means that the policy doesn't care if OpenSSH server is installed or not. If it is installed, scanner will check for it's configuration, if it's not installed, the check will pass.<br />
+A value of 1 indicates that OpensSH server package is not required by policy;<br />
+A value of 2 indicates that OpenSSH server package is required by the policy.<br /></description>
 <value selector="">0</value>
 <value selector="no">1</value>
 <value selector="yes">2</value>

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -227,7 +227,7 @@ has many well-known vulnerability exploits. Exploits of the SSH daemon could pro
 immediate root access to the system.
 </rationale>
 <ident prodtype="rhel7" cce="27320-1" />
-<oval id="sshd_allow_only_protocol2" />
+<oval id="sshd_allow_only_protocol2" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040390" />
 <ref nist="AC-17(8).1(ii),IA-5(1)(c)" disa="197,366" cis="5.2.2"
 srg="SRG-OS-000074-GPOS-00042,SRG-OS-000480-GPOS-00227" cjis="5.5.6" cui="3.1.13,3.5.4" />
@@ -270,7 +270,7 @@ applications. Allowing GSSAPI authentication through SSH exposes the system's
 GSSAPI to remote hosts, increasing the attack surface of the system.
 </rationale>
 <ident prodtype="rhel7" cce="80220-7" />
-<oval id="sshd_disable_gssapi_auth" />
+<oval id="sshd_disable_gssapi_auth" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040430" />
 <ref nist="CM-6(c)" disa="368,318,1812,1813,1814" srg="SRG-OS-000364-GPOS-00151" cui="3.1.12" />
 </Rule>
@@ -295,7 +295,7 @@ system's Kerberos implementation. Vulnerabilities in the system's Kerberos
 implementations may be subject to exploitation.
 </rationale>
 <ident prodtype="rhel7" cce="80221-5" />
-<oval id="sshd_disable_kerb_auth" />
+<oval id="sshd_disable_kerb_auth" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040440" />
 <ref nist="CM-6(c)" disa="368,318,1812,1813,1814" srg="SRG-OS-000364-GPOS-00151" cui="3.1.12" />
 </Rule>
@@ -319,7 +319,7 @@ If other users have access to modify user-specific SSH configuration files, they
 may be able to log into the system as another user.
 </rationale>
 <ident prodtype="rhel7" cce="80222-3" />
-<oval id="sshd_enable_strictmodes" />
+<oval id="sshd_enable_strictmodes" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040450" />
 <ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
@@ -343,7 +343,7 @@ when not needed which would decrease the impact of software vulnerabilities in
 the unprivileged section.
 </rationale>
 <ident prodtype="rhel7" cce="80223-1" />
-<oval id="sshd_use_priv_separation" />
+<oval id="sshd_use_priv_separation" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040460" />
 <ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
@@ -370,7 +370,7 @@ vulnerabilities in the compression software could result in compromise of the
 system from an unauthenticated connection, potentially wih root privileges.
 </rationale>
 <ident prodtype="rhel7" cce="80224-9" />
-<oval id="sshd_disable_compression" />
+<oval id="sshd_disable_compression" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040470" />
 <ref nist="CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
@@ -393,7 +393,7 @@ Providing users feedback on when account accesses last occurred facilitates user
 recognition and reporting of unauthorized account use.
 </rationale>
 <ident prodtype="rhel7" cce="80225-6" />
-<oval id="sshd_print_last_log" />
+<oval id="sshd_print_last_log" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040360" />
 <ref nist="AC-9" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
@@ -512,7 +512,7 @@ This ensures a user login will be terminated as soon as the <tt>ClientAliveCount
 is reached.
 </rationale>
 <ident prodtype="rhel7" cce="27082-7" />
-<oval id="sshd_set_keepalive" />
+<oval id="sshd_set_keepalive" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040340" />
 <ref nist="AC-2(5),SA-8,AC-12" disa="1133,2361" srg="SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109" cis="6.2.12" cjis="5.5.6" cui="3.1.11" />
 </Rule>
@@ -556,7 +556,7 @@ SSH trust relationships mean a compromise on one host
 can allow an attacker to move trivially to other hosts.
 </rationale>
 <ident prodtype="rhel7" cce="27377-1" />
-<oval id="sshd_disable_rhosts" />
+<oval id="sshd_disable_rhosts" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040350" />
 <ref nist="AC-3,CM-6(a)" disa="366" cis="6.2.6" srg="SRG-OS-000480-GPOS-00227" cjis="5.5.6" cui="3.1.12" />
 </Rule>
@@ -580,7 +580,7 @@ assurance that remove login via SSH will require a password, even
 in the event of misconfiguration elsewhere.
 </rationale>
 <ident prodtype="rhel7" cce="80372-6" />
-<oval id="sshd_disable_user_known_hosts" />
+<oval id="sshd_disable_user_known_hosts" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040380" />
 <ref nist="CM-6(a)" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
@@ -603,7 +603,7 @@ assurance that remove login via SSH will require a password, even
 in the event of misconfiguration elsewhere.
 </rationale>
 <ident prodtype="rhel7" cce="80373-4" />
-<oval id="sshd_disable_rhosts_rsa" />
+<oval id="sshd_disable_rhosts_rsa" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040330" />
 <ref nist="CM-6(a)" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
@@ -650,7 +650,7 @@ Open X displays allow an attacker to capture keystrokes and to execute commands
 remotely.
 </rationale>
 <ident prodtype="rhel7" cce="80226-4" />
-<oval id="sshd_enable_x11_forwarding" />
+<oval id="sshd_enable_x11_forwarding" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040710" />
 <ref nist="CM-2(1)(b)" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.13" />
 </Rule>
@@ -674,7 +674,7 @@ accountability of actions performed on the system and also helps to minimize
 direct attack attempts on root's password.
 </rationale>
 <ident prodtype="rhel7" cce="27445-6" />
-<oval id="sshd_disable_root_login" />
+<oval id="sshd_disable_root_login" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040370" />
 <ref nist="AC-3,AC-6(2),IA-2(1),IA-2(5)" disa="366" srg="SRG-OS-000480-GPOS-00227"
 cis="5.2.8" cjis="5.5.6" cui="3.1.1, 3.1.5" />
@@ -699,7 +699,7 @@ remote login via SSH will require a password, even in the event of
 misconfiguration elsewhere.
 </rationale>
 <ident prodtype="rhel7" cce="27471-2" />
-<oval id="sshd_disable_empty_passwords" />
+<oval id="sshd_disable_empty_passwords" value="sshd_required" />
 <ref prodtype="rhel7" stigid="010300" />
 <ref nist="AC-3,AC-6,CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00229" cjis="5.5.6"
 cui="3.1.1,3.1.5" cis="5.2.9"/>
@@ -724,7 +724,7 @@ whose ownership should not be obvious should ensure usage of a banner that does
 not provide easy attribution.
 </rationale>
 <ident prodtype="rhel7" cce="27314-4" />
-<oval id="sshd_enable_warning_banner" />
+<oval id="sshd_enable_warning_banner" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040170" />
 <ref nist="AC-8(a),AC-8(b),AC-8(c)(1),AC-8(c)(2),AC-8(c)(3)"
 disa="48,50,1384,1385,1386,1387,1388"
@@ -750,7 +750,7 @@ SSH environment options potentially allow users to bypass
 access restriction in some configurations.
 </rationale>
 <ident prodtype="rhel7" cce="27363-1" />
-<oval id="sshd_do_not_permit_user_env" />
+<oval id="sshd_do_not_permit_user_env" value="sshd_required" />
 <ref prodtype="rhel7" stigid="010460" />
 <ref nist="CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00229" 
 cis="5.2.10" cjis="5.5.6" cui="3.1.12" />
@@ -794,7 +794,7 @@ utilize authentication that meets industry and government requirements. For gove
 Security Levels 1, 2, 3, or 4 for use on Red Hat Enterprise Linux.
 </rationale>
 <ident prodtype="rhel7" cce="27295-5" />
-<oval id="sshd_use_approved_ciphers" />
+<oval id="sshd_use_approved_ciphers" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040110" />
 <ref nist="AC-3,AC-17(2),AU-10(5),CM-6(b),IA-5(1)(c),IA-7" disa="68,366,803"
 srg="SRG-OS-000033-GPOS-00014,SRG-OS-000120-GPOS-00061,SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093,SRG-OS-000393-GPOS-00173"

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -67,6 +67,16 @@ operator="equals" interactive="0">
 <value selector="default">hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com</value>
 </Value>
 
+<Value id="sshd_required" type="number"
+operator="equals" interactive="0">
+<title>SSH is required to be installed</title>
+<description>Specify if the Policy requires SSH to be installed. Used by SSH Rules
+to determine if SSH should be uninstalled or configured.</description>
+<value selector="">0</value>
+<value selector="no">1</value>
+<value selector="yes">2</value>
+</Value>
+
 <Rule id="package_openssh-server_installed" severity="medium" prodtype="rhel7">
 <title>Install the OpenSSH Server Package</title>
 <description>

--- a/sle11/checks/oval/package_openssh-server_installed.xml
+++ b/sle11/checks/oval/package_openssh-server_installed.xml
@@ -1,0 +1,24 @@
+<def-group>
+  <definition class="compliance" id="package_openssh-server_installed"
+  version="1">
+    <metadata>
+      <title>Package openssh-server Installed</title>
+      <affected family="unix">
+        <platform>SUSE Linux Enterprise 11</platform>
+      </affected>
+      <description>The RPM package openssh-server should be installed.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="package openssh-server is installed"
+      test_ref="test_package_openssh-server_installed" />
+    </criteria>
+  </definition>
+  <linux:rpminfo_test check="all" check_existence="all_exist"
+  id="test_package_openssh-server_installed" version="1"
+  comment="package openssh-server is installed">
+    <linux:object object_ref="obj_package_openssh-server_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_openssh-server_installed" version="1">
+    <linux:name>openssh-server</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/ubuntu14/templates/csv/packages_installed.csv
+++ b/ubuntu14/templates/csv/packages_installed.csv
@@ -8,5 +8,6 @@
 # file under oval_5.11/templates directory!!!
 #
 ntp,
+openssh-server,
 rsyslog,
 syslog-ng,

--- a/ubuntu16/templates/csv/packages_installed.csv
+++ b/ubuntu16/templates/csv/packages_installed.csv
@@ -8,5 +8,6 @@
 # file under oval_5.11/templates directory!!!
 #
 ntp,
+openssh-server,
 rsyslog,
 syslog-ng,

--- a/wrlinux/checks/oval/package_openssh-server_installed.xml
+++ b/wrlinux/checks/oval/package_openssh-server_installed.xml
@@ -1,0 +1,24 @@
+<def-group>
+  <definition class="compliance" id="package_openssh-server_installed"
+  version="1">
+    <metadata>
+      <title>Package openssh-server Installed</title>
+      <affected family="unix">
+        <platform>Wind River Linux 8</platform>
+      </affected>
+      <description>The RPM package openssh-server should be installed.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="package openssh-server is installed"
+      test_ref="test_package_openssh-server_installed" />
+    </criteria>
+  </definition>
+  <linux:rpminfo_test check="all" check_existence="all_exist"
+  id="test_package_openssh-server_installed" version="1"
+  comment="package openssh-server is installed">
+    <linux:object object_ref="obj_package_openssh-server_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_openssh-server_installed" version="1">
+    <linux:name>openssh-server</linux:name>
+  </linux:rpminfo_object>
+</def-group>


### PR DESCRIPTION
Adds Value `sshd_expected` that must be refined when selecting Rules `service_sshd_enabled` or `service_sshd_disabled`. This value sets expectation about sshd presence, and prepares other sshd related Rules to evaluate correctly.

```
<refine-value idref="sshd_expected" selector="yes" />
<select idref="service_sshd_enabled" selected="true" />
```

These changes also extended "Rule/oval" element and allows multiples values to be exported to OVAL checks.

Fixes #2154.