### PR TITLE
Add disable_ctrlaltdel_burstaction OVAL

### DIFF
--- a/rhel7/profiles/ospp-rhel7.xml
+++ b/rhel7/profiles/ospp-rhel7.xml
@@ -271,6 +271,7 @@ the consensus process.
 <!-- enable/disable [assignment: list of external interfaces] -->
 <!-- VENDOR ASSIGNMENTS -->
 <select idref="disable_ctrlaltdel_reboot" selected="true" />
+<select idref="disable_ctrlaltdel_burstaction" selected="true" />
 <select idref="libreswan_approved_tunnels" selected="true" />
 <select idref="no_rsh_trust_files" selected="true" />
 <select idref="package_rsh_removed" selected="true" />

--- a/shared/checks/oval/oval_5.11/disable_ctrlaltdel_burstaction.xml
+++ b/shared/checks/oval/oval_5.11/disable_ctrlaltdel_burstaction.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="compliance" id="disable_ctrlaltdel_burstaction" version="1">
+    <metadata>
+      <title>Disable Ctrl-Alt-Del Burst Action</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>Configure the CtrlAltDelBurstAction setting in /etc/systemd/system.conf
+      to none to prevent a reboot if Ctrl-Alt-Delete is pressed more than 7 times in 2 seconds.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="check CtrlAltDelBurstAction is set to none"
+      test_ref="test_disable_ctrlaltdel_burstaction" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="check if CtrlAltDelBurstAction is set to none"
+  id="test_disable_ctrlaltdel_burstaction" version="1">
+    <ind:object object_ref="obj_disable_ctrlaltdel_burstaction" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_disable_ctrlaltdel_burstaction" version="1">
+    <ind:filepath>/etc/systemd/system.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*CtrlAltDelBurstAction[\s]*=[\s]*none$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -311,7 +311,7 @@ access when the system is rebooted.
 </Rule>
 
 <Rule id="disable_ctrlaltdel_burstaction" severity="high" prodtype="rhel7">
-<title>Disable CtrlAltDelBurstAction</title>
+<title>Disable Ctrl-Alt-Del Burst Action</title>
 <description>
 By default, <tt>SystemD</tt> will reboot the system if the <tt>Ctrl-Alt-Del</tt>
 key sequence is pressed Ctrl-Alt-Delete more than 7 times in 2 seconds.


### PR DESCRIPTION
#### Description:

- Add disable_ctrlaltdel_burstaction OVAL
- Add disable_ctrlaltdel_burstaction rule to OSPP profile
- Fix disable_ctrlaltdel_burstaction rule title

#### Rationale:

- Adds missing OVAL and enables rule in OSPP profile

- Fixes #2277
