### PR TITLE
Fixed the banner enablement option name.

### DIFF
--- a/shared/fixes/ansible/dconf_gnome_banner_enabled.yml
+++ b/shared/fixes/ansible/dconf_gnome_banner_enabled.yml
@@ -7,7 +7,7 @@
   ini_file:
     dest: "/etc/dconf/db/local.d/00-security-settings"
     section: "org/gnome/login-screen"
-    option: banner-message-enabled
+    option: banner-message-enable
     value: true
     create: yes
   tags:


### PR DESCRIPTION
#### Description:

The ansible directive is wrong, so applying the playbook doesn't yield the expected result.

#### Rationale:

The directive is wrong according to https://help.gnome.org/admin/system-admin-guide/stable/login-banner.html.en and according to a test on a VM.