### PR TITLE
Add common python module for centralizing reusable code

### DIFF
--- a/shared/modules/idtranslate_module.py
+++ b/shared/modules/idtranslate_module.py
@@ -3,9 +3,10 @@ try:
 except ImportError:
     import cElementTree as ElementTree
 
+import ssgcommon
 
-oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
-ocil_ns = "http://scap.nist.gov/schema/ocil/2.0"
+oval_ns = ssgcommon.oval_namespace
+ocil_ns = ssgcommon.ocil_namespace
 
 ovaltag_to_abbrev = {
     'definition': 'def',

--- a/shared/modules/ssgcommon.py
+++ b/shared/modules/ssgcommon.py
@@ -1,0 +1,52 @@
+import datetime
+import platform
+
+
+xml_version = """<?xml version="1.0" encoding="UTF-8"?>"""
+oval_header = """
+<oval_definitions
+    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+    xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
+    xmlns:linux="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd
+        http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd
+        http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd
+        http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd
+        http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd">"""
+
+datastream_namespace = "http://scap.nist.gov/schema/scap/source/1.2"
+ocil_namespace = "http://scap.nist.gov/schema/ocil/2.0"
+oval_footer = "</oval_definitions>"
+oval_namespace = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
+ocil_cs = "http://scap.nist.gov/schema/ocil/2"
+xccdf_header = xml_version + "<xccdf>"
+xccdf_footer = "</xccdf>"
+bash_system = "urn:xccdf:fix:script:sh"
+ansible_system = "urn:xccdf:fix:script:ansible"
+puppet_system = "urn:xccdf:fix:script:puppet"
+anaconda_system = "urn:redhat:anaconda:pre"
+cce_system = "https://nvd.nist.gov/cce/index.cfm"
+cce_uri = "http://cce.mitre.org"
+stig_ns = "http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx"
+ssg_version_uri = \
+    "https://github.com/OpenSCAP/scap-security-guide/releases/latest"
+XCCDF11_NS = "http://checklists.nist.gov/xccdf/1.1"
+XCCDF12_NS = "http://checklists.nist.gov/xccdf/1.2"
+
+
+timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def oval_generated_header(product_name, schema_version, ssg_version):
+    return xml_version + oval_header + \
+    """
+    <generator>
+        <oval:product_name>%s from SCAP Security Guide</oval:product_name>
+        <oval:product_version>ssg: %s, python: %s</oval:product_version>
+        <oval:schema_version>%s</oval:schema_version>
+        <oval:timestamp>%s</oval:timestamp>
+    </generator>""" % (product_name, ssg_version, platform.python_version(),
+                       schema_version, timestamp)

--- a/shared/modules/xccdf_utils.py
+++ b/shared/modules/xccdf_utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2
-
 """
 A couple generic XCCDF utilities used by build-all-guides.py and
 build-all-remediation-roles.py
@@ -8,9 +6,10 @@ Author: Martin Preisler <mpreisle@redhat.com>
 """
 
 import re
+import ssgcommon
 
-XCCDF11_NS = "http://checklists.nist.gov/xccdf/1.1"
-XCCDF12_NS = "http://checklists.nist.gov/xccdf/1.2"
+XCCDF11_NS = ssgcommon.XCCDF11_NS
+XCCDF12_NS = ssgcommon.XCCDF12_NS
 
 # if a profile ID ends with a string listed here we skip it
 PROFILE_ID_BLACKLIST = ["test", "index", "default"]

--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -23,10 +23,17 @@ import logging
 from xml.etree import cElementTree as ElementTree
 import json
 import sys
+import os
 import copy
 
 
-XCCDF_NAMESPACE = "http://checklists.nist.gov/xccdf/1.2"
+# Put shared python modules in path
+sys.path.insert(0, os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "../modules"))
+import ssgcommon
+
+XCCDF_NAMESPACE = ssgcommon.XCCDF12_NS
 FILENAME = "PCI_DSS_v3.pdf"
 REMOTE_URL = "https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-1.pdf"
 

--- a/shared/utils/add_stig_references.py
+++ b/shared/utils/add_stig_references.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python2
 
+import os
+
 try:
     from xml.etree import cElementTree as etree
 except ImportError:
@@ -8,6 +10,12 @@ except ImportError:
 import re
 import sys
 import argparse
+
+# Put shared python modules in path
+sys.path.insert(0, os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "modules"))
+import ssgcommon
 
 parser = argparse.ArgumentParser(
     description='Add STIG references to XCCDF files.')
@@ -20,7 +28,7 @@ args = parser.parse_args()
 reference = args.reference
 destination = args.destination
 
-xccdf_namespace = "http://checklists.nist.gov/xccdf/1.1"
+xccdf_namespace = ssgcommon.XCCDF11_NS
 stig_href = 'http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx'
 stig_references_beginning = 'http://iase.disa.mil/stigs/'
 

--- a/shared/utils/combine-ovals.py
+++ b/shared/utils/combine-ovals.py
@@ -27,33 +27,10 @@ sys.path.insert(0, os.path.join(
         os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
         "modules"))
 from map_product_module import map_product, parse_product_name, multi_product_list
+import ssgcommon
 
-oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
-footer = "</oval_definitions>"
-
-
-def _header(schema_version, ssg_version):
-    timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
-    return """<?xml version="1.0" encoding="UTF-8"?>
-<oval_definitions
-    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-    xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
-    xmlns:linux="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd
-        http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd
-        http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd
-        http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd
-        http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd">
-    <generator>
-        <oval:product_name>combine-ovals.py from SCAP Security Guide</oval:product_name>
-        <oval:product_version>ssg: %s, python: %s</oval:product_version>
-        <oval:schema_version>%s</oval:schema_version>
-        <oval:timestamp>%s</oval:timestamp>
-    </generator>""" % (ssg_version, platform.python_version(),
-                       schema_version, timestamp)
+oval_ns = ssgcommon.oval_namespace
+footer = ssgcommon.oval_footer
 
 
 def parse_conf_file(conf_file, product):
@@ -272,7 +249,7 @@ def check_is_loaded(loaded_dict, filename, version):
 
 
 def check_oval_version_from_oval(xml_content, oval_version):
-    oval_file_tree = ElementTree.fromstring(_header("", "") + xml_content + footer)
+    oval_file_tree = ElementTree.fromstring(ssgcommon.oval_header + xml_content + footer)
     for defgroup in oval_file_tree.findall("./{%s}def-group" % oval_ns):
         file_oval_version = defgroup.get("oval_version")
   
@@ -351,7 +328,7 @@ def main():
     if os.path.isfile(args.oval_config):
         multi_platform = \
             parse_conf_file(args.oval_config, args.product)
-        header = _header(args.oval_version, args.ssg_version)
+        header = ssgcommon.oval_generated_header("combine-ovals.py", args.oval_version, args.ssg_version)
     else:
         sys.stderr.write("The directory specified does not contain the %s "
                          "file!\n" % (args.oval_config))

--- a/shared/utils/enable-derivatives.py
+++ b/shared/utils/enable-derivatives.py
@@ -16,12 +16,19 @@ try:
 except ImportError:
     import cElementTree as ElementTree
 
+import os
 import sys
 import re
 from optparse import OptionParser
 
-XCCDF11_NS = "http://checklists.nist.gov/xccdf/1.1"
-XCCDF12_NS = "http://checklists.nist.gov/xccdf/1.2"
+# Put shared python modules in path
+sys.path.insert(0, os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "modules"))
+import ssgcommon
+
+XCCDF11_NS = ssgcommon.XCCDF11_NS
+XCCDF12_NS = ssgcommon.XCCDF12_NS
 
 RHEL_CENTOS_CPE_MAPPING = {
     "cpe:/o:redhat:enterprise_linux:6": "cpe:/o:centos:centos:6",

--- a/shared/utils/profile-stats.py
+++ b/shared/utils/profile-stats.py
@@ -15,16 +15,15 @@ script_desc = \
     "check implemented, how many have a remediation available, ..."
 
 
-xccdf_ns = "http://checklists.nist.gov/xccdf/1.1"
-oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
-bash_rem_system = "urn:xccdf:fix:script:sh"
-ansible_rem_system = "urn:xccdf:fix:script:ansible"
-puppet_rem_system = "urn:xccdf:fix:script:puppet"
-anaconda_rem_system = "urn:redhat:anaconda:pre"
-stig_ns = "http://iase.disa.mil/stigs/Pages/stig-viewing-guidance.aspx"
-cce_system = "https://nvd.nist.gov/cce/index.cfm"
-ssg_version_uri = \
-    "https://github.com/OpenSCAP/scap-security-guide/releases/latest"
+xccdf_ns = ssgcommon.XCCDF11_NS
+oval_ns = ssgcommon.oval_namespace
+bash_rem_system = ssgcommon.bash_system
+ansible_rem_system = ssgcommon.ansible_system
+puppet_rem_system = ssgcommon.puppet_system
+anaconda_rem_system = ssgcommon.anaconda_system
+cce_system = ssgcommon.cce_system
+ssg_version_uri = ssgcommon.ssg_version_uri
+stig_ns = ssgcommon.stig_ns
 console_width = 80
 
 

--- a/shared/utils/relabel-ids.py
+++ b/shared/utils/relabel-ids.py
@@ -20,6 +20,7 @@ sys.path.insert(0, os.path.join(
         os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
         "modules"))
 import idtranslate_module as idtranslate
+import ssgcommon
 
 # This script requires two arguments: an "unlinked" XCCDF file and an ID name
 # scheme. This script is designed to convert and synchronize check IDs
@@ -28,12 +29,12 @@ import idtranslate_module as idtranslate
 # meaningless numbers.
 
 
-oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
-oval_cs = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
-ocil_ns = "http://scap.nist.gov/schema/ocil/2.0"
-ocil_cs = "http://scap.nist.gov/schema/ocil/2"
-xccdf_ns = "http://checklists.nist.gov/xccdf/1.1"
-cce_uri = "http://cce.mitre.org"
+oval_ns = ssgcommon.oval_namespace
+oval_cs = ssgcommon.oval_namespace
+ocil_ns = ssgcommon.ocil_namespace
+ocil_cs = ssgcommon.ocil_cs
+xccdf_ns = ssgcommon.XCCDF11_NS
+cce_uri = ssgcommon.cce_uri
 
 
 def parse_xml_file(xmlfile):

--- a/shared/utils/sds-move-ocil-to-checks.py
+++ b/shared/utils/sds-move-ocil-to-checks.py
@@ -37,15 +37,22 @@
 #   $ ./sds-move-ocil-to-checks.py ssg-rhel6-ds.xml new-ds.xml
 
 import sys
+import os
 
 try:
     from xml.etree import cElementTree as ElementTree
 except ImportError:
     import cElementTree as ElementTree
 
+# Put shared python modules in path
+sys.path.insert(0, os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "modules"))
+import ssgcommon
+
 xlink_ns = "http://www.w3.org/1999/xlink"
-datastream_ns = "http://scap.nist.gov/schema/scap/source/1.2"
-ocil_ns = "http://scap.nist.gov/schema/ocil/2.0"
+datastream_ns = ssgcommon.datastream_namespace
+ocil_ns = ssgcommon.ocil_namespace
 
 
 def move_ocil_ref_from_ds_extended_components_to_ds_checks(datastreamtree, ocilcomp):

--- a/shared/utils/unselect-empty-xccdf-groups.py
+++ b/shared/utils/unselect-empty-xccdf-groups.py
@@ -13,6 +13,8 @@ build datastreams from them!
 
 Author: Martin Preisler <mpreisle@redhat.com>
 """
+import os
+import sys
 
 try:
     from xml.etree import cElementTree as ElementTree
@@ -21,9 +23,15 @@ except ImportError:
 
 from optparse import OptionParser
 
+# Put shared python modules in path
+sys.path.insert(0, os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "modules"))
+import ssgcommon
+
 OSCAP_PATH = "oscap"
 
-XCCDF11_NS = "http://checklists.nist.gov/xccdf/1.1"
+XCCDF11_NS = ssgcommon.XCCDF11_NS
 TRUE_STRINGS = ["true", "1", "True", "TRUE"]
 
 

--- a/shared/utils/verify-input-sanity.py
+++ b/shared/utils/verify-input-sanity.py
@@ -8,41 +8,27 @@
 
 # the python modules that we need
 import os
-import datetime
+import sys
 import lxml.etree as ET
 
-timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+# Put shared python modules in path
+sys.path.insert(0, os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "modules"))
+import ssgcommon
 
 # the "oval_header" variable must be prepended to the body of the check to form
 # valid XML
-oval_header = '''<?xml version="1.0" encoding="UTF-8"?>
-<oval_definitions
-    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-    xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
-    xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-    xmlns:linux="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
-    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd
-        http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsd
-        http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd
-        http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd
-        http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd">
-       <generator>
-        <oval:product_name>testoval.py</oval:product_name>
-        <oval:product_version>0.0.1</oval:product_version>
-        <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>%s</oval:timestamp>
-    </generator>''' % (timestamp)
+oval_header = ssgcommon.oval_generated_header("verify-input-sanity.py", "5.10", "0.0.1")
 
 # the "oval_footer" variable must be appended to the body of the check to form
 # valid XML
-oval_footer = '</oval_definitions>'
+oval_footer = ssgcommon.oval_footer
 
 # the namespace we are working in
-oval_namespace = "{http://oval.mitre.org/XMLSchema/oval-definitions-5}"
-xccdf_header = '<?xml version="1.0" encoding="UTF-8"?><xccdf>'
-xccdf_footer = '</xccdf>'
+oval_namespace = ssgcommon.oval_namespace
+xccdf_header = ssgcommon.xccdf_header
+xccdf_footer = ssgcommon.xccdf_footer
 
 # print a blank line to keep things pretty
 print
@@ -91,10 +77,10 @@ for oval_check in oval_file_list:
         # parse the XML at this point
         tree = ET.fromstring(oval_xml_contents)
         # extract the ID of the check
-        definition_node = tree.findall("./" + oval_namespace + "def-group/*")
+        definition_node = tree.findall("./{%s}def-group/*" % oval_namespace)
         oval_id = "Error"
         for node in definition_node:
-            if node.tag == (oval_namespace + "definition"):
+            if node.tag == ("{%s}definition" % oval_namespace):
                 oval_id = node.get("id")
         # at this point the variable oval_id should contain the id of the oval
         # check now we make sure that the name of the file matches the oval id

--- a/shared/utils/verify-references.py
+++ b/shared/utils/verify-references.py
@@ -38,9 +38,16 @@ Usage:
   ./verify-references.py -h
 """
 
-xccdf_ns = "http://checklists.nist.gov/xccdf/1.1"
-oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
-ocil_cs = "http://scap.nist.gov/schema/ocil/2"
+# Put shared python modules in path
+sys.path.insert(0, os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "modules"))
+import ssgcommon
+
+
+xccdf_ns = ssgcommon.XCCDF11_NS
+oval_ns = ssgcommon.oval_namespace
+ocil_cs = ssgcommon.ocil_cs
 
 # we use these strings to look for references within the XCCDF rules
 nist_ref_href = "http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf"


### PR DESCRIPTION
#### Description:

- Add common python module for centralizing reusable code and python content

#### Rationale:

- Allows to reduce current duplicated code as well as future code in our python scripts and also provide a future API/framework possibilities for scripts.
