### PR TITLE
Fix Application SRG web url to be more fine-grained

### DIFF
--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -14,7 +14,7 @@
 <xsl:variable name="dcid63uri">not_officially_available</xsl:variable>
 <xsl:variable name="disa-cciuri">http://iase.disa.mil/stigs/cci/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-ossrguri">http://iase.disa.mil/stigs/os/general/Pages/index.aspx</xsl:variable>
-<xsl:variable name="disa-appsrguri">http://iase.disa.mil/stigs/app-security/app-servers/Pages/index.aspx</xsl:variable>
+<xsl:variable name="disa-appsrguri">http://iase.disa.mil/stigs/app-security/app-servers/Pages/general.aspx</xsl:variable>
 <!-- Fix for issue https://github.com/OpenSCAP/scap-security-guide/issues/1035 -->
 <xsl:variable name="disa-stigs-os-unix-linux-uri">http://iase.disa.mil/stigs/os/unix-linux/Pages/index.aspx</xsl:variable>
 <xsl:variable name="disa-stigs-os-mainframe-uri">http://iase.disa.mil/stigs/os/mainframe/Pages/index.aspx</xsl:variable>


### PR DESCRIPTION
#### Description:

- Original URL linked to all products in the Application STIG group

#### Rationale:

- Original URL linked to all products in the Application STIG groupings, and this change makes the URL link to the general SRG Application group.
