### PR TITLE
Fix gpgcheck OVAL to validate Scientific Linux gpg keys

### DIFF
--- a/shared/checks/oval/ensure_redhat_gpgkey_installed.xml
+++ b/shared/checks/oval/ensure_redhat_gpgkey_installed.xml
@@ -12,6 +12,8 @@
         <criteria comment="Red Hat Installed" operator="OR">
           <extend_definition comment="RHEL6 installed" definition_ref="installed_OS_is_rhel6" />
           <extend_definition comment="RHEL7 installed" definition_ref="installed_OS_is_rhel7" />
+          <extend_definition comment="SL6 installed" definition_ref="installed_OS_is_sl6" />
+          <extend_definition comment="SL7 installed" definition_ref="installed_OS_is_sl7" />
         </criteria>
         <criterion comment="package gpg-pubkey-fd431d51-4ae0493b is installed"
         test_ref="test_package_gpgkey-fd431d51-4ae0493b_installed" />


### PR DESCRIPTION
#### Description:

- ensure_redhat_gpgkey_installed OVAL check does not currently validate GPG keys. This fixes that.

#### Rationale:

- Scientific Linux has the same gpg key, so just enable OS installed check in OVAL file.
- Fixes #2498
