### PR TITLE
Fixed few remediation errors caused by missing include.

### DIFF
--- a/shared/bash_remediation_functions/rhel7_fedora_perform_audit_adjtimex_settimeofday_stime_remediation.sh
+++ b/shared/bash_remediation_functions/rhel7_fedora_perform_audit_adjtimex_settimeofday_stime_remediation.sh
@@ -1,3 +1,5 @@
+source fix_audit_syscall_rule.sh
+
 # Perform the remediation for the 'adjtimex', 'settimeofday', and 'stime' audit
 # system calls on Red Hat Enterprise Linux 7 or Fedora OSes
 function rhel7_fedora_perform_audit_adjtimex_settimeofday_stime_remediation {

--- a/shared/fixes/bash/disable_ctrlaltdel_burstaction.sh
+++ b/shared/fixes/bash/disable_ctrlaltdel_burstaction.sh
@@ -1,3 +1,6 @@
 # platform = Red Hat Enterprise Linux 7, multi_platform_fedora
 
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
 replace_or_append '/etc/systemd/system.conf' '^CtrlAltDelBurstAction=' 'none' '@CCENUM@' '%s=%s'


### PR DESCRIPTION
#### Description:

- Updated sourcing of helper functions for these rules remediations:
xccdf_org.ssgproject.content_rule_disable_ctrlaltdel_burstaction -> replace_or_append
xccdf_org.ssgproject.content_rule_audit_rules_time_adjtimex -> fix_audit_syscall_rule
xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday -> fix_audit_syscall_rule
xccdf_org.ssgproject.content_rule_audit_rules_time_stime -> fix_audit_syscall_rule

#### Rationale:

- When performing RHEL7 OSPP remediation, four remediations errored because of missing helper functions.

- Fixes RHBZ#1524738
