### PR TITLE
Fix StrictModes and KerberosAuthentication checks

### DIFF
--- a/rhel7/checks/oval/sshd_disable_kerb_auth.xml
+++ b/rhel7/checks/oval/sshd_disable_kerb_auth.xml
@@ -20,14 +20,14 @@ the SSH Server.</description>
       </criteria>
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
   comment="tests the value of KerberosAuthentication setting in the /etc/ssh/sshd_config file"
   id="test_sshd_disable_kerb_auth" version="1">
     <ind:object object_ref="obj_sshd_disable_kerb_auth" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sshd_disable_kerb_auth" version="1">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)KerberosAuthentication(?-i)[\s]+no[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)KerberosAuthentication(?-i)[\s]+yes[\s]*(?:|(?:#.*))?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/rhel7/checks/oval/sshd_enable_strictmodes.xml
+++ b/rhel7/checks/oval/sshd_enable_strictmodes.xml
@@ -20,14 +20,14 @@ and configurations.</description>
       </criteria>
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
   comment="tests the value of StrictModes setting in the /etc/ssh/sshd_config file"
   id="test_sshd_enable_strictmodes" version="1">
     <ind:object object_ref="obj_sshd_enable_strictmodes" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sshd_enable_strictmodes" version="1">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)StrictModes(?-i)[\s]+yes[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)StrictModes(?-i)[\s]+no[\s]*(?:|(?:#.*))?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>


### PR DESCRIPTION
#### Description:

- Fix StrictModes and KerberosAuthentication checks to pass when they are not configured in `sshd_config`

#### Rationale:

- StrictModes and KerberosAuthentication are configured correctly by default. The OVAL checks should pass if they don't exist in `sshd_config`

- Fixes #2457
- Fixes #2456
