### PR TITLE
Update create-stig-overlay.py

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -257,7 +257,11 @@ $ shared/utils/create-stig-overlay.py --disa-xccdf=disa-stig-rhel7-v1r12-xccdf-m
 
 ==== Updating stig_overlay.xml
 
-- Feature needs to be added to shared/utils/create-stig-overlay.py
+To update `stig_overlay.xml`, use the `create-stig-overlay.py` script as
+mentioned above. Then, submit a pull request to replace the `stig_overlay.xml`
+file that is needing to be updated. Please note that as a part of this
+update rules that have been removed from the official STIG will be removed
+here as well.
 
 == Contributing with XCCDFs, OVALs and remediations
 


### PR DESCRIPTION
- No longer checks for stig attribute in <ident /> elements
- Tries to map SRG to SSG rule id rather than just adding 'XXXX'
- Updates manual on how to update stig_overlay.xml