### PR TITLE
Fix expansion of multiple bash populate instances

### DIFF
--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -284,11 +284,19 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
                     # This chunk contains call of 'populate' function
                     if "populate" in fixparts[idx]:
                         varname, fixtextcontribution = get_populate_replacement(remediation_type, fixparts[idx])
-                        # Append the contribution
-                        fix.text += fixtextcontribution
                         # Define new XCCDF <sub> element for the variable
-                        xccdfvarsub = ElementTree.Element("sub",
+                        xccdfvarsub = ElementTree.SubElement(fix, "sub",
                                                         idref=varname)
+
+                        # If this is first sub element,
+                        # the textcontribution needs to go to fix text
+                        # other wise, append to last subelement
+                        if list(fix).index(xccdfvarsub) == 0:
+                            fix.text += fixtextcontribution
+                        else:
+                            previouselem = fix[list(fix).index(xccdfvarsub) - 1]
+                            previouselem.tail += fixtextcontribution
+
                         # If second pair element is not empty, append it as
                         # tail for the subelement (prefixed with closing '"')
                         if fixparts[idx + 1] is not None:
@@ -296,8 +304,6 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
                         # Otherwise append just enclosing '"'
                         else:
                             xccdfvarsub.tail = '"' + '\n'
-                        # Append the new subelement to the fix element
-                        fix.append(xccdfvarsub)
                     # This chunk contains call of other remediation function
                     else:
                         # Extract remediation function name


### PR DESCRIPTION
Multiple calls of populate in bash remediations were messing the fix.
All contribution texts were being inserted before the first sub element.

Like this:
```
sshd_listening_port="
firewalld_sshd_zone="<ns0:sub idref="xccdf_org.ssgproject.content_value_sshd_listening_port" use="legacy"/>"
<ns0:sub idref="xccdf_org.ssgproject.content_value_firewalld_sshd_zone" use="legacy"/>"
```

With these changes we check if contribution text needs to go in fix.text
or tail of previous sub element.