### PR TITLE
fixed syntax issue with sed in auditd_data_retention_space_left.sh

### DIFF
--- a/shared/fixes/bash/auditd_data_retention_space_left.sh
+++ b/shared/fixes/bash/auditd_data_retention_space_left.sh
@@ -3,7 +3,7 @@
 populate var_auditd_space_left
 
 grep -q ^space_left /etc/audit/auditd.conf && \
-  sed -i "s/space_left.*/space_left = $var_auditd_space_left/g" /etc/audit/auditd.conf
+  sed -i "s/^space_left[[:space:]]*=.*/space_left = $var_auditd_space_left/g" /etc/audit/auditd.conf
 if ! [ $? -eq 0 ]; then
     echo "space_left = $var_auditd_space_left" >> /etc/audit/auditd.conf
 fi


### PR DESCRIPTION
#### Description:

Updated sed expression from `space_left.*` to `^space_left[[:space:]]*=.*`

#### Rationale:

Because the sed expression `space_left.*` does not contain a line beginning before the text, and does not contain a whitespace separator and equal sign after the text, it will overwrite any lines that contain space_left anywhere in the line, including space_left_action, admin_space_left, and admin_space_left_action.

```
bash-4.2# cat space_left.sh 
#!/bin/bash

###############################################################################
# BEGIN fix (127 / 239) for 'xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left'
###############################################################################
(>&2 echo "Remediating rule 127/239: 'xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left'")

var_auditd_space_left="100"

grep -q ^space_left /etc/audit/auditd.conf && \
  sed -i "s/^space_left[[:space:]]*=.*/space_left = $var_auditd_space_left/g" /etc/audit/auditd.conf
if ! [ $? -eq 0 ]; then
    echo "space_left = $var_auditd_space_left" >> /etc/audit/auditd.conf
fi
# END fix for 'xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left'
```
```
bash-4.2# cat /etc/audit/auditd.conf
#
# This file controls the configuration of the audit daemon
#

local_events = yes
write_logs = yes
log_file = /var/log/audit/audit.log
log_group = root
log_format = RAW
flush = data
##freq = 50
max_log_file = 6
num_logs = 5
priority_boost = 4
disp_qos = lossy
dispatcher = /sbin/audispd
name_format = NONE
##name = mydomain
max_log_file = 6
space_left = 75
space_left_action = email
action_mail_acct = root
admin_space_left = 50
admin_space_left_action = single
disk_full_action = SUSPEND
disk_error_action = SUSPEND
use_libwrap = yes
##tcp_listen_port = 
tcp_listen_queue = 5
tcp_max_per_addr = 1
##tcp_client_ports = 1024-65535
tcp_client_max_idle = 0
enable_krb5 = no
krb5_principal = auditd
##krb5_key_file = /etc/audit/audit.key
distribute_network = no
max_log_file_action = rotate
```
```
bash-4.2# ./space_left.sh 
Remediating rule 127/239: 'xccdf_org.ssgproject.content_rule_auditd_data_retention_space_left'
```
```
bash-4.2# cat /etc/audit/auditd.conf
#
# This file controls the configuration of the audit daemon
#

local_events = yes
write_logs = yes
log_file = /var/log/audit/audit.log
log_group = root
log_format = RAW
flush = data
##freq = 50
max_log_file = 6
num_logs = 5
priority_boost = 4
disp_qos = lossy
dispatcher = /sbin/audispd
name_format = NONE
##name = mydomain
max_log_file = 6
space_left = 100
space_left_action = email
action_mail_acct = root
admin_space_left = 50
admin_space_left_action = single
disk_full_action = SUSPEND
disk_error_action = SUSPEND
use_libwrap = yes
##tcp_listen_port = 
tcp_listen_queue = 5
tcp_max_per_addr = 1
##tcp_client_ports = 1024-65535
tcp_client_max_idle = 0
enable_krb5 = no
krb5_principal = auditd
##krb5_key_file = /etc/audit/audit.key
distribute_network = no
max_log_file_action = rotate
```

- Fixes #2553 
