### PR TITLE
Fix accounts_umask_etc_login_defs remediation

### DIFF
--- a/shared/fixes/bash/accounts_umask_etc_login_defs.sh
+++ b/shared/fixes/bash/accounts_umask_etc_login_defs.sh
@@ -2,8 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_user_umask
 
-grep -q umask /etc/login.defs && \
-  sed -i "s/umask.*/umask $var_accounts_user_umask/g" /etc/login.defs
-if ! [ $? -eq 0 ]; then
-    echo "umask $var_accounts_user_umask" >> /etc/login.defs
-fi
+replace_or_append '/etc/login.defs' '^UMASK' "$var_accounts_user_umask" '@CCENUM@' '%s %s'


### PR DESCRIPTION
#### Description:

- Fix accounts_umask_etc_login_defs remediation

#### Rationale:

- Current remediation is incorrect and looks for the wrong case in login.defs
- Fixes #2486