### PR TITLE
HTML table sanity check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ endif()
 
 find_program(SHELLCHECK_EXECUTABLE NAMES shellcheck)
 find_program(LINKCHECKER_EXECUTABLE NAMES linkchecker)
+find_program(GREP_EXECUTABLE NAMES grep)
 
 configure_file("${CMAKE_SOURCE_DIR}/oval.config.in" "${CMAKE_BINARY_DIR}/oval.config")
 
@@ -125,6 +126,7 @@ message(STATUS "xmlwf: ${XMLWF_EXECUTABLE}")
 message(STATUS "sed: ${SED_EXECUTABLE}")
 message(STATUS "shellcheck (optional): ${SHELLCHECK_EXECUTABLE}")
 message(STATUS "linkchecker (optional): ${LINKCHECKER_EXECUTABLE}")
+message(STATUS "grep (optional): ${GREP_EXECUTABLE}")
 message(STATUS " ")
 
 message(STATUS "Build options:")
@@ -239,7 +241,7 @@ if (SSG_PRODUCT_WEBMIN)
     add_subdirectory("webmin")
 endif()
 
-ssg_define_linkchecker_tests()
+ssg_define_guide_and_table_tests()
 
 install(FILES "${CMAKE_SOURCE_DIR}/LICENSE"
     DESTINATION ${CMAKE_INSTALL_DOCDIR})

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -64,8 +64,8 @@ else()
     set(OSCAP_OVAL_SCHEMATRON_OPTION "")
 endif()
 
-set(SSG_LINKCHECKER_GUIDE_FILE_LIST "")
-set(SSG_LINKCHECKER_TABLE_FILE_LIST "")
+set(SSG_HTML_GUIDE_FILE_LIST "")
+set(SSG_HTML_TABLE_FILE_LIST "")
 
 macro(ssg_build_bash_remediation_functions)
     file(GLOB BASH_REMEDIATION_FUNCTIONS "${CMAKE_SOURCE_DIR}/shared/bash_remediation_functions/*.sh")
@@ -564,7 +564,7 @@ macro(ssg_build_html_guides PRODUCT)
 
     # despite checking just the index this actually tests all the guides because the index links to them
     # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
-    set(SSG_LINKCHECKER_GUIDE_FILE_LIST "${SSG_LINKCHECKER_GUIDE_FILE_LIST};${CMAKE_BINARY_DIR}/guides/ssg-${PRODUCT}-guide-index.html" PARENT_SCOPE)
+    set(SSG_HTML_GUIDE_FILE_LIST "${SSG_HTML_GUIDE_FILE_LIST};${CMAKE_BINARY_DIR}/guides/ssg-${PRODUCT}-guide-index.html" PARENT_SCOPE)
 endmacro()
 
 macro(ssg_build_remediation_roles PRODUCT TEMPLATE EXTENSION)
@@ -848,7 +848,7 @@ macro(ssg_build_html_table_by_ref PRODUCT REF)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-by-ref-${REF})
 
     # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
-    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${REF}refs.html" PARENT_SCOPE)
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${REF}refs.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${REF}refs.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -871,7 +871,7 @@ macro(ssg_build_html_nistrefs_table PRODUCT PROFILE)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-nistrefs-${PROFILE})
 
     # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
-    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-nistrefs-${PROFILE}.html" PARENT_SCOPE)
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-nistrefs-${PROFILE}.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-nistrefs-${PROFILE}.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -914,7 +914,7 @@ macro(ssg_build_html_cce_table PRODUCT)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-cces)
 
     # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
-    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html" PARENT_SCOPE)
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -953,8 +953,8 @@ macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE DISA_SRG_VERSION)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-srg)
 
     # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
-    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html" PARENT_SCOPE)
-    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" PARENT_SCOPE)
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html" PARENT_SCOPE)
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -1004,8 +1004,8 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-stig)
 
-    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html" PARENT_SCOPE)
-    set(SSG_LINKCHECKER_TABLE_FILE_LIST "${SSG_LINKCHECKER_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html" PARENT_SCOPE)
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html" PARENT_SCOPE)
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -1014,15 +1014,15 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
 endmacro()
 
 macro(ssg_define_linkchecker_tests)
-    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
+    if (SSG_HTML_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
         add_test(
             NAME "linkchecker-ssg-guides"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" --check-extern ${SSG_LINKCHECKER_GUIDE_FILE_LIST}
+            COMMAND "${LINKCHECKER_EXECUTABLE}" --check-extern ${SSG_HTML_GUIDE_FILE_LIST}
         )
 
         add_test(
             NAME "linkchecker-ssg-tables"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" --check-extern ${SSG_LINKCHECKER_TABLE_FILE_LIST}
+            COMMAND "${LINKCHECKER_EXECUTABLE}" --check-extern ${SSG_HTML_TABLE_FILE_LIST}
         )
     endif()
 endmacro()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1013,7 +1013,7 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
 endmacro()
 
-macro(ssg_define_linkchecker_tests)
+macro(ssg_define_guide_and_table_tests)
     if (SSG_HTML_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
         add_test(
             NAME "linkchecker-ssg-guides"
@@ -1024,6 +1024,18 @@ macro(ssg_define_linkchecker_tests)
             NAME "linkchecker-ssg-tables"
             COMMAND "${LINKCHECKER_EXECUTABLE}" --check-extern ${SSG_HTML_TABLE_FILE_LIST}
         )
+    endif()
+
+    if (GREP_EXECUTABLE)
+        foreach(TABLE ${SSG_HTML_TABLE_FILE_LIST})
+            # -z treats newlines as regular chars so we can match multi-line
+            # -v inverts the match, we are trying to make sure the tables don't
+            #    match this pattern
+            add_test(
+                NAME "sanity-ssg-tables-${TABLE}"
+                COMMAND "${GREP_EXECUTABLE}" "-zv" "</thead>[[:space:]]*</table>" "${TABLE}"
+            )
+        endforeach()
     endif()
 endmacro()
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1027,13 +1027,14 @@ macro(ssg_define_guide_and_table_tests)
     endif()
 
     if (GREP_EXECUTABLE)
-        foreach(TABLE ${SSG_HTML_TABLE_FILE_LIST})
+        foreach(TABLE_FILE ${SSG_HTML_TABLE_FILE_LIST})
+            string(REPLACE "${CMAKE_BINARY_DIR}/tables/" "" TEST_NAME "${TABLE_FILE}")
             # -z treats newlines as regular chars so we can match multi-line
             # -v inverts the match, we are trying to make sure the tables don't
             #    match this pattern
             add_test(
-                NAME "sanity-ssg-tables-${TABLE}"
-                COMMAND "${GREP_EXECUTABLE}" "-zv" "</thead>[[:space:]]*</table>" "${TABLE}"
+                NAME "sanity-ssg-tables-${TEST_NAME}"
+                COMMAND "${GREP_EXECUTABLE}" "-zv" "</thead>[[:space:]]*</table>" "${TABLE_FILE}"
             )
         endforeach()
     endif()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -953,8 +953,7 @@ macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE DISA_SRG_VERSION)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-srg)
 
     # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
-    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html" PARENT_SCOPE)
-    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" PARENT_SCOPE)
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html;${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -1004,8 +1003,7 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-stig)
 
-    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html" PARENT_SCOPE)
-    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html" PARENT_SCOPE)
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html;${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1012,7 +1012,7 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
 endmacro()
 
 macro(ssg_define_guide_and_table_tests)
-    if (SSG_HTML_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
+    if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
         add_test(
             NAME "linkchecker-ssg-guides"
             COMMAND "${LINKCHECKER_EXECUTABLE}" --check-extern ${SSG_HTML_GUIDE_FILE_LIST}


### PR DESCRIPTION
#### Description:

- Sanity check to make sure none of the generated HTML tables are empty

#### Rationale:

- It happened to us in the past that changes to an XSLT or XML input made some of the tables empty. Sometimes it takes a few weeks (or more) to notice that because nobody is checking all of the tables. This automated test should help with that.

Credit goes to @matusmarhefka , this is just a port of his downstream test.