### PR TITLE
gpgcheck_globally and gpgcheck_local fail on CentOS

### DIFF
--- a/shared/fixes/ansible/ensure_gpgcheck_globally_activated.yml
+++ b/shared/fixes/ansible/ensure_gpgcheck_globally_activated.yml
@@ -3,7 +3,7 @@
 # strategy = unknown
 # complexity = low
 # disruption = medium
-- name: "Check existence of yum on Fedora"
+- name: Check existence of yum on Fedora
   stat:
     path: /etc/yum.conf
   register: yum_config_file
@@ -12,7 +12,7 @@
 
 # Old versions of Fedora use yum
 
-- name: "Ensure GPG check is globally activated (yum)"
+- name: Ensure GPG check is globally activated (yum)
   ini_file:
     dest: "{{item}}"
     section: main
@@ -20,11 +20,11 @@
     value: 1
     create: False
   with_items: "/etc/yum.conf"
-  when: ansible_distribution == "RedHat" or yum_config_file.stat.exists
+  when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or yum_config_file.stat.exists
   tags:
     @ANSIBLE_TAGS@
 
-- name: "Ensure GPG check is globally activated (dnf)"
+- name: Ensure GPG check is globally activated (dnf)
   ini_file:
     dest: "{{item}}"
     section: main

--- a/shared/fixes/ansible/ensure_gpgcheck_local_packages.yml
+++ b/shared/fixes/ansible/ensure_gpgcheck_local_packages.yml
@@ -3,7 +3,7 @@
 # strategy = unknown
 # complexity = low
 # disruption = medium
-- name: "Check existence of yum on Fedora"
+- name: Check existence of yum on Fedora
   stat:
     path: /etc/yum.conf
   register: yum_config_file
@@ -12,7 +12,7 @@
 
 # Old versions of Fedora use yum
 
-- name: "Ensure GPG check Enabled for Local Packages (Yum)"
+- name: Ensure GPG check Enabled for Local Packages (Yum)
   ini_file:
     dest: "{{item}}"
     section: main
@@ -20,11 +20,11 @@
     value: 1
     create: True
   with_items: "/etc/yum.conf"
-  when: ansible_distribution == "RedHat" or yum_config_file.stat.exists
+  when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or yum_config_file.stat.exists
   tags:
     @ANSIBLE_TAGS@
 
-- name: "Ensure GPG check Enabled for Local Packages (DNF)"
+- name: Ensure GPG check Enabled for Local Packages (DNF)
   ini_file:
     dest: "{{item}}"
     section: main


### PR DESCRIPTION
#### Description:

- ANSIBLE REMEDIATION: Ensure GPG check is globally activated (yum) and Ensure GPG check Enabled for Local Packages (Yum) both fail on CentOS due to ansible_distribution check.

#### Rationale:

- Added CentOS option 


