### PR TITLE
Disable service remediation fails if service is not installed - ansible

### DIFF
--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -8,8 +8,9 @@
     name="{{item}}"
     enabled="no"
     state="stopped"
+  register: service_result
+  failed_when: "service_result|failed and ('Could not find the requested service' not in service_result.msg)"
   with_items:
     - %DAEMONNAME%
   tags:
     @ANSIBLE_TAGS@
-


### PR DESCRIPTION
#### Description:

- Disabling a service fails and halts playbook if service is not installed.

#### Rationale:

- Disabling/Stopping a service that is not installed results in a "Could not find the requested service " error and stops the playbook. Added a failed_when handler to ignore the failure if the result message contains "Could not find the requested service".

