### PR TITLE
Removed installed_OS_is_certified check from aide_use_fips_hashes

### DIFF
--- a/shared/checks/oval/aide_use_fips_hashes.xml
+++ b/shared/checks/oval/aide_use_fips_hashes.xml
@@ -9,7 +9,6 @@
       cryptographic hashes.</description>
     </metadata>
     <criteria operator="AND">
-      <extend_definition comment="Installed OS is certified" definition_ref="installed_OS_is_certified" />
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <criterion comment="non-FIPS hashes are not configured" test_ref="test_aide_non_fips_hashes" />
       <criterion comment="FIPS hashes are configured" test_ref="test_aide_use_fips_hashes" />


### PR DESCRIPTION
#### Description:

Removed the installed_OS_is_certified check from aide_use_fips_hashes

#### Rationale:

When scanning a CentOS 7 machine using the NIST 800-171 profile, the aide_use_fips_hashes check will always fail even if the remediation has been applied.

This is because the aide_use_fips hashes rule includes the extended definition for installed_OS_is_certified, which only passes when running on an official Redhat Enterprise Linux 6 or 7 machine. This check is not necessary as part of this rule because it is already in the profile as a standalone rule.

With this commit, a CentOS 7 machine will properly pass the aide_use_fips_hashes check.  

See console output without this commit:
sudo bash aide_use_fips_hashes.sh (script that includes only the aide_use_fips_hashes remediation)

sudo oscap xccdf eval --rule xccdf_org.ssgproject.content_rule_aide_use_fips_hashes --profile xccdf_org.ssgproject.content_profile_nist-800-171-cui --results ./results/local-results.xml --report ./results/local-report.html /usr/share/xml/scap/ssg/content/ssg-centos7-ds.xml
WARNING: This content points out to the remote resources. Use `--fetch-remote-resources' option to download them.
WARNING: Skipping https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2 file which is referenced from XCCDF content
Title   Configure AIDE to Use FIPS 140-2 for Validating Hashes
Rule    xccdf_org.ssgproject.content_rule_aide_use_fips_hashes
Result  fail

See console output with this commit:
sudo bash aide_use_fips_hashes.sh (script that includes only the aide_use_fips_hashes remediation)

sudo oscap xccdf eval --rule xccdf_org.ssgproject.content_rule_aide_use_fips_hashes --profile xccdf_org.ssgproject.content_profile_nist-800-171-cui --results ./results/local-results.xml --report ./results/local-report.html /usr/share/xml/scap/ssg/content/ssg-centos7-ds.xml
[sudo] password for petna01: 
WARNING: This content points out to the remote resources. Use `--fetch-remote-resources' option to download them.
WARNING: Skipping https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2 file which is referenced from XCCDF content
Title   Configure AIDE to Use FIPS 140-2 for Validating Hashes
Rule    xccdf_org.ssgproject.content_rule_aide_use_fips_hashes
Result  pass
