### PR TITLE
Add ansible content for accounts_password_pam_retry and accounts_password_pam_unix_remember

### DIFF
--- a/shared/fixes/ansible/accounts_password_pam_retry.yml
+++ b/shared/fixes/ansible/accounts_password_pam_retry.yml
@@ -1,0 +1,24 @@
+# platform = multi_platform_rhel, multi_platform_fedora
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+- (xccdf-var var_password_pam_retry)
+
+- name: "Set Password Retry Prompts Permitted Per-Session - system-auth (change)"
+  replace:
+    dest: /etc/pam.d/system-auth
+    follow: yes
+    regexp: '(^.*\spam_pwquality.so\s.*retry\s*=\s*)(\S+)(.*$)'
+    replace: '\g<1>{{ var_password_pam_retry }}\g<3>'
+  tags:
+    @ANSIBLE_TAGS@
+
+- name: "Set Password Retry Prompts Permitted Per-Session - system-auth (add)"
+  replace:
+    dest: /etc/pam.d/system-auth
+    follow: yes
+    regexp: '^.*\spam_pwquality.so\s(?!.*retry\s*=\s*).*$'
+    replace: '\g<0> retry={{ var_password_pam_retry }}'
+  tags:
+    @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/accounts_password_pam_unix_remember.yml
+++ b/shared/fixes/ansible/accounts_password_pam_unix_remember.yml
@@ -1,0 +1,24 @@
+# platform = multi_platform_rhel, multi_platform_fedora
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+- (xccdf-var var_password_pam_unix_remember)
+
+- name: "Do not allow users to reuse recent passwords - system-auth (change)"
+  replace:
+    dest: /etc/pam.d/system-auth
+    follow: yes
+    regexp: '^(password\s+sufficient\s+pam_unix\.so\s.*remember\s*=\s*)(\S+)(.*)$'
+    replace: '\g<1>{{ var_password_pam_unix_remember }}\g<3>'
+  tags:
+    @ANSIBLE_TAGS@
+
+- name: "Do not allow users to reuse recent passwords - system-auth (add)"
+  replace:
+    dest: /etc/pam.d/system-auth
+    follow: yes
+    regexp: '^password\s+sufficient\s+pam_unix\.so\s(?!.*remember\s*=\s*).*$'
+    replace: '\g<0> remember={{ var_password_pam_unix_remember }}'
+  tags:
+    @ANSIBLE_TAGS@


### PR DESCRIPTION
#### Description:

- Add missing ansible fix content for accounts_password_pam_retry and accounts_password_pam_unix_remember

#### Rationale:

- Ansible content is missing
