### PR TITLE
Added --follow-symlinks to sed commands in display_login_attempts.sh

### DIFF
--- a/shared/fixes/bash/display_login_attempts.sh
+++ b/shared/fixes/bash/display_login_attempts.sh
@@ -5,10 +5,10 @@ if ! `grep -q ^[^#].*pam_succeed_if.*showfailed /etc/pam.d/postlogin` ; then
     echo "session     [default=1]   pam_lastlog.so nowtmp showfailed" >> /etc/pam.d/postlogin
     echo "session     optional      pam_lastlog.so silent noupdate showfailed" >> /etc/pam.d/postlogin
   else
-    sed -i '/^session.*pam_succeed_if.so/a session\t    optional\t  pam_lastlog.so silent noupdate showfailed' /etc/pam.d/postlogin
-    sed -i '/^session.*pam_succeed_if.so/a session\t    [default=1]\t  pam_lastlog.so nowtmp showfailed' /etc/pam.d/postlogin
+    sed -i --follow-symlinks '/^session.*pam_succeed_if.so/a session\t    optional\t  pam_lastlog.so silent noupdate showfailed' /etc/pam.d/postlogin
+    sed -i --follow-symlinks '/^session.*pam_succeed_if.so/a session\t    [default=1]\t  pam_lastlog.so nowtmp showfailed' /etc/pam.d/postlogin
   fi
 else
-  sed -i "s/session[ ]*\[default=1][ ]*pam_lastlog.so.*/session     [default=1]   pam_lastlog.so nowtmp showfailed/g" /etc/pam.d/postlogin
-  sed -i "s/session[ ]*optional[ ]*pam_lastlog.so.*/session     optional      pam_lastlog.so silent noupdate showfailed/g" /etc/pam.d/postlogin
+  sed -i --follow-symlinks "s/session[ ]*\[default=1][ ]*pam_lastlog.so.*/session     [default=1]   pam_lastlog.so nowtmp showfailed/g" /etc/pam.d/postlogin
+  sed -i --follow-symlinks "s/session[ ]*optional[ ]*pam_lastlog.so.*/session     optional      pam_lastlog.so silent noupdate showfailed/g" /etc/pam.d/postlogin
 fi


### PR DESCRIPTION
#### Description:

Added --follow-symlinks to sed commands in shared/fixes/bash/display_login_attempts.sh

#### Rationale:

The remediation in shared/fixes/bash/display_login_attempts.sh will always replace replace the symlink from /etc/pam.d/postlogin that is supposed to point to /etc/pam.d/postlogin-ac. At that point, /etc/pam.d/postlogin is now a file with actual contents instead of a symlink. 

The sed lines should have --follow-symlinks added to them to avoid this.

- Fixes #2482 
