### PR TITLE
Add remote_src option to aide build db remediation - ansible

### DIFF
--- a/shared/fixes/ansible/aide_build_database.yml
+++ b/shared/fixes/ansible/aide_build_database.yml
@@ -22,5 +22,6 @@
     src: /var/lib/aide/aide.db.new.gz
     dest: /var/lib/aide/aide.db.gz
     backup: yes
+    remote_src: yes
   tags:
     @ANSIBLE_TAGS@


### PR DESCRIPTION
#### Description:

- Stage AIDE DB fails as it is looking at the host machine for the source file.

#### Rationale:

- Added remote_src option
