### PR TITLE
Update references transforms

### DIFF
--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -13,7 +13,8 @@
 <xsl:variable name="cnss1253uri">http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf</xsl:variable>
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>
-<xsl:variable name="disa-srguri">http://iase.disa.mil/stigs/srgs/Pages/index.aspx</xsl:variable>
+<xsl:variable name="disa-ossrguri">http://iase.disa.mil/stigs/os/general/Pages/index.aspx</xsl:variable>
+<xsl:variable name="disa-appsrguri">http://iase.disa.mil/stigs/app-security/app-servers/Pages/index.aspx</xsl:variable>
 <!-- Fix for issue https://github.com/OpenSCAP/scap-security-guide/issues/1035 -->
 <xsl:variable name="disa-stigs-os-unix-linux-uri">http://iase.disa.mil/stigs/os/unix-linux/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-stigs-os-mainframe-uri">http://iase.disa.mil/stigs/os/mainframe/Pages/index.aspx</xsl:variable>

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -445,7 +445,14 @@
             <xsl:value-of select="normalize-space(concat($os-stigid-concat, .))" />
           </xsl:when>
           <xsl:otherwise>
-            <xsl:value-of select="normalize-space($refitem)" />
+            <xsl:choose>
+              <xsl:when test="name() = 'disa'">
+                <xsl:value-of select='format-number($refitem, "CCI-000000")' />
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="normalize-space($refitem)" />
+              </xsl:otherwise>
+            </xsl:choose>
           </xsl:otherwise>
         </xsl:choose>
       </reference>

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -425,9 +425,12 @@
               <xsl:value-of select="$cisuri" />
             </xsl:if>
           </xsl:if>
-          <xsl:if test="$refsource = 'ossrg'">
-            <xsl:if test="$disa-srguri != 'empty'">
-              <xsl:value-of select="$disa-srguri" />
+          <xsl:if test="$refsource = 'srg'">
+            <xsl:if test="starts-with($refitem, 'SRG-OS-')">
+              <xsl:value-of select="$disa-ossrguri" />
+            </xsl:if>
+            <xsl:if test="starts-with($refitem, 'SRG-APP-')">
+              <xsl:value-of select="$disa-appsrguri" />
             </xsl:if>
           </xsl:if>
           <xsl:if test="$refsource = 'stigid'">

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -388,8 +388,9 @@
 
   <!-- output individual reference -->
   <xsl:template name="ref-output">
-      <xsl:param name="refsource"/>
-      <xsl:param name="refitem"/>
+    <xsl:param name="refsource"/>
+    <xsl:param name="refitem"/>
+    <xsl:if test="$refitem != ''">
       <reference>
         <xsl:attribute name="href">
         <!-- populate the href attribute with a global reference-->
@@ -445,6 +446,7 @@
           </xsl:otherwise>
         </xsl:choose>
       </reference>
+    </xsl:if>
   </xsl:template>
 
   <!-- expand reference to OVAL ID -->

--- a/shared/transforms/shared_xccdf2stigformat.xslt
+++ b/shared/transforms/shared_xccdf2stigformat.xslt
@@ -75,9 +75,12 @@ xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/sch
 		<xsl:for-each select="cdf:reference[@href=$disa-cciuri]">
 			<ident system="{$disa-cciuri}">CCI-<xsl:value-of select="format-number(text(),'000000')"/></ident>
 		</xsl:for-each>
-		<xsl:for-each select="cdf:reference[@href=$disa-srguri]">
-			<ident system="{$disa-srguri}"><xsl:value-of select="text()"/></ident>
+		<xsl:for-each select="cdf:reference[@href=$disa-ossrguri]">
+			<ident system="{$disa-ossrguri}"><xsl:value-of select="text()"/></ident>
 		</xsl:for-each>
+                <xsl:for-each select="cdf:reference[@href=$disa-appsrguri]">
+                        <ident system="{$disa-appsrguri}"><xsl:value-of select="text()"/></ident>
+                </xsl:for-each>
 		<fixtext fixref="{@id}_fix">
 			<xsl:apply-templates select="cdf:description/node()"/>
 		</fixtext>


### PR DESCRIPTION
- Use SRG instead of OSSRG in XSLT transforms
- Detect if SRG is OS or APP and add the correct SRG reference
- Format DISA CCI references correctly
- When there are no references, it adds the url to the non-existent reference which produces
  weird report outputs