### PR TITLE
Update JBoss install OVAL check

### DIFF
--- a/JBoss/EAP/6/templates/static/oval/installed_app_is_eap6.xml
+++ b/JBoss/EAP/6/templates/static/oval/installed_app_is_eap6.xml
@@ -20,10 +20,21 @@
       <reference source="CPE" ref_id="cpe:/a:redhat:jboss_enterprise_application_platform:6.3.3" />
       <reference source="CPE" ref_id="cpe:/a:redhat:jboss_enterprise_application_platform:6.4.4" />
     </metadata>
-    <criteria>
+    <criteria operator="OR">
       <criterion test_ref="test_installed_eap_version_6" />
+      <criterion test_ref="test_installed_eap_version_6_container" />
+      <criterion test_ref="test_package_eap6_installed" />
     </criteria>
   </definition>
+
+  <linux:rpminfo_test check="all" check_existence="all_exist"
+  id="test_package_eap6_installed" version="1"
+  comment="package eap6 is installed">
+    <linux:object object_ref="obj_package_eap6_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_eap6_installed" version="1">
+    <linux:name>eap6</linux:name>
+  </linux:rpminfo_object>
 
   <ind:environmentvariable58_object id="obj_env_installed_eap6_home" version="1">
     <ind:pid xsi:nil="true" datatype="int" />
@@ -34,13 +45,23 @@
     <ind:object object_ref="obj_installed_eap_version_6" />
     <ind:state state_ref="state_installed_eap_version_6" />
   </ind:textfilecontent54_test>
-
   <ind:textfilecontent54_object id="obj_installed_eap_version_6" version="1">
     <ind:path var_ref="local_var_installed_eap_version_6"/>
     <ind:filename>version.txt</ind:filename>
-    <ind:pattern operation="pattern match">Red[\s]+Hat[\s]+JBoss[\s]+Enterprise[\s]+Application[\s]+Platform[\s]+\-[\s]+Version[\s]+6\.[0-4]+\.[0-9]+\.GA</ind:pattern>
+    <ind:pattern operation="pattern match">Red[\s]+Hat[\s]+JBoss[\s]+Enterprise[\s]+Application[\s]+Platform[\s]+\-[\s]+Version[\s]+(.*)GA</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_installed_eap_version_6_container" version="1" check="all" comment="Check EAP Version">
+    <ind:object object_ref="obj_installed_eap_version_6_container" />
+    <ind:state state_ref="state_installed_eap_version_6" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_installed_eap_version_6_container" version="1">
+    <ind:filepath>/opt/eap/version.txt</ind:filepath>
+    <ind:pattern operation="pattern match">Red[\s]+Hat[\s]+JBoss[\s]+Enterprise[\s]+Application[\s]+Platform[\s]+\-[\s]+Version[\s]+(.*)GA</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
   <ind:textfilecontent54_state id="state_installed_eap_version_6" version="1">
     <ind:subexpression operation="pattern match">6\.[0-4]+\.[0-9]+</ind:subexpression>
   </ind:textfilecontent54_state>


### PR DESCRIPTION
- Add capability to check for RPMs, RH container installs, and ENV variable installs
- Fix regex issue