### PR TITLE
Fixing CIS reference number for noexec on /tmp partition

### DIFF
--- a/shared/xccdf/system/permissions/partitions.xml
+++ b/shared/xccdf/system/permissions/partitions.xml
@@ -126,7 +126,7 @@ can expose the system to potential compromise.</rationale>
 <platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="80150-6" />
 <oval id="mount_option_tmp_noexec" />
-<ref nist="CM-7,MP-2" cis="1.1.4" />
+<ref nist="CM-7,MP-2" cis="1.1.5" />
 </Rule>
 
 <Rule id="mount_option_tmp_nosuid" prodtype="rhel7">


### PR DESCRIPTION
#### Description:

Update the CIS reference for noexec on /tmp partition

#### Rationale:

The CIS reference for noexec on /tmp partition should be 1.1.5 instead of 1.1.4
