### PR TITLE
[WIP] Online environment detection for remediation

### DIFF
--- a/shared/bash_remediation_functions/online_environment.sh
+++ b/shared/bash_remediation_functions/online_environment.sh
@@ -1,0 +1,31 @@
+# Function to check if we are remediating an online environment
+# Use this function to idenfity an on-line remediation and perform
+# changes suitable for runtime only.
+# 
+# An online environment is one in which the binaries from filesystem
+# are running. Such environment can be a:
+# - Bare metal machine
+# - Virtual machine
+# - Running container
+# 
+# We use inode number of root directory to verify if we are online.
+# If inode number of root directory is not 2 we are in a chrooted environment,
+# and we are very likely remediating one of the following environemnts:
+# - Anaconda install
+# - Chrooted filesystem
+# - Container image build
+# - Running container
+#
+# Which are all offline environments, except the running container.
+# 
+
+function online_environment {
+    inode=$(ls -di / | cut -d ' ' -f1)
+
+    if [ $inode -eq "2" ]
+    then
+        return 0
+    else
+        return 1
+    fi
+}

--- a/shared/bash_remediation_functions/service_command.sh
+++ b/shared/bash_remediation_functions/service_command.sh
@@ -46,15 +46,17 @@ else
   chkconfig_state="off"
 fi
 
+inode=$(ls -di / | cut -d ' ' -f1)
 # If chkconfig_util is not empty, use chkconfig/service commands.
 if ! [ "x$chkconfig_util" = x ] ; then
-  if online_environment
+
+  if [ $inode -eq "2" ]
   then
       $service_util $service $service_operation
   fi
   $chkconfig_util --level 0123456 $service $chkconfig_state
 else
-  if online_environment
+  if [ $inode -eq "2" ]
   then
       $service_util $service_operation $service
   fi

--- a/shared/bash_remediation_functions/service_command.sh
+++ b/shared/bash_remediation_functions/service_command.sh
@@ -48,10 +48,16 @@ fi
 
 # If chkconfig_util is not empty, use chkconfig/service commands.
 if ! [ "x$chkconfig_util" = x ] ; then
-  $service_util $service $service_operation
+  if online_environment
+  then
+      $service_util $service $service_operation
+  fi
   $chkconfig_util --level 0123456 $service $chkconfig_state
 else
-  $service_util $service_operation $service
+  if online_environment
+  then
+      $service_util $service_operation $service
+  fi
   $service_util $service_state $service
 fi
 


### PR DESCRIPTION
This attempts to create a bash function to try to differentiate an online from an offline environment during remediation.

I assume that if we are scanning a chrooted filesystem, it is always an offline scan. Is there a scenario in witch this is not true?

Use of this function will be to avoid doing runtime configurations when remediating an offline scan.
Example of runtime configurations are starting a service, or rely on running services to apply fixes.