### PR TITLE
Ansible variable rework

### DIFF
--- a/shared/fixes/ansible/account_disable_post_pw_expiration.yml
+++ b/shared/fixes/ansible/account_disable_post_pw_expiration.yml
@@ -10,6 +10,6 @@
     create: yes
     dest: /etc/default/useradd
     regexp: ^INACTIVE
-    line: "INACTIVE={{ var_account_disable_post_pw_expiration }}}"
+    line: "INACTIVE={{ var_account_disable_post_pw_expiration }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/account_disable_post_pw_expiration.yml
+++ b/shared/fixes/ansible/account_disable_post_pw_expiration.yml
@@ -3,11 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_account_disable_post_pw_expiration)
+
 - name: Set Account Expiration Following Inactivity
   lineinfile:
     create: yes
     dest: /etc/default/useradd
     regexp: ^INACTIVE
-    line: INACTIVE=(ansible-populate var_account_disable_post_pw_expiration)
+    line: "INACTIVE={{ var_account_disable_post_pw_expiration }}}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/accounts_logon_fail_delay.yml
+++ b/shared/fixes/ansible/accounts_logon_fail_delay.yml
@@ -1,9 +1,11 @@
 # platform = multi_platform_rhel
-- name: Set accounts logon fail delay to (ansible-populate var_accounts_fail_delay)
+- (xccdf-var var_accounts_fail_delay)
+
+- name: Set accounts logon fail delay
   lineinfile:
     dest: /etc/login.defs
     regexp: ^FAIL_DELAY
-    line: FAIL_DELAY (ansible-populate var_accounts_fail_delay)
+    line: "FAIL_DELAY {{ var_accounts_fail_delay }}"
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/fixes/ansible/accounts_max_concurrent_login_sessions.yml
+++ b/shared/fixes/ansible/accounts_max_concurrent_login_sessions.yml
@@ -3,12 +3,14 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_accounts_max_concurrent_login_sessions)
+
 - name: "Limit the Number of Concurrent Login Sessions Allowed Per User"
   lineinfile:
     state: present
     dest: /etc/security/limits.conf
-    insertbefore: '^# End of file'
-    regexp: '^#?\\*.*maxlogins'
-    line: '*           hard    maxlogins     (ansible-populate var_accounts_max_concurrent_login_sessions)'
+    insertbefore: "^# End of file"
+    regexp: "^#?\\*.*maxlogins"
+    line: "*           hard    maxlogins     {{ var_accounts_max_concurrent_login_sessions }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/accounts_maximum_age_login_defs.yml
+++ b/shared/fixes/ansible/accounts_maximum_age_login_defs.yml
@@ -3,11 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_accounts_maximum_age_login_defs)
+
 - name: Set Password Maximum Age
   lineinfile:
-      create: yes
-      dest: /etc/login.defs
-      regexp: ^#?PASS_MAX_DAYS
-      line: PASS_MAX_DAYS (ansible-populate var_accounts_maximum_age_login_defs)
+    create: yes
+    dest: /etc/login.defs
+    regexp: ^#?PASS_MAX_DAYS
+    line: "PASS_MAX_DAYS {{ var_accounts_maximum_age_login_defs }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/accounts_minimum_age_login_defs.yml
+++ b/shared/fixes/ansible/accounts_minimum_age_login_defs.yml
@@ -3,11 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_accounts_minimum_age_login_defs)
+
 - name: Set Password Minimum Age
   lineinfile:
       create: yes
       dest: /etc/login.defs
       regexp: ^#?PASS_MIN_DAYS
-      line: PASS_MIN_DAYS (ansible-populate var_accounts_minimum_age_login_defs)
+      line: "PASS_MIN_DAYS {{ var_accounts_minimum_age_login_defs }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/accounts_password_minlen_login_defs.yml
+++ b/shared/fixes/ansible/accounts_password_minlen_login_defs.yml
@@ -3,11 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_accounts_password_minlen_login_defs)
+
 - name: "Set Password Minimum Length in login.defs"
   lineinfile:
     dest: /etc/login.defs
     regexp: "^PASS_MIN_LEN *[0-9]*"
     state: present
-    line: "PASS_MIN_LEN        (ansible-populate var_accounts_password_minlen_login_defs)"
+    line: "PASS_MIN_LEN        {{ var_accounts_password_minlen_login_defs }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/accounts_password_pam_maxclassrepeat.yml
+++ b/shared/fixes/ansible/accounts_password_pam_maxclassrepeat.yml
@@ -3,7 +3,7 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: 
+- name: "@RULE_TITLE@"
   lineinfile:
       create: yes
       dest: /etc/security/pwquality.conf

--- a/shared/fixes/ansible/accounts_password_pam_maxclassrepeat.yml
+++ b/shared/fixes/ansible/accounts_password_pam_maxclassrepeat.yml
@@ -3,11 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_password_pam_maxclassrepeat)
+
 - name: "@RULE_TITLE@"
   lineinfile:
       create: yes
       dest: /etc/security/pwquality.conf
       regexp: '^#?\s*maxclassrepeat'
-      line: maxclassrepeat = (ansible-populate var_password_pam_maxclassrepeat)
+      line: "maxclassrepeat = {{ var_password_pam_maxclassrepeat }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/accounts_password_pam_maxrepeat.yml
+++ b/shared/fixes/ansible/accounts_password_pam_maxrepeat.yml
@@ -3,11 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_password_pam_maxrepeat)
+
 - name: Set Password Maximum Consecutive Repeating Characters
   lineinfile:
       create: yes
       dest: /etc/security/pwquality.conf
       regexp: '^#?\s*maxrepeat'
-      line: maxrepeat = (ansible-populate var_password_pam_maxrepeat)
+      line: "maxrepeat = {{ var_password_pam_maxrepeat }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/accounts_password_pam_minlen.yml
+++ b/shared/fixes/ansible/accounts_password_pam_minlen.yml
@@ -3,11 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_password_pam_minlen)
+
 - name: Set Password Minimum Length - /etc/security/pwquality.conf
   lineinfile:
     dest: /etc/security/pwquality.conf
     regexp: ^minlen =
     state: present
-    line: minlen = (ansible-populate var_password_pam_minlen)
+    line: "minlen = {{ var_password_pam_minlen }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/accounts_password_warn_age_login_defs.yml
+++ b/shared/fixes/ansible/accounts_password_warn_age_login_defs.yml
@@ -3,11 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_accounts_password_warn_age_login_defs)
+
 - name: "Set Password Warning Age"
   lineinfile:
     dest: /etc/login.defs
     regexp: "^PASS_WARN_AGE *[0-9]*"
     state: present
-    line: "PASS_WARN_AGE        (ansible-populate var_accounts_password_warn_age_login_defs)"
+    line: "PASS_WARN_AGE        {{ var_accounts_password_warn_age_login_defs }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/accounts_tmout.yml
+++ b/shared/fixes/ansible/accounts_tmout.yml
@@ -3,11 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_accounts_tmout)
+
 - name: Set Interactive Session Timeout
   lineinfile:
       create: yes
       dest: /etc/profile
       regexp: ^#?TMOUT
-      line: TMOUT=(ansible-populate var_accounts_tmout)
+      line: "TMOUT={{ var_accounts_tmout }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/accounts_umask_etc_login_defs.yml
+++ b/shared/fixes/ansible/accounts_umask_etc_login_defs.yml
@@ -3,11 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_accounts_user_umask)
+
 - name: Ensure the Default UMASK is Set Correctly
   lineinfile:
     create: yes
     dest: /etc/login.defs
     regexp: ^UMASK
-    line: UMASK (ansible-populate var_accounts_user_umask)
+    line: "UMASK {{ var_accounts_user_umask }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/auditd_data_retention_action_mail_acct.yml
+++ b/shared/fixes/ansible/auditd_data_retention_action_mail_acct.yml
@@ -3,10 +3,12 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_auditd_action_mail_acct)
+
 - name: Configure auditd mail_acct Action on Low Disk Space
   lineinfile:
     dest: /etc/audit/auditd.conf
-    line: "action_mail_acct = (ansible-populate var_auditd_action_mail_acct)"
+    line: "action_mail_acct = {{ var_auditd_action_mail_acct }}"
     state: present
   #notify: reload auditd
   tags:

--- a/shared/fixes/ansible/auditd_data_retention_admin_space_left_action.yml
+++ b/shared/fixes/ansible/auditd_data_retention_admin_space_left_action.yml
@@ -3,10 +3,12 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_auditd_admin_space_left_action)
+
 - name: Configure auditd admin_space_left Action on Low Disk Space
   lineinfile:
     dest: /etc/audit/auditd.conf
-    line: "admin_space_left_action = (ansible-populate var_auditd_admin_space_left_action)"
+    line: "admin_space_left_action = {{ var_auditd_admin_space_left_action }}"
     regexp: "^admin_space_left_action*"
   #notify: reload auditd
   tags:

--- a/shared/fixes/ansible/auditd_data_retention_max_log_file.yml
+++ b/shared/fixes/ansible/auditd_data_retention_max_log_file.yml
@@ -3,10 +3,12 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_auditd_max_log_file)
+
 - name: Configure auditd Max Log File Size
   lineinfile:
     dest: /etc/audit/auditd.conf
-    line: "max_log_file (ansible-populate var_auditd_max_log_file)"
+    line: "max_log_file {{ var_auditd_max_log_file }}"
     state: present
   #notify: reload auditd
   tags:

--- a/shared/fixes/ansible/auditd_data_retention_max_log_file_action.yml
+++ b/shared/fixes/ansible/auditd_data_retention_max_log_file_action.yml
@@ -3,10 +3,12 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_auditd_max_log_file_action)
+
 - name: Configure auditd max_log_file_action Upon Reaching Maximum Log Size
   lineinfile:
     dest: /etc/audit/auditd.conf
-    line: "max_log_file_action (ansible-populate var_auditd_max_log_file_action)"
+    line: "max_log_file_action {{ var_auditd_max_log_file_action }}"
     state: present
   #notify: reload auditd
   tags:

--- a/shared/fixes/ansible/auditd_data_retention_space_left_action.yml
+++ b/shared/fixes/ansible/auditd_data_retention_space_left_action.yml
@@ -3,10 +3,12 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_auditd_space_left_action)
+
 - name: Configure auditd space_left Action on Low Disk Space
   lineinfile:
     dest: /etc/audit/auditd.conf
-    line: space_left_action = (ansible-populate var_auditd_space_left_action)
+    line: "space_left_action = {{ var_auditd_space_left_action }}"
     regexp: ^space_left_action*
   #notify: reload auditd
   tags:

--- a/shared/fixes/ansible/dconf_gnome_screensaver_idle_delay.yml
+++ b/shared/fixes/ansible/dconf_gnome_screensaver_idle_delay.yml
@@ -3,12 +3,14 @@
 # strategy = unknown
 # complexity = low
 # disruption = medium
+- (xccdf-var inactivity_timeout_value)
+
 - name: "Set GNOME3 Screensaver Inactivity Timeout"
   ini_file:
     dest: "/etc/dconf/db/local/d/00-security-settings"
     section: "org/gnome/desktop/screensaver"
     option: idle-delay
-    value: (ansible-populate inactivity_timeout_value)
+    value: "{{ inactivity_timeout_value }}"
     create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/firewalld_sshd_port_enabled.yml
+++ b/shared/fixes/ansible/firewalld_sshd_port_enabled.yml
@@ -13,12 +13,14 @@
   tags:
     @ANSIBLE_TAGS@
 
+- (xccdf-var sshd_listening_port)
+
 - name: Enable SSHD in firewalld (custom port)
   firewalld:
-    port: (ansible-populate sshd_listening_port)/tcp
+    port: "{{ sshd_listening_port }}/tcp"
     permanent: yes
     state: enabled
-  when: (ansible-populate sshd_listening_port) != 22
+  when: sshd_listening_port != 22
   tags:
     @ANSIBLE_TAGS@
 
@@ -27,7 +29,7 @@
     service: ssh
     permanent: yes
     state: enabled
-  when: (ansible-populate sshd_listening_port) == 22
+  when: sshd_listening_port == 22
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/fixes/ansible/rsyslog_remote_loghost.yml
+++ b/shared/fixes/ansible/rsyslog_remote_loghost.yml
@@ -3,12 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var rsyslog_remote_loghost_address)
 
-- name: "Set rsyslog remote loghost to (ansible-populate rsyslog_remote_loghost_address)"
+- name: "Set rsyslog remote loghost"
   lineinfile:
     dest: /etc/rsyslog.conf
     regexp: "^\\*\\.\\*"
-    line: "*.* @@(ansible-populate rsyslog_remote_loghost_address)"
+    line: "*.* @@{{ rsyslog_remote_loghost_address }}"
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/fixes/ansible/selinux_policytype.yml
+++ b/shared/fixes/ansible/selinux_policytype.yml
@@ -3,8 +3,10 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_selinux_policy_name)
+
 - name: "Configure SELinux Policy"
   selinux:
-    policy: (ansible-populate var_selinux_policy_name)
+    policy: "{{ var_selinux_policy_name }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/selinux_state.yml
+++ b/shared/fixes/ansible/selinux_state.yml
@@ -3,8 +3,10 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var var_selinux_state)
+
 - name: "@RULE_TITLE@"
   selinux:
-    state: (ansible-populate var_selinux_state)
+    state: "{{ var_selinux_state }}"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/sshd_set_idle_timeout.yml
+++ b/shared/fixes/ansible/sshd_set_idle_timeout.yml
@@ -3,12 +3,14 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- (xccdf-var sshd_idle_timeout_value)
+
 - name: Set SSH Idle Timeout Interval
   lineinfile:
     create: yes
     dest: /etc/ssh/sshd_config
     regexp: ^ClientAliveInterval
-    line: ClientAliveInterval (ansible-populate sshd_idle_timeout_value)
+    line: "ClientAliveInterval {{ sshd_idle_timeout_value }}"
     validate: sshd -t -f %s
   #notify: restart sshd
   tags:

--- a/shared/templates/template_ANSIBLE_accounts_password
+++ b/shared/templates/template_ANSIBLE_accounts_password
@@ -1,10 +1,12 @@
 # platform = Red Hat Enterprise Linux 7, multi_platform_fedora
-- name: Ensure PAM variable %VARIABLE% is set to (ansible-populate var_password_pam_%VARIABLE%)
+- (xccdf-var var_password_pam_%VARIABLE%)
+
+- name: Ensure PAM variable %VARIABLE% is set accordingly
   lineinfile:
     create=yes
     dest="/etc/security/pwquality.conf"
     regexp="^%VARIABLE%"
-    line="%VARIABLE% = (ansible-populate var_password_pam_%VARIABLE%)"
+    line="%VARIABLE% = {{ var_password_pam_%VARIABLE% }}"
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/template_ANSIBLE_sebool_var
+++ b/shared/templates/template_ANSIBLE_sebool_var
@@ -3,10 +3,12 @@
 # strategy = enable
 # complexity = low
 # disruption = low
+- (xccdf-var var_%SEBOOLID%)
+
 - name: Set SELinux boolean %SEBOOLID% accordingly
   seboolean:
     name: %SEBOOLID%
-    state: (ansible-populate var_%SEBOOLID%)
+    state: {{ var_%SEBOOLID% }}
     persistent: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_sebool_var
+++ b/shared/templates/template_ANSIBLE_sebool_var
@@ -8,7 +8,7 @@
 - name: Set SELinux boolean %SEBOOLID% accordingly
   seboolean:
     name: %SEBOOLID%
-    state: {{ var_%SEBOOLID% }}
+    state: "{{ var_%SEBOOLID% }}"
     persistent: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_sysctl_var
+++ b/shared/templates/template_ANSIBLE_sysctl_var
@@ -3,10 +3,12 @@
 # strategy = disable
 # complexity = low
 # disruption = medium
+- (xccdf-var sysctl_%SYSCTLID%_value)
+
 - name: Ensure sysctl %SYSCTLVAR% is set
   sysctl:
     name: %SYSCTLVAR%
-    value: (ansible-populate sysctl_%SYSCTLID%_value)
+    value: "{{ sysctl_%SYSCTLID%_value }}"
     state: present
     reload: yes
   tags:

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -190,7 +190,9 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
             r"- \(xccdf-var\s+(\S+)\)",
             r"- name: XCCDF Value \1 # promote to variable\n"
             r"  set_fact:\n"
-            r"    \1: (ansible-populate \1)",
+            r"    \1: (ansible-populate \1)\n"
+            r"  tags:\n"
+            r"    - always",
             fix.text
         )
 

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -187,10 +187,10 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
 
     if remediation_type == "ansible":
         fix_text = re.sub(
-            r'- \(xccdf-var\s+(\S+)\)',
-            r'- name: Populate XCCDF variable \1  # promote to variable\n'
-            r'  set_facts:\n'
-            r'    \1: (ansible-populate \1)',
+            r"- \(xccdf-var\s+(\S+)\)",
+            r"- name: XCCDF Value \1 # promote to variable\n"
+            r"  set_fact:\n"
+            r"    \1: (ansible-populate \1)",
             fix.text
         )
 

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -186,6 +186,14 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
     """
 
     if remediation_type == "ansible":
+        fix.text = re.sub(
+            r'- \(xccdf-var\s+(\S+)\)',
+            r'- name: Populate XCCDF variable \1  # promote to variable\n'
+            r'  set_facts:\n'
+            r'    \1: (ansible-populate \1)',
+            fix.text
+        )
+
         pattern = r'\(ansible-populate\s*(\S+)\)'
 
         # we will get list what looks like

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -186,6 +186,16 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
     """
 
     if remediation_type == "ansible":
+        fix_text = fix.text
+
+        if "(ansible-populate " in fix_text:
+            raise RuntimeError(
+                "(ansible-populate VAR) has been deprecated. Please use "
+                "(xccdf-var VAR) instead. Keep in mind that the latter will "
+                "make an ansible variable out of XCCDF Value as opposed to "
+                "substituting directly."
+            )
+
         fix_text = re.sub(
             r"- \(xccdf-var\s+(\S+)\)",
             r"- name: XCCDF Value \1 # promote to variable\n"
@@ -193,7 +203,7 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
             r"    \1: (ansible-populate \1)\n"
             r"  tags:\n"
             r"    - always",
-            fix.text
+            fix_text
         )
 
         pattern = r'\(ansible-populate\s*(\S+)\)'

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -186,7 +186,7 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
     """
 
     if remediation_type == "ansible":
-        fix.text = re.sub(
+        fix_text = re.sub(
             r'- \(xccdf-var\s+(\S+)\)',
             r'- name: Populate XCCDF variable \1  # promote to variable\n'
             r'  set_facts:\n'
@@ -198,7 +198,7 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
 
         # we will get list what looks like
         # [text, varname, text, varname, ..., text]
-        parts = re.split(pattern, fix.text)
+        parts = re.split(pattern, fix_text)
 
         fix.text = parts[0]  # add first "text"
         for index in range(1, len(parts), 2):


### PR DESCRIPTION
~~This is work in progress, I have opened it to solicit feedback and check if maybe I am doing something wrong that I don't see.~~ This is now ready for review.

#### Description:

Introduce "- (xccdf-var VAR)" substitution command into our Ansible mini language. This creates a set_facts item that "imports" the XCCDF value into an ansible variable. The XCCDF value can be used as a usual ansible variable right after this is called.

In the future I will implement logic in openscap that will promote these set_facts blocks into proper ansible variables at the top of the playbook.

#### Rationale:

Right now we directly substitute the full XCCDF variables into Ansible. That way they appear as string literals instead of ansible variables. This makes it very hard for ansible users to "tailor" the ansible roles using just ansible. The convention dictates that variables appear in a separate file or top of the playbook so that users can change the values before deployment.