### PR TITLE
fixed rpm_verify_permissions to use 4th field in cut statement

### DIFF
--- a/shared/fixes/bash/rpm_verify_permissions.sh
+++ b/shared/fixes/bash/rpm_verify_permissions.sh
@@ -9,7 +9,7 @@ declare -a SETPERMS_RPM_LIST
 
 # Create a list of files on the system having permissions different from what
 # is expected by the RPM database
-FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep '^.M' | cut -d ' ' -f5-))
+FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep '^.M' | cut -d ' ' -f4-))
 
 # For each file path from that list:
 # * Determine the RPM package the file path is shipped by,


### PR DESCRIPTION
#### Description:

Updated the cut statement to use the 4th field from the `rpm -Va` statement

#### Rationale:

In #2205 there is discussion about changing a line in the rpm_verify_permissions remediation to `FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep '^.M' | cut -d ' ' -f4-))`

However, the actual line that was committed was `FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep '^.M' | cut -d ' ' -f5-))`

Since there is no 5th field, this will always return blank, and the rest of the script will have no files to work with, therefore nothing is remediated.

- Fixes #2530 
