### PR TITLE
Firewalld open sshd port

### DIFF
--- a/Fedora/profiles/common.xml
+++ b/Fedora/profiles/common.xml
@@ -53,6 +53,7 @@
 <!-- Network Configuration and Firewalls section rules -->
   <select idref="service_firewalld_enabled" selected="true"/>
   <select idref="set_firewalld_default_zone" selected="true"/>
+  <select idref="firewalld_sshd_port_enabled" selected="true"/>
 
 <!-- System Accounting with Auditd section rules -->
 

--- a/Fedora/profiles/common.xml
+++ b/Fedora/profiles/common.xml
@@ -53,7 +53,6 @@
 <!-- Network Configuration and Firewalls section rules -->
   <select idref="service_firewalld_enabled" selected="true"/>
   <select idref="set_firewalld_default_zone" selected="true"/>
-  <select idref="firewalld_sshd_port_enabled" selected="true"/>
 
 <!-- System Accounting with Auditd section rules -->
 

--- a/RHEL/7/profiles/cjis-rhel7-server.xml
+++ b/RHEL/7/profiles/cjis-rhel7-server.xml
@@ -110,6 +110,7 @@ https://www.fbi.gov/services/cjis/cjis-security-policy-resource-center
 <select idref="kernel_module_sctp_disabled" selected="true"/>
 <select idref="service_firewalld_enabled" selected="true"/>
 <select idref="set_firewalld_default_zone" selected="true"/>
+<select idref="firewalld_sshd_port_enabled" selected="true"/>
 <refine-value idref="sshd_idle_timeout_value" selector="5_minutes" />
 
 <!-- 5.10.1.1 Boundary Protection -->

--- a/RHEL/7/profiles/ospp-rhel7.xml
+++ b/RHEL/7/profiles/ospp-rhel7.xml
@@ -114,6 +114,7 @@ the consensus process.
 
 <select idref="service_firewalld_enabled" selected="true" />
 <select idref="set_firewalld_default_zone" selected="true" />
+<select idref="firewalld_sshd_port_enabled" selected="true"/>
 <select idref="sysctl_kernel_ipv6_disable" selected="true" />
 <select idref="sysctl_net_ipv4_conf_all_accept_redirects" selected="true" />
 <select idref="sysctl_net_ipv4_conf_all_accept_source_route" selected="true" />

--- a/RHEL/7/profiles/rht-ccp.xml
+++ b/RHEL/7/profiles/rht-ccp.xml
@@ -91,6 +91,7 @@
 <select idref="kernel_module_sctp_disabled" selected="true"/>
 <select idref="service_firewalld_enabled" selected="true"/>
 <select idref="set_firewalld_default_zone" selected="true"/>
+<select idref="firewalld_sshd_port_enabled" selected="true"/>
 
 <!-- <select idref="sysctl_kernel_randomize_va_space" selected="true"/>
 <select idref="enable_execshield" selected="true"/>

--- a/shared/templates/static/bash/configure_firewalld_ports.sh
+++ b/shared/templates/static/bash/configure_firewalld_ports.sh
@@ -8,4 +8,37 @@
 
 package_command install firewalld
 
-firewall-cmd --permanent --add-service=ssh
+populate firewalld_sshd_zone
+
+# This assumes that firewalld_sshd_zone is one of the pre-defined zones
+if [ ! -f /etc/firewalld/zones/${firewalld_sshd_zone}.xml ]; then
+    cp /usr/lib/firewalld/zones/${firewalld_sshd_zone}.xml /etc/firewalld/zones/${firewalld_sshd_zone}.xml
+fi
+if ! grep -q 'service name="ssh"' /etc/firewalld/zones/${firewalld_sshd_zone}.xml; then
+    sed -i '/<\/description>/a \
+  <service name="ssh"/>' /etc/firewalld/zones/${firewalld_sshd_zone}.xml
+fi
+
+# Check if any eth interface is bounded to the zone with SSH service enabled
+nic_bound=false
+eth_interface_list=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep -E '^(en|eth)')
+for interface in $eth_interface_list; do
+    if grep -q "ZONE=$firewalld_sshd_zone" /etc/sysconfig/network-scripts/ifcfg-$interface; then
+        nic_bound=true
+        break;
+    fi
+done
+
+if [ $nic_bound = false ];then
+    # Add first NIC to SSH enabled zone
+
+    if ! firewall-cmd --state -q; then
+        replace_or_append "/etc/sysconfig/network-scripts/ifcfg-${eth_interface_list[0]}" '^ZONE=' "$firewalld_sshd_zone" '@CCENUM@' '%s=%s'
+    else
+        # If firewalld service is running, we need to do this step with firewall-cmd
+        # Otherwise firewalld will comunicate with NetworkManage and will revert assigned zone
+        # of NetworkManager managed interfaces upon reload
+        firewall-cmd --zone=$firewalld_sshd_zone --add-interface=${eth_interface_list[0]}
+        firewall-cmd --reload
+    fi
+fi

--- a/shared/templates/static/bash/configure_firewalld_ports.sh
+++ b/shared/templates/static/bash/configure_firewalld_ports.sh
@@ -1,0 +1,11 @@
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# reboot = false
+# complexity = low
+# strategy = configure
+# disruption = low
+
+. /usr/share/scap-security-guide/remediation_functions
+
+package_command install firewalld
+
+firewall-cmd --permanent --add-service=ssh

--- a/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
+++ b/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
@@ -8,10 +8,13 @@
 
 package_command install firewalld
 populate sshd_listening_port
+populate firewalld_sshd_zone
 
 if [ $sshd_listening_port -ne 22 ] ; then
   firewall-cmd --permanent --service=ssh --add-port=$sshd_listening_port/tcp
   firewall-cmd --permanent --service=ssh --remove-port=22/tcp
 fi
 
-firewall-cmd --permanent --zone=public --add-service=ssh
+# Return code is 0 even if zone already enables SSH service,
+# so we just try to add SSH to the zone fearlessly
+firewall-cmd --permanent --zone=$firewalld_sshd_zone --add-service=ssh

--- a/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
+++ b/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
@@ -26,7 +26,7 @@ firewall-cmd --permanent --zone=$firewalld_sshd_zone --add-service=ssh
 
 # Check if any eth interface is bounded to the zone with SSH service enabled
 nic_bound=false
-eth_interface_list=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep '^en')
+eth_interface_list=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep -E '^(en|eth)')
 for interface in $eth_interface_list; do
     zone_of_interface=$(firewall-cmd --get-zone-of-interface=$interface)
     if [ "$zone_of_interface" == "$firewalld_sshd_zone" ]; then

--- a/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
+++ b/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
@@ -23,3 +23,19 @@ fi
 # Return code is 0 even if zone already enables SSH service,
 # so we just try to add SSH to the zone fearlessly
 firewall-cmd --permanent --zone=$firewalld_sshd_zone --add-service=ssh
+
+# Check if any eth interface is bounded to the zone with SSH service enabled
+nic_bound=false
+eth_interface_list=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep '^en')
+for interface in $eth_interface_list; do
+    zone_of_interface=$(firewall-cmd --get-zone-of-interface=$interface)
+    if [ "$zone_of_interface" == "$ssh_zone" ]; then
+        nic_bound=true
+        break;
+    fi
+done
+
+if [ nic_bound = false ];then
+    # Add first NIC to SSH enabled zone
+    firewall-cmd --zone=$firewalld_sshd_zone --add-interface=${eth_interface_list[0]}
+fi

--- a/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
+++ b/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
@@ -7,7 +7,9 @@
 . /usr/share/scap-security-guide/remediation_functions
 
 package_command install firewalld
+
 populate sshd_listening_port
+
 populate firewalld_sshd_zone
 
 if [ $sshd_listening_port -ne 22 ] ; then

--- a/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
+++ b/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
@@ -11,8 +11,13 @@ populate sshd_listening_port
 populate firewalld_sshd_zone
 
 if [ $sshd_listening_port -ne 22 ] ; then
+  # Remove all ports from SSH service
+  ssh_ports=$(firewall-cmd --permanent --service=ssh --get-ports)
+  for port in $ssh_ports; do
+      firewall-cmd --permanent --service=ssh --remove-port=$port
+  done
+
   firewall-cmd --permanent --service=ssh --add-port=$sshd_listening_port/tcp
-  firewall-cmd --permanent --service=ssh --remove-port=22/tcp
 fi
 
 # Return code is 0 even if zone already enables SSH service,

--- a/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
+++ b/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
@@ -29,13 +29,13 @@ nic_bound=false
 eth_interface_list=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep '^en')
 for interface in $eth_interface_list; do
     zone_of_interface=$(firewall-cmd --get-zone-of-interface=$interface)
-    if [ "$zone_of_interface" == "$ssh_zone" ]; then
+    if [ "$zone_of_interface" == "$firewalld_sshd_zone" ]; then
         nic_bound=true
         break;
     fi
 done
 
-if [ nic_bound = false ];then
+if [ $nic_bound = false ];then
     # Add first NIC to SSH enabled zone
     firewall-cmd --zone=$firewalld_sshd_zone --add-interface=${eth_interface_list[0]}
 fi

--- a/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
+++ b/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
@@ -13,25 +13,32 @@ populate sshd_listening_port
 populate firewalld_sshd_zone
 
 if [ $sshd_listening_port -ne 22 ] ; then
-  # Remove all ports from SSH service
-  ssh_ports=$(firewall-cmd --permanent --service=ssh --get-ports)
-  for port in $ssh_ports; do
-      firewall-cmd --permanent --service=ssh --remove-port=$port
-  done
+    # Remove all ports from SSH service
 
-  firewall-cmd --permanent --service=ssh --add-port=$sshd_listening_port/tcp
+    if [ ! -f /etc/firewalld/services/ssh.xml ]; then
+        cp /usr/lib/firewalld/services/ssh.xml /etc/firewall/services/ssh.xml
+    fi
+
+    sed -i '/<port port="[0-9]+" protocol="\S+"\/>/d' /etc/firewalld/services/ssh.xml
+    # Add port defined in sshd_listening_port to ssh service
+    sed -i "/<\/description>/a \
+  <port port=\"$sshd_listening_port\" protocol=\"tcp\"/>" /etc/firewalld/services/ssh.xml
 fi
 
-# Return code is 0 even if zone already enables SSH service,
-# so we just try to add SSH to the zone fearlessly
-firewall-cmd --permanent --zone=$firewalld_sshd_zone --add-service=ssh
+# This assumes that firewalld_sshd_zone is one of the pre-defined zones
+if [ ! -f /etc/firewalld/zones/${firewalld_sshd_zone}.xml ]; then
+    cp /usr/lib/firewalld/zones/${firewalld_sshd_zone}.xml /etc/firewalld/zones/${firewalld_sshd_zone}.xml
+fi
+if ! grep -q 'service name="ssh"' /etc/firewalld/zones/${firewalld_sshd_zone}.xml; then
+    sed -i '/<\/description>/a \
+  <service name="ssh"/>' /etc/firewalld/zones/${firewalld_sshd_zone}.xml
+fi
 
 # Check if any eth interface is bounded to the zone with SSH service enabled
 nic_bound=false
 eth_interface_list=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep -E '^(en|eth)')
 for interface in $eth_interface_list; do
-    zone_of_interface=$(firewall-cmd --get-zone-of-interface=$interface)
-    if [ "$zone_of_interface" == "$firewalld_sshd_zone" ]; then
+    if grep -q "ZONE=$firewalld_sshd_zone" /etc/sysconfig/network-scripts/ifcfg-$interface; then
         nic_bound=true
         break;
     fi
@@ -39,7 +46,14 @@ done
 
 if [ $nic_bound = false ];then
     # Add first NIC to SSH enabled zone
-    firewall-cmd --zone=$firewalld_sshd_zone --add-interface=${eth_interface_list[0]}
-fi
 
-firewall-cmd --reload
+    if ! firewall-cmd --state -q; then
+        replace_or_append "/etc/sysconfig/network-scripts/ifcfg-${eth_interface_list[0]}" '^ZONE=' "$firewalld_sshd_zone" '@CCENUM@' '%s=%s'
+    else
+        # If firewalld service is running, we need to do this step with firewall-cmd
+        # Otherwise firewalld will comunicate with NetworkManage and will revert assigned zone
+        # of NetworkManager managed interfaces upon reload
+        firewall-cmd --zone=$firewalld_sshd_zone --add-interface=${eth_interface_list[0]}
+        firewall-cmd --reload
+    fi
+fi

--- a/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
+++ b/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
@@ -10,7 +10,8 @@ package_command install firewalld
 populate sshd_listening_port
 
 if [ $sshd_listening_port -ne 22 ] ; then
-  firewall-cmd --permanent --add-port=$sshd_listening_port/tcp
-else
-  firewall-cmd --permanent --add-service=ssh
+  firewall-cmd --permanent --service=ssh --add-port=$sshd_listening_port/tcp
+  firewall-cmd --permanent --service=ssh --remove-port=22/tcp
 fi
+
+firewall-cmd --permanent --zone=public --add-service=ssh

--- a/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
+++ b/shared/templates/static/bash/firewalld_sshd_port_enabled.sh
@@ -39,3 +39,5 @@ if [ nic_bound = false ];then
     # Add first NIC to SSH enabled zone
     firewall-cmd --zone=$firewalld_sshd_zone --add-interface=${eth_interface_list[0]}
 fi
+
+firewall-cmd --reload

--- a/shared/templates/static/oval/firewalld_sshd_port_enabled.xml
+++ b/shared/templates/static/oval/firewalld_sshd_port_enabled.xml
@@ -51,7 +51,7 @@
     <ind:xpath>/zone/service[@name='ssh']</ind:xpath>
   </ind:xmlfilecontent_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="any_exist" comment="ssh port is enabled in zones"
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="ssh port is enabled in zones"
   id="test_firewalld_zone_sshd_port_enabled" version="1">
     <ind:object object_ref="object_firewalld_zone_sshd_port_enabled" />
     <ind:state state_ref="state_sshd_listening_port" />

--- a/shared/templates/static/oval/firewalld_sshd_port_enabled.xml
+++ b/shared/templates/static/oval/firewalld_sshd_port_enabled.xml
@@ -11,7 +11,10 @@
     <criteria operator="OR">
       <criterion comment="ssh service is enabled in services" test_ref="test_firewalld_service_sshd_enabled" />
       <criterion comment="ssh port is enabled in services" test_ref="test_firewalld_service_sshd_port_enabled" />
-      <criterion comment="ssh service is enabled in zones" test_ref="test_firewalld_zone_sshd_enabled" />
+      <criteria operator="AND">
+        <criterion comment="ssh service is enabled in zones" test_ref="test_firewalld_zone_sshd_enabled" />
+        <criterion comment="there is at least one NIC assigned to a zone with ssh enabled" test_ref="test_nic_assigned_to_sshd_enabled_zone" />
+      </criteria>
       <criterion comment="ssh port is enabled in zones" test_ref="test_firewalld_zone_sshd_port_enabled" />
     </criteria>
   </definition>
@@ -58,6 +61,39 @@
     <ind:filename operation="pattern match">^.*\.xml$</ind:filename>
     <ind:pattern operation="pattern match">&lt;port.*port="(\d+)"</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Grab list of zones which enable service ssh -->
+  <local_variable id="var_firewalld_sshd_enabled_zones" datatype="string" version="1" comment="firewalld zones with ssh service enabled">
+    <regex_capture pattern="(\S+).xml">
+      <object_component item_field="filename" object_ref="object_firewalld_zone_sshd_enabled" />
+    </regex_capture>
+  </local_variable>
+
+  <!-- check if any of the zones with NIC assigned allows sshd service -->
+  <ind:xmlfilecontent_test check="all" check_existence="at_least_one_exists" comment="ssh service is enabled in zones"
+  id="test_nic_assigned_to_sshd_enabled_zone" version="1">
+    <ind:object object_ref="object_zones_with_nics" />
+  </ind:xmlfilecontent_test>
+  <ind:xmlfilecontent_object id="object_zones_with_nics" version="1">
+    <ind:path>/etc/firewalld/zones</ind:path>
+    <ind:filename operation="pattern match" var_check="at least one" var_ref="var_firewalld_zones_with_assigned_nics"/>
+    <ind:xpath>/zone/service[@name='ssh']</ind:xpath>
+  </ind:xmlfilecontent_object>
+
+  <!-- List of Zones with NIC assigned to it -->
+  <local_variable id="var_firewalld_zones_with_assigned_nics" datatype="string" version="1" comment="firewalld zones with ssh service enabled">
+        <concat>
+         <object_component item_field="subexpression" object_ref="object_nic_assigned_to_firewalld_zone" />
+            <literal_component>.xml</literal_component>
+        </concat>
+  </local_variable>
+  <ind:textfilecontent54_object comment="Check config of all NIC"
+  id="object_nic_assigned_to_firewalld_zone" version="1">
+    <ind:path>/etc/sysconfig/network-scripts</ind:path>
+    <ind:filename operation="pattern match">ifcfg-.*</ind:filename>
+    <ind:pattern operation="pattern match">^ZONE=(.*)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state comment="port ssh is listening" id="state_sshd_listening_port" version="1">

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -42,11 +42,19 @@ operator="equals" interactive="0">
 </Value>
 
 <Value id="firewalld_sshd_zone" type="string"
-operator="equals" interactive="1">
+operator="equals" interactive="0">
 <title>SSH enabled firewalld zone</title>
-<description>Specify firewalld zone to enable SSH service. This value is used only by remediation.</description>
+<description>Specify firewalld zone to enable SSH service. This value is used only for remediation purposes.</description>
 <value selector="">public</value>
-<value selector="default">public</value>
+<value selector="block">block</value>
+<value selector="dmz">dmz</value>
+<value selector="drop">drop</value>
+<value selector="external">external</value>
+<value selector="home">home</value>
+<value selector="internal">internal</value>
+<value selector="public">public</value>
+<value selector="trusted">trusted</value>
+<value selector="work">work</value>
 </Value>
 
 <Value id="sshd_approved_macs" type="string"

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -41,6 +41,14 @@ operator="equals" interactive="0">
 <value selector="default">22</value>
 </Value>
 
+<Value id="firewalld_sshd_zone" type="string"
+operator="equals" interactive="1">
+<title>SSH enabled firewalld zone</title>
+<description>Specify firewalld zone to enable SSH service. This value is used only by remediation.</description>
+<value selector="">public</value>
+<value selector="default">public</value>
+</Value>
+
 <Value id="sshd_approved_macs" type="string"
 operator="equals" interactive="0">
 <title>SSH Approved MACs by FIPS</title>

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_firewalld_sshd_port_enabled/no_nic_in_ssh_zone.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_firewalld_sshd_port_enabled/no_nic_in_ssh_zone.fail.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+# ensure firewalld installed
+yum install firewalld
+
+# Make sure there is a zone with ssh service enabled
+firewall-cmd --permanent --zone=work --add-service=ssh
+
+all_zones=$(firewall-cmd --get-zones)
+eth_interfaces=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep -E '^(en|eth)')
+
+# Make sure NICs are bounded to no zone
+# Note: Interfaces managed by NetworkManager will be assigned to the default firewalld zone
+for zone in $all_zones; do
+    for interface in $eth_interfaces; do
+        firewall-cmd --permanent --zone=$zone --remove-interface=$eth_interface
+    done
+done
+
+# Do not reload, otherwise SSG Test suite will be locked out
+# firewall-cmd --reload

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_firewalld_sshd_port_enabled/no_nic_in_ssh_zone.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_firewalld_sshd_port_enabled/no_nic_in_ssh_zone.fail.sh
@@ -15,7 +15,7 @@ eth_interfaces=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep -E 
 # Note: Interfaces managed by NetworkManager will be assigned to the default firewalld zone
 for zone in $all_zones; do
     for interface in $eth_interfaces; do
-        firewall-cmd --permanent --zone=$zone --remove-interface=$eth_interface
+        firewall-cmd --permanent --zone=$zone --remove-interface=$interface
     done
 done
 

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_firewalld_sshd_port_enabled/no_ssh_zone.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_firewalld_sshd_port_enabled/no_ssh_zone.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+# ensure firewalld installed
+yum install firewalld
+
+all_zones=$(firewall-cmd --get-zones)
+for zone in $all_zones;do
+    firewall-cmd --permanent --zone=$zone --remove-service=ssh
+done
+
+# Do not reload, otherwise SSG Test suite will be locked out
+# firewall-cmd --reload

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_firewalld_sshd_port_enabled/ssh_zone_and_nic_mismatch.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_firewalld_sshd_port_enabled/ssh_zone_and_nic_mismatch.fail.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+# ensure firewalld installed
+yum install firewalld
+
+# Make sure there is only one zone with ssh service enabled
+all_zones=$(firewall-cmd --get-zones)
+for zone in $all_zones;do
+    firewall-cmd --permanent --zone=$zone --remove-service=ssh
+done
+firewall-cmd --permanent --zone=work --add-service=ssh
+
+all_interfaces=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1)
+
+# Make sure NICs are bounded to no zone
+for zone in $all_zones; do
+    for interface in $all_interfaces; do
+        firewall-cmd --permanent --zone=$zone --remove-interface=$interface
+    done
+done
+
+eth_interfaces=$(echo "$all_interfaces" | grep -E '^(en|eth)')
+# Add interface to wrong zone
+firewall-cmd --permanent --zone=trusted --add-interface=${eth_interfaces[0]}
+
+# Do not reload, otherwise SSG Test suite will be locked out
+# firewall-cmd --reload

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_firewalld_sshd_port_enabled/ssh_zone_nic_bounded.pass.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_firewalld_sshd_port_enabled/ssh_zone_nic_bounded.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+# ensure firewalld installed
+yum install firewalld
+
+firewall-cmd --permanent --zone=public --add-service=ssh
+
+eth_interface=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep -E '^(en|eth)')
+
+firewall-cmd --permanent --zone=public --add-interface=${eth_interface[0]}


### PR DESCRIPTION
Select Rule `firewalld_sshd_port_enabled` in Profiles that
- set default zone drop for firewalld and
- allows sshd to be enabled
Except for `stig-rhel7-disa` Profile.

Add remediation for `configure_firewalld_ports`, used only by `stig-rhel7-disa` Profile.

Add OVAL definition to check if current default zone allows ssh. The check fetches current set default zone from `/etc/firewalld/firewalld.conf` and verifies if it allows ssh service.

**Issue:** Above check will lead us to a situation where we will need two runs of scans and remediation.
During first scan, all zones, and current zone will allow service ssh. But then remediation will change default zone to `drop`. And default zone `drop` is not customized to allow `ssh`, and a second run of remediation will be needed.
**Question:** Can we compromise on this check and always check for `/etc/firewalld/zones/drop.xml`?