### PR TITLE
Fix title of DISA STIG profile in RHEL6 DS.

### DIFF
--- a/rhel6/profiles/stig-rhel6-disa.xml
+++ b/rhel6/profiles/stig-rhel6-disa.xml
@@ -1,5 +1,5 @@
 <Profile id="stig-rhel6-server-upstream" extends="common">
-<title>DISA STIG for Red Hat Enterprise Linux 6</title>
+<title override="true">DISA STIG for Red Hat Enterprise Linux 6</title>
 <description>
 This profile contains configuration checks that align to the
 DISA STIG for Red Hat Enterprise Linux 6.


### PR DESCRIPTION
#### Description:

- Fixes DISA STIG profile in RHEL6 DataStream

#### Rationale:

- DISA STIG profile extends common profile, but title is completely different, thus needs `override` attribute.
- Fixes: RHBZ#1521081
