### PR TITLE
[regression] Import ssgcommon in profile-stats

### DIFF
--- a/shared/utils/profile-stats.py
+++ b/shared/utils/profile-stats.py
@@ -2,12 +2,21 @@
 
 import json
 import argparse
+import os
+import os.path
 import sys
 
 try:
     from xml.etree import cElementTree as ElementTree
 except ImportError:
     import cElementTree as ElementTree
+
+# Put shared python modules in path
+sys.path.insert(0, os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "modules"))
+import ssgcommon
+
 
 script_desc = \
     "Obtains and displays XCCDF profile statistics. Namely number " + \
@@ -154,7 +163,7 @@ class XCCDFBenchmark(object):
         if not rule_stats:
             print('Unable to retrieve statistics for %s profile' % profile)
             sys.exit(1)
-        
+
         rule_stats.sort(key=lambda r: r.dict['id'])
 
         profile_stats['profile_id'] = profile


### PR DESCRIPTION
Fixes:

```
$ ninja rhel7-stats
[1/1] [rhel7-stats] generating benchmark statistics
FAILED: rhel7/CMakeFiles/rhel7-stats 
cd /home/mpreisle/d/scap-security-guide/build/rhel7 && /usr/bin/cmake -E echo Benchmark\ statistics\ for\ 'rhel7': && /home/mpreisle/d/scap-security-guide/shared/utils/profile-stats.py --benchmark /home/mpreisle/d/scap-security-guide/build/ssg-rhel7-xccdf.xml --profile all
Benchmark statistics for rhel7:
Traceback (most recent call last):
  File "/home/mpreisle/d/scap-security-guide/shared/utils/profile-stats.py", line 18, in <module>
    xccdf_ns = ssgcommon.XCCDF11_NS
NameError: name 'ssgcommon' is not defined
ninja: build stopped: subcommand failed.
```

profile-stats is broken since the ssgcommon refactorings. See #2427
