### PR TITLE
Fix ID of RHEL6 DISA STIG Profile

### DIFF
--- a/rhel6/CMakeLists.txt
+++ b/rhel6/CMakeLists.txt
@@ -21,7 +21,7 @@ ssg_build_html_cce_table(${PRODUCT})
 
 ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE} ${DISA_SRG_VERSION})
 
-ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-server-upstream" ${DISA_STIG_VERSION})
+ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-disa" ${DISA_STIG_VERSION})
 
 if (SSG_CENTOS_DERIVATIVES_ENABLED)
     ssg_build_derivative_product(${PRODUCT} "centos" "centos6")

--- a/rhel6/kickstart/ssg-rhel6-stig-ks.cfg
+++ b/rhel6/kickstart/ssg-rhel6-stig-ks.cfg
@@ -373,7 +373,7 @@ scap-security-guide
 # To create a system compliant against different RHEL-6 SCAP Security Guide profile specify selected
 # profile name after the --profile oscap tool option
 
-oscap xccdf eval --remediate --profile stig-rhel6-server-upstream --report /root/oscap_stig_remediation_report.html \
+oscap xccdf eval --remediate --profile stig-rhel6-disa --report /root/oscap_stig_remediation_report.html \
 /usr/share/xml/scap/ssg/content/ssg-rhel6-xccdf.xml
 
 %end # End of %post section

--- a/rhel6/profiles/stig-rhel6-disa.xml
+++ b/rhel6/profiles/stig-rhel6-disa.xml
@@ -1,4 +1,4 @@
-<Profile id="stig-rhel6-server-upstream" extends="common">
+<Profile id="stig-rhel6-disa" extends="common">
 <title override="true">DISA STIG for Red Hat Enterprise Linux 6</title>
 <description>
 This profile contains configuration checks that align to the


### PR DESCRIPTION
#### Description:

- Fix ID of RHEL6 STIG DISA Profile

#### Rationale:

- In https://github.com/OpenSCAP/scap-security-guide/pull/2376 STIG Profiles `stig-rhel6-workstation-upstream`, `stig-rhel6-server-gui-upstream`, and `stig-rhel6-server-upstream` for RHEL6 were removed and Profile `stig-rhel6-disa was introduced`. But ID for this profile remained the `stig-rhel6-server-upstream`.

Edit: actually it is the ID that remained old, not filename.

  