### PR TITLE
Services are machine only

### DIFF
--- a/shared/xccdf/services/cron.xml
+++ b/shared/xccdf/services/cron.xml
@@ -5,6 +5,7 @@ be executed at a later time. The cron service is required by almost
 all systems to perform necessary maintenance tasks, while at may or
 may not be required on a given system. Both daemons should be
 configured defensively.</description>
+<platform idref="cpe:/a:machine" />
 
 <Rule id="service_crond_enabled" severity="medium" prodtype="rhel7">
 <title>Enable cron Service</title>

--- a/shared/xccdf/services/mail.xml
+++ b/shared/xccdf/services/mail.xml
@@ -22,6 +22,7 @@ Postfix was coded with security in mind and can also be more effectively contain
 SELinux as its modular design has resulted in separate processes performing specific actions.
 More information is available on its website, <weblink-macro link="http://www.postfix.org"/>.
 </description>
+<platform idref="cpe:/a:machine" />
 
 <Rule id="service_postfix_enabled" prodtype="rhel7">
 <title>Enable Postfix Service</title>

--- a/shared/xccdf/services/ntp.xml
+++ b/shared/xccdf/services/ntp.xml
@@ -53,6 +53,7 @@ The upstream manual pages at <weblink-macro link="http://chrony.tuxfamily.org/ma
 <tt>chronyd</tt> and <weblink-macro link="http://www.ntp.org"/> for <tt>ntpd</tt> provide additional
 information on the capabilities and configuration of each of the NTP daemons.
 </description>
+<platform idref="cpe:/a:machine" />
 
 <Value id="var_multiple_time_servers" type="string" >
 <title>Vendor Approved Time Servers</title>

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -9,6 +9,7 @@ detailed documentation is available from its website,
 <weblink-macro link="http://www.openssh.org"/>. Its server program 
 is called <tt>sshd</tt> and provided by the RPM package
 <tt>openssh-server</tt>.</description>
+<platform idref="cpe:/a:machine" />
 
 <Value id="sshd_idle_timeout_value" type="number"
 operator="equals" interactive="0">

--- a/shared/xccdf/services/sssd.xml
+++ b/shared/xccdf/services/sssd.xml
@@ -11,6 +11,7 @@ For more information, see
 <os-type-macro type="rhel6"><b><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/SSSD-Introduction.html"/></b></os-type-macro>
 <os-type-macro type="rhel7"><b><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/SSSD.html"/></b></os-type-macro>
 </description>
+<platform idref="cpe:/a:machine" />
 
 <Rule id="package_sssd_installed" severity="medium" prodtype="rhel6,rhel7">
 <title prodtype="rhel6,rhel7">Install the SSSD Package</title>

--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -454,6 +454,7 @@ smart card (CAC) authentication:
 that provided by a username and password combination. Smart cards leverage PKI
 (public key infrastructure) in order to provide and verify credentials.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80207-4" />
 <oval id="smartcard_auth" />
 <ref prodtype="rhel7" stigid="010500" />

--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -316,6 +316,7 @@ can reboot the system. If accidentally pressed, as could happen in
 the case of mixed OS environment, this can create the risk of short-term
 loss of availability of systems due to unintentional reboot.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Disabling the <tt>Ctrl-Alt-Del</tt> key sequence
 with <tt>SystemD</tt> DOES NOT disable the <tt>Ctrl-Alt-Del</tt> key sequence
 if running in <tt>graphical.target</tt> mode (e.g. in GNOME, KDE, etc.)! The

--- a/shared/xccdf/system/logging.xml
+++ b/shared/xccdf/system/logging.xml
@@ -16,6 +16,7 @@ a central logging server.
 This section discusses how to configure rsyslog for
 best effect, and how to use tools provided with the system to maintain and
 monitor logs.</description>
+<platform idref="cpe:/a:machine" />
 
 <Rule id="package_rsyslog_installed" severity="medium" prodtype="rhel7">
 <title>Ensure rsyslog is Installed</title>

--- a/shared/xccdf/system/network/firewalld.xml
+++ b/shared/xccdf/system/network/firewalld.xml
@@ -18,6 +18,7 @@ immediately implemented. There is no need to save or apply the changes. No
 unintended disruption of existing network connections occurs as no part of
 the firewall has to be reloaded.
 </description>
+<platform idref="cpe:/a:machine" />
 
 <Group id="firewalld_activation">
 <title>Inspect and Activate Default firewalld Rules</title>

--- a/shared/xccdf/system/software/integrity.xml
+++ b/shared/xccdf/system/software/integrity.xml
@@ -128,6 +128,7 @@ system. The operating system's Information Management Officer (IMO)/Information 
 Security Officer (ISSO) and System Administrators (SAs) must be notified via email and/or
 monitoring system trap when there is an unauthorized modification of a configuration item.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="26952-2" />
 <oval id="aide_periodic_cron_checking"/>
 <ref prodtype="rhel7" stigid="020030" />

--- a/shared/xccdf/system/software/integrity.xml
+++ b/shared/xccdf/system/software/integrity.xml
@@ -554,6 +554,7 @@ and running, run the following command(s):
 Virus scanning software can be used to detect if a system has been compromised by
 computer viruses, as well as to limit their spread to other systems.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <warning category="general">Due to McAfee HIPS being 3rd party software, automated
 remediation is not available for this configuration check.</warning>
 <oval id="install_mcafee_antivirus" />
@@ -573,6 +574,7 @@ for Linux and McAfee Host-based Security System (HBSS) services.
 Virus scanning software can be used to detect if a system has been compromised by
 computer viruses, as well as to limit their spread to other systems.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <oval id="service_nails_enabled" />
 <ident prodtype="rhel7" cce="80128-2" />
 <ref nist="SC-28,SI-3,SI-3(1)(ii)" disa="366,1239,1668"
@@ -593,6 +595,7 @@ $ sudo ls -la avvscan.dat avvnames.dat avvclean.dat</pre>
 Virus scanning software can be used to detect if a system has been compromised by
 computer viruses, as well as to limit their spread to other systems.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <!--oval id="mcafee_antivirus_definitions_updated" /-->
 <ident prodtype="rhel7" cce="80129-0" />
 <ref prodtype="rhel7" stigid="032010" />


### PR DESCRIPTION
Let's not apply Rules related to enabling or configuring services on containers.

Checking these Rules will result in false positives most of the time.
A services configured in a container will not be started unless
an init system is the entry point and starts them or they
are the entry points them selves.