### PR TITLE
Do not check library ownership in libexec

### DIFF
--- a/shared/checks/oval/file_ownership_library_dirs.xml
+++ b/shared/checks/oval/file_ownership_library_dirs.xml
@@ -34,7 +34,7 @@
 
   <unix:file_object comment="library files" id="object_file_ownership_lib_files" version="1">
     <!-- Check that files within /lib, /lib64, /usr/lib, and /usr/lib64 directories belong to user with uid 0 (root) -->
-    <unix:path operation="pattern match">^\/lib(|64)|^\/usr\/lib(|64)</unix:path>
+    <unix:path operation="pattern match">^\/lib(|64)\/|^\/usr\/lib(|64)\/</unix:path>
     <unix:filename operation="pattern match">^.*$</unix:filename>
    <filter action="include">state_owner_libraries_not_root</filter>
   </unix:file_object>


### PR DESCRIPTION
#### Description:

- Do not check library ownership in /usr/libexec since scripts reside in that directory.

#### Rationale:

- /usr/libexec is script directory that does not contain library files.
- Fixes #2473
