### PR TITLE
Fixes Ansible remediations disable_prelink and no_rsh_trust_files

### DIFF
--- a/shared/fixes/ansible/disable_prelink.yml
+++ b/shared/fixes/ansible/disable_prelink.yml
@@ -8,5 +8,6 @@
     path: /etc/sysconfig/prelink
     regexp: '^PRELINKING='
     line: 'PRELINKING=no'
+    create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/no_rsh_trust_files.yml
+++ b/shared/fixes/ansible/no_rsh_trust_files.yml
@@ -16,7 +16,7 @@
       file:
           path: "{{ item.path }}"
           state: absent
-      with_items: "{{ shosts_equiv_locations }}"
-  when: shosts_equiv_locations
+      with_items: "{{ shosts_equiv_locations.files }}"
+      when: shosts_equiv_locations
   tags:
     @ANSIBLE_TAGS@


### PR DESCRIPTION
Fixes fatal errors I faced when testing ansible role for CentOS6 C2S
