### PR TITLE
Ansible: don't use spaces in custom.conf

### DIFF
--- a/shared/fixes/ansible/gnome_gdm_disable_automatic_login.yml
+++ b/shared/fixes/ansible/gnome_gdm_disable_automatic_login.yml
@@ -9,6 +9,7 @@
     section: daemon
     option: AutomaticLoginEnable
     value: false
+    no_extra_spaces: yes
     create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/fixes/ansible/gnome_gdm_disable_guest_login.yml
+++ b/shared/fixes/ansible/gnome_gdm_disable_guest_login.yml
@@ -9,6 +9,7 @@
     section: daemon
     option: TimedLoginEnable
     value: false
+    no_extra_spaces: yes
     create: yes
   tags:
     @ANSIBLE_TAGS@


### PR DESCRIPTION
#### Description:

- When using Ansible, don't use spaces in between = in custom.conf

#### Rationale:

- Checks were failing when fixed with ansible
