### PR TITLE
Fix typo in auditd OVAL files

### DIFF
--- a/shared/checks/oval/auditd_data_retention_max_log_file.xml
+++ b/shared/checks/oval/auditd_data_retention_max_log_file.xml
@@ -31,6 +31,6 @@
     <ind:subexpression operation="greater than or equal" var_ref="var_auditd_max_log_file" datatype="int" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="audit max_log_file settting" datatype="int" id="var_auditd_max_log_file" version="1" />
+  <external_variable comment="audit max_log_file setting" datatype="int" id="var_auditd_max_log_file" version="1" />
 
 </def-group>

--- a/shared/checks/oval/auditd_data_retention_num_logs.xml
+++ b/shared/checks/oval/auditd_data_retention_num_logs.xml
@@ -31,7 +31,7 @@
     <ind:subexpression operation="greater than or equal" var_ref="var_auditd_num_logs" datatype="int" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="audit num_logs settting" datatype="int" id="var_auditd_num_logs" version="1" />
+  <external_variable comment="audit num_logs setting" datatype="int" id="var_auditd_num_logs" version="1" />
 
 
 </def-group>

--- a/shared/checks/oval/auditd_data_retention_space_left.xml
+++ b/shared/checks/oval/auditd_data_retention_space_left.xml
@@ -31,7 +31,7 @@
     <ind:subexpression operation="greater than or equal" var_ref="var_auditd_space_left" datatype="int" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="audit space_left settting" datatype="int" id="var_auditd_space_left" version="1" />
+  <external_variable comment="audit space_left setting" datatype="int" id="var_auditd_space_left" version="1" />
 
 
 </def-group>


### PR DESCRIPTION
#### Description:

- Fix one typo located in three files for shared/OVAL: external variable comment contains the word "settting" which should be "setting".

#### Rationale:

- This is a cosmetic change, but a correction nonetheless.
