### PR TITLE
Added description how to write new rules.

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -583,6 +583,9 @@ A rule may contain those reference-type elements:
 
 * `oval`: Link to the check that is able to determine whether the scanned system complies to the rule. Checks are written in the OVAL language (see the section Checks for further info).
 * `ident`: This is related to products/CCEs that the rule applies to.
++
+When the rule is related to RHEL, it should have a CCE.
+Available CCEs that can be assigned to new rules are listed in the `shared/references/cce-rhel-avail.txt` file.
 * `ref`: If the rule is part of a standard, it is referenced using the `ref` element. One rule can have multiple `ref` elements.
 
 Some of existing rule definitions contain elements that use macros.
@@ -595,7 +598,9 @@ For example, the rule identified by `partition_for_tmp` defined in `shared/xccdf
 
 Checks are connected to rules by the `oval` rule element.
 Remediations (i.e. fixes) are assigned to rules based on their basename.
-Therefore, the rule `sshd_print_last_log` has a `bash` check associated as there is a `bash` script `shared/fixes/bash/sshd_print_last_log.sh`. As there is an Ansible playbook `shared/fixes/ansible/sshd_print_last_log.yml`, the rule has also an associated Ansible fix.
+Therefore, the rule `sshd_print_last_log` has a `bash` fix associated as there is a `bash` script `shared/fixes/bash/sshd_print_last_log.sh`. As there is an Ansible playbook `shared/fixes/ansible/sshd_print_last_log.yml`, the rule has also an Ansible fix associated.
+
+
 
 
 ==== Checks

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -555,8 +555,37 @@ Contributions can be made for rules, checks, remediations or even utilities. The
 
 ==== Rules
 
-...
-// shared/references/cce-rhel-avail.txt
+Rules are input in a quasi-XCCDF format, which is basically an XML container.
+They describe the desired state of the system and may contain labels if they are parts of higher-level standards.
+
+Rules are defined as members of a `Group` in a XML file, most likely below the `shared/xccdf` directory.
+The exact location depends on a rule cathegory.
+For an example of rule group, see `shared/xccdf/system/software/disk_partitioning.xml`.
+
+A rule itself has these attributes:
+
+* `id`: The primary key for the rule. It is referenced by profiles.
+* `severity`: Can be `low`, `medium`, or `high`.
+
+A rule contains those elements:
+
+* `title`: Human-readable title of the rule.
+* `rationale`: Human-readable description of the reason why the rule exists and why it is important from the technical point of view.
+* `description`: Human-readable description, which provides broader context for non-experts.
+* `ocil`: Defines assert statements. The `clause` attribute contains the statement, and the element text describes how to determine whether the statement is true or false. Check out rule `encrypt_partitions` in `shared/xccdf/system/software/disk_partitioning.xml`, that contains the `partitions do not have a type of crypto_LUKS` clause.
+
+A rule may contain those element tags:
+
+* `oval`: Link to the check that is able to determine whether the scanned system complies to the rule. Checks are written in the OVAL language (see the section Checks for further info).
+* `ident`: This is related to products/CCEs that the rule applies to.
+* `ref`: If the rule is part of a standard, it is referenced using the `ref` element. One rule can have multiple `ref` elements.
+
+Rules are disabled by default - even if the scanner knows about them, they are effectively ignored during the scan or remediation.
+A rule may be enabled by a profile, so when the scanner is scanning the given profile, the profile is taken into account.
+For example, the rule identified by `partition_for_tmp` defined in `shared/xccdf/system/software/disk_partitioning.xml` is enabled by the `RHEL7` `C2S` profile in `rhel7/profiles/C2S.xml`.
+
+Checks and remediations are not part of rule definitions - those are just referenced by rules.
+
 
 ==== Checks
 

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -556,8 +556,10 @@ Contributions can be made for rules, checks, remediations or even utilities. The
 ==== Rules
 
 Rules are input in a simplified XCCDF format, which is basically an XML container.
-Rules are defined as members of a `Group` in a XML file, most likely below the `shared/xccdf` directory.
-The exact location depends on a rule cathegory.
+Rules are defined as members of a `Group` in a XML file.
+In the likely case if the rule can be reused in multiple platforms, the file containing the definition will be placed under the `shared/xccdf` directory.
+If the rule is platform-specific, place it under the `<platform>/xccdf` directory.
+The exact location depends on a rule category.
 For an example of rule group, see `shared/xccdf/system/software/disk_partitioning.xml`.
 
 Rules describe the desired state of the system and may contain references if they are parts of higher-level standards.
@@ -574,9 +576,9 @@ A rule contains those elements that are text-centric:
 * `rationale`: Human-readable HTML description of the reason why the rule exists and why it is important from the technical point of view. For example, rationale of the `partition_for_tmp` rule states that:
 +
 The <tt>/tmp</tt> partition is used as temporary storage by many programs. Placing <tt>/tmp</tt> in its own partition enables the setting of more restrictive mount options, which can help protect programs which use it.
-* `description`: Human-readable HTML description, which provides broader context for non-experts than the rationale. For example, rationale of the `partition_for_tmp` rule states that:
+* `description`: Human-readable HTML description, which provides broader context for non-experts than the rationale. For example, description of the `partition_for_tmp` rule states that:
 +
-The <tt>/tmp</tt> partition is used as temporary storage by many programs. Placing <tt>/tmp</tt> in its own partition enables the setting of more restrictive mount options, which can help protect programs which use it.
+The <tt>/var/tmp</tt> directory is a world-writable directory used for temporary file storage. Ensure it has its own partition or logical volume at installation time, or migrate it using LVM.
 * `ocil`: Defines assert statements. The `clause` attribute contains the statement, and the element text describes how to determine whether the statement is true or false. Check out rule `encrypt_partitions` in `shared/xccdf/system/software/disk_partitioning.xml`, that contains the `partitions do not have a type of crypto_LUKS` clause.
 
 A rule may contain those reference-type elements:
@@ -592,9 +594,9 @@ Some of existing rule definitions contain elements that use macros.
 You can find definitions of those macros in one of the files in the `shared/transforms` directory.
 For example, the `ocil` element of `partition_for_tmp` uses the `partition-check-macro`, which is defined in `shared/transforms/shared_shorthand2xccdf.xslt`.
 
-Rules are unselected by default - even if the scanner knows about them, they are effectively ignored during the scan or remediation.
-A rule may be selected by a profile, so when the scanner is scanning using a profile the rule belongs to, the rule is taken into account.
-For example, the rule identified by `partition_for_tmp` defined in `shared/xccdf/system/software/disk_partitioning.xml` belongs to the `RHEL7 C2S` profile in `rhel7/profiles/C2S.xml`.
+Rules are unselected by default - even if the scanner reads rule definitions, they are effectively ignored during the scan or remediation.
+A rule may be selected by any number of profiles, so when the scanner is scanning using a profile the rule is included in, the rule is taken into account.
+For example, the rule identified by `partition_for_tmp` defined in `shared/xccdf/system/software/disk_partitioning.xml` is included in the `RHEL7 C2S` profile in `rhel7/profiles/C2S.xml`.
 
 Checks are connected to rules by the `oval` rule element.
 Remediations (i.e. fixes) are assigned to rules based on their basename.

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -555,36 +555,47 @@ Contributions can be made for rules, checks, remediations or even utilities. The
 
 ==== Rules
 
-Rules are input in a quasi-XCCDF format, which is basically an XML container.
-They describe the desired state of the system and may contain labels if they are parts of higher-level standards.
-
+Rules are input in a simplified XCCDF format, which is basically an XML container.
 Rules are defined as members of a `Group` in a XML file, most likely below the `shared/xccdf` directory.
 The exact location depends on a rule cathegory.
 For an example of rule group, see `shared/xccdf/system/software/disk_partitioning.xml`.
+
+Rules describe the desired state of the system and may contain references if they are parts of higher-level standards.
+For example, the `partition_for_tmp` rule from the mentioned file is part of STIG, so definition of the rule contains the `ref` reference to it.
 
 A rule itself has these attributes:
 
 * `id`: The primary key for the rule. It is referenced by profiles.
 * `severity`: Can be `low`, `medium`, or `high`.
 
-A rule contains those elements:
+A rule contains those elements that are text-centric:
 
 * `title`: Human-readable title of the rule.
-* `rationale`: Human-readable description of the reason why the rule exists and why it is important from the technical point of view.
-* `description`: Human-readable description, which provides broader context for non-experts.
+* `rationale`: Human-readable HTML description of the reason why the rule exists and why it is important from the technical point of view. For example, rationale of the `partition_for_tmp` rule states that:
++
+The <tt>/tmp</tt> partition is used as temporary storage by many programs. Placing <tt>/tmp</tt> in its own partition enables the setting of more restrictive mount options, which can help protect programs which use it.
+* `description`: Human-readable HTML description, which provides broader context for non-experts than the rationale. For example, rationale of the `partition_for_tmp` rule states that:
++
+The <tt>/tmp</tt> partition is used as temporary storage by many programs. Placing <tt>/tmp</tt> in its own partition enables the setting of more restrictive mount options, which can help protect programs which use it.
 * `ocil`: Defines assert statements. The `clause` attribute contains the statement, and the element text describes how to determine whether the statement is true or false. Check out rule `encrypt_partitions` in `shared/xccdf/system/software/disk_partitioning.xml`, that contains the `partitions do not have a type of crypto_LUKS` clause.
 
-A rule may contain those element tags:
+A rule may contain those reference-type elements:
 
 * `oval`: Link to the check that is able to determine whether the scanned system complies to the rule. Checks are written in the OVAL language (see the section Checks for further info).
 * `ident`: This is related to products/CCEs that the rule applies to.
 * `ref`: If the rule is part of a standard, it is referenced using the `ref` element. One rule can have multiple `ref` elements.
 
-Rules are disabled by default - even if the scanner knows about them, they are effectively ignored during the scan or remediation.
-A rule may be enabled by a profile, so when the scanner is scanning the given profile, the profile is taken into account.
-For example, the rule identified by `partition_for_tmp` defined in `shared/xccdf/system/software/disk_partitioning.xml` is enabled by the `RHEL7` `C2S` profile in `rhel7/profiles/C2S.xml`.
+Some of existing rule definitions contain elements that use macros.
+You can find definitions of those macros in one of the files in the `shared/transforms` directory.
+For example, the `ocil` element of `partition_for_tmp` uses the `partition-check-macro`, which is defined in `shared/transforms/shared_shorthand2xccdf.xslt`.
 
-Checks and remediations are not part of rule definitions - those are just referenced by rules.
+Rules are unselected by default - even if the scanner knows about them, they are effectively ignored during the scan or remediation.
+A rule may be selected by a profile, so when the scanner is scanning using a profile the rule belongs to, the rule is taken into account.
+For example, the rule identified by `partition_for_tmp` defined in `shared/xccdf/system/software/disk_partitioning.xml` belongs to the `RHEL7 C2S` profile in `rhel7/profiles/C2S.xml`.
+
+Checks are connected to rules by the `oval` rule element.
+Remediations (i.e. fixes) are assigned to rules based on their basename.
+Therefore, the rule `sshd_print_last_log` has a `bash` check associated as there is a `bash` script `shared/fixes/bash/sshd_print_last_log.sh`. As there is an Ansible playbook `shared/fixes/ansible/sshd_print_last_log.yml`, the rule has also an associated Ansible fix.
 
 
 ==== Checks

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -600,9 +600,6 @@ Checks are connected to rules by the `oval` rule element.
 Remediations (i.e. fixes) are assigned to rules based on their basename.
 Therefore, the rule `sshd_print_last_log` has a `bash` fix associated as there is a `bash` script `shared/fixes/bash/sshd_print_last_log.sh`. As there is an Ansible playbook `shared/fixes/ansible/sshd_print_last_log.yml`, the rule has also an Ansible fix associated.
 
-
-
-
 ==== Checks
 
 Checks are used to evaluate a Rule. They are written using a custom OVAL syntax and are stored as xml files inside the _checks/oval_ directory for the desired platform.


### PR DESCRIPTION
#### Description:

Added description how to write new rules. This will help to get new contributors on board quickly.

#### Rationale:

Section `Rules` of the contributor guide was empty.