### PR TITLE
Deprecate RhostsRSAAuthentication as it have been deprecated in 7.4

### DIFF
--- a/shared/checks/oval/sshd_disable_rhosts_rsa.xml
+++ b/shared/checks/oval/sshd_disable_rhosts_rsa.xml
@@ -15,8 +15,11 @@
       <criteria comment="sshd is installed and configured" operator="AND">
         <extend_definition comment="sshd is required and installed, or requirement is unset"
         definition_ref="sshd_required_or_unset" />
-        <criterion comment="Check RhostsRSAAuthentication in /etc/ssh/sshd_config"
-        negate="true" test_ref="test_sshd_disable_rhosts_rsa" />
+        <criteria comment="SSH version is equal or higher than 7.4 has deprecated RhostsRSAAuthentication" operator="OR">
+          <extend_definition comment="OpenSSH version 7.4 or higher has deprecated RhostsRSAAuthentication" definition_ref="sshd_version_equal_or_higher_than_74" />
+          <criterion comment="Check RhostsRSAAuthentication in /etc/ssh/sshd_config"
+          negate="true" test_ref="test_sshd_disable_rhosts_rsa" />
+        </criteria>
       </criteria>
     </criteria>
   </definition>

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -603,6 +603,11 @@ following line in <tt>/etc/ssh/sshd_config</tt>:
 <pre>RhostsRSAAuthentication no</pre>
 </description>
 <ocil>
+To check which SSH protocol version is allowed, check version of
+<tt>openssh-server</tt> with following command:
+<pre>$ rpm -qi openssh-server | grep Version</pre>
+Versions equal to or higher than 7.4 have deprecated the <tt>RhostsRSAAuthentication</tt> option.
+If version is lower than 7.4, run the following command to check configuration:
 <sshd-check-macro option="RhostsRSAAuthentication" value="no" default="yes" />
 </ocil>
 <rationale>
@@ -610,6 +615,10 @@ Configuring this setting for the SSH daemon provides additional
 assurance that remove login via SSH will require a password, even
 in the event of misconfiguration elsewhere.
 </rationale>
+<warning category="general">As of <tt>openssh-server</tt> version <tt>7.4</tt> and above,
+the <tt>RhostsRSAAuthentication</tt> option has been deprecated, and the line
+<pre>RhostsRSAAuthentication no</pre> in <tt>/etc/ssh/sshd_config</tt> is not
+necessary.</warning>
 <ident prodtype="rhel7" cce="80373-4" />
 <oval id="sshd_disable_rhosts_rsa" value="sshd_required" />
 <ref prodtype="rhel7" stigid="040330" />


### PR DESCRIPTION
#### Description:

- Deprecate RhostsRSAAuthentication as it have been deprecated in 7.4 due to the removal of Protocol 1 in sshd_config

#### Rationale:

- RhostsRSAAuthentication has been deprecated
- Fixes #2478
