### PR TITLE
Fix typos "local/d" -> "local.d"

### DIFF
--- a/shared/fixes/ansible/dconf_gnome_banner_enabled.yml
+++ b/shared/fixes/ansible/dconf_gnome_banner_enabled.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 - name: "Enable GNOME3 Login Warning Banner"
   ini_file:
-    dest: "/etc/dconf/db/local/d/00-security-settings"
+    dest: "/etc/dconf/db/local.d/00-security-settings"
     section: "org/gnome/login-screen"
     option: banner-message-enabled
     value: true

--- a/shared/fixes/ansible/dconf_gnome_screensaver_idle_activation_enabled.yml
+++ b/shared/fixes/ansible/dconf_gnome_screensaver_idle_activation_enabled.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 - name: "Enable GNOME3 Screensaver Idle Activation"
   ini_file:
-    dest: "/etc/dconf/db/local/d/00-security-settings"
+    dest: "/etc/dconf/db/local.d/00-security-settings"
     section: "org/gnome/desktop/screensaver"
     option: idle_activation_enabled
     value: true

--- a/shared/fixes/ansible/dconf_gnome_screensaver_idle_delay.yml
+++ b/shared/fixes/ansible/dconf_gnome_screensaver_idle_delay.yml
@@ -7,7 +7,7 @@
 
 - name: "Set GNOME3 Screensaver Inactivity Timeout"
   ini_file:
-    dest: "/etc/dconf/db/local/d/00-security-settings"
+    dest: "/etc/dconf/db/local.d/00-security-settings"
     section: "org/gnome/desktop/screensaver"
     option: idle-delay
     value: "{{ inactivity_timeout_value }}"

--- a/shared/fixes/ansible/dconf_gnome_screensaver_lock_delay.yml
+++ b/shared/fixes/ansible/dconf_gnome_screensaver_lock_delay.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 - name: "Set GNOME3 Screensaver Lock Delay After Activation Period"
   ini_file:
-    dest: "/etc/dconf/db/local/d/00-security-settings"
+    dest: "/etc/dconf/db/local.d/00-security-settings"
     section: "org/gnome/desktop/screensaver"
     option: lock-delay
     value: uint32 5

--- a/shared/fixes/ansible/dconf_gnome_screensaver_lock_enabled.yml
+++ b/shared/fixes/ansible/dconf_gnome_screensaver_lock_enabled.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 - name: "Enable GNOME3 Screensaver Lock After Idle Period"
   ini_file:
-    dest: "/etc/dconf/db/local/d/00-security-settings"
+    dest: "/etc/dconf/db/local.d/00-security-settings"
     section: "org/gnome/desktop/screensaver"
     option: lock-enabled
     value: true

--- a/shared/fixes/ansible/dconf_gnome_screensaver_mode_blank.yml
+++ b/shared/fixes/ansible/dconf_gnome_screensaver_mode_blank.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 - name: "Implement Blank Screensaver"
   ini_file:
-    dest: "/etc/dconf/db/local/d/00-security-settings"
+    dest: "/etc/dconf/db/local.d/00-security-settings"
     section: "org/gnome/desktop/screensaver"
     option: picture-uri
     value: string ''

--- a/shared/fixes/ansible/dconf_gnome_screensaver_user_info.yml
+++ b/shared/fixes/ansible/dconf_gnome_screensaver_user_info.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 - name: "Disable Full Username on Splash Screen"
   ini_file:
-    dest: "/etc/dconf/db/local/d/00-security-settings"
+    dest: "/etc/dconf/db/local.d/00-security-settings"
     section: "org/gnome/desktop/screensaver"
     option: show-full-name-in-top-bar
     value: false


### PR DESCRIPTION
#### Description:

- Fix a common typo in several ansible fix playbooks

#### Rationale:

- /etc/dconf/db/local/d/00-security-settings is the incorrect file path due to a simple typo in the directory name.
