### PR TITLE
[WIP] Remove .service from service OVAL template files

### DIFF
--- a/OpenStack/RHEL-OSP/7/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/OpenStack/RHEL-OSP/7/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -25,6 +25,6 @@
   </linux:systemdunitdependency_object>
 
   <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_off" comment="%SERVICENAME% is not listed in the dependencies" version="1">
-    <linux:dependency entity_check="none satisfy">%SERVICENAME%.service</linux:dependency>
+    <linux:dependency entity_check="none satisfy">%SERVICENAME%</linux:dependency>
   </linux:systemdunitdependency_state>
 </def-group>

--- a/OpenStack/RHEL-OSP/7/templates/oval_5.11_templates/template_OVAL_service_enabled
+++ b/OpenStack/RHEL-OSP/7/templates/oval_5.11_templates/template_OVAL_service_enabled
@@ -25,6 +25,6 @@
   </linux:systemdunitdependency_object>
 
   <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_on" comment="%SERVICENAME% listed at least once in the dependencies" version="1">
-    <linux:dependency entity_check="at least one">%SERVICENAME%.service</linux:dependency>
+    <linux:dependency entity_check="at least one">%SERVICENAME%</linux:dependency>
   </linux:systemdunitdependency_state>
 </def-group>

--- a/RHEL/7/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/RHEL/7/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -25,6 +25,6 @@
   </linux:systemdunitdependency_object>
 
   <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_off" comment="%SERVICENAME% is not listed in the dependencies" version="1">
-    <linux:dependency entity_check="none satisfy">%SERVICENAME%.service</linux:dependency>
+    <linux:dependency entity_check="none satisfy">%SERVICENAME%</linux:dependency>
   </linux:systemdunitdependency_state>
 </def-group>

--- a/RHEL/7/templates/oval_5.11_templates/template_OVAL_service_enabled
+++ b/RHEL/7/templates/oval_5.11_templates/template_OVAL_service_enabled
@@ -25,6 +25,6 @@
   </linux:systemdunitdependency_object>
 
   <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_on" comment="%SERVICENAME% listed at least once in the dependencies" version="1">
-    <linux:dependency entity_check="at least one">%SERVICENAME%.service</linux:dependency>
+    <linux:dependency entity_check="at least one">%SERVICENAME%</linux:dependency>
   </linux:systemdunitdependency_state>
 </def-group>

--- a/Ubuntu/14.04/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/Ubuntu/14.04/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -25,6 +25,6 @@
   </linux:systemdunitdependency_object>
 
   <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_off" comment="%SERVICENAME% is not listed in the dependencies" version="1">
-    <linux:dependency entity_check="none satisfy">%SERVICENAME%.service</linux:dependency>
+    <linux:dependency entity_check="none satisfy">%SERVICENAME%</linux:dependency>
   </linux:systemdunitdependency_state>
 </def-group>

--- a/Ubuntu/14.04/templates/oval_5.11_templates/template_OVAL_service_enabled
+++ b/Ubuntu/14.04/templates/oval_5.11_templates/template_OVAL_service_enabled
@@ -25,6 +25,6 @@
   </linux:systemdunitdependency_object>
 
   <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_on" comment="%SERVICENAME% listed at least once in the dependencies" version="1">
-    <linux:dependency entity_check="at least one">%SERVICENAME%.service</linux:dependency>
+    <linux:dependency entity_check="at least one">%SERVICENAME%</linux:dependency>
   </linux:systemdunitdependency_state>
 </def-group>

--- a/Ubuntu/16.04/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/Ubuntu/16.04/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -25,6 +25,6 @@
   </linux:systemdunitdependency_object>
 
   <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_off" comment="%SERVICENAME% is not listed in the dependencies" version="1">
-    <linux:dependency entity_check="none satisfy">%SERVICENAME%.service</linux:dependency>
+    <linux:dependency entity_check="none satisfy">%SERVICENAME%</linux:dependency>
   </linux:systemdunitdependency_state>
 </def-group>

--- a/Ubuntu/16.04/templates/oval_5.11_templates/template_OVAL_service_enabled
+++ b/Ubuntu/16.04/templates/oval_5.11_templates/template_OVAL_service_enabled
@@ -25,6 +25,6 @@
   </linux:systemdunitdependency_object>
 
   <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_on" comment="%SERVICENAME% listed at least once in the dependencies" version="1">
-    <linux:dependency entity_check="at least one">%SERVICENAME%.service</linux:dependency>
+    <linux:dependency entity_check="at least one">%SERVICENAME%</linux:dependency>
   </linux:systemdunitdependency_state>
 </def-group>


### PR DESCRIPTION
- Some services run as systemd socket units versus service units. Other services can run as both. 
  This removes .service from the OVAL templates so that both .socket and .service can be handled.
- Fixes #2157