### PR TITLE
Apply to XCCDF file only the Rule and Group elements that apply to product being built

### DIFF
--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -70,7 +70,7 @@
           </xsl:if>
           <xsl:choose>
             <xsl:when test="contains(title/@prodtype, $prod_type) or title/@prodtype = 'all'">
-              <xsl:apply-templates select="title"/>
+              <xsl:apply-templates select="title[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="title[not(@prodtype)]"/>
@@ -78,7 +78,7 @@
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(description/@prodtype, $prod_type) or description/@prodtype = 'all'">
-              <xsl:apply-templates select="description"/>
+              <xsl:apply-templates select="description[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="description[not(@prodtype)]"/>
@@ -86,7 +86,7 @@
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(warning/@prodtype, $prod_type) or warning/@prodtype = 'all'">
-              <xsl:apply-templates select="warning"/>
+              <xsl:apply-templates select="warning[contains(@prodtype, $prod_type or @prodtype = 'all')]"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="warning[not(@prodtype)]"/>
@@ -94,7 +94,7 @@
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(ref/@prodtype, $prod_type) or ref/@prodtype = 'all'">
-              <xsl:apply-templates select="ref"/>
+              <xsl:apply-templates select="ref[contains(@prodtype, $prod_type or @prodtype = 'all')]"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="ref[not(@prodtype)]"/>
@@ -102,39 +102,39 @@
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(rationale/@prodtype, $prod_type) or rationale/@prodtype = 'all'">
-              <xsl:apply-templates select="rationale"/>
+              <xsl:apply-templates select="rationale[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
-              <xsl:apply-templates select="rationale[not(rationale/@prodtype)]"/>
+              <xsl:apply-templates select="rationale[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(requires/@prodtype, $prod_type) or requires/@prodtype = 'all'">
-              <xsl:apply-templates select="requires"/>
+              <xsl:apply-templates select="requires[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
-              <xsl:apply-templates select="requires[not(requires/@prodtype)]"/>
+              <xsl:apply-templates select="requires[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(conflicts/@prodtype, $prod_type) or conflicts/@prodtype = 'all'">
-              <xsl:apply-templates select="conflicts"/>
+              <xsl:apply-templates select="conflicts[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
-              <xsl:apply-templates select="conflicts[not(conflicts/@prodtype)]"/>
+              <xsl:apply-templates select="conflicts[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(platform/@prodtype, $prod_type) or platform/@prodtype = 'all'">
-              <xsl:apply-templates select="platform"/>
+              <xsl:apply-templates select="platform[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
-              <xsl:apply-templates select="platform[not(platform/@prodtype)]"/>
+              <xsl:apply-templates select="platform[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(ident/@prodtype, $prod_type) or ident/@prodtype = 'all'">
-              <xsl:apply-templates select="ident"/>
+              <xsl:apply-templates select="ident[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="ident[not(@prodtype)]"/>
@@ -143,7 +143,7 @@
           <!-- order oval (shorthand tag) first, to indicate to tools to prefer its automated checks -->
           <xsl:choose>
             <xsl:when test="contains(oval/@prodtype, $prod_type) or oval/@prodtype = 'all'">
-              <xsl:apply-templates select="oval"/>
+              <xsl:apply-templates select="oval[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="oval[not(@prodtype)]"/>
@@ -189,7 +189,7 @@
           <xsl:apply-templates select="@*" />
           <xsl:choose>
             <xsl:when test="contains(title/@prodtype, $prod_type) or title/@prodtype = 'all'">
-              <xsl:apply-templates select="title"/>
+              <xsl:apply-templates select="title[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="title[not(@prodtype)]"/>
@@ -197,7 +197,7 @@
           </xsl:choose>
            <xsl:choose>
             <xsl:when test="contains(description/@prodtype, $prod_type) or description/@prodtype = 'all'">
-              <xsl:apply-templates select="description"/>
+              <xsl:apply-templates select="description[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="description[not(@prodtype)]"/>
@@ -205,7 +205,7 @@
           </xsl:choose>
            <xsl:choose>
             <xsl:when test="contains(warning/@prodtype, $prod_type) or warning/@prodtype = 'all'">
-              <xsl:apply-templates select="warning"/>
+              <xsl:apply-templates select="warning[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="warning[not(@prodtype)]"/>
@@ -213,7 +213,7 @@
           </xsl:choose>
            <xsl:choose>
             <xsl:when test="contains(ref/@prodtype, $prod_type) or ref/@prodtype = 'all'">
-              <xsl:apply-templates select="ref"/>
+              <xsl:apply-templates select="ref[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="ref[not(@prodtype)]"/>
@@ -221,7 +221,7 @@
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(rationale/@prodtype, $prod_type) or rationale/@prodtype = 'all'">
-              <xsl:apply-templates select="rationale"/>
+              <xsl:apply-templates select="rationale[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="rationale[not(@prodtype)]"/>
@@ -229,23 +229,23 @@
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(requires/@prodtype, $prod_type) or requires/@prodtype = 'all'">
-              <xsl:apply-templates select="requires"/>
+              <xsl:apply-templates select="requires[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
-              <xsl:apply-templates select="requires[not(requires/@prodtype)]"/>
+              <xsl:apply-templates select="requires[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(conflicts/@prodtype, $prod_type) or conflicts/@prodtype = 'all'">
-              <xsl:apply-templates select="conflicts"/>
+              <xsl:apply-templates select="conflicts[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
-              <xsl:apply-templates select="conflicts[not(conflicts/@prodtype)]"/>
+              <xsl:apply-templates select="conflicts[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
             <xsl:when test="contains(platform/@prodtype, $prod_type) or platform/@prodtype = 'all'">
-              <xsl:apply-templates select="platform"/>
+              <xsl:apply-templates select="platform[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="platform[not(@prodtype)]"/>

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -69,72 +69,99 @@
             </xsl:attribute>
           </xsl:if>
           <xsl:choose>
-            <xsl:when test="contains(title/@prodtype, $prod_type) or title/@prodtype = 'all'">
-              <xsl:apply-templates select="title[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(title/@prodtype, $prod_type)">
+              <xsl:apply-templates select="title[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="title/@prodtype = 'all'">
+              <xsl:apply-templates select="title[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="title[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(description/@prodtype, $prod_type) or description/@prodtype = 'all'">
-              <xsl:apply-templates select="description[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(description/@prodtype, $prod_type)">
+              <xsl:apply-templates select="description[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="description/@prodtype = 'all'">
+              <xsl:apply-templates select="description[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="description[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(warning/@prodtype, $prod_type) or warning/@prodtype = 'all'">
-              <xsl:apply-templates select="warning[contains(@prodtype, $prod_type or @prodtype = 'all')]"/>
+            <xsl:when test="contains(warning/@prodtype, $prod_type)">
+              <xsl:apply-templates select="warning[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="warning/@prodtype = 'all'">
+              <xsl:apply-templates select="warning[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="warning[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(ref/@prodtype, $prod_type) or ref/@prodtype = 'all'">
-              <xsl:apply-templates select="ref[contains(@prodtype, $prod_type or @prodtype = 'all')]"/>
+            <xsl:when test="contains(ref/@prodtype, $prod_type)">
+              <xsl:apply-templates select="ref[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="ref/@prodtype = 'all'">
+              <xsl:apply-templates select="ref[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="ref[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(rationale/@prodtype, $prod_type) or rationale/@prodtype = 'all'">
-              <xsl:apply-templates select="rationale[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(rationale/@prodtype, $prod_type)">
+              <xsl:apply-templates select="rationale[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="rationale/@prodtype = 'all'">
+              <xsl:apply-templates select="rationale[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="rationale[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(requires/@prodtype, $prod_type) or requires/@prodtype = 'all'">
-              <xsl:apply-templates select="requires[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(requires/@prodtype, $prod_type)">
+              <xsl:apply-templates select="requires[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="requires/@prodtype = 'all'">
+              <xsl:apply-templates select="requires[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="requires[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(conflicts/@prodtype, $prod_type) or conflicts/@prodtype = 'all'">
-              <xsl:apply-templates select="conflicts[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(conflicts/@prodtype, $prod_type)">
+              <xsl:apply-templates select="conflicts[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="conflicts/@prodtype = 'all'">
+              <xsl:apply-templates select="conflicts[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="conflicts[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(platform/@prodtype, $prod_type) or platform/@prodtype = 'all'">
-              <xsl:apply-templates select="platform[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(platform/@prodtype, $prod_type)">
+              <xsl:apply-templates select="platform[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="platform/@prodtype = 'all'">
+              <xsl:apply-templates select="platform[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="platform[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(ident/@prodtype, $prod_type) or ident/@prodtype = 'all'">
-              <xsl:apply-templates select="ident[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(ident/@prodtype, $prod_type)">
+              <xsl:apply-templates select="ident[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="ident/@prodtype = 'all'">
+              <xsl:apply-templates select="ident[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="ident[not(@prodtype)]"/>
@@ -142,8 +169,11 @@
           </xsl:choose>
           <!-- order oval (shorthand tag) first, to indicate to tools to prefer its automated checks -->
           <xsl:choose>
-            <xsl:when test="contains(oval/@prodtype, $prod_type) or oval/@prodtype = 'all'">
-              <xsl:apply-templates select="oval[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(oval/@prodtype, $prod_type)">
+              <xsl:apply-templates select="oval[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="oval/@prodtype = 'all'">
+              <xsl:apply-templates select="oval[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="oval[not(@prodtype)]"/>
@@ -188,64 +218,88 @@
         <Group>
           <xsl:apply-templates select="@*" />
           <xsl:choose>
-            <xsl:when test="contains(title/@prodtype, $prod_type) or title/@prodtype = 'all'">
-              <xsl:apply-templates select="title[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(title/@prodtype, $prod_type)">
+              <xsl:apply-templates select="title[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="title/@prodtype = 'all'">
+              <xsl:apply-templates select="title[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="title[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
            <xsl:choose>
-            <xsl:when test="contains(description/@prodtype, $prod_type) or description/@prodtype = 'all'">
-              <xsl:apply-templates select="description[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(description/@prodtype, $prod_type)">
+              <xsl:apply-templates select="description[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="description/@prodtype = 'all'">
+              <xsl:apply-templates select="description[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="description[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
            <xsl:choose>
-            <xsl:when test="contains(warning/@prodtype, $prod_type) or warning/@prodtype = 'all'">
-              <xsl:apply-templates select="warning[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(warning/@prodtype, $prod_type)">
+              <xsl:apply-templates select="warning[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="warning/@prodtype = 'all'">
+              <xsl:apply-templates select="warning[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="warning[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
            <xsl:choose>
-            <xsl:when test="contains(ref/@prodtype, $prod_type) or ref/@prodtype = 'all'">
-              <xsl:apply-templates select="ref[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(ref/@prodtype, $prod_type)">
+              <xsl:apply-templates select="ref[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="ref/@prodtype = 'all'">
+              <xsl:apply-templates select="ref[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="ref[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(rationale/@prodtype, $prod_type) or rationale/@prodtype = 'all'">
-              <xsl:apply-templates select="rationale[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(rationale/@prodtype, $prod_type)">
+              <xsl:apply-templates select="rationale[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="rationale/@prodtype = 'all'">
+              <xsl:apply-templates select="rationale[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="rationale[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(requires/@prodtype, $prod_type) or requires/@prodtype = 'all'">
-              <xsl:apply-templates select="requires[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(requires/@prodtype, $prod_type)">
+              <xsl:apply-templates select="requires[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="requires/@prodtype = 'all'">
+              <xsl:apply-templates select="requires[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="requires[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(conflicts/@prodtype, $prod_type) or conflicts/@prodtype = 'all'">
-              <xsl:apply-templates select="conflicts[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(conflicts/@prodtype, $prod_type)">
+              <xsl:apply-templates select="conflicts[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="conflicts/@prodtype = 'all'">
+              <xsl:apply-templates select="conflicts[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="conflicts[not(@prodtype)]"/>
             </xsl:otherwise>
           </xsl:choose>
           <xsl:choose>
-            <xsl:when test="contains(platform/@prodtype, $prod_type) or platform/@prodtype = 'all'">
-              <xsl:apply-templates select="platform[contains(@prodtype, $prod_type) or @prodtype = 'all']"/>
+            <xsl:when test="contains(platform/@prodtype, $prod_type)">
+              <xsl:apply-templates select="platform[contains(@prodtype, $prod_type)]"/>
+            </xsl:when>
+            <xsl:when test="platform/@prodtype = 'all'">
+              <xsl:apply-templates select="platform[@prodtype = 'all']"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:apply-templates select="platform[not(@prodtype)]"/>


### PR DESCRIPTION
#### Description:

- Apply only the templates of XCCDF elements that match `prodtype` when `prodtype` attribute exists.
This avoids applying multiple elements whose prodtype are not related to actual product.

#### Rationale:

- PR #2138 tries move Debian based products into shared directory. It introduced alternative XCCDF Rule description and rationale for Debian. But our transformations don't handle them well. They endup creating a XCCDF file with multiple description and rationale elements. The creation of HTML tables trips on multiple definitions of description and stop.
- If an XCCDF element's attribute prodtype matched the current product being built, the transformation applied all element's templates.

- Fixes #2172 
- Commit 1af6e92 allows #2138 to build (via cherry-pick)

~~#### Known issue~~
~~Build will fail in case Rule or Group has two elements, one with prodtype all and other with prodtype equal to product being built.~~ 
- In case there are multiple versions of an element, each with different prodtype attribute, choose according to product specificity:
   - First option is element with matching prodtype,
   - Secont options is element witch explicitly applies to all,
   - Last option is element without prodtype attribute.