### PR TITLE
updated kernel module loading init and delete to use b32 and b64

### DIFF
--- a/shared/fixes/bash/audit_rules_kernel_module_loading_delete.sh
+++ b/shared/fixes/bash/audit_rules_kernel_module_loading_delete.sh
@@ -5,10 +5,10 @@
 
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system
-# Note: 32-bit kernel modules can't be loaded / unloaded on 64-bit kernel =>
-#       it's not required on a 64-bit system to check also for the presence
-#       of 32-bit's equivalent of the corresponding rule. Therefore for
-#       each system it's enought to check presence of system's native rule form.
+# If the system has a 32-bit processor, only the 32-bit rule is needed.
+# If the system has a 64-bit processor, both arch 32 and 64 need to be included in
+# the audit file because it is not possible to know if the computer will be booted
+# in 64 or 32 bit mode or for which architecture a binary is compiled.
 [ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
 for ARCH in "${RULE_ARCHS[@]}"

--- a/shared/fixes/bash/audit_rules_kernel_module_loading_delete.sh
+++ b/shared/fixes/bash/audit_rules_kernel_module_loading_delete.sh
@@ -9,7 +9,7 @@
 #       it's not required on a 64-bit system to check also for the presence
 #       of 32-bit's equivalent of the corresponding rule. Therefore for
 #       each system it's enought to check presence of system's native rule form.
-[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b64")
+[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
 for ARCH in "${RULE_ARCHS[@]}"
 do

--- a/shared/fixes/bash/audit_rules_kernel_module_loading_init.sh
+++ b/shared/fixes/bash/audit_rules_kernel_module_loading_init.sh
@@ -5,10 +5,10 @@
 
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system
-# Note: 32-bit kernel modules can't be loaded / unloaded on 64-bit kernel =>
-#       it's not required on a 64-bit system to check also for the presence
-#       of 32-bit's equivalent of the corresponding rule. Therefore for
-#       each system it's enought to check presence of system's native rule form.
+# If the system has a 32-bit processor, only the 32-bit rule is needed.
+# If the system has a 64-bit processor, both arch 32 and 64 need to be included in
+# the audit file because it is not possible to know if the computer will be booted
+# in 64 or 32 bit mode or for which architecture a binary is compiled.
 [ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
 for ARCH in "${RULE_ARCHS[@]}"

--- a/shared/fixes/bash/audit_rules_kernel_module_loading_init.sh
+++ b/shared/fixes/bash/audit_rules_kernel_module_loading_init.sh
@@ -9,7 +9,7 @@
 #       it's not required on a 64-bit system to check also for the presence
 #       of 32-bit's equivalent of the corresponding rule. Therefore for
 #       each system it's enought to check presence of system's native rule form.
-[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b64")
+[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
 for ARCH in "${RULE_ARCHS[@]}"
 do


### PR DESCRIPTION
#### Description:
Updated shared/fixes/bash/audit_rules_kernel_module_loading_delete.sh and shared/fixes/bash/audit_rules_kernel_module_loading_init.sh to create rules for 32 bit and 64 bit.

#### Rationale:

Current OVAL check fails because remediation only applies 64 bit remediation on 64 bit systems, but apparently, you can install a 32 bit kernel on 64 bit systems and still boot it.

See:
https://github.com/GovReady/govready/issues/65#issuecomment-68658479
https://github.com/OpenSCAP/scap-security-guide/pull/2522

- Fixes #2227
