### PR TITLE
Fix XML in rhel7/profiles/C2S.xml

### DIFF
--- a/rhel7/profiles/C2S.xml
+++ b/rhel7/profiles/C2S.xml
@@ -224,7 +224,7 @@ baseline.
 <select idref="service_avahi-daemon_disabled" selected="true" />
 
 <!-- 2.2.4 Ensure CUPS is not enabled (Scored) -->
-<Rule id="service_cups_disabled" prodtype="rhel7">
+<select idref="service_cups_disabled" selected="true" />
 
 <!-- 2.2.5 Ensure DHCP Server is not enabled (Scored) -->
 <select idref="service_dhcpd_disabled" selected="true" />


### PR DESCRIPTION
Rule should have been select, makes no sense to have Rule element in
profile. Probably a copy paste error.

#### Description:
```
[5/38] [rhel7-content] generating shorthand.xml
/home/mpreisle/d/scap-security-guide/rhel7/profiles/C2S.xml:587: parser error : Opening and ending tag mismatch: Rule line 227 and Profile
</Profile>
          ^
/home/mpreisle/d/scap-security-guide/rhel7/profiles/C2S.xml:588: parser error : Premature end of data in tag Profile line 1

^
```

#### Rationale:

Errors are bad.