### PR TITLE
Use ctest instead of `make validate`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,8 @@ message(STATUS "Webmin: ${SSG_PRODUCT_WEBMIN}")
 
 message(STATUS " ")
 
+enable_testing()
+
 include(SSGCommon)
 
 # Targets 'validate', 'stats', 'profile-stats' and 'zipfile' need to be added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,8 @@ if (SSG_PRODUCT_WEBMIN)
     add_subdirectory("webmin")
 endif()
 
+ssg_define_linkchecker_tests()
+
 install(FILES "${CMAKE_SOURCE_DIR}/LICENSE"
     DESTINATION ${CMAKE_INSTALL_DOCDIR})
 install(FILES "${CMAKE_SOURCE_DIR}/README.md"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SSG_VENDOR "ssgproject" CACHE STRING "Specify the XCCDF 1.2 vendor string.")
 
 option(SSG_OVAL_511_ENABLED "If enabled, OVAL 5.11 and OVAL 5.10 checks will be used in the final content. Otherwise only 5.10 checks will be used." TRUE)
 option(SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED "If enabled, schematron validation will be performed as part of the ctest tests. Schematron takes a lot of time to complete but can find more issues than just plain XSD validation." TRUE)
+option(SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED "If enabled, shellcheck validation of bash fixes will be performed as part of the ctest tests. Shellcheck tests don't pass right now, this option is discouraged until that's fixed." FALSE)
 option(SSG_SVG_IN_XCCDF_ENABLED "If enabled, the built XCCDFs will include the SVG SCAP Security Guide logo." TRUE)
 
 option(SSG_PRODUCT_CHROMIUM "If enabled, the Chromium SCAP content will be built" TRUE)
@@ -127,6 +128,7 @@ message(STATUS "Build options:")
 message(STATUS "SSG vendor string: ${SSG_VENDOR}")
 message(STATUS "OVAL 5.11: ${SSG_OVAL_511_ENABLED}")
 message(STATUS "OVAL schematron validation: ${SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED}")
+message(STATUS "shellcheck bash fixes validation: ${SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED}")
 message(STATUS "SVG logo in XCCDFs: ${SSG_SVG_IN_XCCDF_ENABLED}")
 message(STATUS " ")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(SSG_VERSION "${SSG_MAJOR_VERSION}.${SSG_MINOR_VERSION}.${SSG_PATCH_VERSION}"
 set(SSG_VENDOR "ssgproject" CACHE STRING "Specify the XCCDF 1.2 vendor string.")
 
 option(SSG_OVAL_511_ENABLED "If enabled, OVAL 5.11 and OVAL 5.10 checks will be used in the final content. Otherwise only 5.10 checks will be used." TRUE)
-option(SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED "If enabled, schematron validation will be performed as part of the 'validate' targets. Schematron takes a lot of time to complete but can find more issues than just plain XSD validation." TRUE)
+option(SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED "If enabled, schematron validation will be performed as part of the ctest tests. Schematron takes a lot of time to complete but can find more issues than just plain XSD validation." TRUE)
 option(SSG_SVG_IN_XCCDF_ENABLED "If enabled, the built XCCDFs will include the SVG SCAP Security Guide logo." TRUE)
 
 option(SSG_PRODUCT_CHROMIUM "If enabled, the Chromium SCAP content will be built" TRUE)
@@ -157,10 +157,9 @@ enable_testing()
 
 include(SSGCommon)
 
-# Targets 'validate', 'stats', 'profile-stats' and 'zipfile' need to be added
+# Targets 'stats', 'profile-stats' and 'zipfile' need to be added
 # before any product because they will receive dependencies from products added
 
-add_custom_target(validate)
 add_custom_target(stats)
 add_custom_target(profile-stats)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SSG_VENDOR "ssgproject" CACHE STRING "Specify the XCCDF 1.2 vendor string.")
 option(SSG_OVAL_511_ENABLED "If enabled, OVAL 5.11 and OVAL 5.10 checks will be used in the final content. Otherwise only 5.10 checks will be used." TRUE)
 option(SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED "If enabled, schematron validation will be performed as part of the ctest tests. Schematron takes a lot of time to complete but can find more issues than just plain XSD validation." TRUE)
 option(SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED "If enabled, shellcheck validation of bash fixes will be performed as part of the ctest tests. Shellcheck tests don't pass right now, this option is discouraged until that's fixed." FALSE)
+option(SSG_LINKCHECKER_VALIDATION_ENABLED "If enabled, linkchecker will be used to validate URLs in all the HTML guides and tables." TRUE)
 option(SSG_SVG_IN_XCCDF_ENABLED "If enabled, the built XCCDFs will include the SVG SCAP Security Guide logo." TRUE)
 
 option(SSG_PRODUCT_CHROMIUM "If enabled, the Chromium SCAP content will be built" TRUE)
@@ -106,6 +107,7 @@ if (NOT SED_EXECUTABLE)
 endif()
 
 find_program(SHELLCHECK_EXECUTABLE NAMES shellcheck)
+find_program(LINKCHECKER_EXECUTABLE NAMES linkchecker)
 
 configure_file("${CMAKE_SOURCE_DIR}/oval.config.in" "${CMAKE_BINARY_DIR}/oval.config")
 
@@ -122,6 +124,7 @@ message(STATUS "xmllint: ${XMLLINT_EXECUTABLE}")
 message(STATUS "xmlwf: ${XMLWF_EXECUTABLE}")
 message(STATUS "sed: ${SED_EXECUTABLE}")
 message(STATUS "shellcheck (optional): ${SHELLCHECK_EXECUTABLE}")
+message(STATUS "linkchecker (optional): ${LINKCHECKER_EXECUTABLE}")
 message(STATUS " ")
 
 message(STATUS "Build options:")

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -417,21 +417,13 @@ macro(ssg_build_xccdf_final PRODUCT)
         generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
     )
-    add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-xccdf.xml"
+    add_test(
+        NAME "validate-ssg-${PRODUCT}-xccdf.xml"
         COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" xccdf validate "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-        COMMAND "${SSG_SHARED_UTILS}/verify-references.py" --rules-with-invalid-checks --ovaldefs-unused "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-        COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-xccdf.xml"
-        DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-        DEPENDS generate-ssg-${PRODUCT}-oval.xml  # because of verify-references
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-        DEPENDS "${SSG_SHARED_UTILS}/verify-references.py"
-        COMMENT "[${PRODUCT}-validate] validating ssg-${PRODUCT}-xccdf.xml"
     )
-    add_custom_target(
-        validate-ssg-${PRODUCT}-xccdf.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-xccdf.xml"
+    add_test(
+        NAME "verify-references-ssg-${PRODUCT}-xccdf.xml"
+        COMMAND "${SSG_SHARED_UTILS}/verify-references.py" --rules-with-invalid-checks --ovaldefs-unused "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
     )
 
     add_custom_command(
@@ -445,18 +437,6 @@ macro(ssg_build_xccdf_final PRODUCT)
         generate-ssg-${PRODUCT}-xccdf-1.2.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
     )
-    #add_custom_command(
-    #    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-xccdf-1.2.xml"
-    #    COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" xccdf-1.2 validate "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
-    #    COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-xccdf-1.2.xml"
-    #    DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
-    #    DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
-    #    COMMENT "[${PRODUCT}-validate] validating ssg-${PRODUCT}-xccdf-1.2.xml"
-    #)
-    #add_custom_target(
-    #    validate-ssg-${PRODUCT}-xccdf-1.2.xml
-    #    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-xccdf-1.2.xml"
-    #)
 endmacro()
 
 macro(ssg_build_oval_final PRODUCT)
@@ -688,8 +668,6 @@ macro(ssg_build_product PRODUCT)
 
     add_dependencies(
         ${PRODUCT}-validate
-        validate-ssg-${PRODUCT}-xccdf.xml
-        #validate-ssg-${PRODUCT}-xccdf-1.2.xml
         validate-ssg-${PRODUCT}-oval.xml
         #validate-ssg-${PRODUCT}-ocil.xml
         validate-ssg-${PRODUCT}-ds.xml

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -848,6 +848,13 @@ macro(ssg_build_html_table_by_ref PRODUCT REF)
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-by-ref-${REF})
 
+    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
+        add_test(
+            NAME "linkchecker-tables-table-${PRODUCT}-${REF}refs.html"
+            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${REF}refs.html"
+        )
+    endif()
+
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${REF}refs.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
 endmacro()
@@ -868,6 +875,13 @@ macro(ssg_build_html_nistrefs_table PRODUCT PROFILE)
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-nistrefs-${PROFILE})
 
+    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
+        add_test(
+            NAME "linkchecker-tables-table-${PRODUCT}-nistrefs-${PROFILE}.html"
+            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-nistrefs-${PROFILE}.html"
+        )
+    endif()
+
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-nistrefs-${PROFILE}.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
 endmacro()
@@ -887,6 +901,13 @@ macro(ssg_build_html_cce_table PRODUCT)
         DEPENDS "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html"
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-cces)
+
+    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
+        add_test(
+            NAME "linkchecker-tables-table-${PRODUCT}-cces.html"
+            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html"
+        )
+    endif()
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -923,6 +944,18 @@ macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE DISA_SRG_VERSION)
         DEPENDS "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html"
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-srg)
+
+    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
+        add_test(
+            NAME "linkchecker-tables-table-${PRODUCT}-srgmap.html"
+            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html"
+        )
+
+        add_test(
+            NAME "linkchecker-tables-table-${PRODUCT}-srgmap-flat.html"
+            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html"
+        )
+    endif()
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -971,6 +1004,18 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
         DEPENDS "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-testinfo.html"
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-stig)
+
+    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
+        add_test(
+            NAME "linkchecker-tables-table-${PRODUCT}-stig.html"
+            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html"
+        )
+
+        add_test(
+            NAME "linkchecker-tables-table-${PRODUCT}-stig-manual.html"
+            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html"
+        )
+    endif()
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -235,11 +235,11 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGE)
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml"
     )
 
-    if (SHELLCHECK_EXECUTABLE AND "${LANGUAGE}" STREQUAL "bash")
+if (SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED AND SHELLCHECK_EXECUTABLE AND "${LANGUAGE}" STREQUAL "bash")
         file(GLOB BASH_REMEDIATION_FUNCTIONS "${CMAKE_SOURCE_DIR}/shared/bash_remediation_functions/*.sh")
 
         add_test(
-            NAME "${PRODUCT}-bash-fixes-shellcheck"
+            NAME "shellcheck-${PRODUCT}-bash-fixes"
             # format gcc so that people using IDEs can click on errors to get to the problematic lines
             # SC1071: ShellCheck only supports sh/bash/ksh scripts
             # SC1091: Not following: /usr/share/scap-security-guide/remediation_functions

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -451,17 +451,9 @@ macro(ssg_build_oval_final PRODUCT)
         generate-ssg-${PRODUCT}-oval.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
     )
-    add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-oval.xml"
+    add_test(
+        NAME "validate-ssg-${PRODUCT}-oval.xml"
         COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" oval validate ${OSCAP_OVAL_SCHEMATRON_OPTION} "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-        COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-oval.xml"
-        DEPENDS generate-ssg-${PRODUCT}-oval.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-        COMMENT "[${PRODUCT}-validate] validating ssg-${PRODUCT}-oval.xml"
-    )
-    add_custom_target(
-        validate-ssg-${PRODUCT}-oval.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-oval.xml"
     )
 endmacro()
 
@@ -668,7 +660,6 @@ macro(ssg_build_product PRODUCT)
 
     add_dependencies(
         ${PRODUCT}-validate
-        validate-ssg-${PRODUCT}-oval.xml
         #validate-ssg-${PRODUCT}-ocil.xml
         validate-ssg-${PRODUCT}-ds.xml
     )

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -997,12 +997,12 @@ macro(ssg_define_linkchecker_tests)
     if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
         add_test(
             NAME "linkchecker-ssg-guides"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" ${SSG_LINKCHECKER_GUIDE_FILE_LIST}
+            COMMAND "${LINKCHECKER_EXECUTABLE}" --check-extern ${SSG_LINKCHECKER_GUIDE_FILE_LIST}
         )
 
         add_test(
             NAME "linkchecker-ssg-tables"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" ${SSG_LINKCHECKER_TABLE_FILE_LIST}
+            COMMAND "${LINKCHECKER_EXECUTABLE}" --check-extern ${SSG_LINKCHECKER_TABLE_FILE_LIST}
         )
     endif()
 endmacro()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -238,22 +238,14 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGE)
     if (SHELLCHECK_EXECUTABLE AND "${LANGUAGE}" STREQUAL "bash")
         file(GLOB BASH_REMEDIATION_FUNCTIONS "${CMAKE_SOURCE_DIR}/shared/bash_remediation_functions/*.sh")
 
-        add_custom_command(
-            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shellcheck-validation-bash-remediations"
+        add_test(
+            NAME "${PRODUCT}-bash-fixes-shellcheck"
             # format gcc so that people using IDEs can click on errors to get to the problematic lines
             # SC1071: ShellCheck only supports sh/bash/ksh scripts
             # SC1091: Not following: /usr/share/scap-security-guide/remediation_functions
             # TODO: Stop ignoring the exit code as we fix the bash issues
-            COMMAND "${SHELLCHECK_EXECUTABLE}" --format gcc --shell bash --exclude SC1071,SC1091 ${BASH_REMEDIATION_FUNCTIONS} ${LANGUAGE_REMEDIATIONS_DEPENDS} ${SHARED_LANGUAGE_REMEDIATIONS_DEPENDS} ${EXTRA_LANGUAGE_DEPENDS} ${EXTRA_SHARED_LANGUAGE_DEPENDS} || "true"
-            COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/shellcheck-validation-bash-remediations"
-            VERBATIM
-            COMMENT "[${PRODUCT}-validate] validating inputs for bash remediations"
+            COMMAND "${SHELLCHECK_EXECUTABLE}" --format gcc --shell bash --exclude SC1071,SC1091 ${BASH_REMEDIATION_FUNCTIONS} ${LANGUAGE_REMEDIATIONS_DEPENDS} ${SHARED_LANGUAGE_REMEDIATIONS_DEPENDS} ${EXTRA_LANGUAGE_DEPENDS} ${EXTRA_SHARED_LANGUAGE_DEPENDS}
         )
-        add_custom_target(
-            validate-ssg-${PRODUCT}-bash-remediation-inputs
-            DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/shellcheck-validation-bash-remediations"
-        )
-        add_dependencies(${PRODUCT}-validate validate-ssg-${PRODUCT}-bash-remediation-inputs)
     endif()
 endmacro()
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -364,29 +364,13 @@ macro(ssg_build_cpe_dictionary PRODUCT)
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
     )
-    add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-cpe-dictionary.xml"
+    add_test(
+        NAME "validate-ssg-${PRODUCT}-cpe-dictionary.xml"
         COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" cpe validate "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
-        COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-cpe-dictionary.xml"
-        DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
-        COMMENT "[${PRODUCT}-validate] validating ssg-${PRODUCT}-cpe-dictionary.xml"
     )
-    add_custom_target(
-        validate-ssg-${PRODUCT}-cpe-dictionary.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-cpe-dictionary.xml"
-    )
-    add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-cpe-oval.xml"
+    add_test(
+        NAME "validate-ssg-${PRODUCT}-cpe-oval.xml"
         COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" oval validate ${OSCAP_OVAL_SCHEMATRON_OPTION} "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-        COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-cpe-oval.xml"
-        DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-        COMMENT "[${PRODUCT}-validate] validating ssg-${PRODUCT}-cpe-oval.xml"
-    )
-    add_custom_target(
-        validate-ssg-${PRODUCT}-cpe-oval.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-cpe-oval.xml"
     )
 endmacro()
 
@@ -708,8 +692,6 @@ macro(ssg_build_product PRODUCT)
         #validate-ssg-${PRODUCT}-xccdf-1.2.xml
         validate-ssg-${PRODUCT}-oval.xml
         #validate-ssg-${PRODUCT}-ocil.xml
-        validate-ssg-${PRODUCT}-cpe-dictionary.xml
-        validate-ssg-${PRODUCT}-cpe-oval.xml
         validate-ssg-${PRODUCT}-ds.xml
     )
     add_dependencies(validate ${PRODUCT}-validate)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -65,6 +65,7 @@ else()
 endif()
 
 set(SSG_LINKCHECKER_GUIDE_FILE_LIST "")
+set(SSG_LINKCHECKER_TABLE_FILE_LIST "")
 
 macro(ssg_build_bash_remediation_functions)
     file(GLOB BASH_REMEDIATION_FUNCTIONS "${CMAKE_SOURCE_DIR}/shared/bash_remediation_functions/*.sh")
@@ -561,11 +562,9 @@ macro(ssg_build_html_guides PRODUCT)
         DEPENDS "${CMAKE_BINARY_DIR}/guides/ssg-${PRODUCT}-guide-index.html"
     )
 
-    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
-        # despite checking just the index this actually tests all the guides because the index links to them
-        # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
-        set(SSG_LINKCHECKER_GUIDE_FILE_LIST "${SSG_LINKCHECKER_GUIDE_FILE_LIST};${CMAKE_BINARY_DIR}/guides/ssg-${PRODUCT}-guide-index.html" PARENT_SCOPE)
-    endif()
+    # despite checking just the index this actually tests all the guides because the index links to them
+    # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
+    set(SSG_LINKCHECKER_GUIDE_FILE_LIST "${SSG_LINKCHECKER_GUIDE_FILE_LIST};${CMAKE_BINARY_DIR}/guides/ssg-${PRODUCT}-guide-index.html" PARENT_SCOPE)
 endmacro()
 
 macro(ssg_build_remediation_roles PRODUCT TEMPLATE EXTENSION)
@@ -848,12 +847,8 @@ macro(ssg_build_html_table_by_ref PRODUCT REF)
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-by-ref-${REF})
 
-    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
-        add_test(
-            NAME "linkchecker-tables-table-${PRODUCT}-${REF}refs.html"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${REF}refs.html"
-        )
-    endif()
+    # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
+    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${REF}refs.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${REF}refs.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -875,12 +870,8 @@ macro(ssg_build_html_nistrefs_table PRODUCT PROFILE)
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-nistrefs-${PROFILE})
 
-    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
-        add_test(
-            NAME "linkchecker-tables-table-${PRODUCT}-nistrefs-${PROFILE}.html"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-nistrefs-${PROFILE}.html"
-        )
-    endif()
+    # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
+    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-nistrefs-${PROFILE}.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-nistrefs-${PROFILE}.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -902,12 +893,8 @@ macro(ssg_build_html_cce_table PRODUCT)
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-cces)
 
-    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
-        add_test(
-            NAME "linkchecker-tables-table-${PRODUCT}-cces.html"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html"
-        )
-    endif()
+    # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
+    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -945,17 +932,9 @@ macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE DISA_SRG_VERSION)
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-srg)
 
-    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
-        add_test(
-            NAME "linkchecker-tables-table-${PRODUCT}-srgmap.html"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html"
-        )
-
-        add_test(
-            NAME "linkchecker-tables-table-${PRODUCT}-srgmap-flat.html"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html"
-        )
-    endif()
+    # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
+    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html" PARENT_SCOPE)
+    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -1005,17 +984,8 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-stig)
 
-    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
-        add_test(
-            NAME "linkchecker-tables-table-${PRODUCT}-stig.html"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html"
-        )
-
-        add_test(
-            NAME "linkchecker-tables-table-${PRODUCT}-stig-manual.html"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html"
-        )
-    endif()
+    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html" PARENT_SCOPE)
+    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -1024,10 +994,17 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
 endmacro()
 
 macro(ssg_define_linkchecker_tests)
-    add_test(
-        NAME "linkchecker-ssg-guides"
-        COMMAND "${LINKCHECKER_EXECUTABLE}" ${SSG_LINKCHECKER_GUIDE_FILE_LIST}
-    )
+    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
+        add_test(
+            NAME "linkchecker-ssg-guides"
+            COMMAND "${LINKCHECKER_EXECUTABLE}" ${SSG_LINKCHECKER_GUIDE_FILE_LIST}
+        )
+
+        add_test(
+            NAME "linkchecker-ssg-tables"
+            COMMAND "${LINKCHECKER_EXECUTABLE}" ${SSG_LINKCHECKER_TABLE_FILE_LIST}
+        )
+    endif()
 endmacro()
 
 macro(ssg_build_zipfile ZIPNAME)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -558,6 +558,14 @@ macro(ssg_build_html_guides PRODUCT)
         generate-ssg-${PRODUCT}-guide-index.html
         DEPENDS "${CMAKE_BINARY_DIR}/guides/ssg-${PRODUCT}-guide-index.html"
     )
+
+    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
+        add_test(
+            NAME "linkchecker-ssg-${PRODUCT}-guides"
+            # despite checking just the index this actually tests all the guides because the index links to them
+            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/guides/ssg-${PRODUCT}-guide-index.html"
+        )
+    endif()
 endmacro()
 
 macro(ssg_build_remediation_roles PRODUCT TEMPLATE EXTENSION)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -28,7 +28,7 @@
 # this wrapper you wouldn't have been able to do parallel builds of multiple
 # targets at once. E.g.:
 #
-# $ make -j 4 rhel7-guides rhel7-validate
+# $ make -j 4 rhel7-guides rhel7-stats
 #
 # Without the wrapper targets the command above would start generating the
 # XCCDF, OVAL and OCIL files 2 times in parallel which would result in
@@ -469,18 +469,6 @@ macro(ssg_build_ocil_final PRODUCT)
         generate-ssg-${PRODUCT}-ocil.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
     )
-    #add_custom_command(
-    #    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-ocil.xml"
-    #    COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ocil validate "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-    #    COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-ocil.xml"
-    #    DEPENDS generate-ssg-${PRODUCT}-ocil.xml
-    #    DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-    #    COMMENT "[${PRODUCT}-validate] validating ssg-${PRODUCT}-ocil.xml"
-    #)
-    #add_custom_target(
-    #    validate-ssg-${PRODUCT}-ocil.xml
-    #    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-ocil.xml"
-    #)
 endmacro()
 
 macro(ssg_build_pci_dss_xccdf PRODUCT)
@@ -497,18 +485,6 @@ macro(ssg_build_pci_dss_xccdf PRODUCT)
         generate-ssg-${PRODUCT}-pcidss-xccdf-1.2.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-pcidss-xccdf-1.2.xml"
     )
-    #add_custom_command(
-    #    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-pcidss-xccdf-1.2.xml"
-    #    COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" xccdf validate "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-pcidss-xccdf-1.2.xml"
-    #    COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-pcidss-xccdf-1.2.xml"
-    #    DEPENDS generate-ssg-${PRODUCT}-pcidss-xccdf-1.2.xml
-    #    DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-pcidss-xccdf-1.2.xml"
-    #    COMMENT "[${PRODUCT}-validate] validating ssg-${PRODUCT}-pcidss-xccdf-1.2.xml"
-    #)
-    #add_custom_target(
-    #    validate-ssg-${PRODUCT}-pcidss-xccdf-1.2.xml
-    #    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-pcidss-xccdf-1.2.xml"
-    #)
 endmacro()
 
 macro(ssg_build_sds PRODUCT)
@@ -562,17 +538,10 @@ macro(ssg_build_sds PRODUCT)
         generate-ssg-${PRODUCT}-ds.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
     )
-    add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-ds.xml"
+
+    add_test(
+        NAME "validate-ssg-${PRODUCT}-ds.xml"
         COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-validate "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-        COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-ds.xml"
-        DEPENDS generate-ssg-${PRODUCT}-ds.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-        COMMENT "[${PRODUCT}-validate] validating ssg-${PRODUCT}-ds.xml"
-    )
-    add_custom_target(
-        validate-ssg-${PRODUCT}-ds.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${PRODUCT}-ds.xml"
     )
 endmacro()
 
@@ -626,7 +595,6 @@ endmacro()
 
 macro(ssg_build_product PRODUCT)
     add_custom_target(${PRODUCT}-content)
-    add_custom_target(${PRODUCT}-validate)
 
     ssg_build_guide_xml(${PRODUCT})
     ssg_build_shorthand_xml(${PRODUCT})
@@ -657,13 +625,6 @@ macro(ssg_build_product PRODUCT)
         generate-ssg-${PRODUCT}-cpe-dictionary.xml
         generate-ssg-${PRODUCT}-ds.xml
     )
-
-    add_dependencies(
-        ${PRODUCT}-validate
-        #validate-ssg-${PRODUCT}-ocil.xml
-        validate-ssg-${PRODUCT}-ds.xml
-    )
-    add_dependencies(validate ${PRODUCT}-validate)
 
     add_dependencies(zipfile "generate-ssg-${PRODUCT}-ds.xml")
 
@@ -755,7 +716,6 @@ endmacro()
 
 macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
     add_custom_target(${DERIVATIVE}-content)
-    add_custom_target(${DERIVATIVE}-validate)
 
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml"
@@ -769,17 +729,9 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
         generate-ssg-${DERIVATIVE}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml"
     )
-    add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${DERIVATIVE}-xccdf.xml"
-        COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" xccdf validate "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml"
+    add_test(
+        NAME "validate-ssg-${DERIVATIVE}-xccdf.xml"
         COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${DERIVATIVE}-xccdf.xml"
-        DEPENDS generate-ssg-${DERIVATIVE}-xccdf.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml"
-        COMMENT "[${DERIVATIVE}-validate] validating ssg-${DERIVATIVE}-xccdf.xml"
-    )
-    add_custom_target(
-        validate-ssg-${DERIVATIVE}-xccdf.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${DERIVATIVE}-xccdf.xml"
     )
 
     add_custom_command(
@@ -794,17 +746,9 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
         generate-ssg-${DERIVATIVE}-ds.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
     )
-    add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${DERIVATIVE}-ds.xml"
+    add_test(
+        NAME "validate-ssg-${DERIVATIVE}-ds.xml"
         COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-validate "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
-        COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${DERIVATIVE}-ds.xml"
-        DEPENDS generate-ssg-${DERIVATIVE}-ds.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
-        COMMENT "[${DERIVATIVE}-validate] validating ssg-${DERIVATIVE}-ds.xml"
-    )
-    add_custom_target(
-        validate-ssg-${DERIVATIVE}-ds.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/validation-ssg-${DERIVATIVE}-ds.xml"
     )
 
     add_custom_target(${DERIVATIVE} ALL)
@@ -815,13 +759,6 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
         generate-ssg-${DERIVATIVE}-xccdf.xml
         generate-ssg-${DERIVATIVE}-ds.xml
     )
-
-    add_dependencies(
-        ${DERIVATIVE}-validate
-        validate-ssg-${DERIVATIVE}-xccdf.xml
-        validate-ssg-${DERIVATIVE}-ds.xml
-    )
-    add_dependencies(validate ${DERIVATIVE}-validate)
 
     add_dependencies(zipfile "generate-ssg-${DERIVATIVE}-ds.xml")
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -64,6 +64,8 @@ else()
     set(OSCAP_OVAL_SCHEMATRON_OPTION "")
 endif()
 
+set(SSG_LINKCHECKER_GUIDE_FILE_LIST "")
+
 macro(ssg_build_bash_remediation_functions)
     file(GLOB BASH_REMEDIATION_FUNCTIONS "${CMAKE_SOURCE_DIR}/shared/bash_remediation_functions/*.sh")
 
@@ -560,11 +562,9 @@ macro(ssg_build_html_guides PRODUCT)
     )
 
     if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
-        add_test(
-            NAME "linkchecker-ssg-${PRODUCT}-guides"
-            # despite checking just the index this actually tests all the guides because the index links to them
-            COMMAND "${LINKCHECKER_EXECUTABLE}" "${CMAKE_BINARY_DIR}/guides/ssg-${PRODUCT}-guide-index.html"
-        )
+        # despite checking just the index this actually tests all the guides because the index links to them
+        # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
+        set(SSG_LINKCHECKER_GUIDE_FILE_LIST "${SSG_LINKCHECKER_GUIDE_FILE_LIST};${CMAKE_BINARY_DIR}/guides/ssg-${PRODUCT}-guide-index.html" PARENT_SCOPE)
     endif()
 endmacro()
 
@@ -1021,6 +1021,13 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-testinfo.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
+endmacro()
+
+macro(ssg_define_linkchecker_tests)
+    add_test(
+        NAME "linkchecker-ssg-guides"
+        COMMAND "${LINKCHECKER_EXECUTABLE}" ${SSG_LINKCHECKER_GUIDE_FILE_LIST}
+    )
 endmacro()
 
 macro(ssg_build_zipfile ZIPNAME)

--- a/docs/SCAP_and_STIG_Workshop/en-US/Content_Customization.xml
+++ b/docs/SCAP_and_STIG_Workshop/en-US/Content_Customization.xml
@@ -169,11 +169,23 @@ Now that the XCCDF language is written, let's see how it looks in the HTML guide
 $ cd /var/www/html/scap-security-guide/rhel6
 $ make content
 
-To ensure your XCCDF is still SCAP compliant, run a quick “make validate”:
-$ make validate
-oscap xccdf validate-xml output/ssg-rhel6-xccdf.xml
-oscap oval validate-xml output/ssg-rhel6-oval.xml
-oscap oval validate-xml output/ssg-rhel6-cpe-oval.xml
+To ensure your XCCDF is still SCAP compliant, run a quick validation test:
+$ ctest -R validate-ssg-rhel6 -j 4
+Test project /home/mpreisle/d/scap-security-guide/build
+    Start 57: validate-ssg-rhel6-cpe-dictionary.xml
+    Start 58: validate-ssg-rhel6-cpe-oval.xml
+    Start 59: validate-ssg-rhel6-xccdf.xml
+    Start 61: validate-ssg-rhel6-oval.xml
+1/5 Test #57: validate-ssg-rhel6-cpe-dictionary.xml ...   Passed    0.10 sec
+2/5 Test #59: validate-ssg-rhel6-xccdf.xml ............   Passed    0.21 sec
+    Start 62: validate-ssg-rhel6-ds.xml
+3/5 Test #58: validate-ssg-rhel6-cpe-oval.xml .........   Passed    2.00 sec
+4/5 Test #62: validate-ssg-rhel6-ds.xml ...............   Passed    1.90 sec
+5/5 Test #61: validate-ssg-rhel6-oval.xml .............   Passed   97.82 sec
+
+100% tests passed, 0 tests failed out of 5
+
+Total Test time (real) =  97.83 sec
 -->
 			</screen>
 		</para>
@@ -190,7 +202,8 @@ The <description> tag has the ability to handle XHTML arguments. Let's wrap our 
 
 Once updated, re-run the build:
 <screen>
-$ make clean; make content; make validate
+    $ make -j 4
+    $ ctest -j 4
 </screen>
 
 Upon completion, refresh your web browser to see the updated content.

--- a/fedora/xccdf/system/accounts/pam.xml
+++ b/fedora/xccdf/system/accounts/pam.xml
@@ -39,7 +39,7 @@ most users.</warning>
 files, destroying any manually made changes and replacing them with
 a series of system defaults. One reference to the configuration
 file syntax can be found at
-<weblink-macro link="http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html"/>
+<weblink-macro link="http://www.linux-pam.org/Linux-PAM-html/sag-configuration-file.html"/>
 .</warning>
 
 <Value id="var_password_pam_unix_remember" type="number"

--- a/fedora/xccdf/system/network/ssl.xml
+++ b/fedora/xccdf/system/network/ssl.xml
@@ -8,6 +8,6 @@ communications, and many network services include support for it.  TLS or SSL
 can be leveraged to avoid any plaintext transmission of sensitive data.
 <br/>
 For information on how to use OpenSSL, see
-<b><weblink-macro link="http://www.openssl.org/docs/HOWTO/"/></b>.
+<b><weblink-macro link="http://www.openssl.org/docs/"/></b>.
 </description>
 </Group>

--- a/rhel6/xccdf/system/accounts/pam.xml
+++ b/rhel6/xccdf/system/accounts/pam.xml
@@ -39,7 +39,7 @@ most users.</warning>
 files, destroying any manually made changes and replacing them with
 a series of system defaults. One reference to the configuration
 file syntax can be found at
-<weblink-macro link="http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html"/>.</warning>
+<weblink-macro link="http://www.linux-pam.org/Linux-PAM-html/sag-configuration-file.html"/>.</warning>
 
 <Value id="var_password_pam_unix_remember" type="number"
 operator="equals" interactive="0">

--- a/rhel6/xccdf/system/network/ssl.xml
+++ b/rhel6/xccdf/system/network/ssl.xml
@@ -8,8 +8,8 @@ communications, and many network services include support for it.  TLS or SSL
 can be leveraged to avoid any plaintext transmission of sensitive data.
 <br/>
 For information on how to use OpenSSL, see
-<b><weblink-macro link="http://www.openssl.org/docs/HOWTO/"/></b>.  Information on FIPS validation
-of OpenSSL is available at <b><weblink-macro link="http://www.openssl.org/docs/fips/fipsvalidation.html"/></b>
+<b><weblink-macro link="http://www.openssl.org/docs/"/></b>.  Information on FIPS validation
+of OpenSSL is available at <b><weblink-macro link="http://www.openssl.org/docs/fips.html"/></b>
 and <b><weblink-macro link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm"/></b>.
 <!-- Does Red Hat offer any documentation on using OpenSSL? -->
 </description>

--- a/shared/xccdf/system/network/ssl.xml
+++ b/shared/xccdf/system/network/ssl.xml
@@ -8,8 +8,8 @@ communications, and many network services include support for it.  TLS or SSL
 can be leveraged to avoid any plaintext transmission of sensitive data.
 <br/>
 For information on how to use OpenSSL, see
-<b><weblink-macro link="http://www.openssl.org/docs/HOWTO/"/></b>.  Information on FIPS validation
-of OpenSSL is available at <b><weblink-macro link="http://www.openssl.org/docs/fips/fipsvalidation.html"/></b>
+<b><weblink-macro link="http://www.openssl.org/docs/"/></b>.  Information on FIPS validation
+of OpenSSL is available at <b><weblink-macro link="http://www.openssl.org/docs/fips.html"/></b>
 and <b><weblink-macro link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm"/></b>.
 For information on how to use and implement OpenSSL on Red Hat Enterprise Linux, see
 <b><weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Using_OpenSSL.html"/></b>

--- a/ubuntu14/transforms/constants.xslt
+++ b/ubuntu14/transforms/constants.xslt
@@ -10,7 +10,7 @@
 <xsl:variable name="prod_type">ubuntu</xsl:variable>
 
 <!-- Define URI of official Center for Internet Security Benchmark for Ubuntu Linux v1.0 -->
-<xsl:variable name="cisuri">fixme</xsl:variable>
+<xsl:variable name="cisuri">https://www.cisecurity.org/benchmark/ubuntu_linux/</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 <xsl:variable name="os-stigid-concat" />
 

--- a/ubuntu16/transforms/constants.xslt
+++ b/ubuntu16/transforms/constants.xslt
@@ -10,7 +10,7 @@
 <xsl:variable name="prod_type">ubuntu</xsl:variable>
 
 <!-- Define URI of official Center for Internet Security Benchmark for Ubuntu Linux v1.0 -->
-<xsl:variable name="cisuri">fixme</xsl:variable>
+<xsl:variable name="cisuri">https://www.cisecurity.org/benchmark/ubuntu_linux/</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 <xsl:variable name="os-stigid-concat" />
 


### PR DESCRIPTION
#### Description:

- Instead of using a `validate` build target for validation and other tests, this PR switches over to `ctest`
- Adds a test that uses `linkchecker` to check URLs in the HTML guides
- Adds a test that uses `linkchecker` to check URLs in the HTML tables

How to test:
```
cd build/
cmake ../
make -j 4
ctest -j 4
```

#### Rationale:

- `ctest` output is more suitable for regression testing
- it more clearly separates testing and building
