### PR TITLE
HTML tables for ANSSI Rules in RHEL7

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -984,6 +984,26 @@ macro(ssg_build_html_nistrefs_table PRODUCT PROFILE)
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
 endmacro()
 
+macro(ssg_build_html_anssirefs_table PRODUCT PROFILE)
+    add_custom_command(
+        OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-anssirefs-${PROFILE}.html"
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
+        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam profile "${PROFILE}" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-anssirefs-${PROFILE}.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileanssirefs.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileanssirefs.xslt"
+        COMMENT "[${PRODUCT}-tables] generating HTML ANSSI refs table for ${PROFILE} profile"
+    )
+    add_custom_target(
+        generate-${PRODUCT}-table-anssirefs-${PROFILE}
+        DEPENDS "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-anssirefs-${PROFILE}.html"
+    )
+    add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-anssirefs-${PROFILE})
+
+    install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-anssirefs-${PROFILE}.html"
+        DESTINATION "${SSG_TABLE_INSTALL_DIR}")
+endmacro()
+
 macro(ssg_build_html_cce_table PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -988,11 +988,11 @@ macro(ssg_build_html_anssirefs_table PRODUCT PROFILE)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-anssirefs-${PROFILE}.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
-        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam profile "${PROFILE}" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-anssirefs-${PROFILE}.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileanssirefs.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam profile "anssi_${PROFILE}" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-anssirefs-${PROFILE}.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileanssirefs.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileanssirefs.xslt"
-        COMMENT "[${PRODUCT}-tables] generating HTML ANSSI refs table for ${PROFILE} profile"
+        COMMENT "[${PRODUCT}-tables] generating HTML ANSSI refs table for anssi_${PROFILE} profile"
     )
     add_custom_target(
         generate-${PRODUCT}-table-anssirefs-${PROFILE}

--- a/rhel7/CMakeLists.txt
+++ b/rhel7/CMakeLists.txt
@@ -21,6 +21,11 @@ ssg_build_html_nistrefs_table(${PRODUCT} "ospp-${PRODUCT}")
 ssg_build_html_nistrefs_table(${PRODUCT} "C2S")
 ssg_build_html_nistrefs_table(${PRODUCT} "stig-${PRODUCT}-disa")
 
+ssg_build_html_anssirefs_table(${PRODUCT} "anssi_nt28_minimal")
+ssg_build_html_anssirefs_table(${PRODUCT} "anssi_nt28_intermediary")
+ssg_build_html_anssirefs_table(${PRODUCT} "anssi_nt28_enhanced")
+ssg_build_html_anssirefs_table(${PRODUCT} "anssi_nt28_high")
+
 ssg_build_html_cce_table(${PRODUCT})
 
 ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE} ${DISA_SRG_VERSION})

--- a/rhel7/CMakeLists.txt
+++ b/rhel7/CMakeLists.txt
@@ -14,6 +14,7 @@ ssg_build_html_table_by_ref(${PRODUCT} "nist")
 ssg_build_html_table_by_ref(${PRODUCT} "cis")
 ssg_build_html_table_by_ref(${PRODUCT} "cui")
 ssg_build_html_table_by_ref(${PRODUCT} "pcidss")
+ssg_build_html_table_by_ref(${PRODUCT} "anssi")
 
 ssg_build_html_nistrefs_table(${PRODUCT} "common")
 ssg_build_html_nistrefs_table(${PRODUCT} "ospp-${PRODUCT}")

--- a/rhel7/CMakeLists.txt
+++ b/rhel7/CMakeLists.txt
@@ -21,10 +21,10 @@ ssg_build_html_nistrefs_table(${PRODUCT} "ospp-${PRODUCT}")
 ssg_build_html_nistrefs_table(${PRODUCT} "C2S")
 ssg_build_html_nistrefs_table(${PRODUCT} "stig-${PRODUCT}-disa")
 
-ssg_build_html_anssirefs_table(${PRODUCT} "anssi_nt28_minimal")
-ssg_build_html_anssirefs_table(${PRODUCT} "anssi_nt28_intermediary")
-ssg_build_html_anssirefs_table(${PRODUCT} "anssi_nt28_enhanced")
-ssg_build_html_anssirefs_table(${PRODUCT} "anssi_nt28_high")
+ssg_build_html_anssirefs_table(${PRODUCT} "nt28_minimal")
+ssg_build_html_anssirefs_table(${PRODUCT} "nt28_intermediary")
+ssg_build_html_anssirefs_table(${PRODUCT} "nt28_enhanced")
+ssg_build_html_anssirefs_table(${PRODUCT} "nt28_high")
 
 ssg_build_html_cce_table(${PRODUCT})
 

--- a/rhel7/transforms/xccdf2table-profileanssirefs.xslt
+++ b/rhel7/transforms/xccdf2table-profileanssirefs.xslt
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../shared/transforms/shared_xccdf2table-profileanssirefs.xslt"/>
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/shared/transforms/shared_xccdf2table-byref.xslt
+++ b/shared/transforms/shared_xccdf2table-byref.xslt
@@ -139,6 +139,10 @@
 
 			<xsl:if test="$ref='anssi'">
 				<xsl:for-each select="//cdf:reference[@href=$anssiuri]" >
+					<!-- There can be ANSSI references for NT28, NT007 and NT012,
+						let's sort by document and requirement number -->
+					<xsl:sort select="substring-before(.,'(')" data-type="text" />
+					<xsl:sort select="substring-before(substring-after(.,'(R'),')')" data-type="number" />
 					<xsl:call-template name="rule-output">
 						<xsl:with-param name="refinfo" select="." />
 					</xsl:call-template>

--- a/shared/transforms/shared_xccdf2table-profileanssirefs.xslt
+++ b/shared/transforms/shared_xccdf2table-profileanssirefs.xslt
@@ -53,7 +53,8 @@
 		<tr>
 			<td> 
 				<xsl:for-each select="cdf:reference[@href=$anssiuri]">
-					<xsl:sort data-type="text" select="text()"/>
+					<xsl:sort select="substring-before(.,'(')" data-type="text" />
+					<xsl:sort select="substring-before(substring-after(.,'(R'),')')" data-type="number" />
 					<xsl:value-of select="text()"/>
 					<br/>
 				</xsl:for-each>

--- a/shared/transforms/shared_xccdf2table-profileanssirefs.xslt
+++ b/shared/transforms/shared_xccdf2table-profileanssirefs.xslt
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<!-- this style sheet expects parameter $profile, which is the id of the Profile to be shown -->
+
+	<xsl:template match="/">
+		<html>
+		<head>
+			<title><xsl:value-of select="/cdf:Benchmark/cdf:Profile[@id=$profile]/cdf:title" /></title>
+		</head>
+		<body>
+			<br/>
+			<br/>
+			<div style="text-align: center; font-size: x-large; font-weight:bold"><xsl:value-of select="/cdf:Benchmark/cdf:Profile[@id=$profile]/cdf:title" /></div>
+			<br/>
+			<br/>
+			<xsl:apply-templates select="cdf:Benchmark"/>
+		</body>
+		</html>
+	</xsl:template>
+
+
+	<xsl:template match="cdf:Benchmark">
+		<xsl:call-template name="table-style" />
+
+		<table>
+			<thead>
+				<td>ANSSI Mapping</td>
+				<td>Rule Title</td>
+				<td>Description</td>
+				<td>Rationale</td>
+				<td>Variable Setting</td>
+			</thead>
+		<xsl:for-each select="/cdf:Benchmark/cdf:Profile[@id=$profile]/cdf:select">
+			<xsl:variable name="idrefer" select="@idref" />
+			<xsl:variable name="enabletest" select="@selected" />
+			<xsl:for-each select="//cdf:Rule">
+				<xsl:call-template name="ruleplate">
+					<xsl:with-param name="idreference" select="$idrefer" />
+					<xsl:with-param name="enabletest" select="$enabletest" />
+				</xsl:call-template>
+			</xsl:for-each>
+		</xsl:for-each>
+
+		</table>
+	</xsl:template>
+
+
+	<xsl:template match="cdf:Rule" name="ruleplate">
+		<xsl:param name="idreference" />
+		<xsl:param name="enabletest" />
+		<xsl:if test="@id=$idreference and $enabletest='true'">
+		<tr>
+			<td> 
+				<xsl:for-each select="cdf:reference[@href=$anssiuri]">
+					<xsl:sort data-type="text" select="text()"/>
+					<xsl:value-of select="text()"/>
+					<br/>
+				</xsl:for-each>
+			</td> 
+			<td> <xsl:value-of select="cdf:title" /></td>
+			<td> <xsl:apply-templates select="cdf:description"/> </td>
+			<!-- call template to grab text and also child nodes (which should all be xhtml)  -->
+			<td> <xsl:apply-templates select="cdf:rationale"/> </td>
+			<!-- need to resolve <sub idref=""> here  -->
+			<td> <!-- TODO: print refine-value from profile associated with rule --> </td>
+		</tr>
+		</xsl:if>
+	</xsl:template>
+
+
+	<xsl:template match="cdf:check">
+		<xsl:for-each select="cdf:check-export">
+			<xsl:variable name="rulevar" select="@value-id" />
+				<!--<xsl:value-of select="$rulevar" />:-->
+				<xsl:for-each select="/cdf:Benchmark/cdf:Profile[@id=$profile]/cdf:refine-value">
+					<xsl:if test="@idref=$rulevar">
+						<xsl:value-of select="@selector" />
+					</xsl:if>
+				</xsl:for-each>
+		</xsl:for-each>
+	</xsl:template>
+
+
+    <!-- getting rid of XHTML namespace -->
+	<xsl:template match="xhtml:*">
+		<xsl:element name="{local-name()}">
+			<xsl:apply-templates select="node()|@*"/>
+		</xsl:element>
+	</xsl:template>
+
+    <xsl:template match="@*|node()">
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()"/>
+		</xsl:copy>
+	</xsl:template>
+
+    <xsl:template match="cdf:description">
+             <!-- print all the text and children (xhtml elements) of the description -->
+        <xsl:apply-templates select="@*|node()" />
+            </xsl:template>
+
+    <xsl:template match="cdf:rationale">
+             <!-- print all the text and children (xhtml elements) of the description -->
+        <xsl:apply-templates select="@*|node()" />
+            </xsl:template>
+
+
+
+</xsl:stylesheet>

--- a/shared/xccdf/system/logging.xml
+++ b/shared/xccdf/system/logging.xml
@@ -33,7 +33,7 @@ system logging services.
 </rationale>
 <ident prodtype="rhel7" cce="80187-8" />
 <oval id="package_rsyslog_installed" />
-<ref nist="AU-9(2)" disa="1311,1312" cis="4.2.3" />
+<ref nist="AU-9(2)" disa="1311,1312" cis="4.2.3" anssi="NT28(R5),NT28(R46)"/>
 </Rule>
 
 <Rule id="service_rsyslog_enabled" severity="medium" prodtype="rhel7">

--- a/shared/xccdf/system/software/sudo.xml
+++ b/shared/xccdf/system/software/sudo.xml
@@ -33,7 +33,7 @@ is critical that the user re-authenticate.
 <ident prodtype="rhel7" cce="80351-0" />
 <oval id="sudo_remove_nopasswd" />
 <ref prodtype="rhel7" stigid="010340" />
-<ref nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
+<ref nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158" anssi="NT28(R5)"/>
 </Rule>
 
 <Rule id="sudo_remove_no_authenticate" severity="medium" prodtype="rhel7">
@@ -59,7 +59,7 @@ is critical that the user re-authenticate.
 <ident prodtype="rhel7" cce="80350-2" />
 <oval id="sudo_remove_no_authenticate" />
 <ref prodtype="rhel7" stigid="010350" />
-<ref nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158"/>
+<ref nist="IA-11" disa="2038" srg="SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158" anssi="NT28(R5)"/>
 </Rule>
 
 </Group>


### PR DESCRIPTION
#### Description:

- Adds HTML table listing all Rules that reference an ANSSI document
  - `table-rhel7-anssirefs.html`
- Adds a profile for each RHEL7 ANSSI Profile, listing their Rules and its ANSSI references
  - `table-rhel7-anssirefs-nt28_minimal.html`
  - `table-rhel7-anssirefs-nt28_intermediary.html`
  - `table-rhel7-anssirefs-nt28_enhanced.html`
  - `table-rhel7-anssirefs-nt28_high.html`

#### Rationale:

 - `table-rhel7-anssirefs.html` is useful to track which SSG Rules covers which ANSSI requirements.
 - Tables by Profiles are useful to track what SSG Rules are covered in each Security Level defined by ANSSI NT28.

EDIT: table names changed from   `table-rhel7-anssirefs-anssi_nt28_minimal.html` to    `table-rhel7-anssirefs-nt28_minimal.html`