### PR TITLE
Add remediation script for ensure_gpgcheck_repo_metadata.sh rule.

### DIFF
--- a/shared/fixes/bash/ensure_gpgcheck_repo_metadata.sh
+++ b/shared/fixes/bash/ensure_gpgcheck_repo_metadata.sh
@@ -1,0 +1,4 @@
+# platform = multi_platform_rhel
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '/etc/yum.conf' '^repo_gpgcheck' '1' '@CCENUM@'


### PR DESCRIPTION
#### Description:

- Add missing remediation script for ensure_gpgcheck_repo_metadata rule

#### Rationale:

- It seems that during the project tree reorganization, this remediation script disappeared. Then when using SSG 0.1.36, this check is always failed because there is no applicable remediation.
