### PR TITLE
Add test for accounts_umask_etc_login_defs

### DIFF
--- a/tests/data/group_system/group_accounts/group_accounts-session/group_user_umask/rule_accounts_umask_etc_login_defs/correct_value.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/group_user_umask/rule_accounts_umask_etc_login_defs/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+if grep -q "^UMASK" /etc/login.defs; then
+	sed -i "s/^UMASK.*/UMASK 077/" /etc/login.defs
+else
+	echo "UMASK 077" >> /etc/login.defs
+fi

--- a/tests/data/group_system/group_accounts/group_accounts-session/group_user_umask/rule_accounts_umask_etc_login_defs/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/group_user_umask/rule_accounts_umask_etc_login_defs/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+if grep -q "^UMASK" /etc/login.defs; then
+	sed -i "s/^UMASK.*/UMASK 027/" /etc/login.defs
+else
+	echo "UMASK 027" >> /etc/login.defs
+fi


### PR DESCRIPTION
#### Description:

- Adds tests for correct and wrong UMASK for OSPP-RHEL7 profile.

#### Rationale:

- Test scenarios are useful.
  In this particular case, it demonstrated that bash remediation for `accounts_umask_etc_login_defs`  can't deal with `UMASK`, just `umask`.