### PR TITLE
Check all umask settings in umask checks

### DIFF
--- a/shared/checks/oval/accounts_umask_etc_bashrc.xml
+++ b/shared/checks/oval/accounts_umask_etc_bashrc.xml
@@ -62,7 +62,7 @@
     </arithmetic>
   </local_variable>
 
-  <ind:variable_test id="tst_accounts_umask_etc_bashrc" version="1" check="all"
+  <ind:variable_test id="tst_accounts_umask_etc_bashrc" version="1" check="all" check_existence="all_exist"
   comment="Test the retrieved /etc/bashrc umask value(s) match the var_accounts_user_umask requirement">
     <ind:object object_ref="obj_accounts_umask_etc_bashrc" />
     <ind:state state_ref="ste_accounts_umask_etc_bashrc" />

--- a/shared/checks/oval/accounts_umask_etc_csh_cshrc.xml
+++ b/shared/checks/oval/accounts_umask_etc_csh_cshrc.xml
@@ -62,7 +62,7 @@
     </arithmetic>
   </local_variable>
 
-  <ind:variable_test id="tst_accounts_umask_etc_csh_cshrc" version="1" check="all"
+  <ind:variable_test id="tst_accounts_umask_etc_csh_cshrc" version="1" check="all" check_existence="all_exist"
   comment="Test the retrieved /etc/csh.cshrc umask value(s) match the var_accounts_user_umask requirement">
     <ind:object object_ref="obj_accounts_umask_etc_csh_cshrc" />
     <ind:state state_ref="ste_accounts_umask_etc_csh_cshrc" />

--- a/shared/checks/oval/accounts_umask_etc_login_defs.xml
+++ b/shared/checks/oval/accounts_umask_etc_login_defs.xml
@@ -62,7 +62,7 @@
     </arithmetic>
   </local_variable>
 
-  <ind:variable_test id="tst_accounts_umask_etc_login_defs" version="1" check="all"
+  <ind:variable_test id="tst_accounts_umask_etc_login_defs" version="1" check="all" check_existence="all_exist"
   comment="Test the retrieved /etc/login.defs umask value(s) match the var_accounts_user_umask requirement">
     <ind:object object_ref="obj_accounts_umask_etc_login_defs" />
     <ind:state state_ref="ste_accounts_umask_etc_login_defs" />

--- a/shared/checks/oval/accounts_umask_etc_profile.xml
+++ b/shared/checks/oval/accounts_umask_etc_profile.xml
@@ -62,7 +62,7 @@
     </arithmetic>
   </local_variable>
 
-  <ind:variable_test id="tst_accounts_umask_etc_profile" version="1" check="all"
+  <ind:variable_test id="tst_accounts_umask_etc_profile" version="1" check="all" check_existence="all_exist"
   comment="Test the retrieved /etc/profile umask value(s) match the var_accounts_user_umask requirement">
     <ind:object object_ref="obj_accounts_umask_etc_profile" />
     <ind:state state_ref="ste_accounts_umask_etc_profile" />


### PR DESCRIPTION
#### Description:

- Check all umask settings in umask checks by setting `check_existence="all_exist"` in the OVAL checks.

#### Rationale:

- Currently the umask checks were only checking if the first instance of umask was set correctly. This fixes that.

- Fixes #1946
