### PR TITLE
fix kernel_module_loading checks to work properly on 64 bit systems

### DIFF
--- a/shared/checks/oval/audit_rules_kernel_module_loading_delete.xml
+++ b/shared/checks/oval/audit_rules_kernel_module_loading_delete.xml
@@ -8,44 +8,44 @@
       </affected>
       <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
     </metadata>
-      <criteria operator="OR">
 
-        <!-- Test the augenrules case -->
-        <criteria operator="AND">
-          <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-          <criteria operator="OR">
-            <!-- System isn't 64-bit => we check presence of 32-bit version of delete_module audit DAC rule -->
-            <criteria operator="AND">
-              <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
-              <criterion comment="audit augenrules 32-bit delete_module" test_ref="test_32bit_ardm_delete_module_augenrules" />
-            </criteria>
-            <!-- System is 64-bit => we check presence of 64-bit version of delete_module audit DAC rule -->
-            <criteria operator="AND">
-              <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
-              <criterion comment="audit augenrules 64-bit delete_module" test_ref="test_64bit_ardm_delete_module_augenrules" />
-            </criteria>
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criteria operator="OR">
+          <!-- System isn't 64-bit => we check presence of 32-bit version of delete_module audit DAC rule -->
+          <criteria operator="AND">
+            <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
+            <criterion comment="audit augenrules 32-bit delete_module" test_ref="test_32bit_ardm_delete_module_augenrules" />
+          </criteria>
+          <!-- System is 64-bit => we check presence of 64-bit version of delete_module audit DAC rule -->
+          <criteria operator="AND">
+            <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
+            <criterion comment="audit augenrules 64-bit delete_module" test_ref="test_64bit_ardm_delete_module_augenrules" />
           </criteria>
         </criteria>
-
-        <!-- OR test the auditctl case -->
-        <criteria operator="AND">
-          <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-          <criteria operator="OR">
-            <!-- System isn't 64-bit => we check presence of 32-bit version of delete_module audit DAC rule -->
-            <criteria operator="AND">
-              <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
-              <criterion comment="audit auditctl 32-bit delete_module" test_ref="test_32bit_ardm_delete_module_auditctl" />
-            </criteria>
-            <!-- System is 64-bit => we check presence of 64-bit version of delete_module audit DAC rule -->
-            <criteria operator="AND">
-              <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
-              <criterion comment="audit auditctl 64-bit delete_module" test_ref="test_64bit_ardm_delete_module_auditctl" />
-            </criteria>
-          </criteria>
-        </criteria>
-			
       </criteria>
 
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criteria operator="OR">
+          <!-- System isn't 64-bit => we check presence of 32-bit version of delete_module audit DAC rule -->
+          <criteria operator="AND">
+            <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
+            <criterion comment="audit auditctl 32-bit delete_module" test_ref="test_32bit_ardm_delete_module_auditctl" />
+          </criteria>
+          <!-- System is 64-bit => we check presence of 64-bit version of delete_module audit DAC rule -->
+          <criteria operator="AND">
+            <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
+            <criterion comment="audit auditctl 64-bit delete_module" test_ref="test_64bit_ardm_delete_module_auditctl" />
+          </criteria>
+        </criteria>
+      </criteria>
+			
+    </criteria>
   </definition>
 
   <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit delete_module" id="test_32bit_ardm_delete_module_augenrules" version="1">

--- a/shared/checks/oval/audit_rules_kernel_module_loading_delete.xml
+++ b/shared/checks/oval/audit_rules_kernel_module_loading_delete.xml
@@ -8,34 +8,44 @@
       </affected>
       <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
     </metadata>
+      <criteria operator="OR">
 
-    <criteria operator="OR">
-
-      <!-- Test the augenrules case -->
-      <criteria operator="AND">
-        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules 32-bit delete_module" test_ref="test_32bit_ardm_delete_module_augenrules" />
-        <criteria operator="OR">
-          <!-- System either isn't 64-bit => we just check presence of 32-bit version of delete_module audit DAC rule -->
-          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
-          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of delete_module audit DAC rule -->
-          <criterion comment="audit augenrules 64-bit delete_module" test_ref="test_64bit_ardm_delete_module_augenrules" />
+        <!-- Test the augenrules case -->
+        <criteria operator="AND">
+          <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+          <criteria operator="OR">
+            <!-- System isn't 64-bit => we check presence of 32-bit version of delete_module audit DAC rule -->
+            <criteria operator="AND">
+              <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
+              <criterion comment="audit augenrules 32-bit delete_module" test_ref="test_32bit_ardm_delete_module_augenrules" />
+            </criteria>
+            <!-- System is 64-bit => we check presence of 64-bit version of delete_module audit DAC rule -->
+            <criteria operator="AND">
+              <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
+              <criterion comment="audit augenrules 64-bit delete_module" test_ref="test_64bit_ardm_delete_module_augenrules" />
+            </criteria>
+          </criteria>
         </criteria>
+
+        <!-- OR test the auditctl case -->
+        <criteria operator="AND">
+          <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+          <criteria operator="OR">
+            <!-- System isn't 64-bit => we check presence of 32-bit version of delete_module audit DAC rule -->
+            <criteria operator="AND">
+              <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
+              <criterion comment="audit auditctl 32-bit delete_module" test_ref="test_32bit_ardm_delete_module_auditctl" />
+            </criteria>
+            <!-- System is 64-bit => we check presence of 64-bit version of delete_module audit DAC rule -->
+            <criteria operator="AND">
+              <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
+              <criterion comment="audit auditctl 64-bit delete_module" test_ref="test_64bit_ardm_delete_module_auditctl" />
+            </criteria>
+          </criteria>
+        </criteria>
+			
       </criteria>
 
-      <!-- OR test the auditctl case -->
-      <criteria operator="AND">
-        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl 32-bit delete_module" test_ref="test_32bit_ardm_delete_module_auditctl" />
-        <criteria operator="OR">
-          <!-- System either isn't 64-bit => we just check presence of 32-bit version of the delete_module audit DAC rule -->
-          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
-          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of delete_module audit DAC rule -->
-          <criterion comment="audit auditctl 64-bit delete_module" test_ref="test_64bit_ardm_delete_module_auditctl" />
-        </criteria>
-      </criteria>
-
-    </criteria>
   </definition>
 
   <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit delete_module" id="test_32bit_ardm_delete_module_augenrules" version="1">

--- a/shared/checks/oval/audit_rules_kernel_module_loading_delete.xml
+++ b/shared/checks/oval/audit_rules_kernel_module_loading_delete.xml
@@ -34,7 +34,7 @@
         <criteria operator="OR">
           <!-- System isn't 64-bit => we check presence of 32-bit version of delete_module audit DAC rule -->
           <criteria operator="AND">
-            <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
+            <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
             <criterion comment="audit auditctl 32-bit delete_module" test_ref="test_32bit_ardm_delete_module_auditctl" />
           </criteria>
           <!-- System is 64-bit => we check presence of 64-bit version of delete_module audit DAC rule -->

--- a/shared/checks/oval/audit_rules_kernel_module_loading_delete.xml
+++ b/shared/checks/oval/audit_rules_kernel_module_loading_delete.xml
@@ -44,7 +44,7 @@
           </criteria>
         </criteria>
       </criteria>
-			
+
     </criteria>
   </definition>
 

--- a/shared/checks/oval/audit_rules_kernel_module_loading_init.xml
+++ b/shared/checks/oval/audit_rules_kernel_module_loading_init.xml
@@ -10,7 +10,7 @@
     </metadata>
 
     <criteria operator="OR">
-	  
+
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />

--- a/shared/checks/oval/audit_rules_kernel_module_loading_init.xml
+++ b/shared/checks/oval/audit_rules_kernel_module_loading_init.xml
@@ -8,34 +8,44 @@
       </affected>
       <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
     </metadata>
-
-    <criteria operator="OR">
-
-      <!-- Test the augenrules case -->
-      <criteria operator="AND">
-        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules 32-bit init_module" test_ref="test_32bit_ardm_init_module_augenrules" />
-        <criteria operator="OR">
-          <!-- System either isn't 64-bit => we just check presence of 32-bit version of init_module audit DAC rule -->
-          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
-          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of init_module audit DAC rule -->
-          <criterion comment="audit augenrules 64-bit init_module" test_ref="test_64bit_ardm_init_module_augenrules" />
+      <criteria operator="OR">
+	  
+        <!-- Test the augenrules case -->
+        <criteria operator="AND">
+          <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+          <criteria operator="OR">
+            <!-- System isn't 64-bit => we check presence of 32-bit version of init_module audit DAC rule -->
+            <criteria operator="AND">
+              <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
+              <criterion comment="audit augenrules 32-bit init_module" test_ref="test_32bit_ardm_init_module_augenrules" />
+            </criteria>
+            <!-- System is 64-bit => we check presence of 64-bit version of init_module audit DAC rule -->
+            <criteria operator="AND">
+              <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
+              <criterion comment="audit augenrules 64-bit init_module" test_ref="test_64bit_ardm_init_module_augenrules" />
+            </criteria>
+          </criteria>
         </criteria>
+		
+        <!-- OR test the auditctl case -->
+        <criteria operator="AND">
+          <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+          <criteria operator="OR">
+            <!-- System isn't 64-bit => we check presence of 32-bit version of init_module audit DAC rule -->
+            <criteria operator="AND">
+              <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
+              <criterion comment="audit auditctl 32-bit init_module" test_ref="test_32bit_ardm_init_module_auditctl" />
+            </criteria>
+            <!-- System is 64-bit => we check presence of 64-bit version of init_module audit DAC rule -->
+            <criteria operator="AND">
+              <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
+              <criterion comment="audit auditctl 64-bit init_module" test_ref="test_64bit_ardm_init_module_auditctl" />
+            </criteria>
+          </criteria>
+        </criteria>
+		
       </criteria>
 
-      <!-- OR test the auditctl case -->
-      <criteria operator="AND">
-        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl 32-bit init_module" test_ref="test_32bit_ardm_init_module_auditctl" />
-        <criteria operator="OR">
-          <!-- System either isn't 64-bit => we just check presence of 32-bit version of the init_module audit DAC rule -->
-          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
-          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of init_module audit DAC rule -->
-          <criterion comment="audit auditctl 64-bit init_module" test_ref="test_64bit_ardm_init_module_auditctl" />
-        </criteria>
-      </criteria>
-
-    </criteria>
   </definition>
 
   <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit init_module" id="test_32bit_ardm_init_module_augenrules" version="1">

--- a/shared/checks/oval/audit_rules_kernel_module_loading_init.xml
+++ b/shared/checks/oval/audit_rules_kernel_module_loading_init.xml
@@ -27,7 +27,7 @@
           </criteria>
         </criteria>
       </criteria>
-		
+
       <!-- OR test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
@@ -44,7 +44,7 @@
           </criteria>
         </criteria>
       </criteria>
-		
+
     </criteria>
   </definition>
 

--- a/shared/checks/oval/audit_rules_kernel_module_loading_init.xml
+++ b/shared/checks/oval/audit_rules_kernel_module_loading_init.xml
@@ -8,44 +8,44 @@
       </affected>
       <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
     </metadata>
-      <criteria operator="OR">
-	  
-        <!-- Test the augenrules case -->
-        <criteria operator="AND">
-          <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-          <criteria operator="OR">
-            <!-- System isn't 64-bit => we check presence of 32-bit version of init_module audit DAC rule -->
-            <criteria operator="AND">
-              <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
-              <criterion comment="audit augenrules 32-bit init_module" test_ref="test_32bit_ardm_init_module_augenrules" />
-            </criteria>
-            <!-- System is 64-bit => we check presence of 64-bit version of init_module audit DAC rule -->
-            <criteria operator="AND">
-              <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
-              <criterion comment="audit augenrules 64-bit init_module" test_ref="test_64bit_ardm_init_module_augenrules" />
-            </criteria>
-          </criteria>
-        </criteria>
-		
-        <!-- OR test the auditctl case -->
-        <criteria operator="AND">
-          <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-          <criteria operator="OR">
-            <!-- System isn't 64-bit => we check presence of 32-bit version of init_module audit DAC rule -->
-            <criteria operator="AND">
-              <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
-              <criterion comment="audit auditctl 32-bit init_module" test_ref="test_32bit_ardm_init_module_auditctl" />
-            </criteria>
-            <!-- System is 64-bit => we check presence of 64-bit version of init_module audit DAC rule -->
-            <criteria operator="AND">
-              <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
-              <criterion comment="audit auditctl 64-bit init_module" test_ref="test_64bit_ardm_init_module_auditctl" />
-            </criteria>
-          </criteria>
-        </criteria>
-		
-      </criteria>
 
+    <criteria operator="OR">
+	  
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criteria operator="OR">
+          <!-- System isn't 64-bit => we check presence of 32-bit version of init_module audit DAC rule -->
+          <criteria operator="AND">
+            <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
+            <criterion comment="audit augenrules 32-bit init_module" test_ref="test_32bit_ardm_init_module_augenrules" />
+          </criteria>
+          <!-- System is 64-bit => we check presence of 64-bit version of init_module audit DAC rule -->
+          <criteria operator="AND">
+            <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
+            <criterion comment="audit augenrules 64-bit init_module" test_ref="test_64bit_ardm_init_module_augenrules" />
+          </criteria>
+        </criteria>
+      </criteria>
+		
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criteria operator="OR">
+          <!-- System isn't 64-bit => we check presence of 32-bit version of init_module audit DAC rule -->
+          <criteria operator="AND">
+            <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
+            <criterion comment="audit auditctl 32-bit init_module" test_ref="test_32bit_ardm_init_module_auditctl" />
+          </criteria>
+          <!-- System is 64-bit => we check presence of 64-bit version of init_module audit DAC rule -->
+          <criteria operator="AND">
+            <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" />
+            <criterion comment="audit auditctl 64-bit init_module" test_ref="test_64bit_ardm_init_module_auditctl" />
+          </criteria>
+        </criteria>
+      </criteria>
+		
+    </criteria>
   </definition>
 
   <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit init_module" id="test_32bit_ardm_init_module_augenrules" version="1">


### PR DESCRIPTION
#### Description:

The OVAL checks for audit_rules_kernel_module_loading_init and audit_rules_kernel_module_loading_delete will fail if you don't have an audit rule for 32 bit kernel init and delete on 64 bit systems.

This PR fixes those checks to properly only require 32 bit rules on 32 bit systems and 64 bit rules on 64 bit systems.

#### Rationale:

For discussion see : https://github.com/OpenSCAP/scap-security-guide/issues/2227

32 bit kernel modules cannot be loaded on 64 bit systems so auditing loading of 32 bit kernel modules on 64 bit systems is not necessary.

- Fixes #2227 
