### PR TITLE
Add some rules for protection of data in transit and adequate capacity to ensure availabity for  HIPAA

### DIFF
--- a/rhel7/profiles/hippa.xml
+++ b/rhel7/profiles/hippa.xml
@@ -21,4 +21,13 @@ Rule identified for securing of electronic protected health information.
 <select idref="package_rsh-server_removed" selected="true" />
 <select idref="service_sshd_enabled" selected="true" />
 
+<select idref="auditd_data_retention_max_log_file_action" selected="true" />
+<select idref="auditd_data_retention_space_left_action" selected="true" />
+<select idref="auditd_data_retention_admin_space_left_action" selected="true" />
+<select idref="auditd_data_retention_action_mail_acct" selected="true" />
+<select idref="partition_for_var_log_audit" selected="true" />
+
+<select idref="package_rsyslog_installed" selected="true" />
+<select idref="service_rsyslog_enabled" selected="true" />
+<select idref="rsyslog_remote_loghost" selected="true" />
 </Profile>

--- a/rhel7/profiles/hippa.xml
+++ b/rhel7/profiles/hippa.xml
@@ -14,4 +14,11 @@ Rule identified for securing of electronic protected health information.
 
 <select idref="encrypt_partitions" selected="true" />
 
+<select idref="package_telnet_removed" selected="true" />
+<select idref="package_telnet-server_removed" selected="true" />
+
+<select idref="package_rsh_removed" selected="true" />
+<select idref="package_rsh-server_removed" selected="true" />
+<select idref="service_sshd_enabled" selected="true" />
+
 </Profile>

--- a/shared/xccdf/services/obsolete.xml
+++ b/shared/xccdf/services/obsolete.xml
@@ -154,7 +154,9 @@ Removing the <tt>telnet-server</tt> package decreases the risk of the telnet ser
 <ident prodtype="rhel7" cce="27165-0" />
 <oval id="package_telnet-server_removed" />
 <ref prodtype="rhel7" stigid="021710" />
-<ref nist="AC-17(8),CM-7(a)" disa="381" srg="SRG-OS-000095-GPOS-00049" cis="2.1.1" />
+<ref nist="AC-17(8),CM-7(a)" disa="381" srg="SRG-OS-000095-GPOS-00049" cis="2.1.1"
+hipaa="164.312(e)(1),164.312(e)(2)(i),164.312(e)(2)(ii)"
+iso27001-2013="A.8.2.3,A.13.1.1,A.13.2.1,A.13.2.3,A.14.1.2,A.14.1.3"/>
 </Rule>
 
 <Rule id="package_telnet_removed" severity="low" prodtype="rhel7">
@@ -169,7 +171,8 @@ encrypted session and stronger security and is included in Red Hat
 Enterprise Linux.</rationale>
 <ident prodtype="rhel7" cce="27305-2" />
 <oval id="package_telnet_removed" />
-<ref cis="2.3.4" cui="3.1.13" />
+<ref cis="2.3.4" cui="3.1.13" hipaa="164.312(e)(1),164.312(e)(2)(i),164.312(e)(2)(ii)"
+iso27001-2013="A.8.2.3,A.13.1.1,A.13.2.1,A.13.2.3,A.14.1.2,A.14.1.3"/>
 </Rule>
 
 </Group>
@@ -197,7 +200,9 @@ activation.
 <ident prodtype="rhel7" cce="27342-5" />
 <oval id="package_rsh-server_removed" />
 <ref prodtype="rhel7" stigid="020000" />
-<ref nist="AC-17(8),CM-7(a)" disa="381" srg="SRG-OS-000095-GPOS-00049" />
+<ref nist="AC-17(8),CM-7(a)" disa="381" srg="SRG-OS-000095-GPOS-00049"
+hipaa="164.312(e)(1),164.312(e)(2)(i),164.312(e)(2)(ii)"
+iso27001-2013="A.8.2.3,A.13.1.1,A.13.2.1,A.13.2.3,A.14.1.2,A.14.1.3" />
 </Rule>
 
 <Rule id="service_rexec_disabled" severity="high" prodtype="rhel7">
@@ -254,7 +259,9 @@ the clients for <tt>rsh</tt>,<tt>rcp</tt>, and <tt>rlogin</tt>.
 </rationale>
 <ident prodtype="rhel7" cce="27274-0" />
 <oval id="package_rsh_removed" />
-<ref cis="2.3.2" cui="3.1.13" />
+<ref cis="2.3.2" cui="3.1.13"
+hipaa="164.312(e)(1),164.312(e)(2)(i),164.312(e)(2)(ii)"
+iso27001-2013="A.8.2.3,A.13.1.1,A.13.2.1,A.13.2.3,A.14.1.2,A.14.1.3"/>
 </Rule>
 
 <Rule id="service_rlogin_disabled" severity="high" prodtype="rhel7">

--- a/shared/xccdf/system/auditing.xml
+++ b/shared/xccdf/system/auditing.xml
@@ -412,7 +412,8 @@ log data, or which use external processes to transfer it and reclaim space,
 <platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27231-0" />
 <oval id="auditd_data_retention_max_log_file_action" value="var_auditd_max_log_file_action" />
-<ref nist="AU-1(b),AU-4,AU-11,IR-5" pcidss="Req-10.7" cis="5.2.1.3" cjis="5.4.1.1" />
+<ref nist="AU-1(b),AU-4,AU-11,IR-5" pcidss="Req-10.7" cis="5.2.1.3" cjis="5.4.1.1"
+hipaa="164.312(a)(2)(ii)" iso27001-2013="A.12.3.1" />
 </Rule>
 
 <!--
@@ -465,7 +466,9 @@ allow them to take corrective action prior to any disruption.</rationale>
 <platform idref="cpe:/a:machine" />
 <ident prodtype="rhel7" cce="27375-5" />
 <oval id="auditd_data_retention_space_left_action" value="var_auditd_space_left_action"/>
-<ref nist="AU-1(b),AU-4,AU-5(1),AU-5(b),IR-5" disa="1855" pcidss="Req-10.7" cis="5.2.1.2" srg="SRG-OS-000343-GPOS-00134" cjis="5.4.1.1" cui="3.3.1" />
+<ref nist="AU-1(b),AU-4,AU-5(1),AU-5(b),IR-5" disa="1855" pcidss="Req-10.7"
+cis="5.2.1.2" srg="SRG-OS-000343-GPOS-00134" cjis="5.4.1.1" cui="3.3.1"
+hipaa="164.312(a)(2)(ii)" iso27001-2013="A.12.3.1" />
 </Rule>
 
 <Rule id="auditd_data_retention_admin_space_left_action" severity="medium" prodtype="rhel7">
@@ -497,7 +500,9 @@ is used, running low on space for audit records should never occur.
 <ident prodtype="rhel7" cce="27370-6" />
 <ref prodtype="rhel7" stigid="030340" />
 <oval id="auditd_data_retention_admin_space_left_action" value="var_auditd_admin_space_left_action" />
-<ref nist="AU-1(b),AU-4,AU-5(b),IR-5" disa="140,1343" pcidss="Req-10.7" cis="5.2.1.2" cjis="5.4.1.1" cui="3.3.1" />
+<ref nist="AU-1(b),AU-4,AU-5(b),IR-5" disa="140,1343" pcidss="Req-10.7"
+cis="5.2.1.2" cjis="5.4.1.1" cui="3.3.1" hipaa="164.312(a)(2)(ii)"
+iso27001-2013="A.12.3.1" />
 </Rule>
 
 <Rule id="auditd_data_retention_space_left" severity="medium" prodtype="rhel7">
@@ -547,7 +552,9 @@ administrators of the system, who can take appropriate action.</rationale>
 <ident prodtype="rhel7" cce="27394-6" />
 <oval id="auditd_data_retention_action_mail_acct" value="var_auditd_action_mail_acct" />
 <ref prodtype="rhel7" stigid="030350" />
-<ref nist="AU-1(b),AU-4,AU-5(1),AU-5(a),IR-5" disa="1855" pcidss="Req-10.7.a" cis="5.2.1.2" srg="SRG-OS-000343-GPOS-00134" cjis="5.4.1.1" cui="3.3.1" />
+<ref nist="AU-1(b),AU-4,AU-5(1),AU-5(a),IR-5" disa="1855" pcidss="Req-10.7.a"
+cis="5.2.1.2" srg="SRG-OS-000343-GPOS-00134" cjis="5.4.1.1" cui="3.3.1"
+hipaa="164.312(a)(2)(ii)" iso27001-2013="A.12.3.1" />
 </Rule>
 
 <Rule id="auditd_data_retention_flush" prodtype="rhel7">

--- a/shared/xccdf/system/logging.xml
+++ b/shared/xccdf/system/logging.xml
@@ -33,7 +33,8 @@ system logging services.
 </rationale>
 <ident prodtype="rhel7" cce="80187-8" />
 <oval id="package_rsyslog_installed" />
-<ref nist="AU-9(2)" disa="1311,1312" cis="4.2.3" anssi="NT28(R5),NT28(R46)"/>
+<ref nist="AU-9(2)" disa="1311,1312" cis="4.2.3" anssi="NT28(R5),NT28(R46)"
+hipaa="164.312(a)(2)(ii)" iso27001-2013="A.12.3.1" />
 </Rule>
 
 <Rule id="service_rsyslog_enabled" severity="medium" prodtype="rhel7">
@@ -49,7 +50,8 @@ logging services, which are essential to system administration.
 </rationale>
 <ident prodtype="rhel7" cce="80188-6" />
 <oval id="service_rsyslog_enabled" />
-<ref nist="AU-4(1),AU-12" disa="1311,1312,1557,1851" cis="4.2.1.1" anssi="NT28(R5),NT28(R46)"/>
+<ref nist="AU-4(1),AU-12" disa="1311,1312,1557,1851" cis="4.2.1.1" anssi="NT28(R5),NT28(R46)"
+hipaa="164.312(a)(2)(ii)" iso27001-2013="A.12.3.1" />
 </Rule>
 
 <Group id="ensure_rsyslog_log_file_configuration">
@@ -285,7 +287,7 @@ place to view the status of multiple hosts within the enterprise.
 <oval id="rsyslog_remote_loghost" value="rsyslog_remote_loghost_address" />
 <ref prodtype="rhel7" stigid="031000" />
 <ref nist="AU-3(2),AU-4(1),AU-9" disa="366,1348,136,1851" cis="4.2.1.4"
-srg="SRG-OS-000480-GPOS-00227" />
+srg="SRG-OS-000480-GPOS-00227" hipaa="164.312(a)(2)(ii)" iso27001-2013="A.12.3.1" />
 </Rule>
 </Group>
 

--- a/shared/xccdf/system/software/disk_partitioning.xml
+++ b/shared/xccdf/system/software/disk_partitioning.xml
@@ -124,7 +124,8 @@ of space.
 <oval id="partition_for_var_log_audit" />
 <ref prodtype="rhel7" stigid="021330" />
 <ref nist="AU-4,AU-9,SC-32(1)" disa="366" cis="1.1.12"
-srg="SRG-OS-000480-GPOS-00227" />
+srg="SRG-OS-000480-GPOS-00227" hipaa="164.312(a)(2)(ii)"
+iso27001-2013="A.12.3.1" />
 </Rule>
 
 <Rule id="partition_for_home" severity="low" prodtype="rhel7">


### PR DESCRIPTION
#### Description:

- Add rules for protection of data in transit
- Add rules for adequate capacity to ensure availability

#### Rationale:

- Protection of data in transit
  - rsh and telnet don't provide confidentiality or integrity.
  - ssh provides protection for data in transit.
- Adequate capacity to ensure availability
  - Store audit logs in separate partition
  - Configure audit actions for low storage
  - Enable rsyslog and remote storage
