### PR TITLE
RHEL6 build fixes

### DIFF
--- a/RHEL/6/transforms/constants.xslt
+++ b/RHEL/6/transforms/constants.xslt
@@ -12,7 +12,7 @@
 <!-- Define URI of official CIS Red Hat Enterprise Linux 6 Benchmark -->
 <xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Red_Hat_Enterprise_Linux_6_Benchmark_v1.1.0.pdf</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
-<xsl:variable name="os-stigid-concat">DISA FSO </xsl:variable>
+<xsl:variable name="os-stigid-concat"></xsl:variable>
 
 <!-- Define URI for custom CCE identifier which can be used for mapping to corporate policy -->
 <!--xsl:variable name="custom-cce-uri">https://www.example.org</xsl:variable-->

--- a/RHEL/6/xccdf/services/cron.xml
+++ b/RHEL/6/xccdf/services/cron.xml
@@ -18,8 +18,8 @@ maintenance tasks, such as notifying root of system activity.
 enabling the cron daemon is essential.
 </rationale>
 <ident cce="27070-2" />
-<oval id="service_crond_enabled" stigid="RHEL-06-000224" srg="SRG-OS-999999" />
-<ref nist="CM-7" />
+<oval id="service_crond_enabled" />
+<ref nist="CM-7" stigid="RHEL-06-000224" srg="SRG-OS-999999" />
 </Rule>
 
 <Rule id="disable_anacron">


### PR DESCRIPTION
- Remove "DISA FSO" from being added to STIGIDs
- Fix incorrect stigid and srg attributes in oval element by moving to ref element