### PR TITLE
Remove rules no longer in rhel6 STIG profile

### DIFF
--- a/rhel6/profiles/stig-rhel6-disa.xml
+++ b/rhel6/profiles/stig-rhel6-disa.xml
@@ -125,10 +125,6 @@ Storage deployments.
 <refine-value idref="var_password_pam_lcredit" selector="1"/>
 <refine-value idref="sshd_idle_timeout_value" selector="15_minutes"/>
 
-<!-- dropped from DISA content in V1R13 -->
-<select idref="ldap_client_start_tls" selected="false" />
-<select idref="ldap_client_tls_cacertpath" selected="false" />
-
 <select idref="gconf_gnome_disable_ctrlaltdel_reboot" selected="true" />
 
 


### PR DESCRIPTION
#### Description:

- Remove rules no longer in rhel6 STIG profile

#### Rationale:

- The rules no longer exist in the latest RHEL6 STIG release.