### PR TITLE
Changed test suite benchmark specification to use Ref-Id.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -42,12 +42,12 @@ scenario is run separately to eliminate need for cleanup.
 Example of evaluation of default profile (common):
 
 ```
-./test_suite.py profile --hypervisor qemu:///system --domain ssg-test-suite-centos --datastream ssg-centos7-ds.xml --ref-id rid profile-id
+./test_suite.py profile --hypervisor qemu:///system --domain ssg-test-suite-centos --datastream ssg-centos7-ds.xml --xccdf-id xccdf-id profile-id
 ```
 
 where the domain (in this case `ssg-test-suite-centos`), is name of the virtual machine,
 datastream is a datastream file in the local filesystem,
-the ref-id can be obtained by running `oscap info` over the datastream XML,
+the `xccdf-id` can be obtained by running `oscap info` over the datastream XML (look for `Ref-ID`),
 and
 profile-id is not matched by the suffix, so specify it literally (use `oscap info --profiles` to see available profiles).
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -42,12 +42,12 @@ scenario is run separately to eliminate need for cleanup.
 Example of evaluation of default profile (common):
 
 ```
-./test_suite.py profile --hypervisor qemu:///system --domain ssg-test-suite-centos --datastream ssg-centos7-ds.xml --benchmark-id bid profile-id
+./test_suite.py profile --hypervisor qemu:///system --domain ssg-test-suite-centos --datastream ssg-centos7-ds.xml --ref-id rid profile-id
 ```
 
 where the domain (in this case `ssg-test-suite-centos`), is name of the virtual machine,
 datastream is a datastream file in the local filesystem,
-the benchmark id can be identified by examining the datastream XML,
+the ref-id can be obtained by running `oscap info` over the datastream XML,
 and
 profile-id is not matched by the suffix, so specify it literally (use `oscap info --profiles` to see available profiles).
 

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import atexit
 import logging
 import sys
-import xml.etree.cElementTree as ET
 
 import ssg_test_suite.oscap
 import ssg_test_suite.virt

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -10,10 +10,10 @@ import shlex
 import string
 import subprocess
 import sys
-import xml.etree.cElementTree as ET
 
 import ssg_test_suite.oscap as oscap
 import ssg_test_suite.virt
+from ssg_test_suite import xml_operations
 from ssg_test_suite.virt import SnapshotStack
 from ssg_test_suite.log import LogHelper
 from data import iterate_over_rules
@@ -42,15 +42,11 @@ def get_viable_profiles(selected_profiles, datastream, benchmark):
     """Read datastream, and return set intersection of profiles of given
     benchmark and those provided in `selected_profiles` parameter.
     """
-    NS = {'xccdf': "http://checklists.nist.gov/xccdf/1.2"}
 
     valid_profiles = []
-    root = ET.parse(datastream).getroot()
-    benchmark_node = root.find("*//xccdf:Benchmark[@id='{0}']".format(benchmark), NS)
-    if benchmark_node is None:
-        logging.error('Benchmark not found within DataStream')
-        return []
-    for ds_profile_element in benchmark_node.findall('xccdf:Profile', NS):
+    all_profiles = xml_operations.get_all_profiles_in_benchmark(
+        datastream, benchmark, logging)
+    for ds_profile_element in all_profiles:
         ds_profile = ds_profile_element.attrib['id']
         if 'ALL' in selected_profiles:
             valid_profiles += [ds_profile]

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python2
+import xml.etree.cElementTree as ET
+
+import logging
+
+NAMESPACES = {
+    'xccdf': "http://checklists.nist.gov/xccdf/1.2",
+    'ds': "http://scap.nist.gov/schema/scap/source/1.2",
+    'xlink': "http://www.w3.org/1999/xlink",
+}
+
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+
+def infer_benchmark_id_from_component_ref_id(datastream, ref_id):
+    root = ET.parse(datastream).getroot()
+    component_ref_node = root.find("*//ds:component-ref[@id='{0}']"
+                                   .format(ref_id), NAMESPACES)
+    if component_ref_node is None:
+        msg = (
+            'Component reference of Ref-Id {} not found within datastream'
+            .format(ref_id))
+        raise RuntimeError(msg)
+
+    comp_id = component_ref_node.get('{%s}href' % NAMESPACES['xlink'])
+    comp_id = comp_id.lstrip('#')
+    component_node = root.find("ds:component[@id='{0}']"
+                               .format(comp_id), NAMESPACES)
+    if component_node is None:
+        msg = 'Component of Id {} not found within datastream'.format(comp_id)
+        raise RuntimeError(msg)
+
+    benchmark_node = component_node.find("xccdf:Benchmark", NAMESPACES)
+    if benchmark_node is None:
+        msg = (
+            'Benchmark not found within comonent of Id {}'
+            .format(comp_id)
+        )
+        raise RuntimeError(msg)
+
+    return benchmark_node.get('id')
+
+
+def get_all_profiles_in_benchmark(datastream, benchmark_id, logging=None):
+    root = ET.parse(datastream).getroot()
+    benchmark_node = root.find(
+        "*//xccdf:Benchmark[@id='{0}']".format(benchmark_id), NAMESPACES)
+    if benchmark_node is None:
+        if logging is not None:
+            logging.error(
+                "Benchmark ID '{}' not found within DataStream"
+                .format(benchmark_id))
+        return []
+
+    all_profiles = benchmark_node.findall('xccdf:Profile', NAMESPACES)
+    return all_profiles

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -25,16 +25,12 @@ def infer_benchmark_id_from_component_ref_id(datastream, ref_id):
 
     comp_id = component_ref_node.get('{%s}href' % NAMESPACES['xlink'])
     comp_id = comp_id.lstrip('#')
-    component_node = root.find("ds:component[@id='{0}']"
-                               .format(comp_id), NAMESPACES)
-    if component_node is None:
-        msg = 'Component of Id {} not found within datastream'.format(comp_id)
-        raise RuntimeError(msg)
 
-    benchmark_node = component_node.find("xccdf:Benchmark", NAMESPACES)
+    query = ".//ds:component[@id='{}']/xccdf:Benchmark".format(comp_id)
+    benchmark_node = root.find(query, NAMESPACES)
     if benchmark_node is None:
         msg = (
-            'Benchmark not found within comonent of Id {}'
+            'Benchmark not found within component of Id {}'
             .format(comp_id)
         )
         raise RuntimeError(msg)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -6,12 +6,14 @@ import logging
 import os
 import os.path
 import time
+import sys
 
 from ssg_test_suite.log import LogHelper
 import ssg_test_suite.oscap
 import ssg_test_suite.virt
 import ssg_test_suite.profile
 import ssg_test_suite.rule
+from ssg_test_suite import xml_operations
 
 
 parser = argparse.ArgumentParser()
@@ -38,12 +40,12 @@ common_parser.add_argument("--datastream",
                            required=True,
                            help=("Path to the Source DataStream on this "
                                  "machine which is going to be tested"))
-common_parser.add_argument("--benchmark-id",
-                           dest="benchmark_id",
-                           metavar="BENCHMARK",
+common_parser.add_argument("--ref-id",
+                           dest="ref_id",
+                           metavar="REF-ID",
                            required=True,
-                           help=("Benchmark in the Source DataStream "
-                                 "to be used."))
+                           help="Reference ID related to benchmark to be used."
+                                " Get one using 'oscap info <datastream>'.")
 common_parser.add_argument("--loglevel",
                            dest="loglevel",
                            metavar="LOGLEVEL",
@@ -108,6 +110,16 @@ log = logging.getLogger()
 # this is general logger level - needs to be
 # debug otherwise it cuts silently everything
 log.setLevel(logging.DEBUG)
+
+try:
+    bench_id = xml_operations.infer_benchmark_id_from_component_ref_id(
+        options.datastream, options.ref_id)
+    options.benchmark_id = bench_id
+except RuntimeError as exc:
+    msg = "Error inferring benchmark ID: {}".format(str(exc))
+    logging.error(msg)
+    sys.exit(1)
+
 
 LogHelper.add_console_logger(log, options.loglevel)
 # logging dir needs to be created based on other options

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -40,8 +40,8 @@ common_parser.add_argument("--datastream",
                            required=True,
                            help=("Path to the Source DataStream on this "
                                  "machine which is going to be tested"))
-common_parser.add_argument("--ref-id",
-                           dest="ref_id",
+common_parser.add_argument("--xccdf-id",
+                           dest="xccdf_id",
                            metavar="REF-ID",
                            required=True,
                            help="Reference ID related to benchmark to be used."
@@ -113,7 +113,7 @@ log.setLevel(logging.DEBUG)
 
 try:
     bench_id = xml_operations.infer_benchmark_id_from_component_ref_id(
-        options.datastream, options.ref_id)
+        options.datastream, options.xccdf_id)
     options.benchmark_id = bench_id
 except RuntimeError as exc:
     msg = "Error inferring benchmark ID: {}".format(str(exc))


### PR DESCRIPTION
This PR allows to specify the benchmark operated on by the test suite using a component reference ID. This is more convenient as the ID can be queried by 'oscap info'. 

The change makes the command-line interface backwards-incompatible, but backward compatibility can be implemented at minor cost.

Aside from that, a small refactoring was performed, and a XML parsing functionality was moved to a new module, so they can share namespace definitions.