### PR TITLE
Small changes to RHEL7 checks and fixes to comply with STIG

### DIFF
--- a/rhel7/checks/oval/sshd_disable_kerb_auth.xml
+++ b/rhel7/checks/oval/sshd_disable_kerb_auth.xml
@@ -26,14 +26,14 @@ the SSH Server.</description>
       </criteria>
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="tests the value of KerberosAuthentication setting in the /etc/ssh/sshd_config file"
   id="test_sshd_disable_kerb_auth" version="1">
     <ind:object object_ref="obj_sshd_disable_kerb_auth" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sshd_disable_kerb_auth" version="1">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)KerberosAuthentication(?-i)[\s]+yes[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)KerberosAuthentication(?-i)[\s]+no[\s]*(?:|(?:#.*))?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/rhel7/checks/oval/sshd_enable_strictmodes.xml
+++ b/rhel7/checks/oval/sshd_enable_strictmodes.xml
@@ -26,14 +26,14 @@ and configurations.</description>
       </criteria>
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="tests the value of StrictModes setting in the /etc/ssh/sshd_config file"
   id="test_sshd_enable_strictmodes" version="1">
     <ind:object object_ref="obj_sshd_enable_strictmodes" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sshd_enable_strictmodes" version="1">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)StrictModes(?-i)[\s]+no[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)StrictModes(?-i)[\s]+yes[\s]*(?:|(?:#.*))?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/rhel7/fixes/bash/audit_rules_sysadmin_actions.sh
+++ b/rhel7/fixes/bash/audit_rules_sysadmin_actions.sh
@@ -4,5 +4,8 @@
 . /usr/share/scap-security-guide/remediation_functions
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-fix_audit_watch_rule "auditctl" "/etc/sudoers" "wa" "actions"
-fix_audit_watch_rule "augenrules" "/etc/sudoers" "wa" "actions"
+fix_audit_watch_rule "auditctl" "/etc/sudoers" "wa" "privileged-actions"
+fix_audit_watch_rule "augenrules" "/etc/sudoers" "wa" "privileged-actions"
+
+fix_audit_watch_rule "auditctl" "/etc/sudoers.d/" "wa" "privileged-actions"
+fix_audit_watch_rule "augenrules" "/etc/sudoers.d/" "wa" "privileged-actions"

--- a/rhel7/fixes/bash/sshd_use_approved_ciphers.sh
+++ b/rhel7/fixes/bash/sshd_use_approved_ciphers.sh
@@ -3,4 +3,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^Ciphers' 'aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc' '@CCENUM@' '%s %s'
+replace_or_append '/etc/ssh/sshd_config' '^Ciphers' 'aes128-ctr,aes192-ctr,aes256-ctr' '@CCENUM@' '%s %s'

--- a/shared/checks/oval/disable_host_auth.xml
+++ b/shared/checks/oval/disable_host_auth.xml
@@ -25,14 +25,14 @@
       </criteria>
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="sshd HostbasedAuthentication" id="test_sshd_hostbasedauthentication"
   version="1">
     <ind:object object_ref="object_sshd_hostbasedauthentication" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_sshd_hostbasedauthentication" version="2">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)HostbasedAuthentication(?-i)[\s]+yes[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)HostbasedAuthentication(?-i)[\s]+no[\s]*(?:|(?:#.*))?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/shared/checks/oval/partition_for_tmp.xml
+++ b/shared/checks/oval/partition_for_tmp.xml
@@ -13,7 +13,7 @@
       <criterion test_ref="test_tmp_partition" comment="/tmp on own partition" />
     </criteria>
   </definition>
-  <linux:partition_test check="all" check_existence="all_exist"
+  <linux:partition_test check="all" check_existence="none_exist"
   id="test_tmp_partition" version="1" comment="/tmp on own partition">
     <linux:object object_ref="object_own_tmp_partition" />
   </linux:partition_test>

--- a/shared/checks/oval/sshd_disable_rhosts.xml
+++ b/shared/checks/oval/sshd_disable_rhosts.xml
@@ -26,7 +26,7 @@
       </criteria>
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="Tests the value of the IgnoreRhosts[\s]*(&lt;:nocomment:&gt;*) setting in the /etc/ssh/sshd_config file"
   id="test_sshd_rsh_emulation_disabled" version="1">
     <ind:object object_ref="obj_sshd_rsh_emulation_disabled" />
@@ -34,7 +34,7 @@
   <ind:textfilecontent54_object id="obj_sshd_rsh_emulation_disabled"
   version="2">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)IgnoreRhosts(?-i)[\s]+no[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)IgnoreRhosts(?-i)[\s]+yes[\s]*(?:|(?:#.*))?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/shared/fixes/bash/audit_rules_kernel_module_loading_delete.sh
+++ b/shared/fixes/bash/audit_rules_kernel_module_loading_delete.sh
@@ -5,17 +5,17 @@
 
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system
-# If the system has a 32-bit processor, only the 32-bit rule is needed.
-# If the system has a 64-bit processor, both arch 32 and 64 need to be included in
-# the audit file because it is not possible to know if the computer will be booted
-# in 64 or 32 bit mode or for which architecture a binary is compiled.
-[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
+# Note: 32-bit kernel modules can't be loaded / unloaded on 64-bit kernel =>
+#       it's not required on a 64-bit system to check also for the presence
+#       of 32-bit's equivalent of the corresponding rule. Therefore for
+#       each system it's enought to check presence of system's native rule form.
+[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b64")
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
 	PATTERN="-a always,exit -F arch=$ARCH -S delete_module \(-F key=\|-k \).*"
-	GROUP="modules"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S delete_module -k modules"
+	GROUP="module-change"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S delete_module -k module-change"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/fixes/bash/audit_rules_kernel_module_loading_init.sh
+++ b/shared/fixes/bash/audit_rules_kernel_module_loading_init.sh
@@ -5,17 +5,17 @@
 
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system
-# If the system has a 32-bit processor, only the 32-bit rule is needed.
-# If the system has a 64-bit processor, both arch 32 and 64 need to be included in
-# the audit file because it is not possible to know if the computer will be booted
-# in 64 or 32 bit mode or for which architecture a binary is compiled.
-[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
+# Note: 32-bit kernel modules can't be loaded / unloaded on 64-bit kernel =>
+#       it's not required on a 64-bit system to check also for the presence
+#       of 32-bit's equivalent of the corresponding rule. Therefore for
+#       each system it's enought to check presence of system's native rule form.
+[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b64")
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
 	PATTERN="-a always,exit -F arch=$ARCH -S init_module \(-F key=\|-k \).*"
-	GROUP="modules"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S init_module -k modules"
+	GROUP="module-change"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S init_module -k module-change"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/fixes/bash/audit_rules_kernel_module_loading_insmod.sh
+++ b/shared/fixes/bash/audit_rules_kernel_module_loading_insmod.sh
@@ -5,5 +5,5 @@
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 
-fix_audit_watch_rule "auditctl" "/usr/sbin/insmod" "x" "modules"
-fix_audit_watch_rule "augenrules" "/usr/sbin/insmod" "x" "modules"
+fix_audit_watch_rule "auditctl" "/sbin/insmod" "x -F auid!=4294967295" "module-change"
+fix_audit_watch_rule "augenrules" "/sbin/insmod" "x -F auid!=4294967295" "module-change"

--- a/shared/fixes/bash/audit_rules_kernel_module_loading_modprobe.sh
+++ b/shared/fixes/bash/audit_rules_kernel_module_loading_modprobe.sh
@@ -5,5 +5,5 @@
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 
-fix_audit_watch_rule "auditctl" "/usr/sbin/modprobe" "x" "modules"
-fix_audit_watch_rule "augenrules" "/usr/sbin/modprobe" "x" "modules"
+fix_audit_watch_rule "auditctl" "/sbin/modprobe" "x -F auid!=4294967295" "module-change"
+fix_audit_watch_rule "augenrules" "/sbin/modprobe" "x -F auid!=4294967295" "module-change"

--- a/shared/fixes/bash/audit_rules_kernel_module_loading_rmmod.sh
+++ b/shared/fixes/bash/audit_rules_kernel_module_loading_rmmod.sh
@@ -5,5 +5,5 @@
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 
-fix_audit_watch_rule "auditctl" "/usr/sbin/rmmod" "x" "modules"
-fix_audit_watch_rule "augenrules" "/usr/sbin/rmmod" "x" "modules"
+fix_audit_watch_rule "auditctl" "/sbin/rmmod" "x -F auid!=4294967295" "module-change"
+fix_audit_watch_rule "augenrules" "/sbin/rmmod" "x -F auid!=4294967295" "module-change"

--- a/shared/fixes/bash/rpm_verify_permissions.sh
+++ b/shared/fixes/bash/rpm_verify_permissions.sh
@@ -9,7 +9,7 @@ declare -a SETPERMS_RPM_LIST
 
 # Create a list of files on the system having permissions different from what
 # is expected by the RPM database
-FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep '^.M' | cut -d ' ' -f4-))
+FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep '^.M' | cut -d ' ' -f5-))
 
 # For each file path from that list:
 # * Determine the RPM package the file path is shipped by,
@@ -29,4 +29,5 @@ SETPERMS_RPM_LIST=( $(echo "${SETPERMS_RPM_LIST[@]}" | sort -n | uniq) )
 for RPM_PACKAGE in "${SETPERMS_RPM_LIST[@]}"
 do
 	rpm --setperms "${RPM_PACKAGE}"
+	rpm --setugids "${RPM_PACKAGE}"
 done


### PR DESCRIPTION
#### Description:

Small changes to properly comply with the STIG

#### Rationale:

**sshd_disable_kerb_auth.xml**: should only pass if the pattern exists (otherwise it should fail and the fix should be applied)
**sshd_enable_strictmodes.xml**: should only pass if the pattern exists (otherwise it should fail and the fix should be applied)
**audit_rules_sysadmin_actions.sh**: missing /etc/sudoers.d/ and changing actions to privileged-actions
**sshd_use_approved_ciphers.sh**: removing unapproved ciphers
**disable_host_auth.xml**: should only pass if the pattern exists (otherwise it should fail and the fix should be applied)
**partition_for_tmp.xml**: previous check would never not pass
**sshd_disable_rhosts.xml**: should only pass if the pattern exists (otherwise it should fail and the fix should be applied)
**audit_rules_kernel_module_loading_delete.sh**: forcing a single architecture and changing modules to module-change
**audit_rules_kernel_module_loading_init.sh**: forcing a single architecture and changing modules to module-change
**audit_rules_kernel_module_loading_insmod.sh**: adding -F option and changing modules to module-change
**audit_rules_kernel_module_loading_modprobe.sh**: adding -F option and changing modules to module-change
**audit_rules_kernel_module_loading_rmmod.sh**: adding -F option and changing modules to module-change
**rpm_verify_permissions.sh**: adding setugids to loop
