### PR TITLE
Remove duplicate install_smartcard_packages BASH script

### DIFF
--- a/rhel7/fixes/bash/install_smartcard_packages.sh
+++ b/rhel7/fixes/bash/install_smartcard_packages.sh
@@ -1,8 +1,0 @@
-# platform = Red Hat Enterprise Linux 7
-
-# include remediation functions library
-. /usr/share/scap-security-guide/remediation_functions
-
-package_command install esc
-package_command install pam_pkcs11
-package_command install authconfig-gtk


### PR DESCRIPTION
#### Description:

- Remove duplicate install_smartcard_packages BASH script

#### Rationale:

- Duplicate script was accidentally added when one already exists.
- Fixes #2555
