### PR TITLE
Check if prelink is installed before trying to disable

### DIFF
--- a/shared/fixes/ansible/disable_prelink.yml
+++ b/shared/fixes/ansible/disable_prelink.yml
@@ -3,10 +3,22 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- name: Verify Prelink is installed
+  command: rpm -q prelink
+  args:
+    warn: no
+  register: prelink_installed
+  ignore_errors: true
+  failed_when: prelink_installed.rc > 1
+  changed_when: false
+  tags:
+    @ANSIBLE_TAGS@  
+
 - name: disable prelinking
   lineinfile:
     path: /etc/sysconfig/prelink
     regexp: '^PRELINKING='
     line: 'PRELINKING=no'
+  when: prelink_installed.rc == 0
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/disable_prelink.yml
+++ b/shared/fixes/ansible/disable_prelink.yml
@@ -3,14 +3,10 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Verify Prelink is installed
-  command: rpm -q prelink
-  args:
-    warn: no
-  register: prelink_installed
-  ignore_errors: true
-  failed_when: prelink_installed.rc > 1
-  changed_when: false
+- name: Does prelink file exist
+  stat:
+    path=/etc/sysconfig/prelink
+  register: prelink_exists
   tags:
     @ANSIBLE_TAGS@  
 
@@ -19,6 +15,6 @@
     path: /etc/sysconfig/prelink
     regexp: '^PRELINKING='
     line: 'PRELINKING=no'
-  when: prelink_installed.rc == 0
+  when: prelink_exists.stat.exists == True
   tags:
     @ANSIBLE_TAGS@


### PR DESCRIPTION
#### Description:

- ANSIBLE CHECK/REMEDIATION: Playbook fails on disable prelink if prelink is not installed.

#### Rationale:

- Add check to see if prelink is installed as a conditional when to disabling prelink.

