### PR TITLE
Enable chronyd_or_ntpd_set_maxpoll remediation to fix incorrect values of maxpoll

### DIFF
--- a/shared/checks/oval/oval_5.11/chronyd_or_ntpd_set_maxpoll.xml
+++ b/shared/checks/oval/oval_5.11/chronyd_or_ntpd_set_maxpoll.xml
@@ -34,7 +34,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_ntp_set_maxpoll" version="1">
     <ind:filepath>/etc/ntp.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^server[\s]+[\S\]+.*maxpoll[\s]+(\d+)</ind:pattern>
+    <ind:pattern operation="pattern match">^server[\s]+[\S]+.*maxpoll[\s]+(\d+)</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -46,7 +46,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_chrony_set_maxpoll" version="1">
     <ind:filepath>/etc/chrony.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^server[\s]+[\S\]+.*maxpoll[\s]+(\d+)</ind:pattern>
+    <ind:pattern operation="pattern match">^server[\s]+[\S]+.*maxpoll[\s]+(\d+)</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/fixes/bash/chronyd_or_ntpd_set_maxpoll.sh
+++ b/shared/fixes/bash/chronyd_or_ntpd_set_maxpoll.sh
@@ -8,6 +8,9 @@ else
     config_file="/etc/ntp.conf"
 fi
 
+# Set maxpoll values to var_time_service_set_maxpoll
+sed -i "s/^\(server.*maxpoll\) [0-9][0-9]*\(.*\)$/\1 $var_time_service_set_maxpoll \2/" "$config_file"
+
 # Add maxpoll to server entries without maxpoll
 grep -P "^server((?!maxpoll).)*$" $config_file | while read -r line ; do
         sed -i "s/$line/&1 maxpoll $var_time_service_set_maxpoll/" "$config_file"

--- a/shared/fixes/bash/chronyd_or_ntpd_set_maxpoll.sh
+++ b/shared/fixes/bash/chronyd_or_ntpd_set_maxpoll.sh
@@ -2,7 +2,7 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_time_service_set_maxpoll
 
-if ! `/usr/sbin/pidof ntpd`; then
+if ! [ `/usr/sbin/pidof ntpd` ] ; then
     config_file="/etc/chrony.conf"
 else
     config_file="/etc/ntp.conf"

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_one_server_misconfigured.fail.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_one_server_misconfigured.fail.sh
@@ -12,5 +12,3 @@ fi
 echo "server test.ntp.org" >> /etc/chrony.conf
 
 systemctl enable chronyd.service
-
-cat /etc/chrony.conf

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp.pass.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp.pass.sh
@@ -10,3 +10,4 @@ if ! grep "^server.*maxpoll 10" /etc/ntp.conf; then
 fi
 
 systemctl enable ntpd.service
+systemctl start ntpd.service

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp_wrong_maxpoll.fail.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp_wrong_maxpoll.fail.sh
@@ -8,4 +8,6 @@ yum remove -y chrony
 sed -i "s/^server.*/&1 maxpoll 17/" /etc/ntp.conf
 
 systemctl enable ntpd.service
+
+# The remediation configures ntp only if ntpd is running
 systemctl start ntpd.service

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp_wrong_maxpoll.fail.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp_wrong_maxpoll.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+yum install -y ntp
+yum remove -y chrony
+
+sed -i "s/^server.*/&1 maxpoll 17/" /etc/ntp.conf
+
+systemctl enable ntpd.service
+systemctl start ntpd.service


### PR DESCRIPTION
#### Description:

- Remediation can fix incorrect server maxpoll values
- Fixes typo in regular expression in OVAL check that looks for configuration of maxpoll
- Small fixes in remediation and tests

#### Rationale:

- I realized overnight that remediation implemented in #2429 didn't fix server entries with wrong maxpoll values. Came here to fix it and found other issues.

- Related to #2287
