### PR TITLE
Small test suite tweaks

### DIFF
--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -396,7 +396,7 @@ class ProfileRunner(GenericRunner):
         return '{0}-{1}'.format(self.profile, self.stage)
 
     def _get_results_file(self):
-        return '{0}-results'.format(self.profile)
+        return '{0}-{1}-results'.format(self.profile, self.stage)
 
     def make_oscap_call(self):
         self.prepare_oscap_ssh_arguments()

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -247,8 +247,8 @@ def run_rule_checks(
     supported_and_available_remediations = set(
         script_params['remediation']).intersection(is_supported)
 
-    if (script_context not in ['fail', 'error']
-            or len(supported_and_available_remediations) == 0):
+    if (script_context not in ['fail', 'error'] or
+            len(supported_and_available_remediations) == 0):
         return success
 
     success = oscap_run_rule('remediation', 'fixed')


### PR DESCRIPTION
#### Description:

- Small tweaks of latest Test Suite update.

#### Rationale:

- Result files in profile runs were missing stage identifier
- pep8: W503 line break before binary operator
