### PR TITLE
Add test scenarios of rule_umask_for_daemons.

### DIFF
--- a/tests/data/group_system/group_permissions/group_restrictions/group_daemon_umask/rule_umask_for_daemons/adequate.pass.sh
+++ b/tests/data/group_system/group_permissions/group_restrictions/group_daemon_umask/rule_umask_for_daemons/adequate.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_NOTFOUND
+
+sed -i 's/.*umask.*/umask 022/g' /etc/init.d/functions

--- a/tests/data/group_system/group_permissions/group_restrictions/group_daemon_umask/rule_umask_for_daemons/comment.fail.sh
+++ b/tests/data/group_system/group_permissions/group_restrictions/group_daemon_umask/rule_umask_for_daemons/comment.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_NOTFOUND
+
+sed -i 's/.*umask.*/# umask 077/g' /etc/init.d/functions

--- a/tests/data/group_system/group_permissions/group_restrictions/group_daemon_umask/rule_umask_for_daemons/line_not_there.fail.sh
+++ b/tests/data/group_system/group_permissions/group_restrictions/group_daemon_umask/rule_umask_for_daemons/line_not_there.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_NOTFOUND
+
+sed -i '/.*umask.*/d' /etc/init.d/functions

--- a/tests/data/group_system/group_permissions/group_restrictions/group_daemon_umask/rule_umask_for_daemons/strong_weak.fail.sh
+++ b/tests/data/group_system/group_permissions/group_restrictions/group_daemon_umask/rule_umask_for_daemons/strong_weak.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_NOTFOUND
+
+sed -i 's/.*umask.*/umask 007/g' /etc/init.d/functions

--- a/tests/data/group_system/group_permissions/group_restrictions/group_daemon_umask/rule_umask_for_daemons/super_strong.pass.sh
+++ b/tests/data/group_system/group_permissions/group_restrictions/group_daemon_umask/rule_umask_for_daemons/super_strong.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_NOTFOUND
+
+sed -i 's/.*umask.*/umask 077/g' /etc/init.d/functions


### PR DESCRIPTION


#### Description:

- Test scenarios to cover rule_umask_for_daemons. Profile is deliberately NOTFOUND, because there is no profile in RHEL7 with this rule enabled.

#### Rationale:

- Extending test coverage.

- Covers RHBZ#1520493
