### PR TITLE
Replace OSSRG with SRG

### DIFF
--- a/Debian/8/xccdf/system/access.xml
+++ b/Debian/8/xccdf/system/access.xml
@@ -31,7 +31,7 @@ When operating systems provide the capability to escalate a functional capabilit
 is critical that the user re-authenticate.
 </rationale>
 <oval id="sudo_remove_nopasswd" />
-<ref anssi="NT28(R5)" nist="IA-11" disa="2038" ossrg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
+<ref anssi="NT28(R5)" nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
 </Rule>
 
 <Rule id="sudo_remove_no_authenticate" severity="medium">
@@ -55,7 +55,7 @@ When operating systems provide the capability to escalate a functional capabilit
 is critical that the user re-authenticate.
 </rationale>
 <oval id="sudo_remove_no_authenticate" />
-<ref anssi="NT28(R5)" nist="IA-11" disa="2038" ossrg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
+<ref anssi="NT28(R5)" nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
 </Rule>
 
 </Group>

--- a/Fedora/xccdf/system/accounts/restrictions/account_expiration.xml
+++ b/Fedora/xccdf/system/accounts/restrictions/account_expiration.xml
@@ -108,7 +108,7 @@ must be set upon account creation.
 <br/>
 </rationale>
 <ident cce="27498-5" />
-<ref nist="AC-2(2),AC-2(3)" disa="16,1682" ossrg="2" />
+<ref nist="AC-2(2),AC-2(3)" disa="16,1682" srg="2" />
 </Rule>
 
 </Group>

--- a/Fedora/xccdf/system/network/ipsec.xml
+++ b/Fedora/xccdf/system/network/ipsec.xml
@@ -39,7 +39,7 @@ Verify any returned results for organizational approval.
 IP tunneling mechanisms can be used to bypass network filtering.
 </rationale>
 <!--oval id="libreswan_approved_tunnels" /-->
-<ref nist="AC-4" disa="336" ossrg="SRG-OS-000480-GPOS-00227" stigid="040830" />
+<ref nist="AC-4" disa="336" srg="SRG-OS-000480-GPOS-00227" stigid="040830" />
 </Rule>
 
 </Group>

--- a/Fedora/xccdf/system/network/kernel.xml
+++ b/Fedora/xccdf/system/network/kernel.xml
@@ -217,7 +217,7 @@ the system is functioning as a router.
 Accepting source-routed packets in the IPv4 protocol has few legitimate
 uses. It should be disabled unless it is absolutely required.</rationale>
 <oval id="sysctl_net_ipv4_conf_all_accept_source_route" value="sysctl_net_ipv4_conf_all_accept_source_route_value" />
-<ref nist="AC-4,CM-7,SC-5" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="040350" cis="4.2.1" />
+<ref nist="AC-4,CM-7,SC-5" disa="366" srg="SRG-OS-000480-GPOS-00227" stigid="040350" cis="4.2.1" />
 </Rule>
 
 <Rule id="sysctl_net_ipv4_conf_all_accept_redirects" severity="medium">
@@ -305,7 +305,7 @@ uses. It should be disabled unless it is absolutely required, such as when
 IPv4 forwarding is enabled and the system is legitimately functioning as
 a router.</rationale>
 <oval id="sysctl_net_ipv4_conf_default_accept_source_route" value="sysctl_net_ipv4_conf_default_accept_source_route_value" />
-<ref nist="AC-4,CM-7,SC-5,SC-7" disa="1551" ossrg="SRG-OS-000480-GPOS-00227" stigid="040350" cis="4.2.1" />
+<ref nist="AC-4,CM-7,SC-5,SC-7" disa="1551" srg="SRG-OS-000480-GPOS-00227" stigid="040350" cis="4.2.1" />
 </Rule>
 
 <Rule id="sysctl_net_ipv4_conf_default_accept_redirects" severity="medium">
@@ -357,7 +357,7 @@ Ignoring ICMP echo requests (pings) sent to broadcast or multicast
 addresses makes the system slightly more difficult to enumerate on the network.
 </rationale>
 <oval id="sysctl_net_ipv4_icmp_echo_ignore_broadcasts" value="sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" />
-<ref nist="AC-4,CM-7,SC-5" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="040380" cis="4.2.5" />
+<ref nist="AC-4,CM-7,SC-5" disa="366" srg="SRG-OS-000480-GPOS-00227" stigid="040380" cis="4.2.5" />
 </Rule>
 
 <Rule id="sysctl_net_ipv4_icmp_ignore_bogus_error_responses">
@@ -390,7 +390,7 @@ source. This feature is activated when a flood condition is detected, and
 enables the system to continue servicing valid connection requests.
 </rationale>
 <oval id="sysctl_net_ipv4_tcp_syncookies" value="sysctl_net_ipv4_tcp_syncookies_value" />
-<ref nist="AC-4,SC-5(1)(2),SC-5(2),SC-5(3)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="040430" cis="4.2.8" />
+<ref nist="AC-4,SC-5(1)(2),SC-5(2),SC-5(3)" disa="366" srg="SRG-OS-000480-GPOS-00227" stigid="040430" cis="4.2.8" />
 </Rule>
 
 <Rule id="sysctl_net_ipv4_conf_all_rp_filter" severity="medium">

--- a/Fedora/xccdf/system/permissions/files.xml
+++ b/Fedora/xccdf/system/permissions/files.xml
@@ -427,7 +427,7 @@ will not cause problems when accounts are created in the future,
 and the cause should be discovered and addressed.
 </rationale>
 <!-- <oval id="no_files_unowned_by_user" /> -->
-<ref nist="AC-6,CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="020360"/>
+<ref nist="AC-6,CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00227" stigid="020360"/>
 </Rule>
 
 <Rule id="file_permissions_ungroupowned" severity="medium">
@@ -457,7 +457,7 @@ will not cause problems when accounts are created in the future,
 and the cause should be discovered and addressed.
 </rationale>
 <oval id="file_permissions_ungroupowned" />
-<ref nist="AC-6,IA-2" disa="366" ossrg="SRG-OS-000480-GPOS-00227" stigid="020370" />
+<ref nist="AC-6,IA-2" disa="366" srg="SRG-OS-000480-GPOS-00227" stigid="020370" />
 </Rule>
 
 <Rule id="dir_perms_world_writable_system_owned">

--- a/Ubuntu/14.04/xccdf/system/access.xml
+++ b/Ubuntu/14.04/xccdf/system/access.xml
@@ -31,7 +31,7 @@ When operating systems provide the capability to escalate a functional capabilit
 is critical that the user re-authenticate.
 </rationale>
 <oval id="sudo_remove_nopasswd" />
-<ref anssi="NT28(R5)" nist="IA-11" disa="2038" ossrg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
+<ref anssi="NT28(R5)" nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
 </Rule>
 
 <Rule id="sudo_remove_no_authenticate" severity="medium">
@@ -55,7 +55,7 @@ When operating systems provide the capability to escalate a functional capabilit
 is critical that the user re-authenticate.
 </rationale>
 <oval id="sudo_remove_no_authenticate" />
-<ref anssi="NT28(R5)" nist="IA-11" disa="2038" ossrg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
+<ref anssi="NT28(R5)" nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
 </Rule>
 
 </Group>

--- a/Ubuntu/16.04/xccdf/system/access.xml
+++ b/Ubuntu/16.04/xccdf/system/access.xml
@@ -31,7 +31,7 @@ When operating systems provide the capability to escalate a functional capabilit
 is critical that the user re-authenticate.
 </rationale>
 <oval id="sudo_remove_nopasswd" />
-<ref anssi="NT28(R5)" nist="IA-11" disa="2038" ossrg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
+<ref anssi="NT28(R5)" nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
 </Rule>
 
 <Rule id="sudo_remove_no_authenticate" severity="medium">
@@ -55,7 +55,7 @@ When operating systems provide the capability to escalate a functional capabilit
 is critical that the user re-authenticate.
 </rationale>
 <oval id="sudo_remove_no_authenticate" />
-<ref anssi="NT28(R5)" nist="IA-11" disa="2038" ossrg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
+<ref anssi="NT28(R5)" nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
 </Rule>
 
 </Group>

--- a/shared/xccdf/services/base.xml
+++ b/shared/xccdf/services/base.xml
@@ -140,7 +140,7 @@ is little need to run the kdump service.</rationale>
 <ident prodtype="rhel7" cce="80258-7" />
 <oval id="service_kdump_disabled" />
 <ref prodtype="rhel7" stigid="021300" />
-<ref nist="AC-17(8),CM-7,CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-17(8),CM-7,CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="service_mdmonitor_disabled" prodtype="rhel7">

--- a/shared/xccdf/services/cron.xml
+++ b/shared/xccdf/services/cron.xml
@@ -102,7 +102,7 @@ unauthorized user to view or edit sensitive information.</rationale>
 <ident prodtype="rhel7" cce="80378-3" />
 <oval id="file_owner_cron_allow" />
 <ref prodtype="rhel7" stigid="021110" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="file_groupowner_cron_allow" severity="medium" prodtype="rhel7">
@@ -119,7 +119,7 @@ unauthorized user to view or edit sensitive information.</rationale>
 <ident prodtype="rhel7" cce="80379-1" />
 <oval id="file_groupowner_cron_allow" />
 <ref prodtype="rhel7" stigid="021120" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 </Group>
 

--- a/shared/xccdf/services/docker.xml
+++ b/shared/xccdf/services/docker.xml
@@ -22,7 +22,7 @@ has to be enabled.
 </rationale>
 <platform idref="cpe:/a:machine"/>
 <ident prodtype="rhel7" cce="80440-1" />
-<ref nist="" disa="" ossrg="" />
+<ref nist="" disa="" srg="" />
 <oval id="service_docker_enabled" />
 </Rule>
 

--- a/shared/xccdf/services/ftp.xml
+++ b/shared/xccdf/services/ftp.xml
@@ -50,7 +50,7 @@ accidental activation.
 <ident prodtype="rhel7" cce="80245-4" />
 <oval id="package_vsftpd_removed" />
 <ref prodtype="rhel7" stigid="040690" />
-<ref nist="CM-6(b),CM-7" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="CM-6(b),CM-7" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 </Group> <!-- <Group id="disabling_vsftpd"> -->

--- a/shared/xccdf/services/ldap.xml
+++ b/shared/xccdf/services/ldap.xml
@@ -43,7 +43,7 @@ The output should return:
 altered by unauthorized users without detection. The ssl directive specifies
 whether to use TLS or not. If not specified it will default to no.
 It should be set to start_tls rather than doing LDAP over SSL.</rationale>
-<ref nist="AC-17(2),CM-7" disa="1453" ossrg="SRG-OS-000250-GPOS-00093" />
+<ref nist="AC-17(2),CM-7" disa="1453" srg="SRG-OS-000250-GPOS-00093" />
 <ident prodtype="rhel7" cce="80448-4" />
 <oval id="enable_ldap_client" />
 </Rule>
@@ -70,7 +70,7 @@ altered by unauthorized users without detection. The ssl directive specifies
 whether to use TLS or not. If not specified it will default to no. 
 It should be set to start_tls rather than doing LDAP over SSL.</rationale>
 <ref prodtype="rhel7" stigid="040180" />
-<ref nist="AC-17(2),CM-7" disa="1453" ossrg="SRG-OS-000250-GPOS-00093" />
+<ref nist="AC-17(2),CM-7" disa="1453" srg="SRG-OS-000250-GPOS-00093" />
 <ident prodtype="rhel7" cce="80291-8" />
 <oval id="ldap_client_start_tls" />
 </Rule>

--- a/shared/xccdf/services/nfs.xml
+++ b/shared/xccdf/services/nfs.xml
@@ -298,7 +298,7 @@ should be installed to their default location on the local filesystem.</rational
 <ident prodtype="rhel7" cce="80240-5" />
 <oval id="mount_option_nosuid_remote_filesystems" />
 <ref prodtype="rhel7" stigid="021020" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="mount_option_noexec_remote_filesystems" severity="medium" prodtype="rhel7">
@@ -319,7 +319,7 @@ administrative access.</rationale>
 <ident prodtype="rhel7" cce="80436-9" />
 <oval id="mount_option_noexec_remote_filesystems" />
 <ref prodtype="rhel7" stigid="021021" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="mount_option_krb_sec_remote_filesystems" severity="medium" prodtype="rhel7">
@@ -342,7 +342,7 @@ systems to more securely authenticate the remote mount request.
 <ident prodtype="rhel7" cce="27458-9" />
 <oval id="mount_option_krb_sec_remote_filesystems" />
 <ref prodtype="rhel7" stigid="040750" />
-<ref nist="AC-14(1)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-14(1)" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 </Group>
@@ -475,7 +475,7 @@ systems to more securely authenticate the remote mount request.
 </rationale>
 <ident prodtype="rhel7" cce="27464-7" />
 <oval id="use_kerberos_security_all_exports" />
-<ref nist="AC-14(1)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-14(1)" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 </Group> <!-- nfs_configuring_servers -->

--- a/shared/xccdf/services/ntp.xml
+++ b/shared/xccdf/services/ntp.xml
@@ -203,7 +203,7 @@ configured acceptable allowance (drift) may be inaccurate.
 <ident prodtype="rhel7" cce="80439-3" />
 <oval id="chronyd_or_ntpd_set_maxpoll" value="var_time_service_set_maxpoll" />
 <ref prodtype="rhel7" stigid="040500" />
-<ref nist="AU-8(1)(a)" disa="1891,2046" ossrg="SRG-OS-000355-GPOS-00143, SRG-OS-000356-GPOS-00144" />
+<ref nist="AU-8(1)(a)" disa="1891,2046" srg="SRG-OS-000355-GPOS-00143, SRG-OS-000356-GPOS-00144" />
 </Rule>
 
 

--- a/shared/xccdf/services/obsolete.xml
+++ b/shared/xccdf/services/obsolete.xml
@@ -80,7 +80,7 @@ prevents connections from unknown hosts and protocols.
 <ident prodtype="rhel7" cce="27361-5" />
 <oval id="package_tcp_wrappers_installed" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cis="3.4.1"/>
+<ref nist="CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00227" cis="3.4.1"/>
 </Rule>
 
 </Group>
@@ -154,7 +154,7 @@ Removing the <tt>telnet-server</tt> package decreases the risk of the telnet ser
 <ident prodtype="rhel7" cce="27165-0" />
 <oval id="package_telnet-server_removed" />
 <ref prodtype="rhel7" stigid="021710" />
-<ref nist="AC-17(8),CM-7(a)" disa="381" ossrg="SRG-OS-000095-GPOS-00049" cis="2.1.1" />
+<ref nist="AC-17(8),CM-7(a)" disa="381" srg="SRG-OS-000095-GPOS-00049" cis="2.1.1" />
 </Rule>
 
 <Rule id="package_telnet_removed" severity="low" prodtype="rhel7">
@@ -197,7 +197,7 @@ activation.
 <ident prodtype="rhel7" cce="27342-5" />
 <oval id="package_rsh-server_removed" />
 <ref prodtype="rhel7" stigid="020000" />
-<ref nist="AC-17(8),CM-7(a)" disa="381" ossrg="SRG-OS-000095-GPOS-00049" />
+<ref nist="AC-17(8),CM-7(a)" disa="381" srg="SRG-OS-000095-GPOS-00049" />
 </Rule>
 
 <Rule id="service_rexec_disabled" severity="high" prodtype="rhel7">
@@ -326,7 +326,7 @@ activation of NIS or NIS+ services.
 <ident prodtype="rhel7" cce="27399-5" />
 <oval id="package_ypserv_removed" />
 <ref prodtype="rhel7" stigid="020010" />
-<ref nist="AC-17(8),CM-7(a)" disa="381" ossrg="SRG-OS-000095-GPOS-00049" />
+<ref nist="AC-17(8),CM-7(a)" disa="381" srg="SRG-OS-000095-GPOS-00049" />
 </Rule>
 
 <Rule id="service_ypbind_disabled" severity="medium" prodtype="rhel7">
@@ -409,7 +409,7 @@ only authorized personnel, and have access control rules established.
 <ident prodtype="rhel7" cce="80213-2" />
 <oval id="package_tftp-server_removed" />
 <ref prodtype="rhel7" stigid="040700" />
-<ref nist="AC-17(8),CM-6(c),CM-7" disa="318,368,1812,1813,1814" ossrg="SRG-OS-000480-GPOS-00227"  />
+<ref nist="AC-17(8),CM-6(c),CM-7" disa="318,368,1812,1813,1814" srg="SRG-OS-000480-GPOS-00227"  />
 </Rule>
 
 <Rule id="package_tftp_removed" severity="high" prodtype="rhel7">
@@ -455,7 +455,7 @@ server_args = -s /var/lib/tftpboot</pre>
 <ident prodtype="rhel7" cce="80214-0" />
 <oval id="tftpd_uses_secure_mode" />
 <ref prodtype="rhel7" stigid="040720" />
-<ref nist="AC-6,AC-17(8),CM-7" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-6,AC-17(8),CM-7" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/services/quagga.xml
+++ b/shared/xccdf/services/quagga.xml
@@ -33,7 +33,7 @@ the network.
 <ident prodtype="rhel7" cce="27191-6" />
 <oval id="service_zebra_disabled" />
 <ref prodtype="rhel7" stigid="040730" />
-<ref nist="SC-32" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="SC-32" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="package_quagga_removed" severity="medium" prodtype="rhel7">
@@ -55,7 +55,7 @@ removing it provides a safeguard against its activation.
 <ident prodtype="rhel7" cce="27594-1" />
 <oval id="package_quagga_removed" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="SC-32" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="SC-32" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/services/snmp.xml
+++ b/shared/xccdf/services/snmp.xml
@@ -111,7 +111,7 @@ network(s).
 <oval id="snmpd_not_default_password" />
 <ident prodtype="rhel7" cce="27386-2" />
 <ref prodtype="rhel7" stigid="040800" />
-<ref nist="IA-5.1(ii)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="IA-5.1(ii)" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -84,7 +84,7 @@ intercepted and either read or altered.
 <ident prodtype="rhel7" cce="80215-7" />
 <oval id="package_openssh-server_installed" />
 <ref prodtype="rhel7" stigid="040300" />
-<ref nist="SC-8" disa="2418,2420,2421,2422" ossrg="SRG-OS-000423-GPOS-00187,SRG-OS-000423-GPOS-00188,SRG-OS-000423-GPOS-00189,SRG-OS000423-GPOS-00190" />
+<ref nist="SC-8" disa="2418,2420,2421,2422" srg="SRG-OS-000423-GPOS-00187,SRG-OS-000423-GPOS-00188,SRG-OS-000423-GPOS-00189,SRG-OS000423-GPOS-00190" />
 </Rule>
 
 <Rule id="service_sshd_enabled" severity="medium" prodtype="rhel7">
@@ -108,7 +108,7 @@ of interception and modification.
 </rationale>
 <ident prodtype="rhel7" cce="80216-5" />
 <ref prodtype="rhel7" stigid="040310" />
-<ref nist="SC-8" disa="2418,2420,2421,2422" ossrg="SRG-OS-000423-GPOS-00187,SRG-OS-000423-GPOS-00188,SRG-OS-000423-GPOS-00189,SRG-OS000423-GPOS-00190" cui="3.1.13,3.5.4,3.13.8" />
+<ref nist="SC-8" disa="2418,2420,2421,2422" srg="SRG-OS-000423-GPOS-00187,SRG-OS-000423-GPOS-00188,SRG-OS-000423-GPOS-00189,SRG-OS000423-GPOS-00190" cui="3.1.13,3.5.4,3.13.8" />
 <oval id="service_sshd_enabled" />
 </Rule>
 
@@ -134,7 +134,7 @@ may be compromised.
 </rationale>
 <ident prodtype="rhel7" cce="27311-0" />
 <ref prodtype="rhel7" stigid="040410" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.13,3.13.10" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.13,3.13.10" />
 <oval id="file_permissions_sshd_pub_key" />
 </Rule>
 
@@ -148,7 +148,7 @@ impersonated.
 </rationale>
 <ident prodtype="rhel7" cce="27485-2" />
 <ref prodtype="rhel7" stigid="040420" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.13,3.13.10" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.13,3.13.10" />
 <oval id="file_permissions_sshd_private_key" />
 </Rule>
 
@@ -220,7 +220,7 @@ immediate root access to the system.
 <oval id="sshd_allow_only_protocol2" />
 <ref prodtype="rhel7" stigid="040390" />
 <ref nist="AC-17(8).1(ii),IA-5(1)(c)" disa="197,366" cis="5.2.2"
-ossrg="SRG-OS-000074-GPOS-00042,SRG-OS-000480-GPOS-00227" cjis="5.5.6" cui="3.1.13,3.5.4" />
+srg="SRG-OS-000074-GPOS-00042,SRG-OS-000480-GPOS-00227" cjis="5.5.6" cui="3.1.13,3.5.4" />
 </Rule>
 
 <Rule id="sshd_limit_user_access">
@@ -262,7 +262,7 @@ GSSAPI to remote hosts, increasing the attack surface of the system.
 <ident prodtype="rhel7" cce="80220-7" />
 <oval id="sshd_disable_gssapi_auth" />
 <ref prodtype="rhel7" stigid="040430" />
-<ref nist="CM-6(c)" disa="368,318,1812,1813,1814" ossrg="SRG-OS-000364-GPOS-00151" cui="3.1.12" />
+<ref nist="CM-6(c)" disa="368,318,1812,1813,1814" srg="SRG-OS-000364-GPOS-00151" cui="3.1.12" />
 </Rule>
 
 <Rule id="sshd_disable_kerb_auth" severity="medium">
@@ -287,7 +287,7 @@ implementations may be subject to exploitation.
 <ident prodtype="rhel7" cce="80221-5" />
 <oval id="sshd_disable_kerb_auth" />
 <ref prodtype="rhel7" stigid="040440" />
-<ref nist="CM-6(c)" disa="368,318,1812,1813,1814" ossrg="SRG-OS-000364-GPOS-00151" cui="3.1.12" />
+<ref nist="CM-6(c)" disa="368,318,1812,1813,1814" srg="SRG-OS-000364-GPOS-00151" cui="3.1.12" />
 </Rule>
 
 <Rule id="sshd_enable_strictmodes" severity="medium">
@@ -311,7 +311,7 @@ may be able to log into the system as another user.
 <ident prodtype="rhel7" cce="80222-3" />
 <oval id="sshd_enable_strictmodes" />
 <ref prodtype="rhel7" stigid="040450" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
 
 <Rule id="sshd_use_priv_separation" severity="medium">
@@ -335,7 +335,7 @@ the unprivileged section.
 <ident prodtype="rhel7" cce="80223-1" />
 <oval id="sshd_use_priv_separation" />
 <ref prodtype="rhel7" stigid="040460" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
 
 <Rule id="sshd_disable_compression" severity="medium">
@@ -362,7 +362,7 @@ system from an unauthenticated connection, potentially wih root privileges.
 <ident prodtype="rhel7" cce="80224-9" />
 <oval id="sshd_disable_compression" />
 <ref prodtype="rhel7" stigid="040470" />
-<ref nist="CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
+<ref nist="CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
 
 <Rule id="sshd_print_last_log" severity="low">
@@ -385,7 +385,7 @@ recognition and reporting of unauthorized account use.
 <ident prodtype="rhel7" cce="80225-6" />
 <oval id="sshd_print_last_log" />
 <ref prodtype="rhel7" stigid="040360" />
-<ref nist="AC-9" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-9" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="sshd_set_loglevel_info" severity="low">
@@ -482,7 +482,7 @@ enabled on the console or console port that has been let unattended.
 <ident prodtype="rhel7" cce="27433-2" />
 <oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value"/>
 <ref prodtype="rhel7" stigid="040320" />
-<ref nist="AC-2(5),SA-8(i),AC-12" disa="1133,2361" ossrg="SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109" pcidss="Req-8.1.8" cis="6.2.12" cjis="5.5.6" cui="3.1.11" />
+<ref nist="AC-2(5),SA-8(i),AC-12" disa="1133,2361" srg="SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109" pcidss="Req-8.1.8" cis="6.2.12" cjis="5.5.6" cui="3.1.11" />
 </Rule>
 
 <Rule id="sshd_set_keepalive" severity="medium">
@@ -504,7 +504,7 @@ is reached.
 <ident prodtype="rhel7" cce="27082-7" />
 <oval id="sshd_set_keepalive" />
 <ref prodtype="rhel7" stigid="040340" />
-<ref nist="AC-2(5),SA-8,AC-12" disa="1133,2361" ossrg="SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109" cis="6.2.12" cjis="5.5.6" cui="3.1.11" />
+<ref nist="AC-2(5),SA-8,AC-12" disa="1133,2361" srg="SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109" cis="6.2.12" cjis="5.5.6" cui="3.1.11" />
 </Rule>
 
 <Rule id="sshd_set_max_auth_tries" severity="medium">
@@ -548,7 +548,7 @@ can allow an attacker to move trivially to other hosts.
 <ident prodtype="rhel7" cce="27377-1" />
 <oval id="sshd_disable_rhosts" />
 <ref prodtype="rhel7" stigid="040350" />
-<ref nist="AC-3,CM-6(a)" disa="366" cis="6.2.6" ossrg="SRG-OS-000480-GPOS-00227" cjis="5.5.6" cui="3.1.12" />
+<ref nist="AC-3,CM-6(a)" disa="366" cis="6.2.6" srg="SRG-OS-000480-GPOS-00227" cjis="5.5.6" cui="3.1.12" />
 </Rule>
 
 <Rule id="sshd_disable_user_known_hosts" severity="medium">
@@ -572,7 +572,7 @@ in the event of misconfiguration elsewhere.
 <ident prodtype="rhel7" cce="80372-6" />
 <oval id="sshd_disable_user_known_hosts" />
 <ref prodtype="rhel7" stigid="040380" />
-<ref nist="CM-6(a)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
+<ref nist="CM-6(a)" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
 
 <Rule id="sshd_disable_rhosts_rsa" severity="medium">
@@ -595,7 +595,7 @@ in the event of misconfiguration elsewhere.
 <ident prodtype="rhel7" cce="80373-4" />
 <oval id="sshd_disable_rhosts_rsa" />
 <ref prodtype="rhel7" stigid="040330" />
-<ref nist="CM-6(a)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
+<ref nist="CM-6(a)" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.12" />
 </Rule>
 
 <Rule id="disable_host_auth" severity="medium">
@@ -619,7 +619,7 @@ can allow an attacker to move trivially to other hosts.
 <ident prodtype="rhel7" cce="27413-4" />
 <oval id="disable_host_auth" />
 <ref prodtype="rhel7" stigid="010470" />
-<ref nist="AC-3,CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00229" cis="5.2.7" cjis="5.5.6" cui="3.1.12" />
+<ref nist="AC-3,CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00229" cis="5.2.7" cjis="5.5.6" cui="3.1.12" />
 </Rule>
 
 <Rule id="sshd_enable_x11_forwarding" severity="high">
@@ -642,7 +642,7 @@ remotely.
 <ident prodtype="rhel7" cce="80226-4" />
 <oval id="sshd_enable_x11_forwarding" />
 <ref prodtype="rhel7" stigid="040710" />
-<ref nist="CM-2(1)(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.13" />
+<ref nist="CM-2(1)(b)" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.13" />
 </Rule>
 
 <Rule id="sshd_disable_root_login" severity="medium">
@@ -666,7 +666,7 @@ direct attack attempts on root's password.
 <ident prodtype="rhel7" cce="27445-6" />
 <oval id="sshd_disable_root_login" />
 <ref prodtype="rhel7" stigid="040370" />
-<ref nist="AC-3,AC-6(2),IA-2(1),IA-2(5)" disa="366" ossrg="SRG-OS-000480-GPOS-00227"
+<ref nist="AC-3,AC-6(2),IA-2(1),IA-2(5)" disa="366" srg="SRG-OS-000480-GPOS-00227"
 cis="5.2.8" cjis="5.5.6" cui="3.1.1, 3.1.5" />
 </Rule>
 
@@ -691,7 +691,7 @@ misconfiguration elsewhere.
 <ident prodtype="rhel7" cce="27471-2" />
 <oval id="sshd_disable_empty_passwords" />
 <ref prodtype="rhel7" stigid="010300" />
-<ref nist="AC-3,AC-6,CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00229" cjis="5.5.6"
+<ref nist="AC-3,AC-6,CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00229" cjis="5.5.6"
 cui="3.1.1,3.1.5" cis="5.2.9"/>
 </Rule>
 
@@ -718,7 +718,7 @@ not provide easy attribution.
 <ref prodtype="rhel7" stigid="040170" />
 <ref nist="AC-8(a),AC-8(b),AC-8(c)(1),AC-8(c)(2),AC-8(c)(3)"
 disa="48,50,1384,1385,1386,1387,1388"
-ossrg="SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088"
+srg="SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088"
 cis="5.2.16" cjis="5.5.6" cui="3.1.9" />
 </Rule>
 
@@ -742,7 +742,7 @@ access restriction in some configurations.
 <ident prodtype="rhel7" cce="27363-1" />
 <oval id="sshd_do_not_permit_user_env" />
 <ref prodtype="rhel7" stigid="010460" />
-<ref nist="CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00229" 
+<ref nist="CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00229" 
 cis="5.2.10" cjis="5.5.6" cui="3.1.12" />
 </Rule>
 
@@ -787,7 +787,7 @@ Security Levels 1, 2, 3, or 4 for use on Red Hat Enterprise Linux.
 <oval id="sshd_use_approved_ciphers" />
 <ref prodtype="rhel7" stigid="040110" />
 <ref nist="AC-3,AC-17(2),AU-10(5),CM-6(b),IA-5(1)(c),IA-7" disa="68,366,803"
-ossrg="SRG-OS-000033-GPOS-00014,SRG-OS-000120-GPOS-00061,SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093,SRG-OS-000393-GPOS-00173"
+srg="SRG-OS-000033-GPOS-00014,SRG-OS-000120-GPOS-00061,SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093,SRG-OS-000393-GPOS-00173"
 cis="5.2.10" cjis="5.5.6" cui="3.1.13,3.13.11,3.13.8" />
 </Rule>
 
@@ -826,7 +826,7 @@ functions. The only SSHv2 hash algorithms meeting this requirement is SHA2.
 <ident prodtype="rhel7" cce="27455-5" />
 <oval id="sshd_use_approved_macs" value="sshd_approved_macs" />
 <ref prodtype="rhel7" stigid="040400" />
-<ref nist="AC-17(2),IA-7,SC-13" disa="1453" ossrg="SRG-OS-000250-GPOS-00093" cui="3.1.13,3.13.11,3.13.8" />
+<ref nist="AC-17(2),IA-7,SC-13" disa="1453" srg="SRG-OS-000250-GPOS-00093" cui="3.1.13,3.13.11,3.13.8" />
 </Rule>
 
 <!-- similar to sshd_use_approved_ciphers, but without FIPS certification -->

--- a/shared/xccdf/services/sssd.xml
+++ b/shared/xccdf/services/sssd.xml
@@ -28,7 +28,7 @@ The <tt>sssd</tt> package should be installed.
 <ident prodtype="rhel6" cce="RHEL6-CCE-TBD" stig="RHEL6-TBD" />
 <oval prodtype="rhel6,rhel7" id="package_sssd_installed" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="IA-5(10)" disa="TBD" ossrg="TBD" />
+<ref nist="IA-5(10)" disa="TBD" srg="TBD" />
 <ref prodtype="rhel6" nist="IA-5(10)" disa="TBD" />
 </Rule>
 
@@ -46,7 +46,7 @@ The <tt>sssd</tt> package should be installed.
 <ident prodtype="rhel6" cce="RHEL6-CCE-TBD" stig="RHEL6-TBD" />
 <oval prodtype="rhel6,rhel7" id="service_sssd_enabled" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="IA-5(10)" disa="TBD" ossrg="TBD" />
+<ref nist="IA-5(10)" disa="TBD" srg="TBD" />
 <ref prodtype="rhel6" nist="IA-5(10)" disa="TBD" />
 </Rule>
 
@@ -73,7 +73,7 @@ authentication information may be questionable.
 <ident prodtype="rhel7" cce="80364-3" />
 <ident prodtype="rhel6" cce="RHEL6-CCE-TBD" stig="RHEL6-TBD" />
 <oval prodtype="rhel6,rhel7" id="sssd_memcache_timeout" />
-<ref nist="IA-5(13)" disa="2007" ossrg="SRG-OS-000383-GPOS-00166" />
+<ref nist="IA-5(13)" disa="2007" srg="SRG-OS-000383-GPOS-00166" />
 <ref prodtype="rhel6" nist="IA-5(10)" disa="2007" />
 </Rule>
 
@@ -101,7 +101,7 @@ authentication information may be questionable.
 <ident prodtype="rhel7" cce="80365-0" />
 <ident prodtype="rhel6" cce="RHEL6-CCE-TBD" stig="RHEL6-TBD" />
 <oval prodtype="rhel6,rhel7" id="sssd_offline_cred_expiration" />
-<ref nist="IA-5(13)" disa="2007" ossrg="SRG-OS-000383-GPOS-00166" />
+<ref nist="IA-5(13)" disa="2007" srg="SRG-OS-000383-GPOS-00166" />
 <ref prodtype="rhel6" nist="IA-5(13)" disa="2007" />
 </Rule>
 
@@ -129,7 +129,7 @@ authentication information may be questionable.
 <ident prodtype="rhel7" cce="80366-8" />
 <ident prodtype="rhel6" cce="RHEL6-CCE-TBD" stig="RHEL6-TBD" />
 <oval prodtype="rhel6,rhel7" id="sssd_ssh_known_hosts_timeout" />
-<ref nist="IA-5(13)" disa="2007" ossrg="SRG-OS-000383-GPOS-00166" />
+<ref nist="IA-5(13)" disa="2007" srg="SRG-OS-000383-GPOS-00166" />
 </Rule>
 
 <Rule id="sssd_enable_pam_services" severity="medium" prodtype="rhel7">
@@ -158,7 +158,7 @@ authentication device.
 <ident prodtype="rhel7" cce="80437-7" />
 <oval id="sssd_enable_pam_services" />
 <ref prodtype="rhel7" stigid="041002" />
-<ref nist="IA-2(11)" disa="1948,1953,1954" ossrg="SRG-OS-000375-GPOS-00160,SRG-OS-000375-GPOS-00161,SRG-OS-000375-GPOS-00162" />
+<ref nist="IA-2(11)" disa="1948,1953,1954" srg="SRG-OS-000375-GPOS-00160,SRG-OS-000375-GPOS-00161,SRG-OS-000375-GPOS-00162" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/services/xorg.xml
+++ b/shared/xccdf/services/xorg.xml
@@ -36,7 +36,7 @@ long history of security vulnerabilities and should not be used unless approved
 and documented.</rationale>
 <ident prodtype="rhel7" cce="CCE-27285-6" />
 <oval id="xwindows_runlevel_setting" />
-<ref nist="AC-17(8).1(ii)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-17(8).1(ii)" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="package_xorg-x11-server-common_removed" severity="medium" prodtype="rhel7">
@@ -60,7 +60,7 @@ vulnerabilities and should not be installed unless approved and documented.
 <ident prodtype="rhel7" cce="CCE-27218-7" />
 <oval id="package_xorg-x11-server-common_removed" />
 <ref prodtype="rhel7" stigid="040730" />
-<ref nist="AC-17(8).1(ii)" disa="366" cis="3.2" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-17(8).1(ii)" disa="366" cis="3.2" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <!-- to add: guidance in /etc/gdm/custom.conf for xdmcp disable, tcplisten disable -->

--- a/shared/xccdf/system/accounts/banners.xml
+++ b/shared/xccdf/system/accounts/banners.xml
@@ -78,7 +78,7 @@ are not required when such human interfaces do not exist.
 <oval id="banner_etc_issue" value="login_banner_text"/>
 <ref prodtype="rhel7" stigid="010050" />
 <ref nist="AC-8(a),AC-8(b),AC-8(c)(1),AC-8(c)(2),AC-8(c)(3)" disa="48"
-ossrg="SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007"
+srg="SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007"
 cis="1.7.1.2" cui="3.1.9"/>
 </Rule>
 
@@ -129,7 +129,7 @@ with human users and are not required when such human interfaces do not exist.
 <ident prodtype="rhel7" cce="26970-4" />
 <oval id="dconf_gnome_banner_enabled" />
 <ref prodtype="rhel7" stigid="010030" />
-<ref nist="AC-8(a),AC-8(b),AC-8(c)(1),AC-8(c)(2),AC-8(c)(3)" disa="48" ossrg="OS-SRG-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088" cui="3.1.9" />
+<ref nist="AC-8(a),AC-8(b),AC-8(c)(1),AC-8(c)(2),AC-8(c)(3)" disa="48" srg="OS-SRG-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088" cui="3.1.9" />
 </Rule>
 
 <Rule id="dconf_gnome_login_banner_text" severity="medium" prodtype="rhel7">
@@ -167,7 +167,7 @@ process and facilitates possible legal action against attackers.
 <ident prodtype="rhel7" cce="26892-0" />
 <oval id="dconf_gnome_login_banner_text" value="login_banner_text"/>
 <ref prodtype="rhel7" stigid="010040" />
-<ref nist="AC-8(a),AC-8(b),AC-8(c)" disa="48" ossrg="SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088" cui="3.1.9" />
+<ref nist="AC-8(a),AC-8(b),AC-8(c)" disa="48" srg="SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088" cui="3.1.9" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/system/accounts/pam.xml
+++ b/shared/xccdf/system/accounts/pam.xml
@@ -82,7 +82,7 @@ and gives them an opportunity to notify administrators.
 <ident prodtype="rhel7" cce="27275-7" />
 <oval id="display_login_attempts" />
 <ref prodtype="rhel7" stigid="040530" />
-<ref nist="AC-9" disa="366" pcidss="Req-10.2.4" ossrg="SRG-OS-000480-GPOS-00227" cjis="5.5.2" />
+<ref nist="AC-9" disa="366" pcidss="Req-10.2.4" srg="SRG-OS-000480-GPOS-00227" cjis="5.5.2" />
 </Rule>
 
 <Group id="password_quality">
@@ -300,7 +300,7 @@ is different from account lockout, which is provided by the pam_faillock module.
 <ident prodtype="rhel7" cce="27160-1" />
 <oval id="accounts_password_pam_retry" value="var_password_pam_retry"/>
 <ref prodtype="rhel7" stigid="010119" />
-<ref nist="CM-6(b),IA-5(c)" disa="366" cis="6.3.2" ossrg="SRG-OS-000480-GPOS-00225" cjis="5.5.3" />
+<ref nist="CM-6(b),IA-5(c)" disa="366" cis="6.3.2" srg="SRG-OS-000480-GPOS-00225" cjis="5.5.3" />
 </Rule>
 
 <Rule id="accounts_password_pam_maxrepeat" severity="medium" prodtype="rhel7">
@@ -331,7 +331,7 @@ Passwords with excessive repeating characters may be more vulnerable to password
 <ident prodtype="rhel7" cce="27333-4" />
 <oval id="accounts_password_pam_maxrepeat" value="var_password_pam_maxrepeat" />
 <ref prodtype="rhel7" stigid="010180" />
-<ref nist="IA-5,IA-5(c)" disa="195" ossrg="SRG-OS-000072-GPOS-00040" />
+<ref nist="IA-5,IA-5(c)" disa="195" srg="SRG-OS-000072-GPOS-00040" />
 </Rule>
 
 <Rule id="accounts_password_pam_maxclassrepeat" severity="medium" prodtype="rhel7">
@@ -359,7 +359,7 @@ password is compromised.
 <ident prodtype="rhel7" cce="27512-3" />
 <oval id="accounts_password_pam_maxclassrepeat" value="var_password_pam_maxclassrepeat" />
 <ref prodtype="rhel7" stigid="010190" />
-<ref nist="IA-5,IA-5(c)" disa="195" ossrg="SRG-OS-000072-GPOS-00040" />
+<ref nist="IA-5,IA-5(c)" disa="195" srg="SRG-OS-000072-GPOS-00040" />
 </Rule>
 
 <Rule id="accounts_password_pam_dcredit" severity="medium" prodtype="rhel7">
@@ -450,7 +450,7 @@ the password is compromised.
 <ident prodtype="rhel7" cce="27200-5" />
 <oval id="accounts_password_pam_ucredit" value="var_password_pam_ucredit"/>
 <ref prodtype="rhel7" stigid="010120" />
-<ref nist="IA-5(b),IA-5(c),IA-5(1)(a)" disa="192" ossrg="SRG-OS-000069-GPOS-00037" pcidss="Req-8.2.3" cis="6.3.2" />
+<ref nist="IA-5(b),IA-5(c),IA-5(1)(a)" disa="192" srg="SRG-OS-000069-GPOS-00037" pcidss="Req-8.2.3" cis="6.3.2" />
 </Rule>
 
 <Rule id="accounts_password_pam_ocredit" severity="medium" prodtype="rhel7">
@@ -595,7 +595,7 @@ by ensuring a larger search space.
 <ident prodtype="rhel7" cce="CCE-27115-5" />
 <oval id="accounts_password_pam_minclass" value="var_password_pam_minclass"/>
 <ref prodtype="rhel7" stigid="010170" />
-<ref nist="IA-5" disa="195" ossrg="SRG-OS-000072-GPOS-00040" />
+<ref nist="IA-5" disa="195" srg="SRG-OS-000072-GPOS-00040" />
 </Rule>
 </Group>
 </Group>
@@ -647,7 +647,7 @@ prevents direct password guessing attacks.
 <ident prodtype="rhel7" cce="27350-8" />
 <oval id="accounts_passwords_pam_faillock_deny" value="var_accounts_passwords_pam_faillock_deny"/>
 <ref prodtype="rhel7" stigid="010320" />
-<ref nist="AC-7(b)" disa="2238" ossrg="SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005" pcidss="Req-8.1.6" cis="6.3.3" cjis="5.5.3" cui="3.1.8" />
+<ref nist="AC-7(b)" disa="2238" srg="SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005" pcidss="Req-8.1.6" cis="6.3.3" cjis="5.5.3" cui="3.1.8" />
 </Rule>
 
 <Rule id="accounts_passwords_pam_faillock_unlock_time" severity="medium" prodtype="rhel7">
@@ -680,7 +680,7 @@ situations.
 <ident prodtype="rhel7" cce="26884-7" />
 <oval id="accounts_passwords_pam_faillock_unlock_time" value="var_accounts_passwords_pam_faillock_unlock_time"/>
 <ref prodtype="rhel7" stigid="010320" />
-<ref nist="AC-7(b)" disa="002238" ossrg="SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005" pcidss="Req-8.1.7" cis="6.3.3" cjis="5.5.3" cui="3.1.8" />
+<ref nist="AC-7(b)" disa="002238" srg="SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005" pcidss="Req-8.1.7" cis="6.3.3" cjis="5.5.3" cui="3.1.8" />
 </Rule>
 
 <Rule id="accounts_passwords_pam_faillock_deny_root" severity="medium" prodtype="rhel7">
@@ -710,7 +710,7 @@ guessing, otherwise known as brute-forcing, is reduced. Limits are imposed by lo
 <ident prodtype="rhel7" cce="80353-6" />
 <oval id="accounts_passwords_pam_faillock_deny_root" />
 <ref prodtype="rhel7" stigid="010330" />
-<ref nist="AC-7(b)" disa="2238" ossrg="SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005" />
+<ref nist="AC-7(b)" disa="2238" srg="SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005" />
 </Rule>
 
 <Rule id="accounts_passwords_pam_faillock_interval" severity="medium" prodtype="rhel7">
@@ -745,7 +745,7 @@ Limits are imposed by locking the account.
 <ident prodtype="rhel7" cce="27297-1" />
 <oval id="accounts_passwords_pam_faillock_interval" value="var_accounts_passwords_pam_faillock_fail_interval"/>
 <ref prodtype="rhel7" stigid="010320" />
-<ref nist="AC-7(b)" disa="2238" ossrg="SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005" />
+<ref nist="AC-7(b)" disa="2238" srg="SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005" />
 </Rule>
 
 <Rule id="accounts_password_pam_unix_remember" severity="medium" prodtype="rhel7">
@@ -777,7 +777,7 @@ Preventing re-use of previous passwords helps ensure that a compromised password
 <ident prodtype="rhel7" cce="26923-3" />
 <oval id="accounts_password_pam_unix_remember" value="var_password_pam_unix_remember" />
 <ref prodtype="rhel7" stigid="010270" />
-<ref nist="IA-5(f),IA-5(1)(e)" disa="200" ossrg="SRG-OS-000077-GPOS-00045"
+<ref nist="IA-5(f),IA-5(1)(e)" disa="200" srg="SRG-OS-000077-GPOS-00045"
 pcidss="Req-8.2.5" cis="5.3.3" cjis="5.6.2.1.1" cui="3.5.8" />
 </Rule>
 </Group>
@@ -819,7 +819,7 @@ ensures the use of a strong hashing algorithm that makes password cracking attac
 </rationale>
 <ident prodtype="rhel7" cce="27104-9" />
 <ref prodtype="rhel7" stigid="010200" />
-<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="196" ossrg="SRG-OS-000073-GPOS-00041" pcidss="Req-8.2.1" cis="6.3.1" cjis="5.6.2.2" cui="3.13.11" />
+<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="196" srg="SRG-OS-000073-GPOS-00041" pcidss="Req-8.2.1" cis="6.3.1" cjis="5.6.2.2" cui="3.13.11" />
 <oval id="set_password_hashing_algorithm_systemauth" />
 </Rule>
 
@@ -843,7 +843,7 @@ Using a stronger hashing algorithm makes password cracking attacks more difficul
 </rationale>
 <ident prodtype="rhel7" cce="27124-7" />
 <ref prodtype="rhel7" stigid="010210" />
-<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="196" ossrg="SRG-OS-000073-GPOS-00041" pcidss="Req-8.2.1" cis="6.3.1" cjis="5.6.2.2" cui="3.13.11" />
+<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="196" srg="SRG-OS-000073-GPOS-00041" pcidss="Req-8.2.1" cis="6.3.1" cjis="5.6.2.2" cui="3.13.11" />
 <oval id="set_password_hashing_algorithm_logindefs" />
 </Rule>
 
@@ -872,7 +872,7 @@ ensures the use of a strong hashing algorithm that makes password cracking attac
 </rationale>
 <ident prodtype="rhel7" cce="27053-8" />
 <ref prodtype="rhel7" stigid="010220" />
-<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="196" ossrg="SRG-OS-000073-GPOS-00041" pcidss="Req-8.2.1" cjis="5.6.2.2" cui="3.13.11" />
+<ref nist="IA-5(b),IA-5(c),IA-5(1)(c),IA-7" disa="196" srg="SRG-OS-000073-GPOS-00041" pcidss="Req-8.2.1" cjis="5.6.2.2" cui="3.13.11" />
 <oval id="set_password_hashing_algorithm_libuserconf" />
 </Rule>
 </Group>

--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -134,7 +134,7 @@ must be automated as a component of machine provisioning, or followed manually a
 <ident prodtype="rhel7" cce="27309-4" />
 <oval id="bootloader_password" />
 <ref prodtype="rhel7" stigid="010480" />
-<ref nist="IA-2(1),IA-5(e),AC-3" disa="213" ossrg="SRG-OS-000080-GPOS-00048" cis="1.4.2" cui="3.4.5" />
+<ref nist="IA-2(1),IA-5(e),AC-3" disa="213" srg="SRG-OS-000080-GPOS-00048" cis="1.4.2" cui="3.4.5" />
 </Rule>
 
 <Rule id="bootloader_uefi_password" severity="medium" prodtype="rhel7">
@@ -191,7 +191,7 @@ must be automated as a component of machine provisioning, or followed manually a
 <ident prodtype="rhel7" cce="80354-4" />
 <oval id="bootloader_uefi_password" />
 <ref prodtype="rhel7" stigid="010490" />
-<ref nist="AC-3" disa="213" ossrg="SRG-OS-000080-GPOS-00048" cui="3.4.5"
+<ref nist="AC-3" disa="213" srg="SRG-OS-000080-GPOS-00048" cui="3.4.5"
 cis="1.4.2" />
 </Rule>
 
@@ -285,7 +285,7 @@ the non-graphical <tt>multi-user.target</tt> mode.
 <oval id="disable_ctrlaltdel_burstaction" />
 <ident prodtype="rhel7" cce="80449-2" />
 <ref prodtype="rhel7" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.4.5" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.4.5" />
 </Rule>
 
 <Rule id="disable_ctrlaltdel_reboot" severity="high" prodtype="rhel7">
@@ -326,7 +326,7 @@ the non-graphical <tt>multi-user.target</tt> mode.
 <oval id="disable_ctrlaltdel_reboot" />
 <ident prodtype="rhel7" cce="27511-5" />
 <ref prodtype="rhel7" stigid="020230" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.4.5" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.4.5" />
 </Rule>
 
 <Rule id="disable_interactive_boot" severity="medium" prodtype="rhel7">
@@ -412,7 +412,7 @@ The <tt>screen</tt> package allows for a session lock to be implemented and conf
 <ident prodtype="rhel7" cce="27351-6" />
 <oval id="package_screen_installed" />
 <ref prodtype="rhel7" stigid="010090" />
-<ref nist="AC-11(a)" disa="57" ossrg="SRG-OS-000029-GPOS-00010" cui="3.1.10" />
+<ref nist="AC-11(a)" disa="57" srg="SRG-OS-000029-GPOS-00010" cui="3.1.10" />
 </Rule>
 </Group>
 
@@ -459,7 +459,7 @@ that provided by a username and password combination. Smart cards leverage PKI
 <ident prodtype="rhel7" cce="80207-4" />
 <oval id="smartcard_auth" />
 <ref prodtype="rhel7" stigid="010500" />
-<ref nist="IA-2(2)" disa="765,766,767,768,771,772,884" pcidss="Req-8.3" ossrg="SRG-OS-000104-GPOS-00051,SRG-OS-000106-GPOS-00053,SRG-OS-000107-GPOS-00054,SRG-OS-000109-GPOS-00056,SRG-OS-000108-GPOS-00055,SRG-OS-000108-GPOS-00057,SRG-OS-000108-GPOS-00058" />
+<ref nist="IA-2(2)" disa="765,766,767,768,771,772,884" pcidss="Req-8.3" srg="SRG-OS-000104-GPOS-00051,SRG-OS-000106-GPOS-00053,SRG-OS-000107-GPOS-00054,SRG-OS-000109-GPOS-00056,SRG-OS-000108-GPOS-00055,SRG-OS-000108-GPOS-00057,SRG-OS-000108-GPOS-00058" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/system/accounts/restrictions/account_expiration.xml
+++ b/shared/xccdf/system/accounts/restrictions/account_expiration.xml
@@ -63,7 +63,7 @@ who may have compromised their credentials.
 <ident prodtype="rhel7" cce="27355-7" />
 <oval id="account_disable_post_pw_expiration" value="var_account_disable_post_pw_expiration"/>
 <ref prodtype="rhel7" stigid="010310" />
-<ref nist="AC-2(2),AC-2(3),IA-4(e)" disa="795" ossrg="SRG-OS-000118-GPOS-00060"
+<ref nist="AC-2(2),AC-2(3),IA-4(e)" disa="795" srg="SRG-OS-000118-GPOS-00060"
 pcidss="Req-8.1.4" cui="3.5.6" cjis="5.6.2.1.1" />
 </Rule>
 
@@ -113,7 +113,7 @@ must be set upon account creation.
 <br/>
 </rationale>
 <ident prodtype="rhel7" cce="27498-5" />
-<ref nist="AC-2(2),AC-2(3)" disa="16,1682" ossrg="2" />
+<ref nist="AC-2(2),AC-2(3)" disa="16,1682" srg="2" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/system/accounts/restrictions/password_storage.xml
+++ b/shared/xccdf/system/accounts/restrictions/password_storage.xml
@@ -39,7 +39,7 @@ empty passwords should never be used in operational environments.
 <ident prodtype="rhel7" cce="27286-4" />
 <oval id="no_empty_passwords" />
 <ref prodtype="rhel7" stigid="010290" />
-<ref nist="AC-6,IA-5(b),IA-5(c),IA-5(1)(a)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" pcidss="Req-8.2.3" cjis="5.5.2" cui="3.1.1, 3.1.5" />
+<ref nist="AC-6,IA-5(b),IA-5(c),IA-5(1)(a)" disa="366" srg="SRG-OS-000480-GPOS-00227" pcidss="Req-8.2.3" cjis="5.5.2" cui="3.1.1, 3.1.5" />
 </Rule>
 
 <Rule id="accounts_password_all_shadowed" severity="medium" prodtype="rhel7">
@@ -86,7 +86,7 @@ any files associated with the group.
 <ident prodtype="rhel7" cce="CCE-27503-2" />
 <oval id="gid_passwd_group_same" />
 <ref prodtype="rhel7" stigid="020300" />
-<ref nist="IA-2" disa="764" ossrg="SRG-OS-000104-GPOS-00051" pcidss="Req-8.5.a" cjis="5.5.2" />
+<ref nist="IA-2" disa="764" srg="SRG-OS-000104-GPOS-00051" pcidss="Req-8.5.a" cjis="5.5.2" />
 </Rule>
 
 <Rule id="no_netrc_files" severity="medium" prodtype="rhel7">

--- a/shared/xccdf/system/accounts/restrictions/root_logins.xml
+++ b/shared/xccdf/system/accounts/restrictions/root_logins.xml
@@ -192,7 +192,7 @@ access to root privileges in an accountable manner.
 <ident prodtype="rhel7" cce="27175-9" />
 <oval id="accounts_no_uid_except_zero" />
 <ref prodtype="rhel7" stigid="020310" />
-<ref nist="AC-6,IA-2(1),IA-4" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.1, 3.1.5" />
+<ref nist="AC-6,IA-2(1),IA-4" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.1, 3.1.5" />
 </Rule>
 
 <Rule id="root_path_default" prodtype="rhel7">

--- a/shared/xccdf/system/accounts/session.xml
+++ b/shared/xccdf/system/accounts/session.xml
@@ -71,7 +71,7 @@ Check if the system is configured to create home directories for local interacti
 <ident prodtype="rhel7" cce="80434-4" />
 <oval id="accounts_have_homedir_login_defs" />
 <ref prodtype="rhel7" stigid="020610" />
-<ref ossrg="SRG-OS-000480-GPOS-00227" />
+<ref srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="accounts_tmout" severity="medium" prodtype="rhel7">
@@ -149,7 +149,7 @@ enter credentials helps to slow a single-threaded brute force attack.
 <ident prodtype="rhel7" cce="80352-8" />
 <oval id="accounts_logon_fail_delay" value="var_accounts_fail_delay" />
 <ref prodtype="rhel7" stigid="010430" />
-<ref nist="CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00226" />
+<ref nist="CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00226" />
 </Rule>
 
 <Group id="root_paths">
@@ -400,7 +400,7 @@ umask <sub idref="var_accounts_user_umask" /></pre>
 <ident prodtype="rhel7" cce="80205-8" />
 <oval id="accounts_umask_etc_login_defs" value="var_accounts_user_umask" />
 <ref prodtype="rhel7" stigid="020240" />
-<ref nist="CM-6(b),SA-8" disa="366" ossrg="SRG-OS-000480-GPOS-00228" />
+<ref nist="CM-6(b),SA-8" disa="366" srg="SRG-OS-000480-GPOS-00228" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/system/auditing.xml
+++ b/shared/xccdf/system/auditing.xml
@@ -122,7 +122,7 @@ can be held accountable for their actions.
 <oval id="service_auditd_enabled" />
 <ref prodtype="rhel7" stigid="030000" />
 <ref nist="AU-3,AC-17(1),AU-1(b),AU-10,AU-12(a),AU-12(c),AU-14(1),IR-5" disa="126,131"
-ossrg="SRG-OS-000038-GPOS-00016,SRG-OS-000039-GPOS-00017,SRG-OS-000042-GPOS-00021,SRG-OS-000254-GPOS-00095,SRG-OS-000255-GPOS-00096"
+srg="SRG-OS-000038-GPOS-00016,SRG-OS-000039-GPOS-00017,SRG-OS-000042-GPOS-00021,SRG-OS-000254-GPOS-00095,SRG-OS-000255-GPOS-00096"
 pcidss="Req-10" cis="4.1.2" cjis="5.4.1.1" cui="3.3.1,3.3.2,3.3.6" />
 </Rule>
 
@@ -421,7 +421,7 @@ allow them to take corrective action prior to any disruption.</rationale>
 <platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27375-5" />
 <oval id="auditd_data_retention_space_left_action" value="var_auditd_space_left_action"/>
-<ref nist="AU-1(b),AU-4,AU-5(1),AU-5(b),IR-5" disa="1855" pcidss="Req-10.7" cis="5.2.1.2" ossrg="SRG-OS-000343-GPOS-00134" tigid="030340" cjis="5.4.1.1" cui="3.3.1" />
+<ref nist="AU-1(b),AU-4,AU-5(1),AU-5(b),IR-5" disa="1855" pcidss="Req-10.7" cis="5.2.1.2" srg="SRG-OS-000343-GPOS-00134" tigid="030340" cjis="5.4.1.1" cui="3.3.1" />
 </Rule>
 
 <Rule id="auditd_data_retention_admin_space_left_action" severity="medium" prodtype="rhel7">
@@ -475,7 +475,7 @@ administrators of the system, who can take appropriate action.</rationale>
 <ident prodtype="rhel7" cce="27394-6" />
 <oval id="auditd_data_retention_action_mail_acct" value="var_auditd_action_mail_acct" />
 <ref prodtype="rhel7" stigid="030350" />
-<ref nist="AU-1(b),AU-4,AU-5(1),AU-5(a),IR-5" disa="1855" pcidss="Req-10.7.a" cis="5.2.1.2" ossrg="SRG-OS-000343-GPOS-00134" cjis="5.4.1.1" cui="3.3.1" />
+<ref nist="AU-1(b),AU-4,AU-5(1),AU-5(a),IR-5" disa="1855" pcidss="Req-10.7.a" cis="5.2.1.2" srg="SRG-OS-000343-GPOS-00134" cjis="5.4.1.1" cui="3.3.1" />
 </Rule>
 
 <Rule id="auditd_data_retention_flush" prodtype="rhel7">
@@ -600,7 +600,7 @@ exceeded.</rationale>
 <ident prodtype="rhel7" cce="80381-7" />
 <oval id="audit_rules_system_shutdown" />
 <ref prodtype="rhel7" stigid="030010" />
-<ref nist="AU-5,AU-5(a)" disa="139" ossrg="SRG-OS-000046-GPOS-00022,SRG-OS-000047-GPOS-00023" cui="3.3.1,3.3.4" />
+<ref nist="AU-5,AU-5(a)" disa="139" srg="SRG-OS-000046-GPOS-00022,SRG-OS-000047-GPOS-00023" cui="3.3.1,3.3.4" />
 </Rule>
 
 <Group id="audit_time_rules">
@@ -822,7 +822,7 @@ users, groups, or modifications should be investigated for legitimacy.</rational
 <ident prodtype="rhel7" cce="27192-4" />
 <oval id="audit_rules_usergroup_modification" />
 <ref prodtype="rhel7" stigid="030710" />
-<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" ossrg="SRG-OS-000004-GPOS-00004,SRG-OS-000239-GPOS-00089,SRG-OS-000241-GPOS-00090,SRG-OS-000241-GPOS-00091,SRG-OS-000303-GPOS-00120,SRG-OS-000476-GPOS-00221" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" srg="SRG-OS-000004-GPOS-00004,SRG-OS-000239-GPOS-00089,SRG-OS-000241-GPOS-00090,SRG-OS-000241-GPOS-00091,SRG-OS-000303-GPOS-00120,SRG-OS-000476-GPOS-00221" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_usergroup_modification_group" severity="medium" prodtype="rhel7">
@@ -858,7 +858,7 @@ users, groups, or modifications should be investigated for legitimacy.</rational
 <ident prodtype="rhel7" cce="80433-6" />
 <oval id="audit_rules_usergroup_modification_group" />
 <ref prodtype="rhel7" stigid="030871" />
-<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" ossrg="SRG-OS-000004-GPOS-00004"  cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" srg="SRG-OS-000004-GPOS-00004"  cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_usergroup_modification_gshadow" severity="medium" prodtype="rhel7">
@@ -894,7 +894,7 @@ users, groups, or modifications should be investigated for legitimacy.</rational
 <ident prodtype="rhel7" cce="80432-8" />
 <oval id="audit_rules_usergroup_modification_gshadow" />
 <ref prodtype="rhel7" stigid="030872" />
-<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" ossrg="SRG-OS-000004-GPOS-00004"  cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" srg="SRG-OS-000004-GPOS-00004"  cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_usergroup_modification_shadow" severity="medium" prodtype="rhel7">
@@ -930,7 +930,7 @@ users, groups, or modifications should be investigated for legitimacy.</rational
 <ident prodtype="rhel7" cce="80431-0" />
 <oval id="audit_rules_usergroup_modification_shadow" />
 <ref prodtype="rhel7" stigid="030873" />
-<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" ossrg="SRG-OS-000004-GPOS-00004"  cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" srg="SRG-OS-000004-GPOS-00004"  cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_usergroup_modification_passwd" severity="medium" prodtype="rhel7">
@@ -966,7 +966,7 @@ users, groups, or modifications should be investigated for legitimacy.</rational
 <ident prodtype="rhel7" cce="80435-1" />
 <oval id="audit_rules_usergroup_modification_passwd" />
 <ref prodtype="rhel7" stigid="030870" />
-<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" ossrg="SRG-OS-000004-GPOS-00004,SRG-OS-000239-GPOS-00089,SRG-OS-000240-GPOS-00090,SRG-OS-000241-GPOS-00091,SRG-OS-000303-GPOS-00120,SRG-OS-000476-GPOS-00221" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" srg="SRG-OS-000004-GPOS-00004,SRG-OS-000239-GPOS-00089,SRG-OS-000240-GPOS-00090,SRG-OS-000241-GPOS-00091,SRG-OS-000303-GPOS-00120,SRG-OS-000476-GPOS-00221" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 
@@ -1003,7 +1003,7 @@ users, groups, or modifications should be investigated for legitimacy.</rational
 <ident prodtype="rhel7" cce="80430-2" />
 <oval id="audit_rules_usergroup_modification_opasswd" />
 <ref prodtype="rhel7" stigid="030874" />
-<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" ossrg="SRG-OS-000004-GPOS-00004"  cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-2(4),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="18,172,1403,2130" pcidss="Req-10.2.5" cis="5.2.5" srg="SRG-OS-000004-GPOS-00004"  cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_networkconfig_modification" prodtype="rhel7">
@@ -1083,7 +1083,7 @@ attackers, thus compromising its confidentiality.</rationale>
 <platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80125-8" />
 <oval id="file_ownership_var_log_audit" />
-<ref nist="AC-6,AU-1(b),AU-9,IR-5" disa="163" ossrg="SRG-OS-000058-GPOS-00028" pcidss="Req-10.5.1" cjis="5.4.1.1" cui="3.3.1" />
+<ref nist="AC-6,AU-1(b),AU-9,IR-5" disa="163" srg="SRG-OS-000058-GPOS-00028" pcidss="Req-10.5.1" cjis="5.4.1.1" cui="3.3.1" />
 </Rule>
 
 <Rule id="audit_rules_mac_modification" prodtype="rhel7">
@@ -1173,7 +1173,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27339-1" />
 <oval id="audit_rules_dac_modification_chmod" />
 <ref prodtype="rhel7" stigid="030410" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7"/>
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7"/>
 </Rule>
 
 <Rule id="audit_rules_dac_modification_chown" prodtype="rhel7">
@@ -1209,7 +1209,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27364-9" />
 <oval id="audit_rules_dac_modification_chown" />
 <ref prodtype="rhel7" stigid="030370" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000474-GPOS-00219" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000474-GPOS-00219" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchmod" prodtype="rhel7">
@@ -1245,7 +1245,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27393-8" />
 <oval id="audit_rules_dac_modification_fchmod" />
 <ref prodtype="rhel7" stigid="030420" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchmodat" prodtype="rhel7">
@@ -1281,7 +1281,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27388-8" />
 <oval id="audit_rules_dac_modification_fchmodat" />
 <ref prodtype="rhel7" stigid="030430" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchown" prodtype="rhel7">
@@ -1317,7 +1317,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27356-5" />
 <oval id="audit_rules_dac_modification_fchown" />
 <ref prodtype="rhel7" stigid="030380" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000474-GPOS-00219" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000474-GPOS-00219" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fchownat" prodtype="rhel7">
@@ -1353,7 +1353,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27387-0" />
 <oval id="audit_rules_dac_modification_fchownat" />
 <ref prodtype="rhel7" stigid="030400" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000474-GPOS-00219" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000474-GPOS-00219" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fremovexattr" severity="medium" prodtype="rhel7">
@@ -1394,7 +1394,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27353-2" />
 <oval id="audit_rules_dac_modification_fremovexattr" />
 <ref prodtype="rhel7" stigid="030480" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_dac_modification_fsetxattr" prodtype="rhel7">
@@ -1430,7 +1430,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27389-6" />
 <oval id="audit_rules_dac_modification_fsetxattr" />
 <ref prodtype="rhel7" stigid="030450" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_dac_modification_lchown" prodtype="rhel7">
@@ -1466,7 +1466,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27083-5" />
 <oval id="audit_rules_dac_modification_lchown" />
 <ref prodtype="rhel7" stigid="030390" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000474-GPOS-00219" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000474-GPOS-00219" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_dac_modification_lremovexattr" severity="medium" prodtype="rhel7">
@@ -1507,7 +1507,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27410-0" />
 <oval id="audit_rules_dac_modification_lremovexattr" />
 <ref prodtype="rhel7" stigid="030490" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_dac_modification_lsetxattr" prodtype="rhel7">
@@ -1543,7 +1543,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27280-7" />
 <oval id="audit_rules_dac_modification_lsetxattr" />
 <ref prodtype="rhel7" stigid="030460" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000474-GPOS-00219" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000474-GPOS-00219" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_dac_modification_removexattr" severity="medium" prodtype="rhel7">
@@ -1583,7 +1583,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27367-2" />
 <oval id="audit_rules_dac_modification_removexattr" />
 <ref prodtype="rhel7" stigid="030470" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_dac_modification_setxattr" prodtype="rhel7">
@@ -1619,7 +1619,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="27213-8" />
 <oval id="audit_rules_dac_modification_setxattr" />
 <ref prodtype="rhel7" stigid="030440" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="126,172" pcidss="Req-10.5.5" cis="5.2.10" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 </Group>
@@ -1698,7 +1698,7 @@ as an attacker attempting to remove evidence of an intrusion.</rationale>
 <ident prodtype="rhel7" cce="80382-5" />
 <oval id="audit_rules_login_events_tallylog" />
 <ref prodtype="rhel7" stigid="030600" />
-<ref nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" disa="172,2884,126" ossrg="SRG-OS-000392-GPOS-00172,SRG-OS-000470-GPOS-00214,SRG-OS-000473-GPOS-00218" pcidss="Req-10.2.3" cis="5.2.8" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" disa="172,2884,126" srg="SRG-OS-000392-GPOS-00172,SRG-OS-000470-GPOS-00214,SRG-OS-000473-GPOS-00218" pcidss="Req-10.2.3" cis="5.2.8" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_login_events_faillock" severity="medium" prodtype="rhel7">
@@ -1726,7 +1726,7 @@ as an attacker attempting to remove evidence of an intrusion.</rationale>
 <ident prodtype="rhel7" cce="80383-3" />
 <oval id="audit_rules_login_events_faillock" />
 <ref prodtype="rhel7" stigid="030610" />
-<ref nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" disa="172,2884,126" ossrg="SRG-OS-000392-GPOS-00172,SRG-OS-000470-GPOS-00214,SRG-OS-000473-GPOS-00218" pcidss="Req-10.2.3" cis="5.2.8" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" disa="172,2884,126" srg="SRG-OS-000392-GPOS-00172,SRG-OS-000470-GPOS-00214,SRG-OS-000473-GPOS-00218" pcidss="Req-10.2.3" cis="5.2.8" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_login_events_lastlog" severity="medium" prodtype="rhel7">
@@ -1754,7 +1754,7 @@ as an attacker attempting to remove evidence of an intrusion.</rationale>
 <ident prodtype="rhel7" cce="80384-1" />
 <oval id="audit_rules_login_events_lastlog" />
 <ref prodtype="rhel7" stigid="030620" />
-<ref nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" disa="172,2884,126" ossrg="SRG-OS-000392-GPOS-00172,SRG-OS-000470-GPOS-00214,SRG-OS-000473-GPOS-00218" pcidss="Req-10.2.3" cis="5.2.8" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5" disa="172,2884,126" srg="SRG-OS-000392-GPOS-00172,SRG-OS-000470-GPOS-00214,SRG-OS-000473-GPOS-00218" pcidss="Req-10.2.3" cis="5.2.8" cui="3.1.7" />
 </Rule>
 
 </Group>
@@ -1879,7 +1879,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="80385-8" />
 <oval id="audit_rules_unsuccessful_file_modification_creat" />
 <ref prodtype="rhel7" stigid="030500" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_unsuccessful_file_modification_open" severity="medium" prodtype="rhel7">
@@ -1919,7 +1919,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="80386-6" />
 <oval id="audit_rules_unsuccessful_file_modification_open" />
 <ref prodtype="rhel7" stigid="030510" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_unsuccessful_file_modification_openat" severity="medium" prodtype="rhel7">
@@ -1959,7 +1959,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="80387-4" />
 <oval id="audit_rules_unsuccessful_file_modification_openat" />
 <ref prodtype="rhel7" stigid="030520" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_unsuccessful_file_modification_open_by_handle_at" severity="medium" prodtype="rhel7">
@@ -1999,7 +1999,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="80388-2" />
 <oval id="audit_rules_unsuccessful_file_modification_open_by_handle_at" />
 <ref prodtype="rhel7" stigid="030530" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_unsuccessful_file_modification_truncate" severity="medium" prodtype="rhel7">
@@ -2039,7 +2039,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="80389-0" />
 <oval id="audit_rules_unsuccessful_file_modification_truncate" />
 <ref prodtype="rhel7" stigid="030540" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_unsuccessful_file_modification_ftruncate" severity="medium" prodtype="rhel7">
@@ -2079,7 +2079,7 @@ calls with others as identifying earlier in this guide is more efficient.
 <ident prodtype="rhel7" cce="80390-8" />
 <oval id="audit_rules_unsuccessful_file_modification_ftruncate" />
 <ref prodtype="rhel7" stigid="030550" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" ossrg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172,2884" srg="SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.4,Req-10.2.1" cis="5.2.10" cui="3.1.7" />
 </Rule>
 
 </Group>
@@ -2135,7 +2135,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80391-6" />
 <oval id="audit_rules_execution_semanage" />
 <ref prodtype="rhel7" stigid="030560" />
-<ref nist="AU-12(c)" disa="172,2884" ossrg="SRG-OS-000392-GPOS-00172,SRG-OS-000463-GPOS-00207,SRG-OS-000465-GPOS-00209" cui="3.1.7" />
+<ref nist="AU-12(c)" disa="172,2884" srg="SRG-OS-000392-GPOS-00172,SRG-OS-000463-GPOS-00207,SRG-OS-000465-GPOS-00209" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_execution_setsebool" severity="medium" prodtype="rhel7">
@@ -2172,7 +2172,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80392-4" />
 <oval id="audit_rules_execution_setsebool" />
 <ref prodtype="rhel7" stigid="030570" />
-<ref nist="AU-12(c)" disa="172,2884" ossrg="SRG-OS-000392-GPOS-00172,SRG-OS-000463-GPOS-00207,SRG-OS-000465-GPOS-00209" cui="3.1.7" />
+<ref nist="AU-12(c)" disa="172,2884" srg="SRG-OS-000392-GPOS-00172,SRG-OS-000463-GPOS-00207,SRG-OS-000465-GPOS-00209" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_execution_chcon" severity="medium" prodtype="rhel7">
@@ -2209,7 +2209,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80393-2" />
 <oval id="audit_rules_execution_chcon" />
 <ref prodtype="rhel7" stigid="030580" />
-<ref nist="AU-12(c)" disa="172,2884" ossrg="SRG-OS-000392-GPOS-00172,SRG-OS-000463-GPOS-00207,SRG-OS-000465-GPOS-00209" cui="3.1.7"/>
+<ref nist="AU-12(c)" disa="172,2884" srg="SRG-OS-000392-GPOS-00172,SRG-OS-000463-GPOS-00207,SRG-OS-000465-GPOS-00209" cui="3.1.7"/>
 </Rule>
 
 <Rule id="audit_rules_execution_restorecon" severity="medium" prodtype="rhel7">
@@ -2246,7 +2246,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80394-0" />
 <oval id="audit_rules_execution_restorecon" />
 <ref prodtype="rhel7" stigid="030590" />
-<ref nist="AU-12(c)" disa="172,2884" ossrg="SRG-OS-000392-GPOS-00172,SRG-OS-000463-GPOS-00207,SRG-OS-000465-GPOS-00209" cui="3.1.7" />
+<ref nist="AU-12(c)" disa="172,2884" srg="SRG-OS-000392-GPOS-00172,SRG-OS-000463-GPOS-00207,SRG-OS-000465-GPOS-00209" cui="3.1.7" />
 </Rule>
 
 </Group>
@@ -2315,7 +2315,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="27437-3" />
 <oval id="audit_rules_privileged_commands" />
 <ref prodtype="rhel7" stigid="030360" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-2(4),AU-6(9),AU-12(a),AU-12(c),IR-5" disa="2234" ossrg="SRG-OS-000327-GPOS-00127" pcidss="Req-10.2.2" cis="5.2.10" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-2(4),AU-6(9),AU-12(a),AU-12(c),IR-5" disa="2234" srg="SRG-OS-000327-GPOS-00127" pcidss="Req-10.2.2" cis="5.2.10" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_passwd" severity="medium" prodtype="rhel7">
@@ -2352,7 +2352,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80395-7" />
 <oval id="audit_rules_privileged_commands_passwd" />
 <ref prodtype="rhel7" stigid="030630" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_unix_chkpwd" severity="medium" prodtype="rhel7">
@@ -2389,7 +2389,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80396-5" />
 <oval id="audit_rules_privileged_commands_unix_chkpwd" />
 <ref prodtype="rhel7" stigid="030640" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_gpasswd" severity="medium" prodtype="rhel7">
@@ -2426,7 +2426,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80397-3" />
 <oval id="audit_rules_privileged_commands_gpasswd" />
 <ref prodtype="rhel7" stigid="030650" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_chage" severity="medium" prodtype="rhel7">
@@ -2463,7 +2463,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80398-1" />
 <oval id="audit_rules_privileged_commands_chage" />
 <ref prodtype="rhel7" stigid="030660" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_userhelper" severity="medium" prodtype="rhel7">
@@ -2500,7 +2500,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80399-9" />
 <oval id="audit_rules_privileged_commands_userhelper" />
 <ref prodtype="rhel7" stigid="030670" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_su" severity="medium" prodtype="rhel7">
@@ -2537,7 +2537,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80400-5" />
 <oval id="audit_rules_privileged_commands_su" />
 <ref prodtype="rhel7" stigid="030680" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_sudo" severity="medium" prodtype="rhel7">
@@ -2574,7 +2574,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80401-3" />
 <oval id="audit_rules_privileged_commands_sudo" />
 <ref prodtype="rhel7" stigid="030690" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_sudoedit" severity="medium" prodtype="rhel7">
@@ -2611,7 +2611,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80402-1" />
 <oval id="audit_rules_privileged_commands_sudoedit" />
 <ref prodtype="rhel7" stigid="030730" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_newgrp" severity="medium" prodtype="rhel7">
@@ -2648,7 +2648,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80403-9" />
 <oval id="audit_rules_privileged_commands_newgrp" />
 <ref prodtype="rhel7" stigid="030710" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_chsh" severity="medium" prodtype="rhel7">
@@ -2685,7 +2685,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80404-7" />
 <oval id="audit_rules_privileged_commands_chsh" />
 <ref prodtype="rhel7" stigid="030720" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_umount" severity="medium" prodtype="rhel7">
@@ -2722,7 +2722,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80405-4" />
 <oval id="audit_rules_privileged_commands_umount" />
 <ref prodtype="rhel7" stigid="030750" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_postdrop" severity="medium" prodtype="rhel7">
@@ -2759,7 +2759,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80406-2" />
 <oval id="audit_rules_privileged_commands_postdrop" />
 <ref prodtype="rhel7" stigid="030760" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7"  />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7"  />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_postqueue" severity="medium" prodtype="rhel7">
@@ -2796,7 +2796,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80407-0" />
 <oval id="audit_rules_privileged_commands_postqueue" />
 <ref prodtype="rhel7" stigid="030770" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7"  />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7"  />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_ssh_keysign" severity="medium" prodtype="rhel7">
@@ -2833,7 +2833,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80408-8" />
 <oval id="audit_rules_privileged_commands_ssh_keysign" />
 <ref prodtype="rhel7" stigid="030780" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_pt_chown" severity="medium" prodtype="rhel7">
@@ -2870,7 +2870,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80409-6" />
 <oval id="audit_rules_privileged_commands_pt_chown" />
 <ref prodtype="rhel7" stigid="030790" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_crontab" severity="medium" prodtype="rhel7">
@@ -2907,7 +2907,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80410-4" />
 <oval id="audit_rules_privileged_commands_crontab" />
 <ref prodtype="rhel7" stigid="030800" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_privileged_commands_pam_timestamp_check" severity="medium" prodtype="rhel7">
@@ -2944,7 +2944,7 @@ unusual activity.
 <ident prodtype="rhel7" cce="80411-2" />
 <oval id="audit_rules_privileged_commands_pam_timestamp_check" />
 <ref prodtype="rhel7" stigid="030810" />
-<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
+<ref nist="AU-3(1),AU-12(c)" disa="135,172,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215" cui="3.1.7" />
 </Rule>
 
 </Group>
@@ -2976,7 +2976,7 @@ loss.</rationale>
 <ident prodtype="rhel7" cce="27447-2" />
 <oval id="audit_rules_media_export" />
 <ref prodtype="rhel7" stigid="030740" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-3(1),AU-12(a),AU-12(c),IR-5" disa="135,2884" ossrg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.13" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-3(1),AU-12(a),AU-12(c),IR-5" disa="135,2884" srg="SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.13" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Group id="audit_file_deletion_events">
@@ -3051,7 +3051,7 @@ malicious processes that attempt to delete log files to conceal their presence.<
 <ident prodtype="rhel7" cce="80412-0" />
 <oval id="audit_rules_file_deletion_events_rmdir" />
 <ref prodtype="rhel7" stigid="030900" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884" ossrg="SRG-OS-000466-GPOS-00210,SRG-OS-000467-GPOS-00210,SRG-OS-000468-GPOS-00212,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.14" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884" srg="SRG-OS-000466-GPOS-00210,SRG-OS-000467-GPOS-00210,SRG-OS-000468-GPOS-00212,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.14" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_file_deletion_events_unlink" severity="medium" prodtype="rhel7">
@@ -3079,7 +3079,7 @@ malicious processes that attempt to delete log files to conceal their presence.<
 <ident prodtype="rhel7" cce="27206-2" />
 <oval id="audit_rules_file_deletion_events_unlink" />
 <ref prodtype="rhel7" stigid="030910" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884" ossrg="SRG-OS-000466-GPOS-00210,SRG-OS-000467-GPOS-00210,SRG-OS-000468-GPOS-00212,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.14" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884" srg="SRG-OS-000466-GPOS-00210,SRG-OS-000467-GPOS-00210,SRG-OS-000468-GPOS-00212,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.14" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_file_deletion_events_unlinkat" severity="medium" prodtype="rhel7">
@@ -3107,7 +3107,7 @@ malicious processes that attempt to delete log files to conceal their presence.<
 <ident prodtype="rhel7" cce="27206-2" />
 <oval id="audit_rules_file_deletion_events_unlinkat" />
 <ref prodtype="rhel7" stigid="030920" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884" ossrg="SRG-OS-000466-GPOS-00210,SRG-OS-000467-GPOS-00210,SRG-OS-000468-GPOS-00212,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.14" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884" srg="SRG-OS-000466-GPOS-00210,SRG-OS-000467-GPOS-00210,SRG-OS-000468-GPOS-00212,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.14" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_file_deletion_events_rename" severity="medium" prodtype="rhel7">
@@ -3135,7 +3135,7 @@ malicious processes that attempt to delete log files to conceal their presence.<
 <ident prodtype="rhel7" cce="27206-2" />
 <oval id="audit_rules_file_deletion_events_rename" />
 <ref prodtype="rhel7" stigid="030880" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884" ossrg="SRG-OS-000466-GPOS-00210,SRG-OS-000467-GPOS-00210,SRG-OS-000468-GPOS-00212,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.14" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884" srg="SRG-OS-000466-GPOS-00210,SRG-OS-000467-GPOS-00210,SRG-OS-000468-GPOS-00212,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.14" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_file_deletion_events_renameat" severity="medium" prodtype="rhel7">
@@ -3163,7 +3163,7 @@ malicious processes that attempt to delete log files to conceal their presence.<
 <ident prodtype="rhel7" cce="80413-8" />
 <oval id="audit_rules_file_deletion_events_renameat" />
 <ref prodtype="rhel7" stigid="030890" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884" ossrg="SRG-OS-000466-GPOS-00210,SRG-OS-000467-GPOS-00210,SRG-OS-000468-GPOS-00212,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.14" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5,MA-4(1)(a)" disa="366,172,2884" srg="SRG-OS-000466-GPOS-00210,SRG-OS-000467-GPOS-00210,SRG-OS-000468-GPOS-00212,SRG-OS-000392-GPOS-00172" pcidss="Req-10.2.7" cis="5.2.14" cui="3.1.7" />
 </Rule>
 
 </Group>
@@ -3193,7 +3193,7 @@ of what was executed on the system, as well as, for accountability purposes.</ra
 <ident prodtype="rhel7" cce="27461-3" />
 <oval id="audit_rules_sysadmin_actions" />
 <ref prodtype="rhel7" stigid="030700" />
-<ref nist="AC-2(7)(b),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),iAU-3(1),AU-12(a),AU-12(c),IR-5" disa="126,130,135,172,2884" pcidss="Req-10.2.2,Req-10.2.5.b" ossrg="SRG-OS-000037-GPOS-00015,SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215" cjis="5.4.1.1" cui="3.1.7" />
+<ref nist="AC-2(7)(b),AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),iAU-3(1),AU-12(a),AU-12(c),IR-5" disa="126,130,135,172,2884" pcidss="Req-10.2.2,Req-10.2.5.b" srg="SRG-OS-000037-GPOS-00015,SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215" cjis="5.4.1.1" cui="3.1.7" />
 </Rule>
 
 <Group id="audit_kernel_module_loading">
@@ -3271,7 +3271,7 @@ to have an audit trail of modules that have been introduced into the kernel.</ra
 <ident prodtype="rhel7" cce="80414-6" />
 <oval id="audit_rules_kernel_module_loading_init" />
 <ref prodtype="rhel7" stigid="030820" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" ossrg="SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222" pcidss="Req-10.2.7" cis="5.2.17" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" srg="SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222" pcidss="Req-10.2.7" cis="5.2.17" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_kernel_module_loading_delete" severity="medium" prodtype="rhel7">
@@ -3297,7 +3297,7 @@ to have an audit trail of modules that have been introduced into the kernel.</ra
 <ident prodtype="rhel7" cce="80415-3" />
 <oval id="audit_rules_kernel_module_loading_delete" />
 <ref prodtype="rhel7" stigid="030830" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" ossrg="SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222" pcidss="Req-10.2.7" cis="5.2.17" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" srg="SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222" pcidss="Req-10.2.7" cis="5.2.17" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_kernel_module_loading_insmod" severity="medium" prodtype="rhel7">
@@ -3324,7 +3324,7 @@ to have an audit trail of modules that have been introduced into the kernel.</ra
 <ident prodtype="rhel7" cce="80446-8" />
 <oval id="audit_rules_kernel_module_loading_insmod" />
 <ref prodtype="rhel7" stigid="030840" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" ossrg="SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222" pcidss="Req-10.2.7" cis="5.2.17" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" srg="SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222" pcidss="Req-10.2.7" cis="5.2.17" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_kernel_module_loading_rmmod" severity="medium" prodtype="rhel7">
@@ -3351,7 +3351,7 @@ to have an audit trail of modules that have been introduced into the kernel.</ra
 <ident prodtype="rhel7" cce="80416-1" />
 <oval id="audit_rules_kernel_module_loading_rmmod" />
 <ref prodtype="rhel7" stigid="030850" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" ossrg="SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222" pcidss="Req-10.2.7" cis="5.2.17" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" srg="SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222" pcidss="Req-10.2.7" cis="5.2.17" cui="3.1.7" />
 </Rule>
 
 <Rule id="audit_rules_kernel_module_loading_modprobe" severity="medium" prodtype="rhel7">
@@ -3378,7 +3378,7 @@ to have an audit trail of modules that have been introduced into the kernel.</ra
 <ident prodtype="rhel7" cce="80417-9" />
 <oval id="audit_rules_kernel_module_loading_modprobe" />
 <ref prodtype="rhel7" stigid="030860" />
-<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" ossrg="SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222" pcidss="Req-10.2.7" cis="5.2.17" cui="3.1.7" />
+<ref nist="AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5" disa="172" srg="SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222" pcidss="Req-10.2.7" cis="5.2.17" cui="3.1.7" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/system/logging.xml
+++ b/shared/xccdf/system/logging.xml
@@ -204,7 +204,7 @@ facility by unauthorized and malicious users.
 <ident prodtype="rhel7" cce="80380-9" />
 <oval id="rsyslog_cron_logging" />
 <ref prodtype="rhel7" stigid="021100" />
-<ref nist="AU-2(d)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AU-2(d)" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 </Group>
@@ -285,7 +285,7 @@ place to view the status of multiple hosts within the enterprise.
 <oval id="rsyslog_remote_loghost" value="rsyslog_remote_loghost_address" />
 <ref prodtype="rhel7" stigid="031000" />
 <ref nist="AU-3(2),AU-4(1),AU-9" disa="366,1348,136,1851" cis="4.2.1.4"
-ossrg="SRG-OS-000480-GPOS-00227" />
+srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 </Group>
 
@@ -322,7 +322,7 @@ rsyslog by configuring it not to listen on the network.
 <ident prodtype="rhel7" cce="80192-8" />
 <oval id="rsyslog_nolisten" />
 <ref prodtype="rhel7" stigid="031010" />
-<ref nist="AU-9(2),AC-4,CM-6(c)" disa="318,368,1812,1813,1814" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AU-9(2),AC-4,CM-6(c)" disa="318,368,1812,1813,1814" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="rsyslog_accept_remote_messages_tcp" prodtype="rhel7">

--- a/shared/xccdf/system/network/firewalld.xml
+++ b/shared/xccdf/system/network/firewalld.xml
@@ -126,7 +126,7 @@ prevents connections from unknown hosts and protocols.
 <ident prodtype="rhel7" cce="27361-5" />
 <oval id="service_firewalld_enabled" />
 <ref prodtype="rhel7" stigid="040520" />
-<ref nist="CM-6(b)" disa="366" cis="4.7" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.3,3.4.7" />
+<ref nist="CM-6(b)" disa="366" cis="4.7" srg="SRG-OS-000480-GPOS-00227" cui="3.1.3,3.4.7" />
 </Rule>
 
 </Group><!--<Group id="firewalld_activation">-->
@@ -172,7 +172,7 @@ accepted.</rationale>
 <ident prodtype="rhel7" cce="27349-0" />
 <oval id="set_firewalld_default_zone" />
 <ref prodtype="rhel7" stigid="040810" />
-<ref nist="CM-6(b),CM-7" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cjis="5.10.1" cui="3.1.3,3.4.7,3.13.6" />
+<ref nist="CM-6(b),CM-7" disa="366" srg="SRG-OS-000480-GPOS-00227" cjis="5.10.1" cui="3.1.3,3.4.7,3.13.6" />
 </Rule>
 
 <Rule id="configure_firewalld_ports" severity="medium" prodtype="rhel7">
@@ -207,7 +207,7 @@ authorized quality of life issues.</rationale>
 <ident prodtype="rhel7" cce="80447-6" />
 <oval id="configure_firewalld_ports" />
 <ref prodtype="rhel7" stigid="040100" />
-<ref nist="CM-7,CM-7.1(iii),CM-7(b),AC-17(1)" disa="382,2314" ossrg="SRG-OS-000096-GPOS-00050,SRG-OS-000297-GPOS-00115" />
+<ref nist="CM-7,CM-7.1(iii),CM-7(b),AC-17(1)" disa="382,2314" srg="SRG-OS-000096-GPOS-00050,SRG-OS-000297-GPOS-00115" />
 </Rule>
 
 

--- a/shared/xccdf/system/network/ipsec.xml
+++ b/shared/xccdf/system/network/ipsec.xml
@@ -42,7 +42,7 @@ IP tunneling mechanisms can be used to bypass network filtering.
 <ident prodtype="rhel7" cce="80171-2" />
 <!--oval id="libreswan_approved_tunnels" /-->
 <ref prodtype="rhel7" stigid="040820" />
-<ref nist="AC-4" disa="336" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-4" disa="336" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/system/network/ipv6.xml
+++ b/shared/xccdf/system/network/ipv6.xml
@@ -190,7 +190,7 @@ uses. It should be disabled unless it is absolutely required.</rationale>
 <ident prodtype="rhel7" cce="80179-5" />
 <oval id="sysctl_net_ipv6_conf_all_accept_source_route" value="sysctl_net_ipv6_conf_all_accept_source_route_value" />
 <ref prodtype="rhel7" stigid="040830" />
-<ref nist="AC-4" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.20" />
+<ref nist="AC-4" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.20" />
 </Rule>
 
 <Rule id="sysctl_net_ipv6_conf_all_accept_ra" prodtype="rhel7">

--- a/shared/xccdf/system/network/kernel.xml
+++ b/shared/xccdf/system/network/kernel.xml
@@ -29,7 +29,7 @@ The ability to send ICMP redirects is only appropriate for systems acting as rou
 <ident prodtype="rhel7" cce="80156-3" />
 <oval id="sysctl_net_ipv4_conf_default_send_redirects" />
 <ref prodtype="rhel7" stigid="040650" />
-<ref nist="AC-4,CM-7,SC-5,SC-7" disa="366" cis="3.1.2" ossrg="SRG-OS-000480-GPOS-00227" cjis="5.10.1.1" cui="3.1.20" />
+<ref nist="AC-4,CM-7,SC-5,SC-7" disa="366" cis="3.1.2" srg="SRG-OS-000480-GPOS-00227" cjis="5.10.1.1" cui="3.1.20" />
 </Rule>
 
 <Rule id="sysctl_net_ipv4_conf_all_send_redirects" severity="medium" prodtype="rhel7">
@@ -50,7 +50,7 @@ The ability to send ICMP redirects is only appropriate for systems acting as rou
 <ident prodtype="rhel7" cce="80156-3" />
 <oval id="sysctl_net_ipv4_conf_all_send_redirects" />
 <ref prodtype="rhel7" stigid="040660" />
-<ref nist="AC-4,CM-7,SC-5(1)" disa="366" cis="3.1.2" ossrg="SRG-OS-000480-GPOS-00227" cjis="5.10.1.1" cui="3.1.20" />
+<ref nist="AC-4,CM-7,SC-5(1)" disa="366" cis="3.1.2" srg="SRG-OS-000480-GPOS-00227" cjis="5.10.1.1" cui="3.1.20" />
 </Rule>
 
 <Rule id="sysctl_net_ipv4_ip_forward" severity="medium" prodtype="rhel7">
@@ -71,7 +71,7 @@ the network.
 <ident prodtype="rhel7" cce="80157-1" />
 <oval id="sysctl_net_ipv4_ip_forward" />
 <ref prodtype="rhel7" stigid="040740" />
-<ref nist="CM-7,SC-5,SC-32" disa="366" cis="3.1.1" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.20" />
+<ref nist="CM-7,SC-5,SC-32" disa="366" cis="3.1.1" srg="SRG-OS-000480-GPOS-00227" cui="3.1.20" />
 </Rule>
 </Group>
 
@@ -232,7 +232,7 @@ uses. It should be disabled unless it is absolutely required.</rationale>
 <ident prodtype="rhel7" cce="27434-0" />
 <oval id="sysctl_net_ipv4_conf_all_accept_source_route" value="sysctl_net_ipv4_conf_all_accept_source_route_value" />
 <ref prodtype="rhel7" stigid="040610" />
-<ref nist="AC-4,CM-7,SC-5" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cis="3.2.1" cui="3.1.20" />
+<ref nist="AC-4,CM-7,SC-5" disa="366" srg="SRG-OS-000480-GPOS-00227" cis="3.2.1" cui="3.1.20" />
 </Rule>
 
 <Rule id="sysctl_net_ipv4_conf_all_accept_redirects" severity="medium" prodtype="rhel7">
@@ -254,7 +254,7 @@ absolutely required.</rationale>
 <ident prodtype="rhel7" cce="80158-9" />
 <oval id="sysctl_net_ipv4_conf_all_accept_redirects" value="sysctl_net_ipv4_conf_all_accept_redirects_value" />
 <ref prodtype="rhel7" stigid="040641" />
-<ref nist="CM-6(d),CM-7,SC-5" disa="366,1503,1551" cis="3.2.2" ossrg="SRG-OS-000480-GPOS-00227" cjis="5.10.1.1" cui="3.1.20" />
+<ref nist="CM-6(d),CM-7,SC-5" disa="366,1503,1551" cis="3.2.2" srg="SRG-OS-000480-GPOS-00227" cjis="5.10.1.1" cui="3.1.20" />
 </Rule>
 
 <Rule id="sysctl_net_ipv4_conf_all_secure_redirects" severity="medium" prodtype="rhel7">
@@ -330,7 +330,7 @@ a router.</rationale>
 <ident prodtype="rhel7" cce="80162-1" />
 <oval id="sysctl_net_ipv4_conf_default_accept_source_route" value="sysctl_net_ipv4_conf_default_accept_source_route_value" />
 <ref prodtype="rhel7" stigid="040620" />
-<ref nist="AC-4,CM-7,SC-5,SC-7" disa="366,1551" ossrg="SRG-OS-000480-GPOS-00227" cis="3.2.1" cjis="5.10.1.1" cui="3.1.20" />
+<ref nist="AC-4,CM-7,SC-5,SC-7" disa="366,1551" srg="SRG-OS-000480-GPOS-00227" cis="3.2.1" cjis="5.10.1.1" cui="3.1.20" />
 </Rule>
 
 <Rule id="sysctl_net_ipv4_conf_default_accept_redirects" severity="medium" prodtype="rhel7">
@@ -352,7 +352,7 @@ absolutely required.</rationale>
 <ident prodtype="rhel7" cce="80163-9" />
 <oval id="sysctl_net_ipv4_conf_default_accept_redirects" value="sysctl_net_ipv4_conf_default_accept_redirects_value" />
 <ref prodtype="rhel7" stigid="040640" />
-<ref nist="AC-4,CM-7,SC-5,SC-7" disa="1551" cis="3.2.2" ossrg="SRG-OS-000480-GPOS-00227" cjis="5.10.1.1" cui="3.1.20" />
+<ref nist="AC-4,CM-7,SC-5,SC-7" disa="1551" cis="3.2.2" srg="SRG-OS-000480-GPOS-00227" cjis="5.10.1.1" cui="3.1.20" />
 </Rule>
 
 <Rule id="sysctl_net_ipv4_conf_default_secure_redirects" severity="medium" prodtype="rhel7">
@@ -390,7 +390,7 @@ addresses makes the system slightly more difficult to enumerate on the network.
 <ident prodtype="rhel7" cce="80165-4" />
 <oval id="sysctl_net_ipv4_icmp_echo_ignore_broadcasts" value="sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" />
 <ref prodtype="rhel7" stigid="040630" />
-<ref nist="AC-4,CM-7,SC-5" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cis="3.2.5"
+<ref nist="AC-4,CM-7,SC-5" disa="366" srg="SRG-OS-000480-GPOS-00227" cis="3.2.5"
 cjis="5.10.1.1" cui="3.1.20" />
 </Rule>
 
@@ -428,7 +428,7 @@ enables the system to continue servicing valid connection requests.
 <platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27495-1" />
 <oval id="sysctl_net_ipv4_tcp_syncookies" value="sysctl_net_ipv4_tcp_syncookies_value" />
-<ref nist="AC-4,SC-5(1)(2),SC-5(2),SC-5(3)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" 
+<ref nist="AC-4,SC-5(1)(2),SC-5(2),SC-5(3)" disa="366" srg="SRG-OS-000480-GPOS-00227" 
 cis="3.2.8" cjis="5.10.1.1" cui="3.1.20" />
 </Rule>
 

--- a/shared/xccdf/system/network/network.xml
+++ b/shared/xccdf/system/network/network.xml
@@ -56,7 +56,7 @@ including its name and address and should not be used unless needed.
 </rationale>
 <ident prodtype="rhel7" cce="80357-7" />
 <oval id="network_disable_ddns_interfaces" />
-<ref nist="CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="network_disable_zeroconf" prodtype="rhel7">
@@ -105,7 +105,7 @@ time synchronization, centralized authentication, and remote system logging.
 <ident prodtype="rhel7" cce="80438-5" />
 <oval id="network_configure_name_resolution" />
 <ref prodtype="rhel7" stigid="040600" />
-<ref nist="SC-22" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="SC-22" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="network_sniffer_disabled" severity="medium" prodtype="rhel7">
@@ -132,7 +132,7 @@ to only authorized personnel.
 <ident prodtype="rhel7" cce="80174-6" />
 <oval id="network_sniffer_disabled" />
 <ref prodtype="rhel7" stigid="040670" />
-<ref nist="CM-7,CM-7(2).1(i),,MA-3" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="CM-7,CM-7(2).1(i),,MA-3" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/system/permissions/files.xml
+++ b/shared/xccdf/system/permissions/files.xml
@@ -453,7 +453,7 @@ and the cause should be discovered and addressed.
 <ident prodtype="rhel7" cce="80134-0" />
 <oval id="no_files_unowned_by_user" />
 <ref prodtype="rhel7" stigid="020320" />
-<ref nist="AC-3(4),AC-6,CM-6(b)" disa="002165" ossrg="SRG-OS-000480-GPOS-00227" cis="6.1.11" />
+<ref nist="AC-3(4),AC-6,CM-6(b)" disa="002165" srg="SRG-OS-000480-GPOS-00227" cis="6.1.11" />
 </Rule>
 
 <Rule id="file_permissions_ungroupowned" severity="medium" prodtype="rhel7">
@@ -484,7 +484,7 @@ and the cause should be discovered and addressed.
 <ident prodtype="rhel7" cce="80135-7" />
 <oval id="file_permissions_ungroupowned" />
 <ref prodtype="rhel7" stigid="020330" />
-<ref nist="AC-3(4),AC-6,IA-2" disa="02165" ossrg="SRG-OS-000480-GPOS-00227" cis="6.1.12" />
+<ref nist="AC-3(4),AC-6,IA-2" disa="02165" srg="SRG-OS-000480-GPOS-00227" cis="6.1.12" />
 </Rule>
 
 <Rule id="dir_perms_world_writable_system_owned" prodtype="rhel7">
@@ -511,6 +511,6 @@ users.
 <ident prodtype="rhel7" cce="80136-5" />
 <oval id="dir_perms_world_writable_system_owned" />
 <ref prodtype="rhel7" stigid="021030" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 </Group>

--- a/shared/xccdf/system/permissions/mounting.xml
+++ b/shared/xccdf/system/permissions/mounting.xml
@@ -33,7 +33,7 @@ malicious software.</rationale>
 <ident prodtype="rhel7" cce="27277-3" />
 <oval id="kernel_module_usb-storage_disabled" />
 <ref prodtype="rhel7" stigid="020100" />
-<ref nist="AC-19(a),AC-19(d),AC-19(e),IA-3" disa="366,778,1958" ossrg="SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-0016,SRG-OS-000480-GPOS-00227" cui="3.1.21" />
+<ref nist="AC-19(a),AC-19(d),AC-19(e),IA-3" disa="366,778,1958" srg="SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-0016,SRG-OS-000480-GPOS-00227" cui="3.1.21" />
 </Rule>
 
 <Rule id="bootloader_nousb_argument" prodtype="rhel7">
@@ -110,7 +110,7 @@ unknown devices, thereby facilitating malicious activity.
 <ident prodtype="rhel7" cce="27498-5" />
 <oval id="service_autofs_disabled" />
 <ref prodtype="rhel7" stigid="020110" />
-<ref nist="AC-19(a),AC-19(d),AC-19(e),IA-3" disa="366,778,1958" ossrg="SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-00163,SRG-OS-000480-GPOS-00227" cui="3.4.6" cis="1.1.22" />
+<ref nist="AC-19(a),AC-19(d),AC-19(e),IA-3" disa="366,778,1958" srg="SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-00163,SRG-OS-000480-GPOS-00227" cui="3.4.6" cis="1.1.22" />
 </Rule>
 
 <Rule id="kernel_module_cramfs_disabled" prodtype="rhel7" severity="low">

--- a/shared/xccdf/system/permissions/partitions.xml
+++ b/shared/xccdf/system/permissions/partitions.xml
@@ -94,7 +94,7 @@ removable media would allow them to introduce their own highly-privileged progra
 <oval id="mount_option_nosuid_removable_partitions" value="var_removable_partition" />
 <ref prodtype="rhel7" stigid="021010" />
 <ref nist="AC-6,AC-19(a),AC-19(d),AC-19(e),CM-7,MP-2" cis="1.1.19" disa="366"
-ossrg="SRG-OS-000480-GPOS-00227" />
+srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="mount_option_tmp_nodev" prodtype="rhel7">

--- a/shared/xccdf/system/selinux.xml
+++ b/shared/xccdf/system/selinux.xml
@@ -92,7 +92,7 @@ privileges.
 <oval id="selinux_state" value="var_selinux_state"/>
 <ref prodtype="rhel7" stigid="020210" />
 <ref nist="AC-3,AC-3(3),AC-3(4),AC-4,AC-6,AU-9,SI-6(a)" disa="2165,2696"
-cis="1.6.1.2" ossrg="SRG-OS-000445-GPOS-00199" cui="3.1.2,3.7.2" />
+cis="1.6.1.2" srg="SRG-OS-000445-GPOS-00199" cui="3.1.2,3.7.2" />
 </Rule>
 
 <Rule id="selinux_policytype" severity="high" prodtype="rhel7">
@@ -126,7 +126,7 @@ is completed, the system should be reconfigured to
 <oval id="selinux_policytype" value="var_selinux_policy_name"/>
 <ref prodtype="rhel7" stigid="020220" />
 <ref nist="AC-3,AC-3(3),AC-3(4),AC-4,AC-6,AU-9,SI-6(a)" disa="2696"
-cis="1.6.1.3" ossrg="SRG-OS-000445-GPOS-00199" cui="3.1.2,3.7.2" />
+cis="1.6.1.3" srg="SRG-OS-000445-GPOS-00199" cui="3.1.2,3.7.2" />
 </Rule>
 
 <Rule id="package_setroubleshoot_removed" prodtype="rhel7">
@@ -205,7 +205,7 @@ cannot properly restrict access to the device file.
 <ident prodtype="rhel7" cce="27326-8" />
 <oval id="selinux_all_devicefiles_labeled" />
 <ref prodtype="rhel7" stigid="020900" />
-<ref nist="AC-6,AU-9,CM-3(f),CM-7" disa="22,32,368,318,1812,1813,1814" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.2, 3.1.5,3.7.2" />
+<ref nist="AC-6,AU-9,CM-3(f),CM-7" disa="22,32,368,318,1812,1813,1814" srg="SRG-OS-000480-GPOS-00227" cui="3.1.2, 3.1.5,3.7.2" />
 </Rule>
 
 <Rule id="docker_selinux_enabled" severity="high" prodtype="rhel7">
@@ -3596,7 +3596,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="80419-5" />
 <oval id="sebool_abrt_anon_write" value="var_abrt_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" cui="3.7.2" />
+<ref nist="TBD" disa="TBD" srg="TBD" cui="3.7.2" />
 </Rule>
 
 <Rule id="sebool_abrt_handle_event" severity="medium" prodtype="rhel7">
@@ -3614,7 +3614,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="80420-3" />
 <oval id="sebool_abrt_handle_event" value="var_abrt_handle_event" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" cui="3.7.2" />
+<ref nist="TBD" disa="TBD" srg="TBD" cui="3.7.2" />
 </Rule>
 
 <Rule id="sebool_abrt_upload_watch_anon_write" severity="medium" prodtype="rhel7">
@@ -3633,7 +3633,7 @@ to modify public files used for public file transfer services.
 <ident prodtype="rhel7" cce="80421-1" />
 <oval id="sebool_abrt_upload_watch_anon_write" value="var_abrt_upload_watch_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" cui="3.7.2" />
+<ref nist="TBD" disa="TBD" srg="TBD" cui="3.7.2" />
 </Rule>
 
 <Rule id="sebool_antivirus_can_scan_system" severity="medium" prodtype="rhel7">
@@ -3652,7 +3652,7 @@ files on a system.
 <ident prodtype="rhel7" cce="80422-9" />
 <oval id="sebool_antivirus_can_scan_system" value="var_antivirus_can_scan_system" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" cui="3.7.2" />
+<ref nist="TBD" disa="TBD" srg="TBD" cui="3.7.2" />
 </Rule>
 
 <Rule id="sebool_antivirus_use_jit" severity="medium" prodtype="rhel7">
@@ -3670,7 +3670,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="80423-7" />
 <oval id="sebool_antivirus_use_jit" value="var_antivirus_use_jit" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" cui="3.7.2" />
+<ref nist="TBD" disa="TBD" srg="TBD" cui="3.7.2" />
 </Rule>
 
 <Rule id="sebool_auditadm_exec_content" severity="medium" prodtype="rhel7">
@@ -3688,7 +3688,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="80424-5" />
 <oval id="sebool_auditadm_exec_content" value="var_auditadm_exec_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" cui="80424-5" />
+<ref nist="TBD" disa="TBD" srg="TBD" cui="80424-5" />
 </Rule>
 
 <Rule id="sebool_authlogin_nsswitch_use_ldap" severity="medium" prodtype="rhel7">
@@ -3706,7 +3706,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="80425-2" />
 <oval id="sebool_authlogin_nsswitch_use_ldap" value="var_authlogin_nsswitch_use_ldap" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" cui="3.7.2" />
+<ref nist="TBD" disa="TBD" srg="TBD" cui="3.7.2" />
 </Rule>
 
 <Rule id="sebool_authlogin_radius" severity="medium" prodtype="rhel7">
@@ -3724,7 +3724,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="80426-0" />
 <oval id="sebool_authlogin_radius" value="var_authlogin_radius" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" cui="3.7.2" />
+<ref nist="TBD" disa="TBD" srg="TBD" cui="3.7.2" />
 </Rule>
 
 <Rule id="sebool_authlogin_yubikey" severity="medium" prodtype="rhel7">
@@ -3742,7 +3742,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="80427-8" />
 <oval id="sebool_authlogin_yubikey" value="var_authlogin_yubikey" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" cui="3.7.2" />
+<ref nist="TBD" disa="TBD" srg="TBD" cui="3.7.2" />
 </Rule>
 
 <Rule id="sebool_awstats_purge_apache_log_files" severity="medium" prodtype="rhel7">
@@ -3760,7 +3760,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="80428-6" />
 <oval id="sebool_awstats_purge_apache_log_files" value="var_awstats_purge_apache_log_files" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" cui="3.7.2" />
+<ref nist="TBD" disa="TBD" srg="TBD" cui="3.7.2" />
 </Rule>
 
 <Rule id="sebool_boinc_execmem" severity="medium" prodtype="rhel7">
@@ -3778,7 +3778,7 @@ This setting should be disabled.
 <ident prodtype="rhel7" cce="80429-4" />
 <oval id="sebool_boinc_execmem" value="var_boinc_execmem" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" cui="3.7.2" />
+<ref nist="TBD" disa="TBD" srg="TBD" cui="3.7.2" />
 </Rule>
 
 <Rule id="sebool_cdrecord_read_content" severity="medium" prodtype="rhel7">
@@ -3796,7 +3796,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cdrecord_read_content" value="var_cdrecord_read_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cluster_can_network_connect" severity="medium" prodtype="rhel7">
@@ -3814,7 +3814,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cluster_can_network_connect" value="var_cluster_can_network_connect" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cluster_manage_all_files" severity="medium" prodtype="rhel7">
@@ -3832,7 +3832,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cluster_manage_all_files" value="var_cluster_manage_all_files" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cluster_use_execmem" severity="medium" prodtype="rhel7">
@@ -3850,7 +3850,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cluster_use_execmem" value="var_cluster_use_execmem" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cobbler_anon_write" severity="medium" prodtype="rhel7">
@@ -3868,7 +3868,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cobbler_anon_write" value="var_cobbler_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cobbler_can_network_connect" severity="medium" prodtype="rhel7">
@@ -3886,7 +3886,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cobbler_can_network_connect" value="var_cobbler_can_network_connect" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cobbler_use_cifs" severity="medium" prodtype="rhel7">
@@ -3904,7 +3904,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cobbler_use_cifs" value="var_cobbler_use_cifs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cobbler_use_nfs" severity="medium" prodtype="rhel7">
@@ -3922,7 +3922,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cobbler_use_nfs" value="var_cobbler_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_collectd_tcp_network_connect" severity="medium" prodtype="rhel7">
@@ -3940,7 +3940,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_collectd_tcp_network_connect" value="var_collectd_tcp_network_connect" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_condor_tcp_network_connect" severity="medium" prodtype="rhel7">
@@ -3958,7 +3958,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_condor_tcp_network_connect" value="var_condor_tcp_network_connect" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_conman_can_network" severity="medium" prodtype="rhel7">
@@ -3976,7 +3976,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_conman_can_network" value="var_conman_can_network" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cron_can_relabel" severity="medium" prodtype="rhel7">
@@ -3994,7 +3994,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cron_can_relabel" value="var_cron_can_relabel" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cron_system_cronjob_use_shares" severity="medium" prodtype="rhel7">
@@ -4012,7 +4012,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cron_system_cronjob_use_shares" value="var_cron_system_cronjob_use_shares" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cron_userdomain_transition" severity="medium" prodtype="rhel7">
@@ -4031,7 +4031,7 @@ associated user domain(s) instead of the general cronjob domain.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cron_userdomain_transition" value="var_cron_userdomain_transition" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cups_execmem" severity="medium" prodtype="rhel7">
@@ -4049,7 +4049,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cups_execmem" value="var_cups_execmem" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_cvs_read_shadow" severity="medium" prodtype="rhel7">
@@ -4067,7 +4067,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_cvs_read_shadow" value="var_cvs_read_shadow" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_daemons_dump_core" severity="medium" prodtype="rhel7">
@@ -4085,7 +4085,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_daemons_dump_core" value="var_daemons_dump_core" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_daemons_enable_cluster_mode" severity="medium" prodtype="rhel7">
@@ -4103,7 +4103,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_daemons_enable_cluster_mode" value="var_daemons_enable_cluster_mode" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_daemons_use_tcp_wrapper" severity="medium" prodtype="rhel7">
@@ -4121,7 +4121,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_daemons_use_tcp_wrapper" value="var_daemons_use_tcp_wrapper" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_daemons_use_tty" severity="medium" prodtype="rhel7">
@@ -4139,7 +4139,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_daemons_use_tty" value="var_daemons_use_tty" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_dbadm_exec_content" severity="medium" prodtype="rhel7">
@@ -4157,7 +4157,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_dbadm_exec_content" value="var_dbadm_exec_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_dbadm_manage_user_files" severity="medium" prodtype="rhel7">
@@ -4175,7 +4175,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_dbadm_manage_user_files" value="var_dbadm_manage_user_files" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_dbadm_read_user_files" severity="medium" prodtype="rhel7">
@@ -4193,7 +4193,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_dbadm_read_user_files" value="var_dbadm_read_user_files" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_deny_execmem" severity="medium" prodtype="rhel7">
@@ -4211,7 +4211,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_deny_execmem" value="var_deny_execmem" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_deny_ptrace" severity="medium" prodtype="rhel7">
@@ -4229,7 +4229,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_deny_ptrace" value="var_deny_ptrace" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_dhcpc_exec_iptables" severity="medium" prodtype="rhel7">
@@ -4247,7 +4247,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_dhcpc_exec_iptables" value="var_dhcpc_exec_iptables" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_dhcpd_use_ldap" severity="medium" prodtype="rhel7">
@@ -4265,7 +4265,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_dhcpd_use_ldap" value="var_dhcpd_use_ldap" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_docker_connect_any" severity="medium" prodtype="rhel7">
@@ -4283,7 +4283,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_docker_connect_any" value="var_docker_connect_any" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_docker_transition_unconfined" severity="medium" prodtype="rhel7">
@@ -4301,7 +4301,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_docker_transition_unconfined" value="var_docker_transition_unconfined" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_domain_fd_use" severity="medium" prodtype="rhel7">
@@ -4319,7 +4319,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_domain_fd_use" value="var_domain_fd_use" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_domain_kernel_load_modules" severity="medium" prodtype="rhel7">
@@ -4337,7 +4337,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_domain_kernel_load_modules" value="var_domain_kernel_load_modules" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_entropyd_use_audio" severity="medium" prodtype="rhel7">
@@ -4355,7 +4355,7 @@ This setting should be disabled as it uses audit input to generate entropy.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_entropyd_use_audio" value="var_entropyd_use_audio" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_exim_can_connect_db" severity="medium" prodtype="rhel7">
@@ -4373,7 +4373,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_exim_can_connect_db" value="var_exim_can_connect_db" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_exim_manage_user_files" severity="medium" prodtype="rhel7">
@@ -4391,7 +4391,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_exim_manage_user_files" value="var_exim_manage_user_files" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_exim_read_user_files" severity="medium" prodtype="rhel7">
@@ -4409,7 +4409,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_exim_read_user_files" value="var_exim_read_user_files" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_fcron_crond" severity="medium" prodtype="rhel7">
@@ -4427,7 +4427,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_fcron_crond" value="var_fcron_crond" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_fenced_can_network_connect" severity="medium" prodtype="rhel7">
@@ -4445,7 +4445,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_fenced_can_network_connect" value="var_fenced_can_network_connect" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_fenced_can_ssh" severity="medium" prodtype="rhel7">
@@ -4463,7 +4463,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_fenced_can_ssh" value="var_fenced_can_ssh" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_fips_mode" severity="medium" prodtype="rhel7">
@@ -4482,7 +4482,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="80418-7" />
 <oval id="sebool_fips_mode" value="var_fips_mode" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="SC-13" disa="TBD" ossrg="TBD" cui="3.13.11" />
+<ref nist="SC-13" disa="TBD" srg="TBD" cui="3.13.11" />
 </Rule>
 
 <Rule id="sebool_ftpd_anon_write" severity="medium" prodtype="rhel7">
@@ -4500,7 +4500,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ftpd_anon_write" value="var_ftpd_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ftpd_connect_all_unreserved" severity="medium" prodtype="rhel7">
@@ -4518,7 +4518,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ftpd_connect_all_unreserved" value="var_ftpd_connect_all_unreserved" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ftpd_connect_db" severity="medium" prodtype="rhel7">
@@ -4536,7 +4536,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ftpd_connect_db" value="var_ftpd_connect_db" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ftpd_full_access" severity="medium" prodtype="rhel7">
@@ -4554,7 +4554,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ftpd_full_access" value="var_ftpd_full_access" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ftpd_use_cifs" severity="medium" prodtype="rhel7">
@@ -4572,7 +4572,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ftpd_use_cifs" value="var_ftpd_use_cifs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ftpd_use_fusefs" severity="medium" prodtype="rhel7">
@@ -4590,7 +4590,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ftpd_use_fusefs" value="var_ftpd_use_fusefs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ftpd_use_nfs" severity="medium" prodtype="rhel7">
@@ -4608,7 +4608,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ftpd_use_nfs" value="var_ftpd_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ftpd_use_passive_mode" severity="medium" prodtype="rhel7">
@@ -4626,7 +4626,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ftpd_use_passive_mode" value="var_ftpd_use_passive_mode" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ftp_home_dir" severity="medium" prodtype="rhel7">
@@ -4644,7 +4644,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ftp_home_dir" value="var_ftp_home_dir" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_git_cgi_enable_homedirs" severity="medium" prodtype="rhel7">
@@ -4662,7 +4662,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_git_cgi_enable_homedirs" value="var_git_cgi_enable_homedirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_git_cgi_use_cifs" severity="medium" prodtype="rhel7">
@@ -4680,7 +4680,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_git_cgi_use_cifs" value="var_git_cgi_use_cifs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_git_cgi_use_nfs" severity="medium" prodtype="rhel7">
@@ -4698,7 +4698,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_git_cgi_use_nfs" value="var_git_cgi_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_gitosis_can_sendmail" severity="medium" prodtype="rhel7">
@@ -4716,7 +4716,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_gitosis_can_sendmail" value="var_gitosis_can_sendmail" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_git_session_bind_all_unreserved_ports" severity="medium" prodtype="rhel7">
@@ -4734,7 +4734,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_git_session_bind_all_unreserved_ports" value="var_git_session_bind_all_unreserved_ports" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_git_session_users" severity="medium" prodtype="rhel7">
@@ -4752,7 +4752,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_git_session_users" value="var_git_session_users" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_git_system_enable_homedirs" severity="medium" prodtype="rhel7">
@@ -4770,7 +4770,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_git_system_enable_homedirs" value="var_git_system_enable_homedirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_git_system_use_cifs" severity="medium" prodtype="rhel7">
@@ -4788,7 +4788,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_git_system_use_cifs" value="var_git_system_use_cifs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_git_system_use_nfs" severity="medium" prodtype="rhel7">
@@ -4806,7 +4806,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_git_system_use_nfs" value="var_git_system_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_glance_api_can_network" severity="medium" prodtype="rhel7">
@@ -4824,7 +4824,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_glance_api_can_network" value="var_glance_api_can_network" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_glance_use_execmem" severity="medium" prodtype="rhel7">
@@ -4842,7 +4842,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_glance_use_execmem" value="var_glance_use_execmem" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_glance_use_fusefs" severity="medium" prodtype="rhel7">
@@ -4860,7 +4860,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_glance_use_fusefs" value="var_glance_use_fusefs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_global_ssp" severity="medium" prodtype="rhel7">
@@ -4878,7 +4878,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_global_ssp" value="var_global_ssp" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_gluster_anon_write" severity="medium" prodtype="rhel7">
@@ -4896,7 +4896,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_gluster_anon_write" value="var_gluster_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_gluster_export_all_ro" severity="medium" prodtype="rhel7">
@@ -4914,7 +4914,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_gluster_export_all_ro" value="var_gluster_export_all_ro" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_gluster_export_all_rw" severity="medium" prodtype="rhel7">
@@ -4933,7 +4933,7 @@ disable it.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_gluster_export_all_rw" value="var_gluster_export_all_rw" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_gpg_web_anon_write" severity="medium" prodtype="rhel7">
@@ -4951,7 +4951,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_gpg_web_anon_write" value="var_gpg_web_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_gssd_read_tmp" severity="medium" prodtype="rhel7">
@@ -4971,7 +4971,7 @@ be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_gssd_read_tmp" value="var_gssd_read_tmp" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_guest_exec_content" severity="medium" prodtype="rhel7">
@@ -4989,7 +4989,7 @@ This setting should be disabled as no guest accounts should be used.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_guest_exec_content" value="var_guest_exec_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_haproxy_connect_any" severity="medium" prodtype="rhel7">
@@ -5007,7 +5007,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_haproxy_connect_any" value="var_haproxy_connect_any" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_anon_write" severity="medium" prodtype="rhel7">
@@ -5025,7 +5025,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_anon_write" value="var_httpd_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_builtin_scripting" severity="medium" prodtype="rhel7">
@@ -5044,7 +5044,7 @@ or some similary scripting language.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_builtin_scripting" value="var_httpd_builtin_scripting" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_can_check_spam" severity="medium" prodtype="rhel7">
@@ -5062,7 +5062,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_can_check_spam" value="var_httpd_can_check_spam" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_can_connect_ftp" severity="medium" prodtype="rhel7">
@@ -5080,7 +5080,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_can_connect_ftp" value="var_httpd_can_connect_ftp" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_can_connect_ldap" severity="medium" prodtype="rhel7">
@@ -5098,7 +5098,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_can_connect_ldap" value="var_httpd_can_connect_ldap" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_can_connect_mythtv" severity="medium" prodtype="rhel7">
@@ -5116,7 +5116,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_can_connect_mythtv" value="var_httpd_can_connect_mythtv" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_can_connect_zabbix" severity="medium" prodtype="rhel7">
@@ -5134,7 +5134,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_can_connect_zabbix" value="var_httpd_can_connect_zabbix" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_can_network_connect_cobbler" severity="medium" prodtype="rhel7">
@@ -5152,7 +5152,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_can_network_connect_cobbler" value="var_httpd_can_network_connect_cobbler" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_can_network_connect_db" severity="medium" prodtype="rhel7">
@@ -5170,7 +5170,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_can_network_connect_db" value="var_httpd_can_network_connect_db" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_can_network_connect" severity="medium" prodtype="rhel7">
@@ -5188,7 +5188,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_can_network_connect" value="var_httpd_can_network_connect" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_can_network_memcache" severity="medium" prodtype="rhel7">
@@ -5206,7 +5206,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_can_network_memcache" value="var_httpd_can_network_memcache" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_can_network_relay" severity="medium" prodtype="rhel7">
@@ -5224,7 +5224,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_can_network_relay" value="var_httpd_can_network_relay" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_can_sendmail" severity="medium" prodtype="rhel7">
@@ -5242,7 +5242,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_can_sendmail" value="var_httpd_can_sendmail" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_dbus_avahi" severity="medium" prodtype="rhel7">
@@ -5260,7 +5260,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_dbus_avahi" value="var_httpd_dbus_avahi" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_dbus_sssd" severity="medium" prodtype="rhel7">
@@ -5278,7 +5278,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_dbus_sssd" value="var_httpd_dbus_sssd" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_dontaudit_search_dirs" severity="medium" prodtype="rhel7">
@@ -5296,7 +5296,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_dontaudit_search_dirs" value="var_httpd_dontaudit_search_dirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_enable_cgi" severity="medium" prodtype="rhel7">
@@ -5315,7 +5315,7 @@ scripting.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_enable_cgi" value="var_httpd_enable_cgi" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_enable_ftp_server" severity="medium" prodtype="rhel7">
@@ -5333,7 +5333,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_enable_ftp_server" value="var_httpd_enable_ftp_server" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_enable_homedirs" severity="medium" prodtype="rhel7">
@@ -5351,7 +5351,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_enable_homedirs" value="var_httpd_enable_homedirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_execmem" severity="medium" prodtype="rhel7">
@@ -5369,7 +5369,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_execmem" value="var_httpd_execmem" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_graceful_shutdown" severity="medium" prodtype="rhel7">
@@ -5387,7 +5387,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_graceful_shutdown" value="var_httpd_graceful_shutdown" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_manage_ipa" severity="medium" prodtype="rhel7">
@@ -5405,7 +5405,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_manage_ipa" value="var_httpd_manage_ipa" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_mod_auth_ntlm_winbind" severity="medium" prodtype="rhel7">
@@ -5423,7 +5423,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_mod_auth_ntlm_winbind" value="var_httpd_mod_auth_ntlm_winbind" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_mod_auth_pam" severity="medium" prodtype="rhel7">
@@ -5441,7 +5441,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_mod_auth_pam" value="var_httpd_mod_auth_pam" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_read_user_content" severity="medium" prodtype="rhel7">
@@ -5459,7 +5459,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_read_user_content" value="var_httpd_read_user_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_run_ipa" severity="medium" prodtype="rhel7">
@@ -5477,7 +5477,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_run_ipa" value="var_httpd_run_ipa" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_run_preupgrade" severity="medium" prodtype="rhel7">
@@ -5495,7 +5495,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_run_preupgrade" value="var_httpd_run_preupgrade" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_run_stickshift" severity="medium" prodtype="rhel7">
@@ -5513,7 +5513,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_run_stickshift" value="var_httpd_run_stickshift" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_serve_cobbler_files" severity="medium" prodtype="rhel7">
@@ -5531,7 +5531,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_serve_cobbler_files" value="var_httpd_serve_cobbler_files" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_setrlimit" severity="medium" prodtype="rhel7">
@@ -5549,7 +5549,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_setrlimit" value="var_httpd_setrlimit" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_ssi_exec" severity="medium" prodtype="rhel7">
@@ -5567,7 +5567,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_ssi_exec" value="var_httpd_ssi_exec" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_sys_script_anon_write" severity="medium" prodtype="rhel7">
@@ -5585,7 +5585,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_sys_script_anon_write" value="var_httpd_sys_script_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_tmp_exec" severity="medium" prodtype="rhel7">
@@ -5603,7 +5603,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_tmp_exec" value="var_httpd_tmp_exec" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_tty_comm" severity="medium" prodtype="rhel7">
@@ -5621,7 +5621,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_tty_comm" value="var_httpd_tty_comm" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_unified" severity="medium" prodtype="rhel7">
@@ -5639,7 +5639,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_unified" value="var_httpd_unified" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_use_cifs" severity="medium" prodtype="rhel7">
@@ -5657,7 +5657,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_use_cifs" value="var_httpd_use_cifs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_use_fusefs" severity="medium" prodtype="rhel7">
@@ -5675,7 +5675,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_use_fusefs" value="var_httpd_use_fusefs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_use_gpg" severity="medium" prodtype="rhel7">
@@ -5693,7 +5693,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_use_gpg" value="var_httpd_use_gpg" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_use_nfs" severity="medium" prodtype="rhel7">
@@ -5711,7 +5711,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_use_nfs" value="var_httpd_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_use_openstack" severity="medium" prodtype="rhel7">
@@ -5729,7 +5729,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_use_openstack" value="var_httpd_use_openstack" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_use_sasl" severity="medium" prodtype="rhel7">
@@ -5747,7 +5747,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_use_sasl" value="var_httpd_use_sasl" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_httpd_verify_dns" severity="medium" prodtype="rhel7">
@@ -5765,7 +5765,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_httpd_verify_dns" value="var_httpd_verify_dns" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_icecast_use_any_tcp_ports" severity="medium" prodtype="rhel7">
@@ -5783,7 +5783,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_icecast_use_any_tcp_ports" value="var_icecast_use_any_tcp_ports" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_irc_use_any_tcp_ports" severity="medium" prodtype="rhel7">
@@ -5801,7 +5801,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_irc_use_any_tcp_ports" value="var_irc_use_any_tcp_ports" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_irssi_use_full_network" severity="medium" prodtype="rhel7">
@@ -5819,7 +5819,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_irssi_use_full_network" value="var_irssi_use_full_network" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_kdumpgui_run_bootloader" severity="medium" prodtype="rhel7">
@@ -5837,7 +5837,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_kdumpgui_run_bootloader" value="var_kdumpgui_run_bootloader" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_kerberos_enabled" severity="medium" prodtype="rhel7">
@@ -5856,7 +5856,7 @@ applications to run with Kerberos.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_kerberos_enabled" value="var_kerberos_enabled" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ksmtuned_use_cifs" severity="medium" prodtype="rhel7">
@@ -5874,7 +5874,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ksmtuned_use_cifs" value="var_ksmtuned_use_cifs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ksmtuned_use_nfs" severity="medium" prodtype="rhel7">
@@ -5892,7 +5892,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ksmtuned_use_nfs" value="var_ksmtuned_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_logadm_exec_content" severity="medium" prodtype="rhel7">
@@ -5910,7 +5910,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_logadm_exec_content" value="var_logadm_exec_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_logging_syslogd_can_sendmail" severity="medium" prodtype="rhel7">
@@ -5928,7 +5928,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_logging_syslogd_can_sendmail" value="var_logging_syslogd_can_sendmail" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_logging_syslogd_run_nagios_plugins" severity="medium" prodtype="rhel7">
@@ -5946,7 +5946,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_logging_syslogd_run_nagios_plugins" value="var_logging_syslogd_run_nagios_plugins" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_logging_syslogd_use_tty" severity="medium" prodtype="rhel7">
@@ -5965,7 +5965,7 @@ the ability to read/write to terminal.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_logging_syslogd_use_tty" value="var_logging_syslogd_use_tty" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_login_console_enabled" severity="medium" prodtype="rhel7">
@@ -5984,7 +5984,7 @@ If this setting is disabled, it should be enabled as it allows login from
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_login_console_enabled" value="var_login_console_enabled" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_logrotate_use_nfs" severity="medium" prodtype="rhel7">
@@ -6002,7 +6002,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_logrotate_use_nfs" value="var_logrotate_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_logwatch_can_network_connect_mail" severity="medium" prodtype="rhel7">
@@ -6020,7 +6020,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_logwatch_can_network_connect_mail" value="var_logwatch_can_network_connect_mail" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_lsmd_plugin_connect_any" severity="medium" prodtype="rhel7">
@@ -6038,7 +6038,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_lsmd_plugin_connect_any" value="var_lsmd_plugin_connect_any" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mailman_use_fusefs" severity="medium" prodtype="rhel7">
@@ -6056,7 +6056,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mailman_use_fusefs" value="var_mailman_use_fusefs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mcelog_client" severity="medium" prodtype="rhel7">
@@ -6074,7 +6074,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mcelog_client" value="var_mcelog_client" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mcelog_exec_scripts" severity="medium" prodtype="rhel7">
@@ -6092,7 +6092,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mcelog_exec_scripts" value="var_mcelog_exec_scripts" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mcelog_foreground" severity="medium" prodtype="rhel7">
@@ -6110,7 +6110,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mcelog_foreground" value="var_mcelog_foreground" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mcelog_server" severity="medium" prodtype="rhel7">
@@ -6128,7 +6128,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mcelog_server" value="var_mcelog_server" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_minidlna_read_generic_user_content" severity="medium" prodtype="rhel7">
@@ -6146,7 +6146,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_minidlna_read_generic_user_content" value="var_minidlna_read_generic_user_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mmap_low_allowed" severity="medium" prodtype="rhel7">
@@ -6164,7 +6164,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mmap_low_allowed" value="var_mmap_low_allowed" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mock_enable_homedirs" severity="medium" prodtype="rhel7">
@@ -6182,7 +6182,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mock_enable_homedirs" value="var_mock_enable_homedirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mount_anyfile" severity="medium" prodtype="rhel7">
@@ -6201,7 +6201,7 @@ or directory to be mounted.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mount_anyfile" value="var_mount_anyfile" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mozilla_plugin_bind_unreserved_ports" severity="medium" prodtype="rhel7">
@@ -6219,7 +6219,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mozilla_plugin_bind_unreserved_ports" value="var_mozilla_plugin_bind_unreserved_ports" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mozilla_plugin_can_network_connect" severity="medium" prodtype="rhel7">
@@ -6237,7 +6237,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mozilla_plugin_can_network_connect" value="var_mozilla_plugin_can_network_connect" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mozilla_plugin_use_bluejeans" severity="medium" prodtype="rhel7">
@@ -6255,7 +6255,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mozilla_plugin_use_bluejeans" value="var_mozilla_plugin_use_bluejeans" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mozilla_plugin_use_gps" severity="medium" prodtype="rhel7">
@@ -6273,7 +6273,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mozilla_plugin_use_gps" value="var_mozilla_plugin_use_gps" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mozilla_plugin_use_spice" severity="medium" prodtype="rhel7">
@@ -6291,7 +6291,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mozilla_plugin_use_spice" value="var_mozilla_plugin_use_spice" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mozilla_read_content" severity="medium" prodtype="rhel7">
@@ -6309,7 +6309,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mozilla_read_content" value="var_mozilla_read_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mpd_enable_homedirs" severity="medium" prodtype="rhel7">
@@ -6327,7 +6327,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mpd_enable_homedirs" value="var_mpd_enable_homedirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mpd_use_cifs" severity="medium" prodtype="rhel7">
@@ -6345,7 +6345,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mpd_use_cifs" value="var_mpd_use_cifs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mpd_use_nfs" severity="medium" prodtype="rhel7">
@@ -6363,7 +6363,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mpd_use_nfs" value="var_mpd_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mplayer_execstack" severity="medium" prodtype="rhel7">
@@ -6381,7 +6381,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mplayer_execstack" value="var_mplayer_execstack" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_mysql_connect_any" severity="medium" prodtype="rhel7">
@@ -6399,7 +6399,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_mysql_connect_any" value="var_mysql_connect_any" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_nagios_run_pnp4nagios" severity="medium" prodtype="rhel7">
@@ -6417,7 +6417,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_nagios_run_pnp4nagios" value="var_nagios_run_pnp4nagios" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_nagios_run_sudo" severity="medium" prodtype="rhel7">
@@ -6435,7 +6435,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_nagios_run_sudo" value="var_nagios_run_sudo" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_named_tcp_bind_http_port" severity="medium" prodtype="rhel7">
@@ -6453,7 +6453,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_named_tcp_bind_http_port" value="var_named_tcp_bind_http_port" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_named_write_master_zones" severity="medium" prodtype="rhel7">
@@ -6471,7 +6471,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_named_write_master_zones" value="var_named_write_master_zones" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_neutron_can_network" severity="medium" prodtype="rhel7">
@@ -6489,7 +6489,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_neutron_can_network" value="var_neutron_can_network" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_nfsd_anon_write" severity="medium" prodtype="rhel7">
@@ -6507,7 +6507,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_nfsd_anon_write" value="var_nfsd_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_nfs_export_all_ro" severity="medium" prodtype="rhel7">
@@ -6526,7 +6526,7 @@ export read-only mounts.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_nfs_export_all_ro" value="var_nfs_export_all_ro" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_nfs_export_all_rw" severity="medium" prodtype="rhel7">
@@ -6545,7 +6545,7 @@ export read/write mounts.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_nfs_export_all_rw" value="var_nfs_export_all_rw" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_nis_enabled" severity="medium" prodtype="rhel7">
@@ -6563,7 +6563,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_nis_enabled" value="var_nis_enabled" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_nscd_use_shm" severity="medium" prodtype="rhel7">
@@ -6582,7 +6582,7 @@ to use shared memory.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_nscd_use_shm" value="var_nscd_use_shm" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_openshift_use_nfs" severity="medium" prodtype="rhel7">
@@ -6600,7 +6600,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_openshift_use_nfs" value="var_openshift_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_openvpn_can_network_connect" severity="medium" prodtype="rhel7">
@@ -6618,7 +6618,7 @@ This setting should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_openvpn_can_network_connect" value="var_openvpn_can_network_connect" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_openvpn_enable_homedirs" severity="medium" prodtype="rhel7">
@@ -6636,7 +6636,7 @@ This setting should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_openvpn_enable_homedirs" value="var_openvpn_enable_homedirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_openvpn_run_unconfined" severity="medium" prodtype="rhel7">
@@ -6654,7 +6654,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_openvpn_run_unconfined" value="var_openvpn_run_unconfined" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_pcp_bind_all_unreserved_ports" severity="medium" prodtype="rhel7">
@@ -6672,7 +6672,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_pcp_bind_all_unreserved_ports" value="var_pcp_bind_all_unreserved_ports" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_pcp_read_generic_logs" severity="medium" prodtype="rhel7">
@@ -6690,7 +6690,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_pcp_read_generic_logs" value="var_pcp_read_generic_logs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_piranha_lvs_can_network_connect" severity="medium" prodtype="rhel7">
@@ -6708,7 +6708,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_piranha_lvs_can_network_connect" value="var_piranha_lvs_can_network_connect" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_polipo_connect_all_unreserved" severity="medium" prodtype="rhel7">
@@ -6726,7 +6726,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_polipo_connect_all_unreserved" value="var_polipo_connect_all_unreserved" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_polipo_session_bind_all_unreserved_ports" severity="medium" prodtype="rhel7">
@@ -6744,7 +6744,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_polipo_session_bind_all_unreserved_ports" value="var_polipo_session_bind_all_unreserved_ports" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_polipo_session_users" severity="medium" prodtype="rhel7">
@@ -6762,7 +6762,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_polipo_session_users" value="var_polipo_session_users" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_polipo_use_cifs" severity="medium" prodtype="rhel7">
@@ -6780,7 +6780,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_polipo_use_cifs" value="var_polipo_use_cifs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_polipo_use_nfs" severity="medium" prodtype="rhel7">
@@ -6798,7 +6798,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_polipo_use_nfs" value="var_polipo_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_polyinstantiation_enabled" severity="medium" prodtype="rhel7">
@@ -6816,7 +6816,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_polyinstantiation_enabled" value="var_polyinstantiation_enabled" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_postfix_local_write_mail_spool" severity="medium" prodtype="rhel7">
@@ -6835,7 +6835,7 @@ to the mail spool directories.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_postfix_local_write_mail_spool" value="var_postfix_local_write_mail_spool" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_postgresql_can_rsync" severity="medium" prodtype="rhel7">
@@ -6853,7 +6853,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_postgresql_can_rsync" value="var_postgresql_can_rsync" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_postgresql_selinux_transmit_client_label" severity="medium" prodtype="rhel7">
@@ -6871,7 +6871,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_postgresql_selinux_transmit_client_label" value="var_postgresql_selinux_transmit_client_label" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_postgresql_selinux_unconfined_dbadm" severity="medium" prodtype="rhel7">
@@ -6890,7 +6890,7 @@ execute Data Manipulation Language (DML) statements.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_postgresql_selinux_unconfined_dbadm" value="var_postgresql_selinux_unconfined_dbadm" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_postgresql_selinux_users_ddl" severity="medium" prodtype="rhel7">
@@ -6909,7 +6909,7 @@ execute Data Definition Language (DDL) statements.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_postgresql_selinux_users_ddl" value="var_postgresql_selinux_users_ddl" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_pppd_can_insmod" severity="medium" prodtype="rhel7">
@@ -6927,7 +6927,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_pppd_can_insmod" value="var_pppd_can_insmod" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_pppd_for_user" severity="medium" prodtype="rhel7">
@@ -6945,7 +6945,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_pppd_for_user" value="var_pppd_for_user" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_privoxy_connect_any" severity="medium" prodtype="rhel7">
@@ -6963,7 +6963,7 @@ This setting should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_privoxy_connect_any" value="var_privoxy_connect_any" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_prosody_bind_http_port" severity="medium" prodtype="rhel7">
@@ -6981,7 +6981,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_prosody_bind_http_port" value="var_prosody_bind_http_port" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_puppetagent_manage_all_files" severity="medium" prodtype="rhel7">
@@ -6999,7 +6999,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_puppetagent_manage_all_files" value="var_puppetagent_manage_all_files" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_puppetmaster_use_db" severity="medium" prodtype="rhel7">
@@ -7017,7 +7017,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_puppetmaster_use_db" value="var_puppetmaster_use_db" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_racoon_read_shadow" severity="medium" prodtype="rhel7">
@@ -7035,7 +7035,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_racoon_read_shadow" value="var_racoon_read_shadow" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_rsync_anon_write" severity="medium" prodtype="rhel7">
@@ -7053,7 +7053,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_rsync_anon_write" value="var_rsync_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_rsync_client" severity="medium" prodtype="rhel7">
@@ -7071,7 +7071,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_rsync_client" value="var_rsync_client" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_rsync_export_all_ro" severity="medium" prodtype="rhel7">
@@ -7089,7 +7089,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_rsync_export_all_ro" value="var_rsync_export_all_ro" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_rsync_full_access" severity="medium" prodtype="rhel7">
@@ -7107,7 +7107,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_rsync_full_access" value="var_rsync_full_access" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_samba_create_home_dirs" severity="medium" prodtype="rhel7">
@@ -7125,7 +7125,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_samba_create_home_dirs" value="var_samba_create_home_dirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_samba_domain_controller" severity="medium" prodtype="rhel7">
@@ -7143,7 +7143,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_samba_domain_controller" value="var_samba_domain_controller" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_samba_enable_home_dirs" severity="medium" prodtype="rhel7">
@@ -7161,7 +7161,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_samba_enable_home_dirs" value="var_samba_enable_home_dirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_samba_export_all_ro" severity="medium" prodtype="rhel7">
@@ -7179,7 +7179,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_samba_export_all_ro" value="var_samba_export_all_ro" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_samba_export_all_rw" severity="medium" prodtype="rhel7">
@@ -7197,7 +7197,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_samba_export_all_rw" value="var_samba_export_all_rw" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_samba_load_libgfapi" severity="medium" prodtype="rhel7">
@@ -7215,7 +7215,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_samba_load_libgfapi" value="var_samba_load_libgfapi" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_samba_portmapper" severity="medium" prodtype="rhel7">
@@ -7233,7 +7233,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_samba_portmapper" value="var_samba_portmapper" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_samba_run_unconfined" severity="medium" prodtype="rhel7">
@@ -7251,7 +7251,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_samba_run_unconfined" value="var_samba_run_unconfined" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_samba_share_fusefs" severity="medium" prodtype="rhel7">
@@ -7269,7 +7269,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_samba_share_fusefs" value="var_samba_share_fusefs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_samba_share_nfs" severity="medium" prodtype="rhel7">
@@ -7287,7 +7287,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_samba_share_nfs" value="var_samba_share_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_sanlock_use_fusefs" severity="medium" prodtype="rhel7">
@@ -7305,7 +7305,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_sanlock_use_fusefs" value="var_sanlock_use_fusefs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_sanlock_use_nfs" severity="medium" prodtype="rhel7">
@@ -7323,7 +7323,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_sanlock_use_nfs" value="var_sanlock_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_sanlock_use_samba" severity="medium" prodtype="rhel7">
@@ -7341,7 +7341,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_sanlock_use_samba" value="var_sanlock_use_samba" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_saslauthd_read_shadow" severity="medium" prodtype="rhel7">
@@ -7359,7 +7359,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_saslauthd_read_shadow" value="var_saslauthd_read_shadow" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_secadm_exec_content" severity="medium" prodtype="rhel7">
@@ -7377,7 +7377,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_secadm_exec_content" value="var_secadm_exec_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_secure_mode_insmod" severity="medium" prodtype="rhel7">
@@ -7395,7 +7395,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_secure_mode_insmod" value="var_secure_mode_insmod" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_secure_mode" severity="medium" prodtype="rhel7">
@@ -7413,7 +7413,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_secure_mode" value="var_secure_mode" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_secure_mode_policyload" severity="medium" prodtype="rhel7">
@@ -7431,7 +7431,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_secure_mode_policyload" value="var_secure_mode_policyload" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_direct_dri_enabled" severity="medium" prodtype="rhel7">
@@ -7450,7 +7450,7 @@ Otherwise, enable it.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_direct_dri_enabled" value="var_selinuxuser_direct_dri_enabled" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_execheap" severity="medium" prodtype="rhel7">
@@ -7468,7 +7468,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_execheap" value="var_selinuxuser_execheap" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_execmod" severity="medium" prodtype="rhel7">
@@ -7486,7 +7486,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_execmod" value="var_selinuxuser_execmod" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_execstack" severity="medium" prodtype="rhel7">
@@ -7505,7 +7505,7 @@ to make their stack executable.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_execstack" value="var_selinuxuser_execstack" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_mysql_connect_enabled" severity="medium" prodtype="rhel7">
@@ -7523,7 +7523,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_mysql_connect_enabled" value="var_selinuxuser_mysql_connect_enabled" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_ping" severity="medium" prodtype="rhel7">
@@ -7542,7 +7542,7 @@ to use ping and traceroute which is helpful for network troubleshooting.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_ping" value="var_selinuxuser_ping" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_postgresql_connect_enabled" severity="medium" prodtype="rhel7">
@@ -7560,7 +7560,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_postgresql_connect_enabled" value="var_selinuxuser_postgresql_connect_enabled" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_rw_noexattrfile" severity="medium" prodtype="rhel7">
@@ -7579,7 +7579,7 @@ on filesystems that do not have extended attributes e.g. FAT, CDROM, FLOPPY, etc
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_rw_noexattrfile" value="var_selinuxuser_rw_noexattrfile" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_share_music" severity="medium" prodtype="rhel7">
@@ -7597,7 +7597,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_share_music" value="var_selinuxuser_share_music" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_tcp_server" severity="medium" prodtype="rhel7">
@@ -7615,7 +7615,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_tcp_server" value="var_selinuxuser_tcp_server" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_udp_server" severity="medium" prodtype="rhel7">
@@ -7633,7 +7633,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_udp_server" value="var_selinuxuser_udp_server" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_selinuxuser_use_ssh_chroot" severity="medium" prodtype="rhel7">
@@ -7651,7 +7651,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_selinuxuser_use_ssh_chroot" value="var_selinuxuser_use_ssh_chroot" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_sftpd_anon_write" severity="medium" prodtype="rhel7">
@@ -7669,7 +7669,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_sftpd_anon_write" value="var_sftpd_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_sftpd_enable_homedirs" severity="medium" prodtype="rhel7">
@@ -7687,7 +7687,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_sftpd_enable_homedirs" value="var_sftpd_enable_homedirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_sftpd_full_access" severity="medium" prodtype="rhel7">
@@ -7705,7 +7705,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_sftpd_full_access" value="var_sftpd_full_access" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_sftpd_write_ssh_home" severity="medium" prodtype="rhel7">
@@ -7723,7 +7723,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_sftpd_write_ssh_home" value="var_sftpd_write_ssh_home" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_sge_domain_can_network_connect" severity="medium" prodtype="rhel7">
@@ -7741,7 +7741,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_sge_domain_can_network_connect" value="var_sge_domain_can_network_connect" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_sge_use_nfs" severity="medium" prodtype="rhel7">
@@ -7759,7 +7759,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_sge_use_nfs" value="var_sge_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_smartmon_3ware" severity="medium" prodtype="rhel7">
@@ -7777,7 +7777,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_smartmon_3ware" value="var_smartmon_3ware" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_smbd_anon_write" severity="medium" prodtype="rhel7">
@@ -7795,7 +7795,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_smbd_anon_write" value="var_smbd_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_spamassassin_can_network" severity="medium" prodtype="rhel7">
@@ -7813,7 +7813,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_spamassassin_can_network" value="var_spamassassin_can_network" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_spamd_enable_home_dirs" severity="medium" prodtype="rhel7">
@@ -7831,7 +7831,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_spamd_enable_home_dirs" value="var_spamd_enable_home_dirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_squid_connect_any" severity="medium" prodtype="rhel7">
@@ -7850,7 +7850,7 @@ ports.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_squid_connect_any" value="var_squid_connect_any" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_squid_use_tproxy" severity="medium" prodtype="rhel7">
@@ -7868,7 +7868,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_squid_use_tproxy" value="var_squid_use_tproxy" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ssh_chroot_rw_homedirs" severity="medium" prodtype="rhel7">
@@ -7886,7 +7886,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ssh_chroot_rw_homedirs" value="var_ssh_chroot_rw_homedirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ssh_keysign" severity="medium" prodtype="rhel7">
@@ -7904,7 +7904,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ssh_keysign" value="var_ssh_keysign" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_ssh_sysadm_login" severity="medium" prodtype="rhel7">
@@ -7922,7 +7922,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_ssh_sysadm_login" value="var_ssh_sysadm_login" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_staff_exec_content" severity="medium" prodtype="rhel7">
@@ -7940,7 +7940,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_staff_exec_content" value="var_staff_exec_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_staff_use_svirt" severity="medium" prodtype="rhel7">
@@ -7958,7 +7958,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_staff_use_svirt" value="var_staff_use_svirt" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_swift_can_network" severity="medium" prodtype="rhel7">
@@ -7976,7 +7976,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_swift_can_network" value="var_swift_can_network" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_sysadm_exec_content" severity="medium" prodtype="rhel7">
@@ -7994,7 +7994,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_sysadm_exec_content" value="var_sysadm_exec_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_telepathy_connect_all_ports" severity="medium" prodtype="rhel7">
@@ -8012,7 +8012,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_telepathy_connect_all_ports" value="var_telepathy_connect_all_ports" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_telepathy_tcp_connect_generic_network_ports" severity="medium" prodtype="rhel7">
@@ -8031,7 +8031,7 @@ ports.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_telepathy_tcp_connect_generic_network_ports" value="var_telepathy_tcp_connect_generic_network_ports" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_tftp_anon_write" severity="medium" prodtype="rhel7">
@@ -8049,7 +8049,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_tftp_anon_write" value="var_tftp_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_tftp_home_dir" severity="medium" prodtype="rhel7">
@@ -8067,7 +8067,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_tftp_home_dir" value="var_tftp_home_dir" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_tmpreaper_use_nfs" severity="medium" prodtype="rhel7">
@@ -8085,7 +8085,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_tmpreaper_use_nfs" value="var_tmpreaper_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_tmpreaper_use_samba" severity="medium" prodtype="rhel7">
@@ -8103,7 +8103,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_tmpreaper_use_samba" value="var_tmpreaper_use_samba" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_tor_bind_all_unreserved_ports" severity="medium" prodtype="rhel7">
@@ -8121,7 +8121,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_tor_bind_all_unreserved_ports" value="var_tor_bind_all_unreserved_ports" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_tor_can_network_relay" severity="medium" prodtype="rhel7">
@@ -8139,7 +8139,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_tor_can_network_relay" value="var_tor_can_network_relay" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_unconfined_chrome_sandbox_transition" severity="medium" prodtype="rhel7">
@@ -8157,7 +8157,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_unconfined_chrome_sandbox_transition" value="var_unconfined_chrome_sandbox_transition" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_unconfined_login" severity="medium" prodtype="rhel7">
@@ -8175,7 +8175,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_unconfined_login" value="var_unconfined_login" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_unconfined_mozilla_plugin_transition" severity="medium" prodtype="rhel7">
@@ -8193,7 +8193,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_unconfined_mozilla_plugin_transition" value="var_unconfined_mozilla_plugin_transition" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_unprivuser_use_svirt" severity="medium" prodtype="rhel7">
@@ -8211,7 +8211,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_unprivuser_use_svirt" value="var_unprivuser_use_svirt" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_use_ecryptfs_home_dirs" severity="medium" prodtype="rhel7">
@@ -8229,7 +8229,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_use_ecryptfs_home_dirs" value="var_use_ecryptfs_home_dirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_use_fusefs_home_dirs" severity="medium" prodtype="rhel7">
@@ -8247,7 +8247,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_use_fusefs_home_dirs" value="var_use_fusefs_home_dirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_use_lpd_server" severity="medium" prodtype="rhel7">
@@ -8265,7 +8265,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_use_lpd_server" value="var_use_lpd_server" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_use_nfs_home_dirs" severity="medium" prodtype="rhel7">
@@ -8283,7 +8283,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_use_nfs_home_dirs" value="var_use_nfs_home_dirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_user_exec_content" severity="medium" prodtype="rhel7">
@@ -8301,7 +8301,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_user_exec_content" value="var_user_exec_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_use_samba_home_dirs" severity="medium" prodtype="rhel7">
@@ -8319,7 +8319,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_use_samba_home_dirs" value="var_use_samba_home_dirs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_varnishd_connect_any" severity="medium" prodtype="rhel7">
@@ -8337,7 +8337,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_varnishd_connect_any" value="var_varnishd_connect_any" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_read_qemu_ga_data" severity="medium" prodtype="rhel7">
@@ -8355,7 +8355,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_read_qemu_ga_data" value="var_virt_read_qemu_ga_data" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_rw_qemu_ga_data" severity="medium" prodtype="rhel7">
@@ -8373,7 +8373,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_rw_qemu_ga_data" value="var_virt_rw_qemu_ga_data" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_sandbox_use_all_caps" severity="medium" prodtype="rhel7">
@@ -8391,7 +8391,7 @@ This setting is disabled as containers should not run with privileges.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_sandbox_use_all_caps" value="var_virt_sandbox_use_all_caps" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_sandbox_use_audit" severity="medium" prodtype="rhel7">
@@ -8410,7 +8410,7 @@ to send audit messages.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_sandbox_use_audit" value="var_virt_sandbox_use_audit" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_sandbox_use_mknod" severity="medium" prodtype="rhel7">
@@ -8428,7 +8428,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_sandbox_use_mknod" value="var_virt_sandbox_use_mknod" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_sandbox_use_netlink" severity="medium" prodtype="rhel7">
@@ -8446,7 +8446,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_sandbox_use_netlink" value="var_virt_sandbox_use_netlink" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_sandbox_use_nfs" severity="medium" prodtype="rhel7">
@@ -8464,7 +8464,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_sandbox_use_nfs" value="var_virt_sandbox_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_sandbox_use_samba" severity="medium" prodtype="rhel7">
@@ -8482,7 +8482,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_sandbox_use_samba" value="var_virt_sandbox_use_samba" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_sandbox_use_sys_admin" severity="medium" prodtype="rhel7">
@@ -8500,7 +8500,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_sandbox_use_sys_admin" value="var_virt_sandbox_use_sys_admin" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_transition_userdomain" severity="medium" prodtype="rhel7">
@@ -8518,7 +8518,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_transition_userdomain" value="var_virt_transition_userdomain" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_use_comm" severity="medium" prodtype="rhel7">
@@ -8536,7 +8536,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_use_comm" value="var_virt_use_comm" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_use_execmem" severity="medium" prodtype="rhel7">
@@ -8554,7 +8554,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_use_execmem" value="var_virt_use_execmem" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_use_fusefs" severity="medium" prodtype="rhel7">
@@ -8572,7 +8572,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_use_fusefs" value="var_virt_use_fusefs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_use_nfs" severity="medium" prodtype="rhel7">
@@ -8590,7 +8590,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_use_nfs" value="var_virt_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_use_rawip" severity="medium" prodtype="rhel7">
@@ -8608,7 +8608,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_use_rawip" value="var_virt_use_rawip" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_use_samba" severity="medium" prodtype="rhel7">
@@ -8626,7 +8626,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_use_samba" value="var_virt_use_samba" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_use_sanlock" severity="medium" prodtype="rhel7">
@@ -8644,7 +8644,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_use_sanlock" value="var_virt_use_sanlock" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_use_usb" severity="medium" prodtype="rhel7">
@@ -8662,7 +8662,7 @@ This setting should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_use_usb" value="var_virt_use_usb" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_virt_use_xserver" severity="medium" prodtype="rhel7">
@@ -8680,7 +8680,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_virt_use_xserver" value="var_virt_use_xserver" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_webadm_manage_user_files" severity="medium" prodtype="rhel7">
@@ -8698,7 +8698,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_webadm_manage_user_files" value="var_webadm_manage_user_files" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_webadm_read_user_files" severity="medium" prodtype="rhel7">
@@ -8716,7 +8716,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_webadm_read_user_files" value="var_webadm_read_user_files" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_wine_mmap_zero_ignore" severity="medium" prodtype="rhel7">
@@ -8734,7 +8734,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_wine_mmap_zero_ignore" value="var_wine_mmap_zero_ignore" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xdm_bind_vnc_tcp_port" severity="medium" prodtype="rhel7">
@@ -8752,7 +8752,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xdm_bind_vnc_tcp_port" value="var_xdm_bind_vnc_tcp_port" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xdm_exec_bootloader" severity="medium" prodtype="rhel7">
@@ -8770,7 +8770,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xdm_exec_bootloader" value="var_xdm_exec_bootloader" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xdm_sysadm_login" severity="medium" prodtype="rhel7">
@@ -8788,7 +8788,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xdm_sysadm_login" value="var_xdm_sysadm_login" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xdm_write_home" severity="medium" prodtype="rhel7">
@@ -8806,7 +8806,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xdm_write_home" value="var_xdm_write_home" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xend_run_blktap" severity="medium" prodtype="rhel7">
@@ -8824,7 +8824,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xend_run_blktap" value="var_xend_run_blktap" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xend_run_qemu" severity="medium" prodtype="rhel7">
@@ -8842,7 +8842,7 @@ If this setting is disabled, it should be enabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xend_run_qemu" value="var_xend_run_qemu" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xen_use_nfs" severity="medium" prodtype="rhel7">
@@ -8860,7 +8860,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xen_use_nfs" value="var_xen_use_nfs" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xguest_connect_network" severity="medium" prodtype="rhel7">
@@ -8879,7 +8879,7 @@ This setting should be disabled as guest users should not be able to configure
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xguest_connect_network" value="var_xguest_connect_network" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xguest_exec_content" severity="medium" prodtype="rhel7">
@@ -8898,7 +8898,7 @@ executables.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xguest_exec_content" value="var_xguest_exec_content" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xguest_mount_media" severity="medium" prodtype="rhel7">
@@ -8917,7 +8917,7 @@ any media.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xguest_mount_media" value="var_xguest_mount_media" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xguest_use_bluetooth" severity="medium" prodtype="rhel7">
@@ -8936,7 +8936,7 @@ or use bluetooth.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xguest_use_bluetooth" value="var_xguest_use_bluetooth" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xserver_clients_write_xshm" severity="medium" prodtype="rhel7">
@@ -8954,7 +8954,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xserver_clients_write_xshm" value="var_xserver_clients_write_xshm" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xserver_execmem" severity="medium" prodtype="rhel7">
@@ -8972,7 +8972,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xserver_execmem" value="var_xserver_execmem" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_xserver_object_manager" severity="medium" prodtype="rhel7">
@@ -8990,7 +8990,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_xserver_object_manager" value="var_xserver_object_manager" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_zabbix_can_network" severity="medium" prodtype="rhel7">
@@ -9008,7 +9008,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_zabbix_can_network" value="var_zabbix_can_network" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_zarafa_setrlimit" severity="medium" prodtype="rhel7">
@@ -9026,7 +9026,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_zarafa_setrlimit" value="var_zarafa_setrlimit" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_zebra_write_config" severity="medium" prodtype="rhel7">
@@ -9044,7 +9044,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_zebra_write_config" value="var_zebra_write_config" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_zoneminder_anon_write" severity="medium" prodtype="rhel7">
@@ -9062,7 +9062,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_zoneminder_anon_write" value="var_zoneminder_anon_write" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 <Rule id="sebool_zoneminder_run_sudo" severity="medium" prodtype="rhel7">
@@ -9080,7 +9080,7 @@ If this setting is enabled, it should be disabled.
 <ident prodtype="rhel7" cce="RHEL7-CCE-TBD" />
 <oval id="sebool_zoneminder_run_sudo" value="var_zoneminder_run_sudo" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="TBD" disa="TBD" ossrg="TBD" />
+<ref nist="TBD" disa="TBD" srg="TBD" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/system/software/disk_partitioning.xml
+++ b/shared/xccdf/system/software/disk_partitioning.xml
@@ -41,7 +41,7 @@ restrictive mount options, which can help protect programs which use it.
 <ident prodtype="rhel7" cce="27173-4" />
 <oval id="partition_for_tmp" />
 <ref prodtype="rhel7" stigid="021340" />
-<ref nist="SC-32(1)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cis="1.1.2" />
+<ref nist="SC-32(1)" disa="366" srg="SRG-OS-000480-GPOS-00227" cis="1.1.2" />
 </Rule>
 
 <Rule id="partition_for_var" severity="low" prodtype="rhel7">
@@ -62,7 +62,7 @@ world-writable directories installed by other software packages.
 <ident prodtype="rhel7" cce="26404-4" />
 <oval id="partition_for_var" />
 <ref prodtype="rhel7" stigid="021320" />
-<ref nist="SC-32(1)" cis="1.1.6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="SC-32(1)" cis="1.1.6" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="partition_for_var_log" prodtype="rhel7">
@@ -105,7 +105,7 @@ of space.
 <oval id="partition_for_var_log_audit" />
 <ref prodtype="rhel7" stigid="021330" />
 <ref nist="AU-4,AU-9,SC-32(1)" disa="366" cis="1.1.12"
-ossrg="SRG-OS-000480-GPOS-00227" />
+srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="partition_for_home" severity="low" prodtype="rhel7">
@@ -127,7 +127,7 @@ users cannot trivially fill partitions used for log or audit data storage.
 <ident prodtype="rhel7" cce="80144-9" />
 <oval id="partition_for_home" />
 <ref prodtype="rhel7" stigid="021310" />
-<ref nist="SC-32(1)" disa="366,1208" cis="1.1.13" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="SC-32(1)" disa="366,1208" cis="1.1.13" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="encrypt_partitions" severity="high" prodtype="rhel7">
@@ -174,7 +174,7 @@ the risk of its loss if the system is lost.
 </rationale>
 <platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27128-8" />
-<ref nist="SC-13,SC-28(1)" disa="1199,2476" ossrg="SRG-OS-000405-GPOS-00184,SRG-OS-000185-GPOS-00079"
+<ref nist="SC-13,SC-28(1)" disa="1199,2476" srg="SRG-OS-000405-GPOS-00184,SRG-OS-000185-GPOS-00079"
 cui="3.13.16" />
 </Rule>
 

--- a/shared/xccdf/system/software/gnome.xml
+++ b/shared/xccdf/system/software/gnome.xml
@@ -82,7 +82,7 @@ system security.
 <ident prodtype="rhel7" cce="80104-3" />
 <oval id="gnome_gdm_disable_automatic_login" />
 <ref prodtype="rhel7" stigid="010440" />
-<ref nist="CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00229" cui="3.1.1" />
+<ref nist="CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00229" cui="3.1.1" />
 </Rule>
 
 <Rule id="gnome_gdm_disable_guest_login" severity="high" prodtype="rhel7">
@@ -110,7 +110,7 @@ system security.
 <ident prodtype="rhel7" cce="80105-0" />
 <oval id="gnome_gdm_disable_guest_login" />
 <ref prodtype="rhel7" stigid="010450" />
-<ref nist="CM-6(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00229" cui="3.1.1" />
+<ref nist="CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00229" cui="3.1.1" />
 </Rule>
 
 <Rule id="dconf_gnome_disable_user_list" severity="medium" prodtype="rhel7">
@@ -182,7 +182,7 @@ due to reboot.
 <ident prodtype="rhel7" cce="80107-6" />
 <oval id="dconf_gnome_disable_restart_shutdown" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.2" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.2" />
 </Rule>
 
 <Rule id="dconf_gnome_enable_smartcard_auth" severity="medium" prodtype="rhel7">
@@ -339,7 +339,7 @@ a user's session has idled and take action to initiate a session lock.
 <ident prodtype="rhel7" cce="80110-0" />
 <oval id="dconf_gnome_screensaver_idle_delay" value="inactivity_timeout_value" />
 <ref prodtype="rhel7" stigid="010070" />
-<ref nist="AC-11(a)" disa="57" pcidss="Req-8.1.8" ossrg="SRG-OS-000029-GPOS-00010" cjis="5.5.5" cui="3.1.10" />
+<ref nist="AC-11(a)" disa="57" pcidss="Req-8.1.8" srg="SRG-OS-000029-GPOS-00010" cjis="5.5.5" cui="3.1.10" />
 </Rule>
 
 <Rule id="dconf_gnome_screensaver_idle_activation_enabled" severity="medium" prodtype="rhel7">
@@ -381,7 +381,7 @@ controlled-access area.
 <ident prodtype="rhel7" cce="80111-8" />
 <oval id="dconf_gnome_screensaver_idle_activation_enabled" />
 <ref prodtype="rhel7" stigid="010100" />
-<ref nist="AC-11(a)" disa="57" ossrg="SRG-OS-000029-GPOS-00010" pcidss="Req-8.1.8"
+<ref nist="AC-11(a)" disa="57" srg="SRG-OS-000029-GPOS-00010" pcidss="Req-8.1.8"
 cjis="5.5.5" cui="3.1.10" />
 </Rule>
 
@@ -416,7 +416,7 @@ of the information system but does not want to logout because of the temporary n
 <ident prodtype="rhel7" cce="80112-6" />
 <oval id="dconf_gnome_screensaver_lock_enabled" />
 <ref prodtype="rhel7" stigid="010060" />
-<ref nist="AC-11(b)" disa="56" pcidss="Req-8.1.8" ossrg="SRG-OS-000028-GPOS-00009,OS-SRG-000030-GPOS-00011" cjis="5.5.5" cui="3.1.10" />
+<ref nist="AC-11(b)" disa="56" pcidss="Req-8.1.8" srg="SRG-OS-000028-GPOS-00009,OS-SRG-000030-GPOS-00011" cjis="5.5.5" cui="3.1.10" />
 </Rule>
 
 <Rule id="dconf_gnome_screensaver_lock_delay" severity="medium" prodtype="rhel7">
@@ -451,7 +451,7 @@ of the information system but does not want to logout because of the temporary n
 <ident prodtype="rhel7" cce="80370-0" />
 <oval id="dconf_gnome_screensaver_lock_delay" value="var_screensaver_lock_delay" />
 <ref prodtype="rhel7" stigid="010110" />
-<ref nist="AC-11(a)" disa="56" pcidss="Req-8.1.8" ossrg="OS-SRG-000029-GPOS-00010" cui="3.1.10" />
+<ref nist="AC-11(a)" disa="56" pcidss="Req-8.1.8" srg="OS-SRG-000029-GPOS-00010" cui="3.1.10" />
 </Rule>
 
 <Rule id="dconf_gnome_screensaver_mode_blank" prodtype="rhel7">
@@ -549,7 +549,7 @@ session lock. As such, users should not be allowed to change session settings.
 <ident prodtype="rhel7" cce="80371-8" />
 <oval id="dconf_gnome_session_user_locks" />
 <ref prodtype="rhel7" stigid="010081" />
-<ref nist="AC-11(a)" disa="57" ossrg="SRG-OS-00029-GPOS-0010" cui="3.1.10"/>
+<ref nist="AC-11(a)" disa="57" srg="SRG-OS-00029-GPOS-0010" cui="3.1.10"/>
 </Rule>
 
 </Group>
@@ -604,7 +604,7 @@ loss of availability of systems due to unintentional reboot.
 <oval id="dconf_gnome_disable_ctrlaltdel_reboot" />
 <ident prodtype="rhel7" cce="80124-1" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="AC-6" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.2" />
+<ref nist="AC-6" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.2" />
 </Rule>
 
 <Rule id="dconf_gnome_disable_user_admin" severity="high" prodtype="rhel7">
@@ -883,7 +883,7 @@ remotely.
 <oval id="dconf_gnome_remote_access_encryption" />
 <ident prodtype="rhel7" cce="80121-7" />
 <ref prodtype="rhel7" stigid="TBD" />
-<ref nist="CM-2(1)(b)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.1.13" />
+<ref nist="CM-2(1)(b)" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.1.13" />
 </Rule>
 
 </Group>

--- a/shared/xccdf/system/software/integrity.xml
+++ b/shared/xccdf/system/software/integrity.xml
@@ -133,7 +133,7 @@ monitoring system trap when there is an unauthorized modification of a configura
 <oval id="aide_periodic_cron_checking"/>
 <ref prodtype="rhel7" stigid="020030" />
 <ref nist="CM-3(d),CM-3(e),CM-3(5),CM-6(d),CM-6(3),SC-28,SI-7"
-disa="1744" pcidss="Req-11.5" cis="1.3.2" ossrg="SRG-OS-000363-GPOS-00150"
+disa="1744" pcidss="Req-11.5" cis="1.3.2" srg="SRG-OS-000363-GPOS-00150"
 cjis="5.10.1.3" />
 </Rule>
 
@@ -169,7 +169,7 @@ monitoring system trap when there is an unauthorized modification of a configura
 <ident prodtype="rhel7" cce="80374-2" />
 <oval id="aide_scan_notification"/>
 <ref prodtype="rhel7" stigid="020040" />
-<ref nist="CM-3(5)" disa="1744" ossrg="SRG-OS-000363-GPOS-00150" />
+<ref nist="CM-3(5)" disa="1744" srg="SRG-OS-000363-GPOS-00150" />
 </Rule>
 
 <Rule id="aide_verify_acls" severity="medium" prodtype="rhel7">
@@ -195,7 +195,7 @@ verified by the file integrity tools.
 <ident prodtype="rhel7" cce="80375-9" />
 <oval id="aide_verify_acls"/>
 <ref prodtype="rhel7" stigid="021600" />
-<ref nist="SI-7.1" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="SI-7.1" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="aide_verify_ext_attributes" severity="medium" prodtype="rhel7">
@@ -221,7 +221,7 @@ with security implications.
 <ident prodtype="rhel7" cce="80376-7" />
 <oval id="aide_verify_ext_attributes"/>
 <ref prodtype="rhel7" stigid="021610" />
-<ref nist="SI-7.1" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="SI-7.1" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="aide_use_fips_hashes" severity="medium" prodtype="rhel7">
@@ -247,7 +247,7 @@ have not been altered. These hashes must be FIPS 140-2 approved cryptographic ha
 <ident prodtype="rhel7" cce="80377-5" />
 <oval id="aide_use_fips_hashes"/>
 <ref prodtype="rhel7" stigid="021620" />
-<ref nist="SI-7(1)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" cui="3.13.11" />
+<ref nist="SI-7(1)" disa="366" srg="SRG-OS-000480-GPOS-00227" cui="3.13.11" />
 </Rule>
 
 </Group>
@@ -307,7 +307,7 @@ Bugzilla #1275532.
 <ident prodtype="rhel7" cce="27209-6" />
 <oval id="rpm_verify_permissions" />
 <ref prodtype="rhel7" stigid="010010" />
-<ref nist="AC-6,AU-9(1),AU-9(3),CM-6(d),CM-6(3)" disa="1494,1496" pcidss="Req-11.5" cis="1.2.6,6.1.3,6.1.4,6.1.5,6.1.6,6.1.7,6.1.8,6.1.9,6.2.3" ossrg="SRG-OS-000257-GPOS-00098,SRG-OS-000278-GPOS-00108" cjis="5.10.4.1" cui="3.3.8,3.4.1" />
+<ref nist="AC-6,AU-9(1),AU-9(3),CM-6(d),CM-6(3)" disa="1494,1496" pcidss="Req-11.5" cis="1.2.6,6.1.3,6.1.4,6.1.5,6.1.6,6.1.7,6.1.8,6.1.9,6.2.3" srg="SRG-OS-000257-GPOS-00098,SRG-OS-000278-GPOS-00108" cjis="5.10.4.1" cui="3.3.8,3.4.1" />
 </Rule>
 
 <Rule id="rpm_verify_hashes" severity="high" prodtype="rhel7">
@@ -350,7 +350,7 @@ be a sign of nefarious activity on the system.</rationale>
 <ident prodtype="rhel7" cce="27157-7" />
 <oval id="rpm_verify_hashes" />
 <ref prodtype="rhel7" stigid="010020" />
-<ref nist="CM-6(d),CM-6(3),SI-7(1)" disa="663" pcidss="Req-11.5" cis="1.2.6" ossrg="SRG-OS-000480-GPOS-00227" cjis="5.10.4.1" cui="3.3.8,3.4.1" />
+<ref nist="CM-6(d),CM-6(3),SI-7(1)" disa="663" pcidss="Req-11.5" cis="1.2.6" srg="SRG-OS-000480-GPOS-00227" cjis="5.10.4.1" cui="3.3.8,3.4.1" />
 </Rule>
 
 </Group>
@@ -487,7 +487,7 @@ remediation is not available for this configuration check.</warning>
 <oval id="install_mcafee_hbss_hips" />
 <ident prodtype="rhel7" cce="80368-4" />
 <ref nist="SC-7,SI-4(1).1" disa="366,1263" pcidss="Req-11.4"
-ossrg="STG-OS-000480-GPOS-00227" />
+srg="STG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="install_mcafee_hbss_accm" severity="medium" prodtype="rhel7">
@@ -510,7 +510,7 @@ remediation is not available for this configuration check.</warning>
 <oval id="install_mcafee_hbss_accm" />
 <ident prodtype="rhel7" cce="80126-6" />
 <ref nist="SC-7,SI-4(1).1" disa="366,1263" pcidss="Req-11.4"
-ossrg="STG-OS-000480-GPOS-00227" />
+srg="STG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="install_mcafee_hbss_pa" severity="medium" prodtype="rhel7">
@@ -533,7 +533,7 @@ intrusion attempts.
 remediation is not available for this configuration check.</warning>
 <ident prodtype="rhel7" cce="80369-2" />
 <ref nist="SC-7,SI-4(1).1" disa="366,1263" pcidss="Req-11.4"
-ossrg="STG-OS-000480-GPOS-00227" />
+srg="STG-OS-000480-GPOS-00227" />
 </Rule>
 
 </Group>
@@ -561,7 +561,7 @@ remediation is not available for this configuration check.</warning>
 <oval id="install_mcafee_antivirus" />
 <ident prodtype="rhel7" cce="80127-4" />
 <ref prodtype="rhel7" stigid="032000" />
-<ref nist="SC-28,SI-3,SI-3(1)(ii)" disa="366,1239,1668" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="SC-28,SI-3,SI-3(1)(ii)" disa="366,1239,1668" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="service_nails_enabled" severity="medium" prodtype="rhel7">
@@ -579,7 +579,7 @@ computer viruses, as well as to limit their spread to other systems.
 <oval id="service_nails_enabled" />
 <ident prodtype="rhel7" cce="80128-2" />
 <ref nist="SC-28,SI-3,SI-3(1)(ii)" disa="366,1239,1668"
-ossrg="SRG-OS-000480-GPOS-00227" />
+srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 <Rule id="mcafee_antivirus_definitions_updated" severity="medium" prodtype="rhel7">
@@ -600,7 +600,7 @@ computer viruses, as well as to limit their spread to other systems.
 <!--oval id="mcafee_antivirus_definitions_updated" /-->
 <ident prodtype="rhel7" cce="80129-0" />
 <ref prodtype="rhel7" stigid="032010" />
-<ref nist="SC-28,SI-3,SI-3(1)(ii)" disa="366,1239,1668" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="SC-28,SI-3,SI-3(1)(ii)" disa="366,1239,1668" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
 </Group>
@@ -642,7 +642,7 @@ and validated.
 <ident prodtype="rhel7" cce="80358-5" />
 <oval id="package_dracut-fips_installed" />
 <ref nist="AC-17(2)" disa="68,2450"
-ossrg="SRG-OS-000033-GPOS-00014,SRG-OS-000396-GPOS-00176,SRG-OS-000478-GPOS-00223" cjis="5.10.1.2"
+srg="SRG-OS-000033-GPOS-00014,SRG-OS-000396-GPOS-00176,SRG-OS-000478-GPOS-00223" cjis="5.10.1.2"
 cui="3.13.11,3.13.8" />
 </Rule>
 
@@ -688,7 +688,7 @@ vendors.</warning>
 <ident prodtype="rhel7" cce="80359-3" />
 <oval id="grub2_enable_fips_mode" />
 <ref prodtype="rhel7" stigid="021350" />
-<ref nist="AC-17(2)" disa="68,2450" ossrg="SRG-OS-000033-GPOS-00014,SRG-OS-000396-GPOS-00176,SRG-OS-000478-GPOS-00223" cjis="5.10.1.2" cui="3.13.8,3.13.11" />
+<ref nist="AC-17(2)" disa="68,2450" srg="SRG-OS-000033-GPOS-00014,SRG-OS-000396-GPOS-00176,SRG-OS-000478-GPOS-00223" cjis="5.10.1.2" cui="3.13.8,3.13.11" />
 </Rule>
 
 </Group>
@@ -728,7 +728,7 @@ the system software as well as meet government certifications.
 <ident prodtype="rhel7" cce="80349-4" />
 <oval id="installed_OS_is_certified" />
 <ref prodtype="rhel7" stigid="020250" />
-<ref nist="SI-2(c)" disa="366" ossrg="SRG-OS-000480-GPOS-00227" />
+<ref nist="SI-2(c)" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 </Group>
 

--- a/shared/xccdf/system/software/sudo.xml
+++ b/shared/xccdf/system/software/sudo.xml
@@ -33,7 +33,7 @@ is critical that the user re-authenticate.
 <ident prodtype="rhel7" cce="80351-0" />
 <oval id="sudo_remove_nopasswd" />
 <ref prodtype="rhel7" stigid="010340" />
-<ref nist="IA-11" disa="2038" ossrg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
+<ref nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
 </Rule>
 
 <Rule id="sudo_remove_no_authenticate" severity="medium" prodtype="rhel7">
@@ -59,7 +59,7 @@ is critical that the user re-authenticate.
 <ident prodtype="rhel7" cce="80350-2" />
 <oval id="sudo_remove_no_authenticate" />
 <ref prodtype="rhel7" stigid="010350" />
-<ref nist="IA-11" disa="2038" ossrg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
+<ref nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
 </Rule>
 
 </Group>

--- a/shared/xccdf/system/software/updating.xml
+++ b/shared/xccdf/system/software/updating.xml
@@ -41,7 +41,7 @@ cryptographically verify packages are from Red Hat.
 </rationale>
 <ident prodtype="rhel7" cce="26957-1" />
 <oval id="ensure_redhat_gpgkey_installed" />
-<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" ossrg="366" 
+<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" srg="366" 
 pcidss="Req-6.2" cis="1.2.3" cjis="5.10.4.1" cui="3.4.8" />
 </Rule>
 
@@ -85,7 +85,7 @@ Authority (CA).
 <ident prodtype="rhel7" cce="26989-4" />
 <oval id="ensure_gpgcheck_globally_activated" />
 <ref prodtype="rhel7" stigid="020050" />
-<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" ossrg="SRG-OS-000366-GPOS-00153"
+<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" srg="SRG-OS-000366-GPOS-00153"
 pcidss="Req-6.2" cis="1.2.2" cjis="5.10.4.1" cui="3.4.8" />
 </Rule>
 
@@ -114,7 +114,7 @@ Authority (CA).
 </rationale>
 <ident prodtype="rhel7" cce="26876-3" />
 <oval id="ensure_gpgcheck_never_disabled" />
-<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" ossrg="366" pcidss="Req-6.2" 
+<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" srg="366" pcidss="Req-6.2" 
 cjis="5.10.4.1" cui="3.4.8" />
 </Rule>
 
@@ -158,7 +158,7 @@ lack of prompt attention to patching could result in a system compromise.
 <!-- Particular OVAL check is defined directly via <check> element above -->
 <!-- DO NOT REFERENCE an OVAL id here !!! -->
 <ref prodtype="rhel7" stigid="020260" />
-<ref nist="SI-2,SI-2(c),MA-1(b)" disa="366" pcidss="Req-6.2" cis="1.7" ossrg="SRG-OS-000480-GPOS-00227" cjis="5.10.4.1" />
+<ref nist="SI-2,SI-2(c),MA-1(b)" disa="366" pcidss="Req-6.2" cis="1.7" srg="SRG-OS-000480-GPOS-00227" cjis="5.10.4.1" />
 </Rule>
 
 <Rule id="clean_components_post_updating" severity="low" prodtype="rhel7">
@@ -183,7 +183,7 @@ system after updates have been installed may be exploited by some adversaries.
 <ident prodtype="rhel7" cce="CCE-80346-0" />
 <oval id="clean_components_post_updating" />
 <ref prodtype="rhel7" stigid="020200" />
-<ref nist="SI-2(6)" disa="2617" ossrg="SRG-OS-000437-GPOS-00194" cui="3.4.8" />
+<ref nist="SI-2(6)" disa="2617" srg="SRG-OS-000437-GPOS-00194" cui="3.4.8" />
 </Rule>
 
 <Rule id="ensure_gpgcheck_local_packages" severity="high" prodtype="rhel7">
@@ -211,7 +211,7 @@ be signed with a certificate recognized and approved by the organization.
 <ident prodtype="rhel7" cce="CCE-80347-8" />
 <oval id="ensure_gpgcheck_local_packages" />
 <ref prodtype="rhel7" stigid="020060" />
-<ref nist="CM-5(3)" disa="1749" ossrg="SRG-OS-000366-GPOS-00153" cui="3.4.8" />
+<ref nist="CM-5(3)" disa="1749" srg="SRG-OS-000366-GPOS-00153" cui="3.4.8" />
 </Rule>
 
 <Rule id="ensure_gpgcheck_repo_metadata" severity="high" prodtype="rhel7">
@@ -264,7 +264,7 @@ This issue of Red Hat Enterprise Linux repositories was reported in
 <ident prodtype="rhel7" cce="CCE-80348-6" />
 <oval id="ensure_gpgcheck_repo_metadata" />
 <ref prodtype="rhel7" stigid="020070" />
-<ref nist="CM-5(3)" disa="1749" ossrg="SRG-OS-000366-GPOS-00153" />
+<ref nist="CM-5(3)" disa="1749" srg="SRG-OS-000366-GPOS-00153" />
 </Rule>
 
 </Group>


### PR DESCRIPTION
- This replaces the OSSRG references to SRG references. This simplifies SSG as there are currently
  3 ways to do SRGs: APPSRG, SRG, and OSSRG. This standardizes on SRG.