### PR TITLE
Specify default LUKS cipher and minimum key size

### DIFF
--- a/rhel6/xccdf/system/software/disk_partitioning.xml
+++ b/rhel6/xccdf/system/software/disk_partitioning.xml
@@ -146,7 +146,10 @@ Any <i>PASSPHRASE</i> is stored in the Kickstart in plaintext, and the Kickstart
 Omitting the <tt>--passphrase=</tt> option from the partition definition will cause the
 installer to pause and interactively ask for the passphrase during installation.
 <br /><br />
-Detailed information on encrypting partitions using LUKS can be found on
+By default, the <tt>Anaconda</tt> installer uses <tt>aes-xts-plain64</tt> cipher
+with a minimum <tt>512</tt> bit key size which should be compatible with FIPS enabled.
+<br /><br />
+Detailed information on encrypting partitions using LUKS or LUKS ciphers can be found on
 the Red Hat Documentation web site:<br />
 <weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security_Guide/chap-Security_Guide-Encryption.html#sect-Security_Guide-LUKS_Disk_Encryption"/>
 </description>

--- a/shared/xccdf/system/software/disk_partitioning.xml
+++ b/shared/xccdf/system/software/disk_partitioning.xml
@@ -170,7 +170,10 @@ Any <i>PASSPHRASE</i> is stored in the Kickstart in plaintext, and the Kickstart
 Omitting the <tt>--passphrase=</tt> option from the partition definition will cause the
 installer to pause and interactively ask for the passphrase during installation.
 <br /><br />
-Detailed information on encrypting partitions using LUKS can be found on
+By default, the <tt>Anaconda</tt> installer uses <tt>aes-xts-plain64</tt> cipher
+with a minimum <tt>512</tt> bit key size which should be compatible with FIPS enabled.
+<br /><br />
+Detailed information on encrypting partitions using LUKS or LUKS ciphers can be found on
 the Red Hat Documentation web site:<br />
 <weblink-macro link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html"/>
 </description>


### PR DESCRIPTION
#### Description:

- Recommend LUKS cipher and minimum key size

#### Rationale:

- No cipher or key size recommended for LUKS

- Fixes #806
