### PR TITLE
Add XCCDF Value sshd_required to other products

### DIFF
--- a/debian8/xccdf/services/ssh.xml
+++ b/debian8/xccdf/services/ssh.xml
@@ -21,6 +21,19 @@ operator="equals" interactive="0">
 <value selector="120_minutes">7200</value>
 </Value>
 
+<Value id="sshd_required" type="number"
+operator="equals" interactive="0">
+<title>SSH is required to be installed</title>
+<description>Specify if the Policy requires SSH to be installed. Used by SSH Rules
+to determine if SSH should be uninstalled or configured.<br />
+A value of 0 means that the policy doesn't care if OpenSSH server is installed or not. If it is installed, scanner will check for it's configuration, if it's not installed, the check will pass.<br />
+A value of 1 indicates that OpenSSH server package is not required by the policy;<br />
+A value of 2 indicates that OpenSSH server package is required by the policy.<br /></description>
+<value selector="">0</value>
+<value selector="no">1</value>
+<value selector="yes">2</value>
+</Value>
+
 <Rule id="service_sshd_disabled">
 <title>Disable SSH Server if possible (unusual cases)</title>
 <description>Most of the time, the SSH server is needed. However, it can be disabled, do so.
@@ -59,7 +72,7 @@ result in security vulnerabilities and
 should not be used.
 </rationale>
 <ident cce="" />
-<oval id="sshd_allow_only_protocol2" />
+<oval id="sshd_allow_only_protocol2" value="sshd_required" />
 <ref nist="AC-17(7),IA-5(1)(c)" anssi="NT007(R1)" />
 </Rule>
 
@@ -91,7 +104,7 @@ guards against compromises one system leading trivially
 to compromises on another.
 </rationale>
 <ident cce="" />
-<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value"/>
+<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value" value2="sshd_required" />
 <ref nist="AC-2(5),SA-8" pcidss="Req-8.1.8" />
 </Rule>
 
@@ -114,7 +127,7 @@ This ensures a user login will be terminated as soon as the <tt>ClientAliveCount
 is reached.
 </rationale>
 <ident cce="" />
-<oval id="sshd_set_keepalive" />
+<oval id="sshd_set_keepalive" value="sshd_required" />
 <ref nist="AC-2(5),SA-8"  />
 </Rule>
 
@@ -158,7 +171,7 @@ remote login via SSH will require a password,
 even in the event of misconfiguration elsewhere.
 </rationale>
 <ident cce="" />
-<oval id="sshd_disable_empty_passwords" />
+<oval id="sshd_disable_empty_passwords" value="sshd_required" />
 <ref nist="AC-3" anssi="NT007(R17)" />
 </Rule>
 

--- a/fedora/xccdf/services/ssh.xml
+++ b/fedora/xccdf/services/ssh.xml
@@ -25,6 +25,19 @@ operator="equals" interactive="0">
 <value selector="default">22</value>
 </Value>
 
+<Value id="sshd_required" type="number"
+operator="equals" interactive="0">
+<title>SSH is required to be installed</title>
+<description>Specify if the Policy requires SSH to be installed. Used by SSH Rules
+to determine if SSH should be uninstalled or configured.<br />
+A value of 0 means that the policy doesn't care if OpenSSH server is installed or not. If it is installed, scanner will check for it's configuration, if it's not installed, the check will pass.<br />
+A value of 1 indicates that OpenSSH server package is not required by the policy;<br />
+A value of 2 indicates that OpenSSH server package is required by the policy.<br /></description>
+<value selector="">0</value>
+<value selector="no">1</value>
+<value selector="yes">2</value>
+</Value>
+
 <Group id="ssh_server">
 <title>Configure OpenSSH Server if Necessary</title>
 <description>If the system needs to act as an SSH server, then certain changes
@@ -45,7 +58,7 @@ Permitting direct root login reduces auditable information about who ran
 privileged commands on the system and also allows direct attack attempts on
 root's password.
 </rationale>
-<oval id="sshd_disable_root_login" />
+<oval id="sshd_disable_root_login" value="sshd_required" />
 <ref nist="AC-6(2),IA-2(1)" disa="770" />
 </Rule>
 
@@ -63,7 +76,7 @@ Configuring this setting for the SSH daemon provides additional assurance that
 remote login via SSH will require a password, even in the event of
 misconfiguration elsewhere.
 </rationale>
-<oval id="sshd_disable_empty_passwords" />
+<oval id="sshd_disable_empty_passwords" value="sshd_required" />
 <ref disa="765,766"/>
 </Rule>
 
@@ -88,7 +101,7 @@ SSH from correctly detecting that the user is idle.
 Causing idle users to be automatically logged out guards against compromises
 one system leading trivially to compromises on another.
 </rationale>
-<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value"/>
+<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value" value2="sshd_required" />
 <ref disa="879,1133"/>
 </Rule>
 
@@ -103,7 +116,7 @@ follows:
 This ensures a user login will be terminated as soon as the
 <tt>ClientAliveCountMax</tt> is reached.
 </rationale>
-<oval id="sshd_set_keepalive" />
+<oval id="sshd_set_keepalive" value="sshd_required" />
 <ref disa="879,1133"/>
 </Rule>
 

--- a/rhel6/xccdf/services/ssh.xml
+++ b/rhel6/xccdf/services/ssh.xml
@@ -21,6 +21,19 @@ operator="equals" interactive="0">
 <value selector="120_minutes">7200</value>
 </Value>
 
+<Value id="sshd_required" type="number"
+operator="equals" interactive="0">
+<title>SSH is required to be installed</title>
+<description>Specify if the Policy requires SSH to be installed. Used by SSH Rules
+to determine if SSH should be uninstalled or configured.<br />
+A value of 0 means that the policy doesn't care if OpenSSH server is installed or not. If it is installed, scanner will check for it's configuration, if it's not installed, the check will pass.<br />
+A value of 1 indicates that OpenSSH server package is not required by the policy;<br />
+A value of 2 indicates that OpenSSH server package is required by the policy.<br /></description>
+<value selector="">0</value>
+<value selector="no">1</value>
+<value selector="yes">2</value>
+</Value>
+
 <Rule id="service_sshd_disabled">
 <title>Disable SSH Server If Possible (Unusual)</title>
 <description>The SSH server service, sshd, is commonly needed.
@@ -81,7 +94,7 @@ result in security vulnerabilities and
 should not be used.
 </rationale>
 <ident cce="27072-8" />
-<oval id="sshd_allow_only_protocol2" />
+<oval id="sshd_allow_only_protocol2" value="sshd_required" />
 <ref nist="AC-3(10),IA-5(1)(c)" disa="776,774,1436" stigid="RHEL-06-000227"
 srg="SRG-OS-000112" />
 </Rule>
@@ -171,7 +184,7 @@ guards against compromises one system leading trivially
 to compromises on another.
 </rationale>
 <ident cce="26919-1" />
-<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value"/>
+<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value" value2="sshd_required" />
 <ref nist="AC-2(5),SA-8" pcidss="Req-8.1.8" disa="879,1133" stigid="RHEL-06-000230"
 srg="SRG-OS-000163" />
 </Rule>
@@ -195,7 +208,7 @@ This ensures a user login will be terminated as soon as the <tt>ClientAliveCount
 is reached.
 </rationale>
 <ident cce="26282-4" />
-<oval id="sshd_set_keepalive" />
+<oval id="sshd_set_keepalive" value="sshd_required" />
 <ref nist="AC-2(5),SA-8" disa="879,1133" stigid="RHEL-06-000231"
 srg="SRG-OS-000126" />
 </Rule>
@@ -219,7 +232,7 @@ SSH trust relationships mean a compromise on one host
 can allow an attacker to move trivially to other hosts.
 </rationale>
 <ident cce="27124-7" />
-<oval id="sshd_disable_rhosts" />
+<oval id="sshd_disable_rhosts" value="sshd_required" />
 <ref nist="AC-3" disa="765,766" stigid="RHEL-06-000234" 
 srg="SRG-OS-000106" />
 </Rule>
@@ -244,7 +257,7 @@ SSH trust relationships mean a compromise on one host
 can allow an attacker to move trivially to other hosts.
 </rationale>
 <ident cce="27091-8" />
-<oval id="disable_host_auth" />
+<oval id="disable_host_auth" value="sshd_required" />
 <ref nist="AC-3" disa="765,766" stigid="RHEL-06-000236" 
 srg="SRG-OS-000106" />
 </Rule>
@@ -267,7 +280,7 @@ privileged commands on the system
 and also allows direct attack attempts on root's password.
 </rationale>
 <ident cce="27100-7" />
-<oval id="sshd_disable_root_login" />
+<oval id="sshd_disable_root_login" value="sshd_required" />
 <ref nist="AC-3,AC-6(2),IA-2(1)" disa="770" stigid="RHEL-06-000237"
 srg="SRG-OS-000109" />
 </Rule>
@@ -291,7 +304,7 @@ remote login via SSH will require a password,
 even in the event of misconfiguration elsewhere.
 </rationale>
 <ident cce="26887-0" />
-<oval id="sshd_disable_empty_passwords" />
+<oval id="sshd_disable_empty_passwords" value="sshd_required" />
 <ref nist="AC-3" disa="765,766" stigid="RHEL-06-000239"
 srg="SRG-OS-000106" />
 </Rule>
@@ -315,7 +328,7 @@ whose ownership should not be obvious should ensure usage of a banner that does
 not provide easy attribution.
 </rationale>
 <ident cce="27112-2" />
-<oval id="sshd_enable_warning_banner" />
+<oval id="sshd_enable_warning_banner" value="sshd_required" />
 <ref nist="AC-8(a)" disa="48" stigid="RHEL-06-000240"
 srg="SRG-OS-000023" />
 </Rule>
@@ -339,7 +352,7 @@ SSH environment options potentially allow users to bypass
 access restriction in some configurations.
 </rationale>
 <ident cce="27201-3" />
-<oval id="sshd_do_not_permit_user_env" />
+<oval id="sshd_do_not_permit_user_env" value="sshd_required" />
 <ref disa="1414" stigid="RHEL-06-000241" srg="SRG-OS-000242" />
 </Rule>
 
@@ -364,7 +377,7 @@ Approved algorithms should impart some level of confidence in their
 implementation. These are also required for compliance.
 </rationale>
 <ident cce="26555-3" />
-<oval id="sshd_use_approved_ciphers" />
+<oval id="sshd_use_approved_ciphers" value="sshd_required" />
 <ref nist="AC-3,AC-17(2),SI-7,IA-5(1)(c),IA-7" disa="803,1144,1145,1146" stigid="RHEL-06-000243" 
 srg="SRG-OS-000169" />
 </Rule>
@@ -389,7 +402,7 @@ hmac-sha2-512, hmac-sha2-256, and hmac-sha1 hash functions.
 Approved algorithms should impart some level of confidence in their
 implementation. These are also required for compliance.
 </rationale>
-<oval id="sshd_use_approved_macs" />
+<oval id="sshd_use_approved_macs" value="sshd_required" />
 <ref nist="AC-17(2),IA-7,SC-13" disa="68,1453,803,2449,2450" />
 </Rule>
 

--- a/shared/checks/oval/disable_host_auth.xml
+++ b/shared/checks/oval/disable_host_auth.xml
@@ -7,12 +7,15 @@
       </affected>
       <description>SSH host-based authentication should be disabled.</description>
     </metadata>
-    <criteria comment="SSH is not being used or conditions are met"
-    operator="OR">
-      <extend_definition comment="sshd service is disabled"
-      definition_ref="service_sshd_disabled" />
-      <criterion comment="Check HostbasedAuthentication in /etc/ssh/sshd_config"
-      test_ref="test_sshd_hostbasedauthentication" />
+    <criteria comment="SSH is not installed or conditions are met" operator="OR">
+      <extend_definition comment="sshd is not required and not installed, or requirement is unset"
+      definition_ref="sshd_not_required_or_unset" />
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required and installed, or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <criterion comment="Check HostbasedAuthentication in /etc/ssh/sshd_config"
+        test_ref="test_sshd_hostbasedauthentication" />
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -635,7 +635,7 @@ SSH trust relationships mean a compromise on one host
 can allow an attacker to move trivially to other hosts.
 </rationale>
 <ident prodtype="rhel7" cce="27413-4" />
-<oval id="disable_host_auth" />
+<oval id="disable_host_auth" value="sshd_required" />
 <ref prodtype="rhel7" stigid="010470" />
 <ref nist="AC-3,CM-6(b)" disa="366" srg="SRG-OS-000480-GPOS-00229" cis="5.2.7" cjis="5.5.6" cui="3.1.12" />
 </Rule>

--- a/ubuntu14/xccdf/services/ssh.xml
+++ b/ubuntu14/xccdf/services/ssh.xml
@@ -21,6 +21,19 @@ operator="equals" interactive="0">
 <value selector="120_minutes">7200</value>
 </Value>
 
+<Value id="sshd_required" type="number"
+operator="equals" interactive="0">
+<title>SSH is required to be installed</title>
+<description>Specify if the Policy requires SSH to be installed. Used by SSH Rules
+to determine if SSH should be uninstalled or configured.<br />
+A value of 0 means that the policy doesn't care if OpenSSH server is installed or not. If it is installed, scanner will check for it's configuration, if it's not installed, the check will pass.<br />
+A value of 1 indicates that OpenSSH server package is not required by the policy;<br />
+A value of 2 indicates that OpenSSH server package is required by the policy.<br /></description>
+<value selector="">0</value>
+<value selector="no">1</value>
+<value selector="yes">2</value>
+</Value>
+
 <Rule id="service_sshd_disabled">
 <title>Disable SSH Server if possible (unusual cases)</title>
 <description>Most of the time, the SSH server is needed. However, it can be disabled, do so.
@@ -59,7 +72,7 @@ result in security vulnerabilities and
 should not be used.
 </rationale>
 <ident cce="" />
-<oval id="sshd_allow_only_protocol2" />
+<oval id="sshd_allow_only_protocol2" value="sshd_required" />
 <ref nist="AC-17(7),IA-5(1)(c)" anssi="NT007(R1)" />
 </Rule>
 
@@ -91,7 +104,7 @@ guards against compromises one system leading trivially
 to compromises on another.
 </rationale>
 <ident cce="" />
-<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value"/>
+<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value" value2="sshd_required" />
 <ref nist="AC-2(5),SA-8" pcidss="Req-8.1.8" />
 </Rule>
 
@@ -114,7 +127,7 @@ This ensures a user login will be terminated as soon as the <tt>ClientAliveCount
 is reached.
 </rationale>
 <ident cce="" />
-<oval id="sshd_set_keepalive" />
+<oval id="sshd_set_keepalive" value="sshd_required" />
 <ref nist="AC-2(5),SA-8"  />
 </Rule>
 
@@ -135,7 +148,7 @@ privileged commands on the system
 and also allows direct attack attempts on root's password.
 </rationale>
 <ident cce="" />
-<oval id="sshd_disable_root_login" />
+<oval id="sshd_disable_root_login" value="sshd_required" />
 <ref nist="AC-3,AC-6(2),IA-2(1)" anssi="NT007(R21)"  />
 </Rule>
 
@@ -158,7 +171,7 @@ remote login via SSH will require a password,
 even in the event of misconfiguration elsewhere.
 </rationale>
 <ident cce="" />
-<oval id="sshd_disable_empty_passwords" />
+<oval id="sshd_disable_empty_passwords" value="sshd_required" />
 <ref nist="AC-3" anssi="NT007(R17)" />
 </Rule>
 

--- a/ubuntu16/xccdf/services/ssh.xml
+++ b/ubuntu16/xccdf/services/ssh.xml
@@ -21,6 +21,19 @@ operator="equals" interactive="0">
 <value selector="120_minutes">7200</value>
 </Value>
 
+<Value id="sshd_required" type="number"
+operator="equals" interactive="0">
+<title>SSH is required to be installed</title>
+<description>Specify if the Policy requires SSH to be installed. Used by SSH Rules
+to determine if SSH should be uninstalled or configured.<br />
+A value of 0 means that the policy doesn't care if OpenSSH server is installed or not. If it is installed, scanner will check for it's configuration, if it's not installed, the check will pass.<br />
+A value of 1 indicates that OpenSSH server package is not required by the policy;<br />
+A value of 2 indicates that OpenSSH server package is required by the policy.<br /></description>
+<value selector="">0</value>
+<value selector="no">1</value>
+<value selector="yes">2</value>
+</Value>
+
 <Rule id="service_sshd_disabled">
 <title>Disable SSH Server if possible (unusual cases)</title>
 <description>Most of the time, the SSH server is needed. However, it can be disabled, do so.
@@ -59,7 +72,7 @@ result in security vulnerabilities and
 should not be used.
 </rationale>
 <ident cce="" />
-<oval id="sshd_allow_only_protocol2" />
+<oval id="sshd_allow_only_protocol2" value="sshd_required" />
 <ref nist="AC-17(7),IA-5(1)(c)" anssi="NT007(R1)" />
 </Rule>
 
@@ -91,7 +104,7 @@ guards against compromises one system leading trivially
 to compromises on another.
 </rationale>
 <ident cce="" />
-<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value"/>
+<oval id="sshd_set_idle_timeout" value="sshd_idle_timeout_value" value2="sshd_required" />
 <ref nist="AC-2(5),SA-8" pcidss="Req-8.1.8" />
 </Rule>
 
@@ -114,7 +127,7 @@ This ensures a user login will be terminated as soon as the <tt>ClientAliveCount
 is reached.
 </rationale>
 <ident cce="" />
-<oval id="sshd_set_keepalive" />
+<oval id="sshd_set_keepalive" value="sshd_required" />
 <ref nist="AC-2(5),SA-8"  />
 </Rule>
 
@@ -135,7 +148,7 @@ privileged commands on the system
 and also allows direct attack attempts on root's password.
 </rationale>
 <ident cce="" />
-<oval id="sshd_disable_root_login" />
+<oval id="sshd_disable_root_login" value="sshd_required" />
 <ref nist="AC-3,AC-6(2),IA-2(1)" anssi="NT007(R21)"  />
 </Rule>
 
@@ -158,7 +171,7 @@ remote login via SSH will require a password,
 even in the event of misconfiguration elsewhere.
 </rationale>
 <ident cce="" />
-<oval id="sshd_disable_empty_passwords" />
+<oval id="sshd_disable_empty_passwords" value="sshd_required" />
 <ref nist="AC-3" anssi="NT007(R17)" />
 </Rule>
 


### PR DESCRIPTION
#### Description:

- Add Value `sshd_required` to products that implement their own SSH Rules.
- Edit OVAL check for Rule `disable_host_auth` to use Value `sshd_required`.

#### Rationale:

#2272 introduced Value `sshd_required` for SSH Rules in Shared.
But some products don't gather XCCDF Rules for SSH from shared, they have their own Rules in their own directories, these products are:
- Fedora
- RHEL6
- Debian 8
- Ubuntu 14 and 16

Although, these products have their own Rules for SSH, they still rely on OVAL checks from shared.
So the Rules need to define Value `sshd_required`.

- Fixes #2426
