### PR TITLE
Fix chronyd or ntpd set maxpoll

### DIFF
--- a/shared/fixes/bash/chronyd_or_ntpd_set_maxpoll.sh
+++ b/shared/fixes/bash/chronyd_or_ntpd_set_maxpoll.sh
@@ -13,5 +13,5 @@ sed -i "s/^\(server.*maxpoll\) [0-9][0-9]*\(.*\)$/\1 $var_time_service_set_maxpo
 
 # Add maxpoll to server entries without maxpoll
 grep -P "^server((?!maxpoll).)*$" $config_file | while read -r line ; do
-        sed -i "s/$line/&1 maxpoll $var_time_service_set_maxpoll/" "$config_file"
+        sed -i "s/$line/& maxpoll $var_time_service_set_maxpoll/" "$config_file"
 done

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony.pass.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony.pass.sh
@@ -6,7 +6,7 @@ yum install -y chrony
 yum remove -y ntp
 
 if ! grep "^server.*maxpoll 10" /etc/chrony.conf; then
-    sed -i "s/^server.*/&1 maxpoll 10/" /etc/chrony.conf
+    sed -i "s/^server.*/& maxpoll 10/" /etc/chrony.conf
 fi
 
 systemctl enable chronyd.service

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_one_server_misconfigured.fail.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_one_server_misconfigured.fail.sh
@@ -6,7 +6,7 @@ yum install -y chrony
 yum remove -y ntp
 
 if ! grep "^server.*maxpoll 10" /etc/chrony.conf; then
-    sed -i "s/^server.*/&1 maxpoll 10/" /etc/chrony.conf
+    sed -i "s/^server.*/& maxpoll 10/" /etc/chrony.conf
 fi
 
 echo "server test.ntp.org" >> /etc/chrony.conf

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp.pass.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp.pass.sh
@@ -6,7 +6,7 @@ yum install -y ntp
 yum remove -y chrony
 
 if ! grep "^server.*maxpoll 10" /etc/ntp.conf; then
-    sed -i "s/^server.*/&1 maxpoll 10/" /etc/ntp.conf
+    sed -i "s/^server.*/& maxpoll 10/" /etc/ntp.conf
 fi
 
 systemctl enable ntpd.service

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp_wrong_maxpoll.fail.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp_wrong_maxpoll.fail.sh
@@ -5,7 +5,7 @@
 yum install -y ntp
 yum remove -y chrony
 
-sed -i "s/^server.*/&1 maxpoll 17/" /etc/ntp.conf
+sed -i "s/^server.*/& maxpoll 17/" /etc/ntp.conf
 
 systemctl enable ntpd.service
 


### PR DESCRIPTION
#### Description:
Replaced `&1` with `&` in xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_set_maxpoll bash remediation and tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll

#### Rationale:

The ampersand in sed matched the entire previous expression and the 1 is then treated as literal, which leads to an invalid file syntax which causes ntp or chrony to fail to start:
```
bash-4.2# systemctl status chronyd
● chronyd.service - NTP client/server
   Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Thu 2018-01-18 12:36:46 PST; 1h 43min ago
     Docs: man:chronyd(8)
           man:chrony.conf(5)
  Process: 805 ExecStart=/usr/sbin/chronyd $OPTIONS (code=exited, status=1/FAILURE)

Jan 18 12:36:46 localhost.localdomain systemd[1]: Starting NTP client/server...
Jan 18 12:36:46 localhost.localdomain chronyd[805]: Could not parse server directive at line 3 in file /etc/chrony.conf
Jan 18 12:36:46 localhost.localdomain systemd[1]: chronyd.service: control process exited, code=exited status=1
Jan 18 12:36:46 localhost.localdomain systemd[1]: Failed to start NTP client/server.
Jan 18 12:36:46 localhost.localdomain systemd[1]: Unit chronyd.service entered failed state.
Jan 18 12:36:46 localhost.localdomain systemd[1]: chronyd.service failed.
```
```
bash-4.2# head -6 /etc/chrony.conf
# Use public servers from the pool.ntp.org project.
# Please consider joining the pool (http://www.pool.ntp.org/join.html).
server 0.centos.pool.ntp.org iburst1 maxpoll 10
server 1.centos.pool.ntp.org iburst1 maxpoll 10
server 2.centos.pool.ntp.org iburst1 maxpoll 10
server 3.centos.pool.ntp.org iburst1 maxpoll 10
```
```
bash-4.2# cat chrony.sh 
#!/bin/bash

###############################################################################
# BEGIN fix (233 / 239) for 'xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_set_maxpoll'
###############################################################################
(>&2 echo "Remediating rule 233/239: 'xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_set_maxpoll'")

var_time_service_set_maxpoll="10"

if ! [ `/usr/sbin/pidof ntpd` ] ; then
    config_file="/etc/chrony.conf"
else
    config_file="/etc/ntp.conf"
fi

# Set maxpoll values to var_time_service_set_maxpoll
sed -i "s/^\(server.*maxpoll\) [0-9][0-9]*\(.*\)$/\1 $var_time_service_set_maxpoll \2/" "$config_file"

# Add maxpoll to server entries without maxpoll
grep -P "^server((?!maxpoll).)*$" $config_file | while read -r line ; do
        sed -i "s/$line/& maxpoll $var_time_service_set_maxpoll/" "$config_file"
done
# END fix for 'xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_set_maxpoll'
```
```
bash-4.2# sed -i 's/1 maxpoll 10//g' /etc/chrony.conf
bash-4.2# head -6 /etc/chrony.conf
# Use public servers from the pool.ntp.org project.
# Please consider joining the pool (http://www.pool.ntp.org/join.html).
server 0.centos.pool.ntp.org iburst
server 1.centos.pool.ntp.org iburst
server 2.centos.pool.ntp.org iburst
server 3.centos.pool.ntp.org iburst
```
```
bash-4.2# ./chrony.sh
Remediating rule 233/239: 'xccdf_org.ssgproject.content_rule_chronyd_or_ntpd_set_maxpoll'
bash-4.2# head -6 /etc/chrony.conf
# Use public servers from the pool.ntp.org project.
# Please consider joining the pool (http://www.pool.ntp.org/join.html).
server 0.centos.pool.ntp.org iburst maxpoll 10
server 1.centos.pool.ntp.org iburst maxpoll 10
server 2.centos.pool.ntp.org iburst maxpoll 10
server 3.centos.pool.ntp.org iburst maxpoll 10
```
- Fixes #2551 
