### PR TITLE
template_BASH_sebool_var: Fix template missing remediation functions

### DIFF
--- a/shared/templates/template_BASH_sebool_var
+++ b/shared/templates/template_BASH_sebool_var
@@ -5,6 +5,7 @@
 # disruption = low
 # Include source function library.
 
+. /usr/share/scap-security-guide/remediation_functions
 populate var_%SEBOOLID%
 
 setsebool -P %SEBOOLID% var_%SEBOOLID%


### PR DESCRIPTION
Populate is not expanded correctly in sebool remediations using
variable.