### PR TITLE
Disable pt_chown rule

### DIFF
--- a/rhel7/profiles/stig-rhel7-disa.xml
+++ b/rhel7/profiles/stig-rhel7-disa.xml
@@ -523,7 +523,8 @@ Storage deployments.
 <select idref="audit_rules_privileged_commands_ssh_keysign" selected="true" />
 
 <!-- SRG-OS-000042-GPOS-00020, SV-86805r2_rule, RHEL-07-030790 -->
-<select idref="audit_rules_privileged_commands_pt_chown" selected="true" />
+<!-- No longer built as part of RHEL7. See 
+     https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2013-2207 for more info--> 
 
 <!-- SRG-OS-000042-GPOS-00020, SV-86807r2_rule, RHEL-07-030800 -->
 <select idref="audit_rules_privileged_commands_crontab" selected="true" />


### PR DESCRIPTION
#### Description:

- Disable pt_chown rule

#### Rationale:

- pt_chown is no longer built with RHEL7. See
  https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2013-2207
