### PR TITLE
Add test coverage for rule_accounts_have_homedir_login_defs

### DIFF
--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/comment.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/comment.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = none
+
+if grep -q "^CREATE_HOME" /etc/login.defs; then
+	sed -i "s/^CREATE_HOME.*/#CREATE_HOME yes/" /etc/login.defs
+else
+	echo "#CREATE_HOME yes" >> /etc/login.defs
+fi

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/comment.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/comment.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
-# remediation = none
+# remediation = bash
 
 if grep -q "^CREATE_HOME" /etc/login.defs; then
 	sed -i "s/^CREATE_HOME.*/#CREATE_HOME yes/" /etc/login.defs

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/correct_value.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+if grep -q "^CREATE_HOME" /etc/login.defs; then
+	sed -i "s/^CREATE_HOME.*/CREATE_HOME yes/" /etc/login.defs
+else
+	echo "CREATE_HOME yes" >> /etc/login.defs
+fi

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/line_not_there.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/line_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
-# remediation = none
+# remediation = bash
 
 sed -i "/.*CREATE_HOME.*/d" /etc/login.defs

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/line_not_there.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/line_not_there.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = none
+
+sed -i "/.*CREATE_HOME.*/d" /etc/login.defs

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/wrong_value.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = none
+
+if grep -q "^CREATE_HOME" /etc/login.defs; then
+	sed -i "s/^CREATE_HOME.*/CREATE_HOME no/" /etc/login.defs
+else
+	echo "CREATE_HOME no" >> /etc/login.defs
+fi

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/wrong_value.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
-# remediation = none
+# remediation = bash
 
 if grep -q "^CREATE_HOME" /etc/login.defs; then
 	sed -i "s/^CREATE_HOME.*/CREATE_HOME no/" /etc/login.defs


### PR DESCRIPTION
#### Description:

- Basic test coverage for `rule_accounts_have_homedir_login_defs`

#### Rationale:

- Supports  https://bugzilla.redhat.com/show_bug.cgi?id=1465683
