### PR TITLE
Fix UsePrivilegeSeparation ansible remediation

### DIFF
--- a/shared/fixes/ansible/sshd_use_priv_separation.yml
+++ b/shared/fixes/ansible/sshd_use_priv_separation.yml
@@ -8,7 +8,7 @@
     create: yes
     dest: /etc/ssh/sshd_config
     regexp: (?i)^#?useprivilegeseparation
-    line: UsePrivilegeSeparation yes
+    line: UsePrivilegeSeparation sandbox
     validate: sshd -t -f %s
   #notify: restart sshd
   tags:


### PR DESCRIPTION
#### Description:

- Fixed Ansible remediation of UsePrivilegeSeparation from `yes` to `sandbox`.

#### Rationale:

- Originally merged in #2162 , un-fixed by mistake later on.
