### PR TITLE
fixed template_BASH_sebool_var with valid bash syntax

### DIFF
--- a/shared/templates/template_BASH_sebool_var
+++ b/shared/templates/template_BASH_sebool_var
@@ -8,4 +8,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_%SEBOOLID%
 
-setsebool -P %SEBOOLID% var_%SEBOOLID%
+setsebool -P %SEBOOLID% $var_%SEBOOLID%


### PR DESCRIPTION
#### Description:

Added a `$` to var_%SEBOOLID%

#### Rationale:

The current template is broken, and generates bash fix scripts that result in the following error because bash variables must be prefixed with a `$`: `setsebool: illegal value var_abrt_upload_watch_anon_write for boolean abrt_upload_watch_anon_write`

- Fixes #2513 
