### PR TITLE
Disable service remediation fails if service is not installed. - ansible

### DIFF
--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -9,7 +9,7 @@
     enabled="no"
     state="stopped"
   register: service_result
-  failed_when: "service_result|failed and ('find' not in service_result.msg and 'found' not in service_result.msg)"
+  failed_when: "service_result|failed and ('Could not find the requested service' not in service_result.msg)"
   with_items:
     - %DAEMONNAME%
   tags:

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -8,6 +8,8 @@
     name="{{item}}"
     enabled="no"
     state="stopped"
+  register: service_result
+  failed_when: "service_result|failed and ('find' not in service_result.msg and 'found' not in service_result.msg)"
   with_items:
     - %DAEMONNAME%
   tags:


### PR DESCRIPTION
#### Description:

- Disabling a service fails and halts playbook if service is not installed.

#### Rationale:

- Disabling/Stopping a service that is not installed results in a  "Could not find the requested service " error and stops the playbook.  Added a failed_when handler to ignore the failure if the result message contains "Could not find the requested service".  


