### PR TITLE
Fix lock-delay variable description

### DIFF
--- a/shared/xccdf/system/software/gnome.xml
+++ b/shared/xccdf/system/software/gnome.xml
@@ -295,8 +295,8 @@ settings, see <b><weblink-macro link="https://access.redhat.com/documentation/en
 </Value>
 
 <Value id="var_screensaver_lock_delay" type="number" operator="equals">
-<title>Screensaver Inactivity timeout</title>
-<description>Choose allowed duration (in seconds) of inactive graphical sessions</description>
+<title>Screensaver Lock Delay</title>
+<description>Choose allowed duration (in seconds) after a screensaver becomes active before displaying an authentication prompt</description>
 <value>0</value>
 <value selector="immediate">0</value>
 <value selector="5_seconds">5</value>


### PR DESCRIPTION
#### Description:

- Fix the screensaver lock-delay variable description

#### Rationale:

- Description was incorrect for what the lock delay is used for

- Fixes #2351
