### PR TITLE
Adding /var/tmp checks based on CIS guidance.

### DIFF
--- a/RHEL/7/profiles/C2S.xml
+++ b/RHEL/7/profiles/C2S.xml
@@ -56,11 +56,16 @@ baseline.
 <select idref="partition_for_var" selected="true" />
 
 <!--	1.1.7	Ensure separate partition exists for /var/tmp (Scored) -->
-<!-- TO DO -->
+<select idref="partition_for_var_tmp" selected="true" />
 
 <!--	1.1.8	Ensure nodev option set on /var/tmp partition (Scored) -->
+<select idref="mount_option_var_tmp_nodev" selected="true" />
+
 <!--	1.1.9	Ensure nosuid option set on /var/tmp partition (Scored) -->
+<select idref="mount_option_var_tmp_nosuid" selected="true" />
+
 <!--	1.1.10	Ensure noexec option set on /var/tmp partition (Scored) -->
+<select idref="mount_option_var_tmp_noexec" selected="true" />
 
 <!--	1.1.11	Ensure separate partition exists for /var/log (Scored) -->
 <select idref="partition_for_var_log" selected="true" />

--- a/RHEL/7/templates/csv/mount_options.csv
+++ b/RHEL/7/templates/csv/mount_options.csv
@@ -6,3 +6,6 @@
 /tmp,nodev
 /tmp,noexec
 /tmp,nosuid
+/var/tmp,nodev
+/var/tmp,noexec
+/var/tmp,nosuid

--- a/shared/oval/partition_for_var_tmp.xml
+++ b/shared/oval/partition_for_var_tmp.xml
@@ -1,0 +1,23 @@
+<def-group>
+  <definition class="compliance" id="partition_for_var_tmp" version="1">
+    <metadata>
+      <title>Ensure /var/tmp Located On Separate Partition</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+      </affected>
+      <description>The /var/tmp directory is a world-writable directory used for
+      temporary file storage. Verify that it has its own partition or logical
+      volume.</description>
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_var_tmp_partition" comment="/var/tmp on own partition" />
+    </criteria>
+  </definition>
+  <linux:partition_test check="all" check_existence="all_exist"
+  id="test_var_tmp_partition" version="1" comment="/var/tmp on own partition">
+    <linux:object object_ref="object_own_var_tmp_partition" />
+  </linux:partition_test>
+  <linux:partition_object id="object_own_var_tmp_partition" version="1">
+    <linux:mount_point>/var/tmp</linux:mount_point>
+  </linux:partition_object>
+</def-group>

--- a/shared/xccdf/system/permissions/partitions.xml
+++ b/shared/xccdf/system/permissions/partitions.xml
@@ -242,4 +242,51 @@ necessary to meet requirements, the storage location <tt>/var/tmp</tt> should be
 <ref nist="CM-7" cis="1.1.6" />
 </Rule>
 
+<Rule id="mount_option_var_tmp_nodev" prodtype="rhel7">
+<title>Add nodev Option to /var/tmp</title>
+<description>
+The <tt>nodev</tt> mount option can be used to prevent device files from
+being created in <tt>/var/tmp</tt>.
+Legitimate character and block devices should not exist
+within temporary directories like <tt>/var/tmp</tt>. 
+<mount-desc-macro option="nodev" part="/var/tmp" />
+</description>
+<rationale>The only legitimate location for device files is the <tt>/dev</tt> directory
+located on the root partition. The only exception to this is chroot jails.</rationale>
+<platform idref="cpe:/a:machine" />
+<ident prodtype="rhel7" cce="TBD" />
+<oval id="mount_option_var_tmp_nodev" />
+<ref cis="1.1.8" />
+</Rule>
+
+<Rule id="mount_option_var_tmp_noexec" prodtype="rhel7">
+<title>Add noexec Option to /var/tmp</title>
+<description>The <tt>noexec</tt> mount option can be used to prevent binaries
+from being executed out of <tt>/var/tmp</tt>.
+<mount-desc-macro option="noexec" part="/var/tmp" />
+</description>
+<rationale>Allowing users to execute binaries from world-writable directories
+such as <tt>/var/tmp</tt> should never be necessary in normal operation and
+can expose the system to potential compromise.</rationale>
+<platform idref="cpe:/a:machine" />
+<ident prodtype="rhel7" cce="TBD" />
+<oval id="mount_option_var_tmp_noexec" />
+<ref cis="1.1.10" />
+</Rule>
+
+<Rule id="mount_option_var_tmp_nosuid" prodtype="rhel7">
+<title>Add nosuid Option to /var/tmp</title>
+<description>The <tt>nosuid</tt> mount option can be used to prevent
+execution of setuid programs in <tt>/var/tmp</tt>. The SUID and SGID permissions
+should not be required in these world-writable directories.
+<mount-desc-macro option="nosuid" part="/var/tmp" />
+</description>
+<rationale>The presence of SUID and SGID executables should be tightly controlled. Users
+should not be able to execute SUID or SGID binaries from temporary storage partitions.</rationale>
+<platform idref="cpe:/a:machine" />
+<ident prodtype="rhel7" cce="TBD" />
+<oval id="mount_option_var_tmp_nosuid" />
+<ref cis="1.1.9" />
+</Rule>
+
 </Group>

--- a/shared/xccdf/system/software/disk_partitioning.xml
+++ b/shared/xccdf/system/software/disk_partitioning.xml
@@ -24,6 +24,25 @@ listed above. The Logical Volume Manager (LVM) makes this possible.
 See the LVM HOWTO at <weblink-macro link="http://tldp.org/HOWTO/LVM-HOWTO/"/>
 for more detailed information on LVM.</description>
 
+<Rule id="partition_for_var_tmp" severity="low" prodtype="rhel7">
+<title>Ensure /var/tmp Located On Separate Partition</title>
+<description>
+The <tt>/var/tmp</tt> directory is a world-writable directory used
+for temporary file storage. Ensure it has its own partition or
+logical volume at installation time, or migrate it using LVM.
+</description>
+<ocil><partition-check-macro part="/var/tmp "/></ocil>
+<rationale>
+The <tt>/var/tmp</tt> partition is used as temporary storage by many programs.
+Placing <tt>/var/tmp</tt> in its own partition enables the setting of more
+restrictive mount options, which can help protect programs which use it.
+</rationale>
+<platform idref="cpe:/a:machine" />
+<ident prodtype="rhel7" cce="TBD" />
+<oval id="partition_for_var_tmp" />
+<ref cis="1.1.7" />
+</Rule>
+
 <Rule id="partition_for_tmp" severity="low" prodtype="rhel7">
 <title>Ensure /tmp Located On Separate Partition</title>
 <description>


### PR DESCRIPTION
This should add rules and oval for 1.1.7, 1.1.8, 1.1.9, and 1.1.10 from the CIS guidance.