### PR TITLE
Fix two stigid mappings

### DIFF
--- a/shared/xccdf/services/quagga.xml
+++ b/shared/xccdf/services/quagga.xml
@@ -32,7 +32,6 @@ the network.
 </rationale>
 <ident prodtype="rhel7" cce="27191-6" />
 <oval id="service_zebra_disabled" />
-<ref prodtype="rhel7" stigid="040730" />
 <ref nist="SC-32" disa="366" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 

--- a/shared/xccdf/system/auditing.xml
+++ b/shared/xccdf/system/auditing.xml
@@ -465,7 +465,7 @@ allow them to take corrective action prior to any disruption.</rationale>
 <platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27375-5" />
 <oval id="auditd_data_retention_space_left_action" value="var_auditd_space_left_action"/>
-<ref nist="AU-1(b),AU-4,AU-5(1),AU-5(b),IR-5" disa="1855" pcidss="Req-10.7" cis="5.2.1.2" srg="SRG-OS-000343-GPOS-00134" tigid="030340" cjis="5.4.1.1" cui="3.3.1" />
+<ref nist="AU-1(b),AU-4,AU-5(1),AU-5(b),IR-5" disa="1855" pcidss="Req-10.7" cis="5.2.1.2" srg="SRG-OS-000343-GPOS-00134" cjis="5.4.1.1" cui="3.3.1" />
 </Rule>
 
 <Rule id="auditd_data_retention_admin_space_left_action" severity="medium" prodtype="rhel7">
@@ -495,6 +495,7 @@ is used, running low on space for audit records should never occur.
 </rationale>
 <platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27370-6" />
+<ref prodtype="rhel7" stigid="030340" />
 <oval id="auditd_data_retention_admin_space_left_action" value="var_auditd_admin_space_left_action" />
 <ref nist="AU-1(b),AU-4,AU-5(b),IR-5" disa="140,1343" pcidss="Req-10.7" cis="5.2.1.2" cjis="5.4.1.1" cui="3.3.1" />
 </Rule>


### PR DESCRIPTION
Hello,

During my STIG 1.3 review, I found two OpenSCAP rule which didn't have the correct STIGID mapping : 
  - service_zebra_disabled was linked to STIG rule referring to X Windows manager check
  - auditd_data_retention_admin_space_left_action wasn't mapped correctly due to a typo

HTH