### PR TITLE
Add check and remediation for RHEL-07-040550 (shosts.equiv)

### DIFF
--- a/rhel7/fixes/bash/no_host_based_files.sh
+++ b/rhel7/fixes/bash/no_host_based_files.sh
@@ -1,5 +1,0 @@
-# platform = Red Hat Enterprise Linux 7
-
-if [ -f /etc/hosts.equiv ]; then
-        /bin/rm -f /etc/hosts.equiv
-fi

--- a/shared/checks/oval/no_host_based_files.xml
+++ b/shared/checks/oval/no_host_based_files.xml
@@ -1,0 +1,22 @@
+<def-group oval_version="5.11">
+  <definition class="compliance" id="no_host_based_files" version="1">
+    <metadata>
+      <title>No shosts.equiv file deployed on the system</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+      </affected>
+      <description>There should not be any shosts.equiv files on the system.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_no_shosts_equiv" negate="true" />
+    </criteria>
+  </definition>
+  <unix:file_test check="all" check_existence="at_least_one_exists" comment="look for shosts.equiv in /" id="test_no_shosts_equiv" version="1">
+    <unix:object object_ref="object_no_shosts_equiv_files_root" />
+  </unix:file_test>
+  <unix:file_object comment="look for any shosts.equiv file on the system" id="object_no_shosts_equiv_files_root" version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
+    <unix:path operation="equals">/</unix:path>
+    <unix:filename operation="pattern match">shosts\.equiv$</unix:filename>
+  </unix:file_object>
+</def-group>

--- a/shared/checks/oval/no_host_based_files.xml
+++ b/shared/checks/oval/no_host_based_files.xml
@@ -1,4 +1,4 @@
-<def-group oval_version="5.11">
+<def-group oval_version="5.10">
   <definition class="compliance" id="no_host_based_files" version="1">
     <metadata>
       <title>No shosts.equiv file deployed on the system</title>
@@ -7,11 +7,11 @@
       </affected>
       <description>There should not be any shosts.equiv files on the system.</description>
     </metadata>
-    <criteria operator="AND">
-      <criterion test_ref="test_no_shosts_equiv" negate="true" />
+    <criteria>
+    	<criterion test_ref="test_no_shosts_equiv"/>
     </criteria>
   </definition>
-  <unix:file_test check="all" check_existence="at_least_one_exists" comment="look for shosts.equiv in /" id="test_no_shosts_equiv" version="1">
+  <unix:file_test check="all" check_existence="none_exist" comment="look for shosts.equiv in /" id="test_no_shosts_equiv" version="1">
     <unix:object object_ref="object_no_shosts_equiv_files_root" />
   </unix:file_test>
   <unix:file_object comment="look for any shosts.equiv file on the system" id="object_no_shosts_equiv_files_root" version="1">

--- a/shared/fixes/bash/no_host_based_files.sh
+++ b/shared/fixes/bash/no_host_based_files.sh
@@ -1,0 +1,2 @@
+# platform = multi_platform_rhel
+find / -type f -name shosts.equiv -exec rm -f '{}' \;

--- a/shared/fixes/bash/no_host_based_files.sh
+++ b/shared/fixes/bash/no_host_based_files.sh
@@ -1,2 +1,10 @@
 # platform = multi_platform_rhel
-find / -type f -name shosts.equiv -exec rm -f '{}' \;
+
+# Identify local mounts
+MOUNT_LIST=$(df | grep "^/dev" | awk '{ print $6 }') 
+
+# Find file on each listed mount point
+for cur_mount in ${MOUNT_LIST}
+do
+	find ${cur_mount} -xdev -type f -name "shosts.equiv" -exec rm -f {} \;
+done

--- a/shared/xccdf/services/obsolete.xml
+++ b/shared/xccdf/services/obsolete.xml
@@ -303,16 +303,16 @@ unauthenticated access to a system.</rationale>
 <Rule id="no_host_based_files" severity="high" prodtype="rhel7">
 <title>Remove Host-Based Authentication Files</title>
 <description>
-The <tt>/etc/shosts.equiv</tt> file list remote hosts
+The <tt>shosts.equiv</tt> file list remote hosts
 and users that are trusted by the local system.
 To remove these files, run the following command to delete them from any
 location:
-<pre>$ sudo rm /etc/shosts.equiv</pre>
+<pre>$ sudo rm /[path]/[to]/[file]/shosts.equiv</pre>
 </description>
 <ocil clause="these files exist">
-To verify that there are no <tt>/etc/shosts.equiv</tt> files
+To verify that there are no <tt>shosts.equiv</tt> files
 on the system, run the following command:
-<pre>$ sudo ls /etc/shosts.equiv</pre>
+<pre>$ find / -name shosts.equiv</pre>
 No output should be returned.
 </ocil>
 <rationale>


### PR DESCRIPTION
#### Description:

OVAL check if there is any shosts.equiv files on the file system.
Remediation removes all the shosts.equiv files if there is a finding.

#### Rationale:

- Add check and remediation for shosts.equiv files detection.

- Fixes #1856 
