### PR TITLE
Fixing reference to outdated PAM configuration manual

### DIFF
--- a/shared/xccdf/system/accounts/pam.xml
+++ b/shared/xccdf/system/accounts/pam.xml
@@ -39,7 +39,7 @@ most users.</warning>
 files, destroying any manually made changes and replacing them with
 a series of system defaults. One reference to the configuration
 file syntax can be found at
-<weblink-macro link="http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html"/>
+<weblink-macro link="http://www.linux-pam.org/Linux-PAM-html/sag-configuration-file.html"/>
 .</warning>
 
 <Value id="var_password_pam_unix_remember" type="number"


### PR DESCRIPTION
#### Description:

- Fixed reference to PAM configuration manual

#### Rationale:

- PAM configuration manual probably moved to different location, thus URL in our guides https://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/ no longer works

