### PR TITLE
Handle different SRG reference types in CMake

### DIFF
--- a/RHEL/6/CMakeLists.txt
+++ b/RHEL/6/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 set(PRODUCT "rhel6")
 set(DISA_SRG_VERSION "v1r4")
 set(DISA_STIG_VERSION "v1r12")
+set(DISA_SRG_TYPE "os")
 
 ssg_build_product(${PRODUCT})
 
@@ -18,7 +19,7 @@ ssg_build_html_nistrefs_table(${PRODUCT} "C2S")
 
 ssg_build_html_cce_table(${PRODUCT})
 
-ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_VERSION})
+ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE} ${DISA_SRG_VERSION})
 
 ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-server-upstream" ${DISA_STIG_VERSION})
 

--- a/RHEL/7/CMakeLists.txt
+++ b/RHEL/7/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 set(PRODUCT "rhel7")
 set(DISA_SRG_VERSION "v1r4")
 set(DISA_STIG_VERSION "v1r1")
+set(DISA_SRG_TYPE "os")
 
 ssg_build_product(${PRODUCT})
 
@@ -21,7 +22,7 @@ ssg_build_html_nistrefs_table(${PRODUCT} "stig-${PRODUCT}-disa")
 
 ssg_build_html_cce_table(${PRODUCT})
 
-ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_VERSION})
+ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE} ${DISA_SRG_VERSION})
 
 ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-disa" ${DISA_STIG_VERSION})
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1034,17 +1034,17 @@ macro(ssg_build_html_cce_table PRODUCT)
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
 endmacro()
 
-macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_VERSION)
+macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE DISA_SRG_VERSION)
     # we have to encode spaces in paths before passing them as stringparams to xsltproc
     string(REPLACE " " "%20" CMAKE_CURRENT_BINARY_DIR_NO_SPACES "${CMAKE_CURRENT_BINARY_DIR}")
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
         # We need to use xccdf-linked.xml because ssg-${PRODUCT}-xccdf.xml has the srg_support Group removed
-        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${SSG_SHARED_REFS}/disa-os-srg-${DISA_SRG_VERSION}.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${SSG_SHARED_REFS}/disa-${DISA_SRG_TYPE}-srg-${DISA_SRG_VERSION}.xml"
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-        DEPENDS "${SSG_SHARED_REFS}/disa-os-srg-${DISA_SRG_VERSION}.xml"
+        DEPENDS "${SSG_SHARED_REFS}/disa-${DISA_SRG_TYPE}-srg-${DISA_SRG_VERSION}.xml"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt"
         COMMENT "[${PRODUCT}-tables] generating HTML SRG map table (flat=no)"
     )
@@ -1052,10 +1052,10 @@ macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_VERSION)
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
         # We need to use xccdf-linked.xml because ssg-${PRODUCT}-xccdf.xml has the srg_support Group removed
-        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam flat "y" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${SSG_SHARED_REFS}/disa-os-srg-${DISA_SRG_VERSION}.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam flat "y" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${SSG_SHARED_REFS}/disa-${DISA_SRG_TYPE}-srg-${DISA_SRG_VERSION}.xml"
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-        DEPENDS "${SSG_SHARED_REFS}/disa-os-srg-${DISA_SRG_VERSION}.xml"
+        DEPENDS "${SSG_SHARED_REFS}/disa-${DISA_SRG_TYPE}-srg-${DISA_SRG_VERSION}.xml"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt"
         COMMENT "[${PRODUCT}-tables] generating HTML SRG map table (flat=yes)"
     )


### PR DESCRIPTION
- With different APP and OS SRG references, CMake need to build the correct HTML tables based on the SRG type. This adds the DISA_SRG_TYPE variable for local CMakeLists.txt to be able to handle this.