### PR TITLE
Fix OVAL for chronyd_or_ntpd_set_maxpoll and add remediation

### DIFF
--- a/shared/checks/oval/oval_5.11/chronyd_or_ntpd_set_maxpoll.xml
+++ b/shared/checks/oval/oval_5.11/chronyd_or_ntpd_set_maxpoll.xml
@@ -30,8 +30,8 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_ntp_set_maxpoll" version="1">
     <ind:filepath>/etc/ntp.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*maxpoll[\s]+(\d+)$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:pattern operation="pattern match">^server[\s]+[\S\]+.*maxpoll[\s]+(\d+)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -42,8 +42,8 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_chrony_set_maxpoll" version="1">
     <ind:filepath>/etc/chrony.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*maxpoll[\s]+(\d+)$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:pattern operation="pattern match">^server[\s]+[\S\]+.*maxpoll[\s]+(\d+)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_time_service_set_maxpoll" version="1">

--- a/shared/checks/oval/oval_5.11/chronyd_or_ntpd_set_maxpoll.xml
+++ b/shared/checks/oval/oval_5.11/chronyd_or_ntpd_set_maxpoll.xml
@@ -13,11 +13,15 @@
         <extend_definition comment="service ntpd enabled" definition_ref="service_ntpd_enabled" />
         <criterion comment="check if maxpoll is set in /etc/ntp.conf"
         test_ref="test_ntp_set_maxpoll" />
+        <criterion comment="check if all server entries have maxpoll set in /etc/ntp.conf"
+        test_ref="test_ntp_all_server_has_maxpoll"/>
       </criteria>
       <criteria operator="AND">
         <extend_definition comment="service chronyd enabled" definition_ref="service_chronyd_enabled" />
         <criterion comment="check if maxpoll is set in /etc/chrony.conf"
         test_ref="test_chrony_set_maxpoll" />
+        <criterion comment="check if all server entries have maxpoll set in /etc/chrony.conf"
+        test_ref="test_chrony_all_server_has_maxpoll"/>
       </criteria>
     </criteria>
   </definition>
@@ -52,5 +56,33 @@
 
   <external_variable comment="maxpoll value" datatype="int"
   id="var_time_service_set_maxpoll" version="1" />
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="check if all server entries have maxpoll set in /etc/ntp.conf"
+  id="test_ntp_all_server_has_maxpoll" version="1">
+    <ind:object object_ref="obj_ntp_all_server_has_maxpoll" />
+    <ind:state state_ref="state_server_has_maxpoll" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_ntp_all_server_has_maxpoll" version="1">
+    <ind:filepath>/etc/ntp.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^server[\s]+[\S]+[\s]+(.*)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="check if all server entries have maxpoll set in /etc/chrony.conf"
+  id="test_chrony_all_server_has_maxpoll" version="1">
+    <ind:object object_ref="obj_chrony_all_server_has_maxpoll" />
+    <ind:state state_ref="state_server_has_maxpoll" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_chrony_all_server_has_maxpoll" version="1">
+    <ind:filepath>/etc/chrony.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^server[\s]+[\S]+[\s]+(.*)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_server_has_maxpoll" version="1">
+    <ind:subexpression operation="pattern match" datatype="string">maxpoll \d+</ind:subexpression>
+  </ind:textfilecontent54_state>
 
 </def-group>

--- a/shared/fixes/bash/chronyd_or_ntpd_set_maxpoll.sh
+++ b/shared/fixes/bash/chronyd_or_ntpd_set_maxpoll.sh
@@ -1,0 +1,14 @@
+# platform = multi_platform_rhel
+. /usr/share/scap-security-guide/remediation_functions
+populate var_time_service_set_maxpoll
+
+if ! `/usr/sbin/pidof ntpd`; then
+    config_file="/etc/chrony.conf"
+else
+    config_file="/etc/ntp.conf"
+fi
+
+# Add maxpoll to server entries without maxpoll
+grep -P "^server((?!maxpoll).)*$" $config_file | while read -r line ; do
+        sed -i "s/$line/&1 maxpoll $var_time_service_set_maxpoll/" "$config_file"
+done

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony.pass.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+yum install -y chrony
+yum remove -y ntp
+
+if ! grep "^server.*maxpoll 10" /etc/chrony.conf; then
+    sed -i "s/^server.*/&1 maxpoll 10/" /etc/chrony.conf
+fi
+
+systemctl enable chronyd.service

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_nothing_done.fail.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_nothing_done.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+yum install -y chrony
+yum remove -y ntp
+
+systemctl enable chronyd.service

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_one_server_misconfigured.fail.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_one_server_misconfigured.fail.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+yum install -y chrony
+yum remove -y ntp
+
+if ! grep "^server.*maxpoll 10" /etc/chrony.conf; then
+    sed -i "s/^server.*/&1 maxpoll 10/" /etc/chrony.conf
+fi
+
+echo "server test.ntp.org" >> /etc/chrony.conf
+
+systemctl enable chronyd.service
+
+cat /etc/chrony.conf

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp.pass.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+yum install -y ntp
+yum remove -y chrony
+
+if ! grep "^server.*maxpoll 10" /etc/ntp.conf; then
+    sed -i "s/^server.*/&1 maxpoll 10/" /etc/ntp.conf
+fi
+
+systemctl enable ntpd.service


### PR DESCRIPTION
#### Description:

- Fixes regular expression in OVAL check that looks for configuration of `maxpoll`.
- Extends OVAL check to verify if all `server` entries in config file has `maxpoll` set.
- Adds tests and remediation for `chronyd_or_ntpd_set_maxpoll`.

#### Rationale:

- OVAL check for `chronyd_or_ntpd_set_maxpoll` is wrong and there is no remediation for it.

- Fixes #2287
