### PR TITLE
Ensure libsemanage-python is installed or Ansible SELinux boolean tas…

### DIFF
--- a/shared/templates/template_ANSIBLE_sebool_var
+++ b/shared/templates/template_ANSIBLE_sebool_var
@@ -5,6 +5,11 @@
 # disruption = low
 - (xccdf-var var_%SEBOOLID%)
 
+- name: Ensure libsemanage-python installed
+  package:
+    name: libsemanage-python
+    state: latest
+
 - name: Set SELinux boolean %SEBOOLID% accordingly
   seboolean:
     name: %SEBOOLID%


### PR DESCRIPTION
#### Description:

- Installs libsemanage-python if package is not present on the system.  Centos7 minimal install doesn't include this package.

#### Rationale:

- All ansible seboolean tasks require this package.  Ansible playbooks halts with error when package is not available.
