### PR TITLE
Fix selector for var_time_service_set_maxpoll

### DIFF
--- a/RHEL/7/profiles/stig-rhel7-disa.xml
+++ b/RHEL/7/profiles/stig-rhel7-disa.xml
@@ -44,7 +44,7 @@ Storage deployments.
 <refine-value idref="var_password_pam_retry" selector="3" />
 <refine-value idref="var_accounts_max_concurrent_login_sessions" selector="10" />
 <refine-value idref="var_accounts_tmout" selector="10_min" />
-<refine-value idref="var_time_service_set_maxpoll" selector="disa" />
+<refine-value idref="var_time_service_set_maxpoll" selector="17_seconds" />
 <refine-value idref="sysctl_net_ipv4_conf_all_accept_source_route_value" selector="disabled" />
 <refine-value idref="sysctl_net_ipv4_conf_default_accept_source_route_value" selector="disabled" />
 <refine-value idref="sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" selector="enabled" />


### PR DESCRIPTION
Use 17_seconds instead of non existent disa selector.

Follows changes made in #2252.