### PR TITLE
Add GDM login banner checks to C2S profile.

### DIFF
--- a/rhel7/profiles/C2S.xml
+++ b/rhel7/profiles/C2S.xml
@@ -195,6 +195,9 @@ baseline.
 <!--	1.7.1.5	Ensure permissions on /etc/issue are configured (Scored) -->
 <!--	1.7.1.6	Ensure permissions on /etc/issue.net are configured (Not Scored) -->
 <!--	1.7.2	Ensure GDM login banner is configured (Scored) -->
+<select idref="dconf_gnome_login_banner_text" selected="true" />
+<select idref="dconf_gnome_banner_enabled" selected="true" />
+
 <!--	1.8	Ensure updates, patches, and additional security software are installed (Not Scored) -->
 <select idref="security_patches_up_to_date" selected="true" />
 

--- a/shared/xccdf/system/accounts/banners.xml
+++ b/shared/xccdf/system/accounts/banners.xml
@@ -130,7 +130,7 @@ with human users and are not required when such human interfaces do not exist.
 <ident prodtype="rhel7" cce="26970-4" />
 <oval id="dconf_gnome_banner_enabled" />
 <ref prodtype="rhel7" stigid="010030" />
-<ref nist="AC-8(a),AC-8(b),AC-8(c)(1),AC-8(c)(2),AC-8(c)(3)" disa="48" srg="OS-SRG-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088" cui="3.1.9" />
+<ref nist="AC-8(a),AC-8(b),AC-8(c)(1),AC-8(c)(2),AC-8(c)(3)" disa="48" srg="OS-SRG-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088" cui="3.1.9" cis="1.7.2" />
 </Rule>
 
 <Rule id="dconf_gnome_login_banner_text" severity="medium" prodtype="rhel7">
@@ -168,7 +168,7 @@ process and facilitates possible legal action against attackers.
 <ident prodtype="rhel7" cce="26892-0" />
 <oval id="dconf_gnome_login_banner_text" value="login_banner_text"/>
 <ref prodtype="rhel7" stigid="010040" />
-<ref nist="AC-8(a),AC-8(b),AC-8(c)" disa="48" srg="SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088" cui="3.1.9" />
+<ref nist="AC-8(a),AC-8(b),AC-8(c)" disa="48" srg="SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088" cui="3.1.9" cis="1.7.2" />
 </Rule>
 
 </Group>


### PR DESCRIPTION
#### Description:

CIS rule 1.7.2 has a couple components already written so added those to the C2S profile and added the cis reference in the checks.

#### Rationale:

CIS rule 1.7.2 has two pieces written so those have been added. The only drawback is there are a few components of this rule that are still not checked.