### PR TITLE
reset IFS back to default in ensure_redhat_gpgkey_installed.sh

### DIFF
--- a/shared/fixes/bash/ensure_redhat_gpgkey_installed.sh
+++ b/shared/fixes/bash/ensure_redhat_gpgkey_installed.sh
@@ -15,7 +15,7 @@ then
   IFS=$'\n' GPG_OUT=($(gpg --with-fingerprint "${REDHAT_RELEASE_KEY}" | grep 'Key fingerprint ='))
   GPG_RESULT=$?
   # Reset IFS back to default
-  unset $IFS
+  unset IFS
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then

--- a/shared/fixes/bash/ensure_redhat_gpgkey_installed.sh
+++ b/shared/fixes/bash/ensure_redhat_gpgkey_installed.sh
@@ -15,7 +15,7 @@ then
   IFS=$'\n' GPG_OUT=($(gpg --with-fingerprint "${REDHAT_RELEASE_KEY}" | grep 'Key fingerprint ='))
   GPG_RESULT=$?
   # Reset IFS back to default
-  unset IFS
+  unset $IFS
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then

--- a/shared/fixes/bash/ensure_redhat_gpgkey_installed.sh
+++ b/shared/fixes/bash/ensure_redhat_gpgkey_installed.sh
@@ -14,6 +14,8 @@ then
   # (to ensure there won't be e.g. CRC error).
   IFS=$'\n' GPG_OUT=($(gpg --with-fingerprint "${REDHAT_RELEASE_KEY}" | grep 'Key fingerprint ='))
   GPG_RESULT=$?
+  # Reset IFS back to default
+  unset IFS
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then


### PR DESCRIPTION
#### Description:

Reset IFS back to default in ensure_redhat_gpgkey_installed.sh to avoid breaking subsequent remediations.

#### Rationale:

Line 15 of shared/fixes/bash/ensure_redhat_gpgkey_installed.sh sets IFS (the Internal Field Separator special environment variable) to `$'\n'` from its default of `<tab><space><newline>`.

If not reset to default after this, and remediations are run in a single script, any eval that starts with `sed -i` in subsequent remediations will fail with the message `sed -i: command not found` due to the fact that the eval expects `<space>` in the Internal Field Separator list.

- Fixes #2511 
