### PR TITLE
[WIP] Update multi-platform and remove oval.config usage

### DIFF
--- a/shared/checks/oval/sshd_allow_only_protocol2.xml
+++ b/shared/checks/oval/sshd_allow_only_protocol2.xml
@@ -3,9 +3,9 @@
     <metadata>
       <title>Ensure Only Protocol 2 Connections Allowed</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_debian</platform>
-        <platform>multi_platform_ubuntu</platform>
+        <platform>rhel</platform>
+        <platform>debian</platform>
+        <platform>ubuntu</platform>
       </affected>
       <description>The OpenSSH daemon should be running protocol 2.</description>
     </metadata>


### PR DESCRIPTION
#### Description:

- Allow usage of short names e.g. rhel7 or long names e.g. Red Hat Enterprise Linux 7
- Add product currently being built instead of all products for multi-platform OVAL
- Remove usage of oval.config

#### Rationale:

- Use of multi_platform is a bit unwieldy.
