### PR TITLE
Fixes ansible remediations

### DIFF
--- a/shared/fixes/ansible/dconf_gnome_disable_automount.yml
+++ b/shared/fixes/ansible/dconf_gnome_disable_automount.yml
@@ -18,6 +18,7 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/desktop/media-handling/automount'
     line: '/org/gnome/desktop/media-handling/automount'
+    create: yes
   tags:
     @ANSIBLE_TAGS@
 
@@ -36,6 +37,7 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/desktop/media-handling/automount-open'
     line: '/org/gnome/desktop/media-handling/automount-open'
+    create: yes
   tags:
     @ANSIBLE_TAGS@
 
@@ -54,6 +56,7 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/desktop/media-handling/autorun-never'
     line: '/org/gnome/desktop/media-handling/autorun-never'
+    create: yes
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/fixes/ansible/dconf_gnome_disable_ctrlaltdel_reboot.yml
+++ b/shared/fixes/ansible/dconf_gnome_disable_ctrlaltdel_reboot.yml
@@ -18,5 +18,6 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/settings-daemon/plugins/media-keys/logout'
     line: '/org/gnome/settings-daemon/plugins/media-keys/logout'
+    create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/dconf_gnome_disable_geolocation.yml
+++ b/shared/fixes/ansible/dconf_gnome_disable_geolocation.yml
@@ -26,6 +26,7 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/system/location/enabled'
     line: '/org/gnome/system/location/enabled'
+    create: yes
   tags:
     @ANSIBLE_TAGS@
 
@@ -34,5 +35,6 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/clocks/geolocation'
     line: '/org/gnome/clocks/geolocation'
+    create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/dconf_gnome_disable_restart_shutdown.yml
+++ b/shared/fixes/ansible/dconf_gnome_disable_restart_shutdown.yml
@@ -18,5 +18,6 @@
     path: /etc/dconf/db/gdm.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/login-screen/disable-restart-buttons'
     line: '/org/gnome/login-screen/disable-restart-buttons'
+    create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/dconf_gnome_disable_thumbnailers.yml
+++ b/shared/fixes/ansible/dconf_gnome_disable_thumbnailers.yml
@@ -18,5 +18,6 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/desktop/thumbnailers/disable-all'
     line: '/org/gnome/desktop/thumbnailers/disable-all'
+    create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/dconf_gnome_disable_user_admin.yml
+++ b/shared/fixes/ansible/dconf_gnome_disable_user_admin.yml
@@ -18,5 +18,6 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/desktop/lockdown/user-administration-disabled'
     line: '/org/gnome/desktop/lockdown/user-administration-disabled'
+    create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/dconf_gnome_disable_user_list.yml
+++ b/shared/fixes/ansible/dconf_gnome_disable_user_list.yml
@@ -18,5 +18,6 @@
     path: /etc/dconf/db/gdm.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/login-screen/disable-user-list'
     line: '/org/gnome/login-screen/disable-user-list'
+    create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/dconf_gnome_disable_wifi_create.yml
+++ b/shared/fixes/ansible/dconf_gnome_disable_wifi_create.yml
@@ -18,5 +18,6 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/nm-applet/disable-wifi-create'
     line: '/org/gnome/nm-applet/disable-wifi-create'
+    create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/dconf_gnome_disable_wifi_notification.yml
+++ b/shared/fixes/ansible/dconf_gnome_disable_wifi_notification.yml
@@ -18,5 +18,6 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/nm-applet/suppress-wireless-networks-available'
     line: '/org/gnome/nm-applet/suppress-wireless-networks-available'
+    create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/dconf_gnome_screensaver_mode_blank.yml
+++ b/shared/fixes/ansible/dconf_gnome_screensaver_mode_blank.yml
@@ -18,5 +18,6 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/desktop/screensaver/picture-uri'
     line: '/org/gnome/desktop/screensaver/picture-uri'
+    create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/dconf_gnome_screensaver_user_info.yml
+++ b/shared/fixes/ansible/dconf_gnome_screensaver_user_info.yml
@@ -18,5 +18,6 @@
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/desktop/screensaver/show-full-name-in-top-bar'
     line: '/org/gnome/desktop/screensaver/show-full-name-in-top-bar'
+    create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/no_rsh_trust_files.yml
+++ b/shared/fixes/ansible/no_rsh_trust_files.yml
@@ -16,7 +16,7 @@
       file:
           path: "{{ item.path }}"
           state: absent
-      with_items: "{{ shosts_equiv_locations }}"
-  when: shosts_equiv_locations
+      with_items: "{{ shosts_equiv_locations.files }}"
+      when: shosts_equiv_locations
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/sshd_disable_empty_passwords.yml
+++ b/shared/fixes/ansible/sshd_disable_empty_passwords.yml
@@ -3,7 +3,7 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Diable SSH Access via Empty Passwords
+- name: Disable SSH Access via Empty Passwords
   lineinfile:
     create: yes
     dest: /etc/ssh/sshd_config


### PR DESCRIPTION
Several ansibles remediation try to write on a file that may not exist, and in this case Ansible raises a fatal error. So now those remediations can create the missing files.

The no-rsh-trust-files remediation had the following two errors:
- Missing ".files" after the result of the find module. 
- The when condition seems to be in the wrong indentation, as the block execution cannot depend on a variable set inside the block.