### PR TITLE
Avoid 3 copy paste definitions of subprocess_check_output

### DIFF
--- a/shared/modules/ssgcommon.py
+++ b/shared/modules/ssgcommon.py
@@ -1,5 +1,6 @@
 import datetime
 import platform
+import subprocess
 
 
 xml_version = """<?xml version="1.0" encoding="UTF-8"?>"""
@@ -56,3 +57,29 @@ def oval_generated_header(product_name, schema_version, ssg_version):
         <oval:timestamp>%s</oval:timestamp>
     </generator>""" % (product_name, ssg_version, platform.python_version(),
                        schema_version, timestamp)
+
+
+def subprocess_check_output(*popenargs, **kwargs):
+    # Backport of subprocess.check_output taken from
+    # https://gist.github.com/edufelipe/1027906
+    #
+    # Originally from Python 2.7 stdlib under PSF, compatible with LGPL2+
+    # Copyright (c) 2003-2005 by Peter Astrand <astrand@lysator.liu.se>
+    # Changes by Eduardo Felipe
+
+    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+    output, unused_err = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        error = subprocess.CalledProcessError(retcode, cmd)
+        error.output = output
+        raise error
+    return output
+
+
+if hasattr(subprocess, "check_output"):
+    # if available we just use the real function
+    subprocess_check_output = subprocess.check_output

--- a/shared/modules/ssgcommon.py
+++ b/shared/modules/ssgcommon.py
@@ -63,7 +63,7 @@ def subprocess_check_output(*popenargs, **kwargs):
     # Backport of subprocess.check_output taken from
     # https://gist.github.com/edufelipe/1027906
     #
-    # Originally from Python 2.7 stdlib under PSF, compatible with LGPL2+
+    # Originally from Python 2.7 stdlib under PSF, compatible with BSD-3
     # Copyright (c) 2003-2005 by Peter Astrand <astrand@lysator.liu.se>
     # Changes by Eduardo Felipe
 

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -15,8 +15,6 @@ except ImportError:
 
 import os.path
 import argparse
-import subprocess
-
 import threading
 import Queue
 import sys
@@ -33,32 +31,6 @@ import ssgcommon
 OSCAP_PATH = "oscap"
 
 
-def subprocess_check_output(*popenargs, **kwargs):
-    # Backport of subprocess.check_output taken from
-    # https://gist.github.com/edufelipe/1027906
-    #
-    # Originally from Python 2.7 stdlib under PSF, compatible with LGPL2+
-    # Copyright (c) 2003-2005 by Peter Astrand <astrand@lysator.liu.se>
-    # Changes by Eduardo Felipe
-
-    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
-    output, unused_err = process.communicate()
-    retcode = process.poll()
-    if retcode:
-        cmd = kwargs.get("args")
-        if cmd is None:
-            cmd = popenargs[0]
-        error = subprocess.CalledProcessError(retcode, cmd)
-        error.output = output
-        raise error
-    return output
-
-
-if hasattr(subprocess, "check_output"):
-    # if available we just use the real function
-    subprocess_check_output = subprocess.check_output
-
-
 def generate_guide_for_input_content(input_content, benchmark_id, profile_id):
     """Returns HTML guide for given input_content and profile_id
     combination. This function assumes only one Benchmark exists
@@ -72,9 +44,7 @@ def generate_guide_for_input_content(input_content, benchmark_id, profile_id):
         args.extend(["--profile", profile_id])
     args.append(input_content)
 
-    ret = subprocess_check_output(args).decode("utf-8")
-
-    return ret
+    return ssgcommon.subprocess_check_output(args).decode("utf-8")
 
 
 def get_cpu_count():

--- a/shared/utils/build-all-remediation-roles.py
+++ b/shared/utils/build-all-remediation-roles.py
@@ -14,7 +14,6 @@ except ImportError:
 
 import os.path
 import argparse
-import subprocess
 
 import threading
 import Queue
@@ -27,37 +26,13 @@ sys.path.insert(0, os.path.join(
         os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
         "modules"))
 import xccdf_utils
+import ssgcommon
 
 OSCAP_PATH = "oscap"
 
 
-def subprocess_check_output(*popenargs, **kwargs):
-    # Backport of subprocess.check_output taken from
-    # https://gist.github.com/edufelipe/1027906
-    #
-    # Originally from Python 2.7 stdlib under PSF, compatible with LGPL2+
-    # Copyright (c) 2003-2005 by Peter Astrand <astrand@lysator.liu.se>
-    # Changes by Eduardo Felipe
-
-    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
-    output, unused_err = process.communicate()
-    retcode = process.poll()
-    if retcode:
-        cmd = kwargs.get("args")
-        if cmd is None:
-            cmd = popenargs[0]
-        error = subprocess.CalledProcessError(retcode, cmd)
-        error.output = output
-        raise error
-    return output
-
-
-if hasattr(subprocess, "check_output"):
-    # if available we just use the real function
-    subprocess_check_output = subprocess.check_output
-
-
-def generate_role_for_input_content(input_content, benchmark_id, profile_id, template):
+def generate_role_for_input_content(input_content, benchmark_id, profile_id,
+                                    template):
     """Returns remediation role for given input_content and profile_id
     combination. This function assumes only one Benchmark exists
     in given input_content!
@@ -74,9 +49,7 @@ def generate_role_for_input_content(input_content, benchmark_id, profile_id, tem
     args.extend(["--template", template])
     args.append(input_content)
 
-    ret = subprocess_check_output(args).decode("utf-8")
-
-    return ret
+    return ssgcommon.subprocess_check_output(args).decode("utf-8")
 
 
 def add_minimum_ansible_version(ansible_src):

--- a/shared/utils/oscap-svg-support.py
+++ b/shared/utils/oscap-svg-support.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python2
 
-import subprocess
 import tempfile
 import sys
+import os.path
+
+
+# Put shared python modules in path
+sys.path.insert(0, os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+        "modules"))
+import ssgcommon
 
 
 svg_benchmark = """<?xml version="1.0"?>
@@ -29,32 +36,6 @@ svg_benchmark = """<?xml version="1.0"?>
 """
 
 
-def subprocess_check_output(*popenargs, **kwargs):
-    # Backport of subprocess.check_output taken from
-    # https://gist.github.com/edufelipe/1027906
-    #
-    # Originally from Python 2.7 stdlib under PSF, compatible with LGPL2+
-    # Copyright (c) 2003-2005 by Peter Astrand <astrand@lysator.liu.se>
-    # Changes by Eduardo Felipe
-
-    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
-    output, unused_err = process.communicate()
-    retcode = process.poll()
-    if retcode:
-        cmd = kwargs.get("args")
-        if cmd is None:
-            cmd = popenargs[0]
-        error = subprocess.CalledProcessError(retcode, cmd)
-        error.output = output
-        raise error
-    return output
-
-
-if hasattr(subprocess, "check_output"):
-    # if available we just use the real function
-    subprocess_check_output = subprocess.check_output
-
-
 def main():
     oscap_executable = sys.argv[1]
 
@@ -62,7 +43,7 @@ def main():
     xccdf.write(svg_benchmark.encode("utf-8"))
     xccdf.flush()
 
-    out = subprocess_check_output(
+    out = ssgcommon.subprocess_check_output(
         [oscap_executable, "xccdf", "generate", "guide", xccdf.name]
     ).decode("utf-8")
 


### PR DESCRIPTION
#### Description:

- I was trying to resolve all licensing loose ends and found this function with a LGPL compatibility comment. Turns out it was defined 3 times in the code-base.

#### Rationale:

- Comment about compatibility with BSD-3 makes more sense
- More definitions make it more difficult to maintain the code and fix it