### PR TITLE
Remove STIG idents

### DIFF
--- a/shared/xccdf/application/chromium.xml
+++ b/shared/xccdf/application/chromium.xml
@@ -113,9 +113,9 @@ security requirements.
 <warning category="general">If the <tt>.json</tt> file in
 <tt>/etc/chromium/policies/managed</tt> is not formatted correctly,
 no policies will be configured or set correctly.</warning>
-<ident stig="" />
+<ident cce="" />
 <oval id="chromium_policy_file" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="" />
 </Rule>
 
 <Rule id="chromium_disable_firewall_traversal">
@@ -137,9 +137,9 @@ The output should contain:
 Remote connections should never be allowed to bypass the system firewall
 as there is no way to verify if they can be trusted.
 </rationale>
-<ident stig="DTBC0001" />
+<ident cce="" />
 <oval id="chromium_disable_firewall_traversal" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0001" />
 </Rule>
 
 <Rule id="chromium_block_desktop_notifications">
@@ -161,9 +161,9 @@ Disabling Chromium's ability to display notifications on the desktop helps preve
 malicious websites from controlling desktop notifications or fooling users into
 clicking on a potentially compromised notification.
 </rationale>
-<ident stig="DTBC0003" />
+<ident cce="" />
 <oval id="chromium_block_desktop_notifications" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0003" />
 </Rule>
 
 <Rule id="chromium_disable_popups">
@@ -183,9 +183,9 @@ The output should contain:
 Pop-up windows should be disabled to prevent malicious websites from controlling
 pop-up windows or fooling users into clicking on the wrong window.
 </rationale>
-<ident stig="DTBC0004" />
+<ident cce="" />
 <oval id="chromium_disable_popups" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0004" />
 </Rule>
 
 <Rule id="chromium_disallow_location_tracking">
@@ -208,9 +208,9 @@ create a tracking cookie on the browser. If the information of what sites are
 being accessed is made available to unauthorized persons, this violates 
 confidentiality requirements, and over time poses a significant OPSEC issue.
 </rationale>
-<ident stig="DTBC0002" />
+<ident cce="" />
 <oval id="chromium_disallow_location_tracking" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0002" />
 </Rule>
 
 <Rule id="chromium_blacklist_extension_installation">
@@ -231,9 +231,9 @@ The output should contain:
 Extensions can access almost anything on a system. This means they pose a high risk
 to any system that would allow all extensions to be installed by default.
 </rationale>
-<ident stig="DTBC0006" />
+<ident cce="" />
 <oval id="chromium_blacklist_extension_installation" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0006" />
 </Rule>
 
 <Rule id="chromium_extension_whitelist">
@@ -256,9 +256,9 @@ The output should contain:
 The whitelist should only contain organizationally approved extensions. This is to prevent
 a user from accidently whitelisitng a malicious extension.
 </rationale>
-<ident stig="DTBC0003" />
+<ident cce="" />
 <oval id="chromium_extension_whitelist" value="var_extension_whitelist" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0003" />
 </Rule>
 
 <Rule id="chromium_default_search_provider_name">
@@ -278,9 +278,9 @@ The output should contain:
 When doing internet searches, it is important to set an organizationally approved search
 provider as well as use an encrypted connection via https.
 </rationale>
-<ident stig="DTBC0007" />
+<ident cce="" />
 <oval id="chromium_default_search_provider_name" value="var_default_search_provider_name" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0007" />
 </Rule>
 
 <Rule id="chromium_enable_encrypted_searching">
@@ -300,9 +300,9 @@ The output should contain:
 <rationale>
 When doing internet searches, it is important to use an encrypted connection via https.
 </rationale>
-<ident stig="DTBC0008" />
+<ident cce="" />
 <oval id="chromium_enable_encrypted_searching" value="var_enable_encrypted_searching" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0008" />
 </Rule>
 
 <Rule id="chromium_default_search_provider">
@@ -321,9 +321,9 @@ The output should contain:
 A default search is performed when the user types text in the omnibox that is not a URL.
 This should be organizationally defined and not allowed to be changed by a user.
 </rationale>
-<ident stig="DTBC0009" />
+<ident cce="" />
 <oval id="chromium_default_search_provider" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0009" />
 </Rule>
 
 <Rule id="chromium_disable_cleartext_passwords">
@@ -342,9 +342,9 @@ The output should contain:
 <rationale>
 Cleartext passwords would allow another individual to see password via shoulder surfing.
 </rationale>
-<ident stig="DTBC0010" />
+<ident cce="" />
 <oval id="chromium_disable_cleartext_passwords" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0010" />
 </Rule>
 
 <Rule id="chromium_disable_password_manager">
@@ -365,9 +365,9 @@ Enables saving passwords and using saved passwords in Google Chromium. Malicious
 sites may take advantage of this feature by using hidden fields gain access
 to the stored information.
 </rationale>
-<ident stig="DTBC0011" />
+<ident cce="" />
 <oval id="chromium_disable_password_manager" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0011" />
 </Rule>
 
 <Rule id="chromium_http_authentication">
@@ -386,9 +386,9 @@ The output should contain:
 <rationale>
 Specifies which HTTP Authentication schemes are supported by Google Chromium.
 </rationale>
-<ident stig="DTBC0012" />
+<ident cce="" />
 <oval id="chromium_http_authentication" value="var_trusted_home_page" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0012" />
 </Rule>
 
 <Rule id="chromium_disable_outdated_plugins">
@@ -408,9 +408,9 @@ Running outdated plugins could lead to system compromise through the use
 of known exploits. Having plugins updated to the most current version
 ensures the smallest attack surfuce possible. 
 </rationale>
-<ident stig="DTBC0013" />
+<ident cce="" />
 <oval id="chromium_disable_outdated_plugins" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0013" />
 </Rule>
 
 <Rule id="chromium_plugins_require_authorization">
@@ -430,9 +430,9 @@ The output should contain:
 Outdated plugins can compromise security and should request authorization from
 the user before running.
 </rationale>
-<ident stig="DTBC0014" />
+<ident cce="" />
 <oval id="chromium_plugins_require_authorization" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0014" />
 </Rule>
 
 <Rule id="chromium_disable_thirdparty_cookies">
@@ -454,9 +454,9 @@ are not from the domain that is in the browser's address bar. This prevents
 cookies from being set by web page elements that are not from the domain
 that is in the browser's address bar.
 </rationale>
-<ident stig="DTBC0015" />
+<ident cce="" />
 <oval id="chromium_disable_thirdparty_cookies" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0015" />
 </Rule>
 
 <Rule id="chromium_disable_background_processing">
@@ -478,9 +478,9 @@ resources that might otherwise be needed. Second, it does not make it
 obvious to the user that it is running and poorly written extensions could
 cause instability on the system.
 </rationale>
-<ident stig="DTBC0017" />
+<ident cce="" />
 <oval id="chromium_disable_background_processing" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0017" />
 </Rule>
 
 <Rule id="chromium_disable_3d_graphics_api">
@@ -501,9 +501,9 @@ This setting prevents web pages from accessing the graphics processing unit
 (GPU). Specifically, web pages cannot access the WebGL API and plugins cannot
 use the Pepper 3D API in order to reduce the attack surface.
 </rationale>
-<ident stig="DTBC0019" />
+<ident cce="" />
 <oval id="chromium_disable_3d_graphics_api" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0019" />
 </Rule>
 
 <Rule id="chromium_disable_google_sync">
@@ -524,9 +524,9 @@ of information such as email, calendars, viewing history, etc. This feature must
 be disabled because the organization does not have control over the servers the
 data is stored on.
 </rationale>
-<ident stig="DTBC0020" />
+<ident cce="" />
 <oval id="chromium_disable_google_sync" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0020" />
 </Rule>
 
 <Rule id="chromium_disable_protocol_schemas">
@@ -550,9 +550,9 @@ If a scheme or its associated protocol used by a browser is insecure or obsolete
 vulnerabilities can be exploited resulting in exposed data or unrestricted access
 to the browser's system.
 </rationale>
-<ident stig="DTBC0021" />
+<ident cce="" />
 <oval id="chromium_disable_protocol_schemas" value="var_url_blacklist" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0021" />
 </Rule>
 
 <Rule id="chromium_disable_autocomplete">
@@ -573,9 +573,9 @@ It is possible with the AutoFill feature that it will cache sensitive data and s
 it in the user's profile, where it might not be protected as rigorously as required by
 organizational policy.
 </rationale>
-<ident stig="DTBC0022" />
+<ident cce="" />
 <oval id="chromium_disable_autocomplete" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0022" />
 </Rule>
 
 <Rule id="chromium_disable_cloud_print_sharing">
@@ -596,9 +596,9 @@ Google Chromium has the capability to act as a proxy between Google Cloud Print
 and legacy printers connected to the machine. Users can then enable the cloud
 print proxy by authentication with their Google account. 
 </rationale>
-<ident stig="DTBC0023" />
+<ident cce="" />
 <oval id="chromium_disable_cloud_print_sharing" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0023" />
 </Rule>
 
 <Rule id="chromium_disable_network_prediction">
@@ -617,9 +617,9 @@ The output should contain:
 This controls not only DNS prefetching but also TCP and SSL preconnection
 and prerendering of web pages.
 </rationale>
-<ident stig="DTBC0025" />
+<ident cce="" />
 <oval id="chromium_disable_network_prediction" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0025" />
 </Rule>
 
 <Rule id="chromium_disable_metrics_reporting">
@@ -639,9 +639,9 @@ The output should contain:
 Anonymous reporting of usage and crash-related data is sent to Google.
 A crash report could contain sensitive information from the computer's memory.
 </rationale>
-<ident stig="DTBC0026" />
+<ident cce="" />
 <oval id="chromium_disable_metrics_reporting" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0026" />
 </Rule>
 
 <Rule id="chromium_disable_search_suggestions">
@@ -662,9 +662,9 @@ The output should contain:
 Search suggestion should be disabled as it could lead to searches being conducted
 that were never intended to be made.
 </rationale>
-<ident stig="DTBC0027" />
+<ident cce="" />
 <oval id="chromium_disable_search_suggestions" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0027" />
 </Rule>
 
 <Rule id="chromium_disable_saved_passwords">
@@ -684,9 +684,9 @@ Importing of saved passwords should be disabled as it could lead to
 unencrypted account passwords stored on the system from another browser
 to be viewed.
 </rationale>
-<ident stig="DTBC0029" />
+<ident cce="" />
 <oval id="chromium_disable_saved_passwords" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0029" />
 </Rule>
 
 <Rule id="chromium_disable_incognito_mode">
@@ -708,9 +708,9 @@ Incognito mode allows the user to browse the Internet without recording their
 browsing history/activity. From a forensics perspective, this is unacceptable.
 Best practice requires that browser history is retained.   
 </rationale>
-<ident stig="DTBC0030" />
+<ident cce="" />
 <oval id="chromium_disable_incognito_mode" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0030" />
 </Rule>
 
 <Rule id="chromium_disable_plugin_blacklist">
@@ -732,9 +732,9 @@ Plugins can access almost anything on a system and users can enable or install t
 at will. This means they pose a high risk to any system that would allow all plugins
 to be installed by default.
 </rationale>
-<ident stig="DTBC0034" />
+<ident cce="" />
 <oval id="chromium_disable_plugin_blacklist" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0034" />
 </Rule>
 
 <Rule id="chromium_enable_approved_plugins">
@@ -755,9 +755,9 @@ The output should contain:
 The whitelist should only contain organizationally approved plugins. This is to prevent
 a user from accidently whitelisitng a malicious plugin.
 </rationale>
-<ident stig="DTBC0035" />
+<ident cce="" />
 <oval id="chromium_enable_approved_plugins" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0035" />
 </Rule>
 
 <Rule id="chromium_disable_automatic_installation">
@@ -778,9 +778,9 @@ The automatic search and installation of missing or not installed plugins should
 disabled as this can cause significant risk if a unapproved or vulnerable plugin were
 to be installed without proper permissions or authorization.
 </rationale>
-<ident stig="DTBC0036" />
+<ident cce="" />
 <oval id="chromium_disable_automatic_installation" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0036" />
 </Rule>
 
 <Rule id="chromium_check_cert_revocation">
@@ -801,9 +801,9 @@ Certificates are revoked when they have been compromised or are no longer valid,
 and this option protects users from submitting confidential data to a site that
 may be fraudulent or not secure.
 </rationale>
-<ident stig="DTBC0037" />
+<ident cce="" />
 <oval id="chromium_check_cert_revocation" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0037" />
 </Rule>
 
 <Rule id="chromium_enable_safe_browsing">
@@ -824,9 +824,9 @@ The output should contain:
 Safe browsing uses a signature database to test sites when they are be loaded
 to ensure that sites do not contain any known malware.
 </rationale>
-<ident stig="DTBC0038" />
+<ident cce="" />
 <oval id="chromium_enable_safe_browsing" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0038" />
 </Rule>
 
 <Rule id="chromium_enable_browser_history">
@@ -845,9 +845,9 @@ The output should contain:
 <rationale>
 Best practice requires that browser history is retained.
 </rationale>
-<ident stig="DTBC0039" />
+<ident cce="" />
 <oval id="chromium_enable_browser_history" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0039" />
 </Rule>
 
 <Rule id="chromium_default_block_plugins">
@@ -867,9 +867,9 @@ The output should contain:
 Websites should not be allowed to automatically run plugins as the plugins
 may be outdated or compromised.
 </rationale>
-<ident stig="DTBC0040" />
+<ident cce="" />
 <oval id="chromium_default_block_plugins" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0040" />
 </Rule>
 
 <Rule id="chromium_disable_session_cookies">
@@ -889,9 +889,9 @@ The output should contain:
 Cookies should only be allowed per session and only for approved URLs as 
 permanently stored cookies can be used for malicious intent.
 </rationale>
-<ident stig="DTBC0045" />
+<ident cce="" />
 <oval id="chromium_disable_session_cookies" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0045" />
 </Rule>
 
 <Rule id="chromium_trusted_home_page">
@@ -914,9 +914,9 @@ If no home page is defined then there is a possibility that a URL to a malicious
 site may be used as a home page which could effectively cause a denial of service
 to the browser.
 </rationale>
-<ident stig="DTBC0048" />
+<ident cce="" />
 <oval id="chromium_trusted_home_page" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0048" />
 </Rule>
 
 <Rule id="chromium_whitelist_plugin_urls">
@@ -938,8 +938,8 @@ The output should contain:
 <rationale>
 Only approved plugins for approved sites should be allowed to be utilized.
 </rationale>
-<ident stig="DTBC0051" />
+<ident cce="" />
 <oval id="chromium_whitelist_plugin_urls" />
-<ref nist="" disa="" />
+<ref nist="" disa="" stigid="DTBC0051" />
 </Rule>
 </Group>

--- a/shared/xccdf/application/firefox.xml
+++ b/shared/xccdf/application/firefox.xml
@@ -49,8 +49,8 @@ and deploying Firefox configuration settings. It also prevents validating
 settings easily from automated security tools.
 </rationale>
 <oval id="firefox_preferences-lock_settings_obscure" />
-<ident stig="DTBF070" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF070" />
 </Rule>
 
 <Rule id="firefox_preferences-lock_settings_config_file" severity="medium">
@@ -71,8 +71,8 @@ Locked settings prevents users from accessing about:config and changing
 the security settings set by the system administrator.
 </rationale>
 <oval id="firefox_preferences-lock_settings_config_file" />
-<ident stig="DTBF070" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF070" />
 </Rule>
 
 </Group>
@@ -162,8 +162,8 @@ Automatic updates from untrusted sites puts the enclave at
 risk of attack and may override security settings.
 </rationale>
 <oval id="firefox_preferences-addons_plugin_updates" />
-<ident stig="DTBF090" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF090" />
 </Rule>
 
 <Rule id="firefox_preferences-autofill_forms" severity="medium">
@@ -187,8 +187,8 @@ is not saved. This mitigates the risk of a website gleaning private
 information from prefilled information.
 </rationale>
 <oval id="firefox_preferences-autofill_forms" />
-<ident stig="DTBF140" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF140" />
 </Rule>
 
 <Rule id="firefox_preferences-autofill_passwords" severity="medium">
@@ -211,8 +211,8 @@ the saved password files and gain access to the user's accounts on
 various hosts.
 </rationale>
 <oval id="firefox_preferences-autofill_passwords" />
-<ident stig="DTBF150" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF150" />
 </Rule>
 
 <Rule id="firefox_preferences-auto-update_of_firefox" severity="medium">
@@ -236,8 +236,8 @@ many other default settings which point to untrusted sites which must be
 changed to point to an authorized update site that is not publicly accessible.
 </rationale>
 <oval id="firefox_preferences-auto-update_of_firefox" />
-<ident stig="DTBF080" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF080" />
 </Rule>
 
 <Group id="firefox_preferences-cookies">
@@ -270,8 +270,8 @@ Data operation when closing the browser in order to clear cookies and
 other data installed by websites visited during the session.
 </rationale>
 <oval id="firefox_preferences-cookies_clear" />
-<ident stig="DTBF170" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF170" />
 </Rule>
 
 <Rule id="firefox_preferences-cookies_user_notice" severity="medium">
@@ -295,8 +295,8 @@ Data operation when closing the browser in order to clear cookies and
 other data installed by websites visited during the session.
 </rationale>
 <oval id="firefox_preferences-cookies_user_notice" />
-<ident stig="DTBF170" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF170" />
 </Rule>
 
 </Group>
@@ -327,8 +327,8 @@ type is automatically opened in the future. This can be a security issue. New fi
 types cannot be added directly to the Application plugin listing.
 </rationale>
 <oval id="firefox_preferences-open_confirmation" value="var_required_file_types"/>
-<ident stig="DTBF110" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF110" />
 </Rule>
 
 <Rule id="firefox_preferences-password_store" severity="medium">
@@ -350,8 +350,8 @@ Autofill of a password can be enabled when a site is visited. This feature could
 be used to autofill the certificate pin which could lead to compromise of DoD information.
 </rationale>
 <oval id="firefox_preferences-password_store" />
-<ident stig="DTBF160" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF160" />
 </Rule>
 
 <Rule id="firefox_preferences-search_update" severity="medium">
@@ -374,8 +374,8 @@ This setting overrides a number of other settings which may direct the applicati
 to access external URLs.
 </rationale>
 <oval id="firefox_preferences-search_update" />
-<ident stig="DTBF085" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF085" />
 </Rule>
 
 <Rule id="firefox_preferences-shell_protocol" severity="medium">
@@ -397,8 +397,8 @@ If enabled, this setting would allow the browser to access the Windows shell.
 This could allow access to the underlying system.
 </rationale>
 <oval id="firefox_preferences-shell_protocol" />
-<ident stig="DTBF105" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF105" />
 </Rule>
 
 <Rule id="firefox_preferences-ssl_version_2" severity="medium">
@@ -420,8 +420,8 @@ Use of versions prior to TLS 1.0 are not permitted because these versions are
 non-standard. SSL 2.0 and SSL 3.0 contain a number of security flaws.
 </rationale>
 <oval id="firefox_preferences-ssl_version_2" />
-<ident stig="DTBF010" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF010" />
 </Rule>
 
 <Rule id="firefox_preferences-ssl_protocol_tls" severity="medium">
@@ -440,8 +440,8 @@ Earlier versions of SSL have known security vulnerabilities and are not
 authorized for use in DOD environments.
 </rationale>
 <oval id="firefox_preferences-ssl_protocol_tls" />
-<ident stig="DTBF030" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF030" />
 </Rule>
 
 <Rule id="firefox_preferences-verification" severity="medium">
@@ -463,8 +463,8 @@ security for DoD information. Access will be denied to the user if
 certificate management is not configured.
 </rationale>
 <oval id="firefox_preferences-verification" />
-<ident stig="DTBF050" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF050" />
 </Rule>
 
 <Rule id="firefox_preferences-ssl_version_3" severity="medium">
@@ -485,8 +485,8 @@ Earlier versions of SSL have known security vulnerabilities and are not
 authorized for use in DOD.
 </rationale>
 <oval id="firefox_preferences-ssl_version_3" />
-<ident stig="DTBF020" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF020" />
 </Rule>
 
 <Rule id="firefox_preferences-home_page" severity="medium">
@@ -512,8 +512,8 @@ mitigate the possibility of automatic inadvertent execution of scripts
 added to a previously safe site.
 </rationale>
 <oval id="firefox_preferences-home_page" value="var_default_home_page"/>
-<ident stig="DTBF017" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF017" />
 </Rule>
 
 <Rule id="installed_firefox_version_supported" severity="high">
@@ -544,8 +544,8 @@ patches. These updates are not available for unsupported version which
 can leave the application vulnerable to attack.
 </rationale>
 <oval id="installed_firefox_version_supported" />
-<ident stig="DTBF003" />
-<ref nist="DCMC-1" disa="" />
+<ident cce="" />
+<ref nist="DCMC-1" disa="" stigid="DTBF003" />
 </Rule>
 
 <Rule id="firefox_preferences-javascript_status_bar_text" severity="medium">
@@ -569,8 +569,8 @@ Webpage authors can disable many features of a popup window that they open.
 This setting prevents the status bar from being hidden.
 </rationale>
 <oval id="firefox_preferences-javascript_status_bar_text" />
-<ident stig="DTBF185" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF185" />
 </Rule>
 
 <Rule id="firefox_preferences-javascript_context_menus" severity="medium">
@@ -592,8 +592,8 @@ A website may execute JavaScript that can make changes to these
 context menus. This can help disguise an attack.
 </rationale>
 <oval id="firefox_preferences-javascript_context_menus" />
-<ident stig="DTBF183" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF183" />
 </Rule>
 
 <Rule id="firefox_preferences-javascript_status_bar_changes" severity="medium">
@@ -616,8 +616,8 @@ to the browser’s appearance to hide unauthorized activity. This activity
 can help disguise an attack taking place in a minimized background window.
 </rationale>
 <oval id="firefox_preferences-javascript_status_bar_changes" />
-<ident stig="DTBF184" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF184" />
 </Rule>
 
 <Rule id="firefox_preferences-javascript_window_resizing" severity="medium">
@@ -639,8 +639,8 @@ JavaScript can make changes to the browser’s appearance. This activity
 can help disguise an attack taking place in a minimized background window.
 </rationale>
 <oval id="firefox_preferences-javascript_window_resizing" />
-<ident stig="DTBF181" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF181" />
 </Rule>
 
 <Rule id="firefox_preferences-javascript_window_changes" severity="medium">
@@ -662,8 +662,8 @@ JavaScript can make changes to the browser’s appearance. Allowing a website
 to use JavaScript to raise and lower browser windows may disguise an attack.
 </rationale>
 <oval id="firefox_preferences-javascript_window_changes" />
-<ident stig="DTBF182" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF182" />
 </Rule>
 
 <Rule id="firefox_preferences-non-secure_page_warning" severity="medium">
@@ -686,8 +686,8 @@ conditions in a previous page are not currently being viewed under
 the same security settings.
 </rationale>
 <oval id="firefox_preferences-non-secure_page_warning" />
-<ident stig="DTBF130" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF130" />
 </Rule>
 
 <Rule id="firefox_preferences-pop-up_windows" severity="medium">
@@ -708,8 +708,8 @@ Popup windows may be used to launch an attack within a new browser window
 with altered settings.
 </rationale>
 <oval id="firefox_preferences-pop-up_windows" />
-<ident stig="DTBF180" />
-<ref nist="ECSC-1" disa="" />
+<ident cce="" />
+<ref nist="ECSC-1" disa="" stigid="DTBF180" />
 </Rule>
 
 <Rule id="firefox_preferences-auto-download_actions" severity="medium">
@@ -734,7 +734,7 @@ file is opened with a selected external application or saved to disk
 instead.
 </rationale>
 <oval id="firefox_preferences-auto-download_actions" />
-<ident stig="DTBF100" />
-<ref nist="DCMC-1" disa="" />
+<ident cce="" />
+<ref nist="DCMC-1" disa="" stigid="DTBF100" />
 </Rule>
 </Group>

--- a/shared/xccdf/application/java.xml
+++ b/shared/xccdf/application/java.xml
@@ -52,8 +52,8 @@ Without the deployment.config file, setting particular options for the Java
 control panel is impossible.
 </rationale>
 <oval id="java_jre_deployment_config_exists" />
-<ident cce="" stig="JRE0070-UX" />
-<ref nist="DCBP-1" disa="" />
+<ident cce="" />
+<ref nist="DCBP-1" disa="" stigid="JRE0070-UX" />
 </Rule>
 
 <Rule id="java_jre_deployment_config_properties" severity="medium">
@@ -79,8 +79,8 @@ If the value of this key is true, JRE will not run if the path to the properties
 file is invalid.
 </rationale>
 <oval id="java_jre_deployment_config_properties" />
-<ident cce="" stig="JRE0060-UX" />
-<ref nist="DCBP-1" disa="" />
+<ident cce="" />
+<ref nist="DCBP-1" disa="" stigid="JRE0060-UX" />
 </Rule>
 
 <Rule id="java_jre_deployment_config_mandatory" severity="medium">
@@ -105,8 +105,8 @@ If the value of this key is true, JRE will not run if the path to the properties
 file is invalid.
 </rationale>
 <oval id="java_jre_deployment_config_mandatory" />
-<ident cce="" stig="JRE0060-UX" />
-<ref nist="DCBP-1" disa="" />
+<ident cce="" />
+<ref nist="DCBP-1" disa="" stigid="JRE0060-UX" />
 </Rule>
 
 </Group>
@@ -134,8 +134,8 @@ no system-wide exists. Without the deployment.properties file, setting particula
 options for the Java control panel is impossible.
 </rationale>
 <oval id="java_jre_deployment_properties_exists" />
-<ident cce="" stig="JRE0080-UX" />
-<ref nist="DCBP-1" disa="" />
+<ident cce="" />
+<ref nist="DCBP-1" disa="" stigid="JRE0080-UX" />
 </Rule>
 
 <Rule id="java_jre_untrusted_sources" severity="medium">
@@ -158,8 +158,8 @@ may result in acquiring malware, and risks system modification, invasion of
 privacy, or denial of service.
 </rationale>
 <oval id="java_jre_untrusted_sources" />
-<ident cce="" stig="JRE0001-UX" />
-<ref nist="DCBP-1" disa="" />
+<ident cce="" />
+<ref nist="DCBP-1" disa="" stigid="JRE0001-UX" />
 </Rule>
 
 <Rule id="java_jre_untrusted_sources_locked" severity="medium">
@@ -184,8 +184,8 @@ change the permission settings which control the execution of signed Java
 applets contributes to a more consistent security profile.
 </rationale>
 <oval id="java_jre_untrusted_sources_locked" />
-<ident cce="" stig="JRE0010-UX" />
-<ref nist="DCBP-1" disa="" />
+<ident cce="" />
+<ref nist="DCBP-1" disa="" stigid="JRE0010-UX" />
 </Rule>
 
 <Rule id="java_jre_validation_crl" severity="medium">
@@ -209,8 +209,8 @@ revoked certificate may result in spoofing, malware, system modification,
 invasion of privacy, and denial of service.
 </rationale>
 <oval id="java_jre_validation_crl" />
-<ident cce="" stig="JRE0020-UX" />
-<ref nist="DCBP-1" disa="" />
+<ident cce="" />
+<ref nist="DCBP-1" disa="" stigid="JRE0020-UX" />
 </Rule>
 
 <Rule id="java_jre_validation_crl_locked" severity="medium">
@@ -234,8 +234,8 @@ and denial of service. As such, ensuring users cannot change settings
 contributes to a more consistent security profile.
 </rationale>
 <oval id="java_jre_validation_crl_locked" />
-<ident cce="" stig="JRE0030-UX" />
-<ref nist="DCBP-1" disa="" />
+<ident cce="" />
+<ref nist="DCBP-1" disa="" stigid="JRE0030-UX" />
 </Rule>
 
 <Rule id="java_jre_validation_ocsp" severity="medium">
@@ -259,8 +259,8 @@ certificate may result in malware execution , system modification, invasion of p
 and denial of service.
 </rationale>
 <oval id="java_jre_validation_ocsp" />
-<ident cce="" stig="JRE0040-UX" />
-<ref nist="DCBP-1" disa="" />
+<ident cce="" />
+<ref nist="DCBP-1" disa="" stigid="JRE0040-UX" />
 </Rule>
 
 <Rule id="java_jre_validation_ocsp_locked" severity="medium">
@@ -285,8 +285,8 @@ and denial of service. As such, ensuring users cannot change settings contribute
 a more consistent security profile.
 </rationale>
 <oval id="java_jre_validation_ocsp_locked" />
-<ident cce="" stig="JRE0050-UX" />
-<ref nist="DCBP-1" disa="" />
+<ident cce="" />
+<ref nist="DCBP-1" disa="" stigid="JRE0050-UX" />
 </Rule>
 
 <Rule id="java_jre_updated" severity="medium">
@@ -315,8 +315,8 @@ Running an older version of the JRE can introduce security
 vulnerabilities to the system.
 </rationale>
 <!--oval id="java_jre_updated" /-->
-<ident cce="" stig="JRE0090-UX" />
-<ref nist="DCBP-1" disa="" />
+<ident cce="" />
+<ref nist="DCBP-1" disa="" stigid="JRE0090-UX" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/services/sssd.xml
+++ b/shared/xccdf/services/sssd.xml
@@ -24,7 +24,7 @@ The <tt>sssd</tt> package should be installed.
 <rationale prodtype="rhel6,rhel7">
 </rationale>
 <ident prodtype="rhel7" cce="80362-7" />
-<ident prodtype="rhel6" cce="RHEL6-CCE-TBD" stig="RHEL6-TBD" />
+<ident prodtype="rhel6" cce="RHEL6-CCE-TBD" />
 <oval prodtype="rhel6,rhel7" id="package_sssd_installed" />
 <ref prodtype="rhel7" stigid="TBD" />
 <ref nist="IA-5(10)" disa="TBD" ossrg="TBD" />
@@ -42,7 +42,7 @@ The <tt>sssd</tt> package should be installed.
 <rationale prodtype="rhel6,rhel7">
 </rationale>
 <ident prodtype="rhel7" cce="80363-5" />
-<ident prodtype="rhel6" cce="RHEL6-CCE-TBD" stig="RHEL6-TBD" />
+<ident prodtype="rhel6" cce="RHEL6-CCE-TBD" />
 <oval prodtype="rhel6,rhel7" id="service_sssd_enabled" />
 <ref prodtype="rhel7" stigid="TBD" />
 <ref nist="IA-5(10)" disa="TBD" ossrg="TBD" />
@@ -70,7 +70,7 @@ If cached authentication information is out-of-date, the validity of the
 authentication information may be questionable.
 </rationale>
 <ident prodtype="rhel7" cce="80364-3" />
-<ident prodtype="rhel6" cce="RHEL6-CCE-TBD" stig="RHEL6-TBD" />
+<ident prodtype="rhel6" cce="RHEL6-CCE-TBD" />
 <oval prodtype="rhel6,rhel7" id="sssd_memcache_timeout" />
 <ref nist="IA-5(13)" disa="2007" ossrg="SRG-OS-000383-GPOS-00166" />
 <ref prodtype="rhel6" nist="IA-5(10)" disa="2007" />
@@ -98,7 +98,7 @@ If cached authentication information is out-of-date, the validity of the
 authentication information may be questionable.
 </rationale>
 <ident prodtype="rhel7" cce="80365-0" />
-<ident prodtype="rhel6" cce="RHEL6-CCE-TBD" stig="RHEL6-TBD" />
+<ident prodtype="rhel6" cce="RHEL6-CCE-TBD" />
 <oval prodtype="rhel6,rhel7" id="sssd_offline_cred_expiration" />
 <ref nist="IA-5(13)" disa="2007" ossrg="SRG-OS-000383-GPOS-00166" />
 <ref prodtype="rhel6" nist="IA-5(13)" disa="2007" />
@@ -126,7 +126,7 @@ If cached authentication information is out-of-date, the validity of the
 authentication information may be questionable.
 </rationale>
 <ident prodtype="rhel7" cce="80366-8" />
-<ident prodtype="rhel6" cce="RHEL6-CCE-TBD" stig="RHEL6-TBD" />
+<ident prodtype="rhel6" cce="RHEL6-CCE-TBD" />
 <oval prodtype="rhel6,rhel7" id="sssd_ssh_known_hosts_timeout" />
 <ref nist="IA-5(13)" disa="2007" ossrg="SRG-OS-000383-GPOS-00166" />
 </Rule>


### PR DESCRIPTION
- Removes `<ident stig="" />` in favor of `<ref stigid="" />`
  This is to standardize how STIGIDs are done in SSG instead of having two different ways of doing the
  same thing