### PR TITLE
Mcafee related rules as machine only

### DIFF
--- a/shared/xccdf/system/software/integrity.xml
+++ b/shared/xccdf/system/software/integrity.xml
@@ -461,6 +461,7 @@ $ sudo ls -la avvscan.dat avvnames.dat avvclean.dat</pre>
 Virus scanning software can be used to detect if a system has been compromised by
 computer viruses, as well as to limit their spread to other systems.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <oval id="install_antivirus" />
 <ident prodtype="rhel7" cce="27140-3" />
 <ref nist="SC-28, SI-3" disa="1239,1668"/>

--- a/shared/xccdf/system/software/integrity.xml
+++ b/shared/xccdf/system/software/integrity.xml
@@ -422,6 +422,7 @@ Verify this intrusion detection software is active.
 Host-based intrusion detection tools provide a system-level defense when an
 intruder gains access to a system or network.
 </rationale>
+<platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="26818-5" />
 <oval id="install_hids" />
 <ref nist="SC-7" disa="1263" pcidss="Req-11.4" />


### PR DESCRIPTION
#### Description:

- Mark Rules `install_hids` and `install_antivirus` as machine-only.

#### Rationale:

- Both rules are closely related to McAffee antivirus, wich runs as service, and we should mark services related Rule as machine-only.
