### PR TITLE
Updated aide_scan_notification remediation to run cron job as root

### DIFF
--- a/shared/fixes/bash/aide_scan_notification.sh
+++ b/shared/fixes/bash/aide_scan_notification.sh
@@ -10,7 +10,7 @@ if [ -f /var/spool/cron/root ]; then
 	VARSPOOL=/var/spool/cron/root
 fi
 
-if ! grep -qR '^.*\/usr\/sbin\/aide\s*\-\-check.*\|.*\/bin\/mail\s*-s\s*".*"\s*root@.*$' $CRONTAB $VARSPOOL $CRONDIRS; then
+if ! grep -qR '^.*\/usr\/sbin\/aide\s*\-\-check.*|.*\/bin\/mail\s*-s\s*".*"\s*root@.*$' $CRONTAB $VARSPOOL $CRONDIRS; then
 	echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost' >> $CRONTAB
 fi
 

--- a/shared/fixes/bash/aide_scan_notification.sh
+++ b/shared/fixes/bash/aide_scan_notification.sh
@@ -11,6 +11,6 @@ if [ -f /var/spool/cron/root ]; then
 fi
 
 if ! grep -qR '^.*\/usr\/sbin\/aide\s*\-\-check.*\|.*\/bin\/mail\s*-s\s*".*"\s*root@.*$' $CRONTAB $VARSPOOL $CRONDIRS; then
-	echo '0 5 * * * /usr/sbin/aide  --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost' >> $CRONTAB
+	echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost' >> $CRONTAB
 fi
 


### PR DESCRIPTION
#### Description:

Updated aide_scan_notification remediation to run cron job as root and removed '\\' before the '|' to make the grep check compatible with regular grep syntax.

#### Rationale:

The check for aide_periodic_cron_checking expects the word 'root' in /etc/crontab between the time and the command, so the line added by aide_scan_notification will not satisfy it because it does not contain the word 'root' in that location.

The check for aide_scan_notification needs mail to be sent at the end of the check and so it will not be satisfied by the remediation for aide_periodic_cron_checking.

By adding root to the cron remediation for aide_scan_notification, the line added to /etc/crontab will satisfy both checks and you will not end up with 2 cron jobs for aide running every day.

The remediation for aide_periodic_cron_checking adds the following line to /etc/crontab:
`0 5 * * * /usr/sbin/aide  --check`

When the aide_scan_notification remediation is run, because the pipe is escaped, it is literally interpreted as match if you find either of these values `'0 5 * * * /usr/sbin/aide  --check' OR '/bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost'`

Removing '\' before the '|' makes the grep check compatible with regular grep syntax.

Fixes #2496 #2495 #2112 
