### PR TITLE
Move deprecated content list to User Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ remote machine but the SSG content doesn't need to be.
 # oscap-ssh root@192.168.1.123 22 xccdf eval --profile xccdf_org.ssgproject.content_profile_usgcb-rhel6-server --results-arf arf.xml --report report.html /usr/share/xml/scap/ssg/content/ssg-rhel6-ds.xml
 ```
 
-## Legacy Content
+## Deprecated Content
 
-- Red Hat Enterprise Linux 5 is considered End-of-Life as of March 31, 2017. [SSG 0.1.34](https://github.com/OpenSCAP/scap-security-guide/releases/tag/v0.1.34) contains the last release with Red Hat Enterprise Linux 5 content.
-- JBoss EAP 5 is considered End-of-Life as of November 30, 2016 [SSG 0.1.35](https://github.com/OpenSCAP/scap-security-guide/releases/tag/v0.1.35) contains the last release with JBoss EAP 5 content.
+For a list of deprecated content, review the [Deprecated Content Table](https://github.com/OpenSCAP/scap-security-guide/blob/master/docs/manual/user_guide.adoc#Deprecated-Content)
+in the User Guide.
 
 ## Support
 

--- a/docs/manual/user_guide.adoc
+++ b/docs/manual/user_guide.adoc
@@ -313,6 +313,22 @@ fi
 
 This output could be redirected to a bash script, or built into your RHEL6 provisioning process (e.g. the %post section of a kickstart).
 
+## Deprecated Content
+
+.Deprecated Content
+|===
+|Product |EOL Date |Last Release
+
+|JBoss EAP 5
+|November 30, 2016
+| link:https://github.com/OpenSCAP/scap-security-guide/releases/tag/v0.1.35[SSG 0.1.35]
+
+|Red Hat Enterprise Linux 5
+|March 31, 2017
+| link:https://github.com/OpenSCAP/scap-security-guide/releases/tag/v0.1.34)[SSG 0.1.34]
+
+|===
+
 == Alternative Scanning Tools
 
 === SPAWAR SCAP Compliance Checker (SCC)


### PR DESCRIPTION
#### Description:

- Moves the deprecated content list to the User Guide

#### Rationale:

- Allows the deprecated content list to grow without having to clutter the README.md