### PR TITLE
cmake/SSGCommon.cmake: added check for override attribute

### DIFF
--- a/chromium/profiles/stig-chromium-upstream.xml
+++ b/chromium/profiles/stig-chromium-upstream.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-chromium-upstream" xmlns="http://checklists.nist.gov/xccdf/1.1" >
-<title>Upstream STIG for Google Chromium</title>
-<description>This profile is developed under the DoD consensus model and DISA FSO Vendor STIG process,
+<title override="true">Upstream STIG for Google Chromium</title>
+<description override="true">This profile is developed under the DoD consensus model and DISA FSO Vendor STIG process,
 serving as the upstream development environment for the Google Chromium STIG.
 
 As a result of the upstream/downstream relationship between the SCAP Security Guide project

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -428,6 +428,23 @@ macro(ssg_build_xccdf_final PRODUCT)
         NAME "verify-references-ssg-${PRODUCT}-xccdf.xml"
         COMMAND "${SSG_SHARED_UTILS}/verify-references.py" --rules-with-invalid-checks --ovaldefs-unused "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
     )
+    add_test(
+        NAME "verify-ssg-${PRODUCT}-xccdf.xml-override-true-all-profile-titles"
+        COMMAND "${XMLLINT_EXECUTABLE}" --xpath "//*[local-name()=\"Profile\"]/*[local-name()=\"title\"][not(@override=\"true\")]" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+    )
+    add_test(
+        NAME "verify-ssg-${PRODUCT}-xccdf.xml-override-true-all-profile-descriptions"
+        COMMAND "${XMLLINT_EXECUTABLE}" --xpath "//*[local-name()=\"Profile\"]/*[local-name()=\"description\"][not(@override=\"true\")]" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+    )
+    # Sets WILL_FAIL property for all '*-override-true-all-profile-*' tests to
+    # true as it is expected that XPath of a passing test will be empty (and
+    # non-zero exit code is returned in such case).
+    set_tests_properties(
+        "verify-ssg-${PRODUCT}-xccdf.xml-override-true-all-profile-titles"
+        "verify-ssg-${PRODUCT}-xccdf.xml-override-true-all-profile-descriptions"
+        PROPERTIES
+        WILL_FAIL true
+    )
 
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"

--- a/debian8/profiles/anssi_np_nt28_minimal.xml
+++ b/debian8/profiles/anssi_np_nt28_minimal.xml
@@ -1,6 +1,6 @@
 <Profile id="anssi_np_nt28_minimal">
-<title>Profile for ANSSI DAT-NT28 Minimal Level</title>
-<description>This profile contains items to be applied systematically.</description>
+<title override="true">Profile for ANSSI DAT-NT28 Minimal Level</title>
+<description override="true">This profile contains items to be applied systematically.</description>
 
 <!-- partitioning -->
 <!-- system -->

--- a/debian8/profiles/common.xml
+++ b/debian8/profiles/common.xml
@@ -1,6 +1,6 @@
 <Profile id="common">
-<title>Common Profile for General-Purpose Debian Systems</title>
-<description>This profile contains items common to general-purpose Debian 8 installations.</description>
+<title override="true">Common Profile for General-Purpose Debian Systems</title>
+<description override="true">This profile contains items common to general-purpose Debian 8 installations.</description>
 
 <!-- partitioning -->
 <select idref="partition_for_tmp" selected="true"/>

--- a/fedora/profiles/common.xml
+++ b/fedora/profiles/common.xml
@@ -1,6 +1,6 @@
 <Profile id="common">
-<title>Common Profile for General-Purpose Fedora Systems</title>
-<description>This profile contains items common to general-purpose Fedora installations.</description>
+<title override="true">Common Profile for General-Purpose Fedora Systems</title>
+<description override="true">This profile contains items common to general-purpose Fedora installations.</description>
 
   <select idref="disable_prelink" selected="true"/>
   <select idref="aide_build_database" selected="true"/>

--- a/fedora/profiles/standard.xml
+++ b/fedora/profiles/standard.xml
@@ -1,6 +1,6 @@
 <Profile id="standard">
-<title>Standard System Security Profile</title>
-<description>This profile contains rules to ensure standard security baseline of a Fedora system.
+<title override="true">Standard System Security Profile</title>
+<description override="true">This profile contains rules to ensure standard security baseline of a Fedora system.
 Regardless of your system's workload all of these checks should pass.</description>
 
 <select idref="ensure_gpgcheck_globally_activated" selected="true" />

--- a/firefox/profiles/stig-firefox-upstream.xml
+++ b/firefox/profiles/stig-firefox-upstream.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-firefox-upstream" xmlns="http://checklists.nist.gov/xccdf/1.1" >
-<title>Upstream Firefox STIG</title>
-<description>This profile is developed under the DoD consensus model and DISA FSO Vendor STIG process,
+<title override="true">Upstream Firefox STIG</title>
+<description override="true">This profile is developed under the DoD consensus model and DISA FSO Vendor STIG process,
 serving as the upstream development environment for the Firefox STIG.
 
 As a result of the upstream/downstream relationship between the SCAP Security Guide project

--- a/jboss_fuse6/profiles/common.xml
+++ b/jboss_fuse6/profiles/common.xml
@@ -1,6 +1,6 @@
 <Profile id="common">
-<title>Common Profile for General-Purpose JBoss Systems</title>
-<description>This profile contains items common to general-purpose JBoss Fuse installations.</description>
+<title override="true">Common Profile for General-Purpose JBoss Systems</title>
+<description override="true">This profile contains items common to general-purpose JBoss Fuse installations.</description>
 
 <!-- Apache ActiveMQ settings -->
 <select idref="jboss_activemq-default_users_removed" selected="true"/>

--- a/jre/profiles/stig-java-upstream.xml
+++ b/jre/profiles/stig-java-upstream.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-java-upstream" xmlns="http://checklists.nist.gov/xccdf/1.1" >
-<title>Java Runtime Environment (JRE) STIG</title>
-<description>The Java Runtime Environment (JRE) is a bundle developed
+<title override="true">Java Runtime Environment (JRE) STIG</title>
+<description override="true">The Java Runtime Environment (JRE) is a bundle developed
 and offered by Oracle Corporation which includes the Java Virtual Machine
 (JVM), class libraries, and other components necessary to run Java
 applications and applets. Certain default settings within the JRE pose

--- a/ocp3/profiles/C2S-ocp-master.xml
+++ b/ocp3/profiles/C2S-ocp-master.xml
@@ -1,6 +1,6 @@
 <Profile id="C2S-ocp-master" extends="C2S-ocp-node">
-<title>C2S for Red Hat Enterprise OpenShift Container Platform 3 Master Node</title>
-<description>This profile demonstrates compliance against the
+<title override="true">C2S for Red Hat Enterprise OpenShift Container Platform 3 Master Node</title>
+<description override="true">This profile demonstrates compliance against the
 U.S. Government Commercial Cloud Services (C2S) baseline.
 
 This baseline was inspired by the Center for Internet Security

--- a/ocp3/profiles/C2S-ocp-node.xml
+++ b/ocp3/profiles/C2S-ocp-node.xml
@@ -1,6 +1,6 @@
 <Profile id="C2S-ocp-node">
-<title>C2S for Red Hat Enterprise OpenShift Container Platform 3 Node</title>
-<description>This profile demonstrates compliance against the
+<title override="true">C2S for Red Hat Enterprise OpenShift Container Platform 3 Node</title>
+<description override="true">This profile demonstrates compliance against the
 U.S. Government Commercial Cloud Services (C2S) baseline.
 
 This baseline was inspired by the Center for Internet Security

--- a/opensuse/profiles/common.xml
+++ b/opensuse/profiles/common.xml
@@ -1,6 +1,6 @@
 <Profile id="common">
-<title>Common Profile for General-Purpose Systems</title>
-<description>This profile contains items common to general-purpose desktop and server installations.</description>
+<title override="true">Common Profile for General-Purpose Systems</title>
+<description override="true">This profile contains items common to general-purpose desktop and server installations.</description>
 <!--<select idref="partition_for_tmp" selected="true"/>-->
 <!--<select idref="partition_for_var" selected="true"/>-->
 <!--<select idref="partition_for_var_log" selected="true"/>-->

--- a/opensuse/profiles/standard.xml
+++ b/opensuse/profiles/standard.xml
@@ -1,6 +1,6 @@
 <Profile id="standard">
-<title>Standard System Security Profile</title>
-<description>This profile contains rules to ensure standard security baseline of a OpenSUSE system.
+<title override="true">Standard System Security Profile</title>
+<description override="true">This profile contains rules to ensure standard security baseline of a OpenSUSE system.
 Regardless of your system's workload all of these checks should pass.</description>
 
 <!--select idref="ensure_gpgcheck_globally_activated" selected="true" /-->

--- a/rhel6/profiles/C2S.xml
+++ b/rhel6/profiles/C2S.xml
@@ -1,6 +1,6 @@
 <Profile id="C2S">
-<title>C2S for Red Hat Enterprise Linux 6</title>
-<description>This profile demonstrates compliance against the 
+<title override="true">C2S for Red Hat Enterprise Linux 6</title>
+<description override="true">This profile demonstrates compliance against the 
 U.S. Government Commercial Cloud Services (C2S) baseline.
 
 This baseline was inspired by the Center for Internet Security

--- a/rhel6/profiles/CS2.xml
+++ b/rhel6/profiles/CS2.xml
@@ -1,6 +1,6 @@
 <Profile id="CS2">
-<title>Example Server Profile</title>
-<description>
+<title override="true">Example Server Profile</title>
+<description override="true">
   This profile is an example of a customized server profile.
 </description>
 

--- a/rhel6/profiles/CSCF-RHEL6-MLS.xml
+++ b/rhel6/profiles/CSCF-RHEL6-MLS.xml
@@ -1,6 +1,6 @@
 <Profile id="CSCF-RHEL6-MLS">
-<title>CSCF RHEL6 MLS Core Baseline</title>
-<description> This profile reflects the Centralized Super Computing Facility 
+<title override="true">CSCF RHEL6 MLS Core Baseline</title>
+<description override="true"> This profile reflects the Centralized Super Computing Facility 
 (CSCF) baseline for Red Hat Enterprise Linux 6. This baseline has received 
 government ATO through the ICD 503 process, utilizing the CNSSI 1253 cross 
 domain overlay. This profile should be considered in active development. 

--- a/rhel6/profiles/common.xml
+++ b/rhel6/profiles/common.xml
@@ -1,6 +1,6 @@
 <Profile id="common">
-<title>Common Profile for General-Purpose Systems</title>
-<description>This profile contains items common to general-purpose
+<title override="true">Common Profile for General-Purpose Systems</title>
+<description override="true">This profile contains items common to general-purpose
 desktop and server installations.</description>
 <select idref="partition_for_tmp" selected="true"/>
 <select idref="partition_for_var" selected="true"/>

--- a/rhel6/profiles/fisma-medium-rhel6-server.xml
+++ b/rhel6/profiles/fisma-medium-rhel6-server.xml
@@ -1,6 +1,6 @@
 <Profile id="fisma-medium-rhel6-server">
-<title>FISMA Medium for Red Hat Enterprise Linux 6</title>
-<description>FISMA Medium for Red Hat Enterprise Linux 6.</description>
+<title override="true">FISMA Medium for Red Hat Enterprise Linux 6</title>
+<description override="true">FISMA Medium for Red Hat Enterprise Linux 6.</description>
 
 <!-- ACCESS CONTROL (AC) -->
 <!-- 	AC-2(2)

--- a/rhel6/profiles/pci-dss.xml
+++ b/rhel6/profiles/pci-dss.xml
@@ -1,6 +1,6 @@
 <Profile id="pci-dss" xmlns="http://checklists.nist.gov/xccdf/1.1">
-<title>PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 6</title>
-<description>This is a *draft* profile for PCI-DSS v3.</description>
+<title override="true">PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 6</title>
+<description override="true">This is a *draft* profile for PCI-DSS v3.</description>
 
 <refine-value idref="var_password_pam_unix_remember" selector="4" />
 <refine-value idref="var_account_disable_post_pw_expiration" selector="90" />

--- a/rhel6/profiles/rht-ccp.xml
+++ b/rhel6/profiles/rht-ccp.xml
@@ -1,6 +1,6 @@
 <Profile id="rht-ccp" xmlns="http://checklists.nist.gov/xccdf/1.1">
-<title>Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)</title>
-<description>This is a *draft* SCAP profile for Red Hat Certified Cloud Providers</description>
+<title override="true">Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)</title>
+<description override="true">This is a *draft* SCAP profile for Red Hat Certified Cloud Providers</description>
 <!-- CONFIGURATION OPTIONS -->
 <refine-value idref="var_selinux_state" selector="enforcing"/>
 <refine-value idref="var_selinux_policy_name" selector="targeted"/>

--- a/rhel6/profiles/standard.xml
+++ b/rhel6/profiles/standard.xml
@@ -1,6 +1,6 @@
 <Profile id="standard">
-<title>Standard System Security Profile</title>
-<description>This profile contains rules to ensure standard security 
+<title override="true">Standard System Security Profile</title>
+<description override="true">This profile contains rules to ensure standard security 
 baseline of Red Hat Enterprise Linux 6 system. Regardless of your system's
 workload all of these checks should pass.</description>
 

--- a/rhel6/profiles/stig-rhel6-disa.xml
+++ b/rhel6/profiles/stig-rhel6-disa.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-rhel6-disa" extends="common">
 <title override="true">DISA STIG for Red Hat Enterprise Linux 6</title>
-<description>
+<description override="true">
 This profile contains configuration checks that align to the
 DISA STIG for Red Hat Enterprise Linux 6.
 

--- a/rhel6/profiles/usgcb-rhel6-server.xml
+++ b/rhel6/profiles/usgcb-rhel6-server.xml
@@ -1,6 +1,6 @@
 <Profile id="usgcb-rhel6-server">
-<title>United States Government Configuration Baseline (USGCB)</title>
-<description>This profile is a working draft for a USGCB submission against
+<title override="true">United States Government Configuration Baseline (USGCB)</title>
+<description override="true">This profile is a working draft for a USGCB submission against
 RHEL6 Server.</description>
 
 <select idref="kernel_disable_entropy_contribution_for_solid_state_drives" selected="true" />

--- a/rhel7/profiles/C2S.xml
+++ b/rhel7/profiles/C2S.xml
@@ -1,6 +1,6 @@
 <Profile id="C2S">
-<title>C2S for Red Hat Enterprise Linux 7</title>
-<description>This profile demonstrates compliance against the
+<title override="true">C2S for Red Hat Enterprise Linux 7</title>
+<description override="true">This profile demonstrates compliance against the
 U.S. Government Commercial Cloud Services (C2S) baseline.
 
 This baseline was inspired by the Center for Internet Security

--- a/rhel7/profiles/anssi_nt28_minimal.xml
+++ b/rhel7/profiles/anssi_nt28_minimal.xml
@@ -1,6 +1,6 @@
 <Profile id="anssi_nt28_minimal">
-<title>ANSSI DAT-NT28 (minimal)</title>
-<description>Draft profile for ANSSI compliance at the minimal level. ANSSI stands for Agence nationale de la sécurité des systèmes d'information. Based on https://www.ssi.gouv.fr/.</description>
+<title override="true">ANSSI DAT-NT28 (minimal)</title>
+<description override="true">Draft profile for ANSSI compliance at the minimal level. ANSSI stands for Agence nationale de la sécurité des systèmes d'information. Based on https://www.ssi.gouv.fr/.</description>
 
 <!-- partitioning -->
 <!-- system -->

--- a/rhel7/profiles/cjis-rhel7-server.xml
+++ b/rhel7/profiles/cjis-rhel7-server.xml
@@ -1,5 +1,5 @@
 <Profile id="cjis-rhel7-server">
-<title>Criminal Justice Information Services (CJIS) Security Policy</title>
+<title override="true">Criminal Justice Information Services (CJIS) Security Policy</title>
 <description override="true">This profile is derived from FBI's CJIS v5.4
 Security Policy. A copy of this policy can be found at the CJIS Security
 Policy Resource Center:

--- a/rhel7/profiles/common.xml
+++ b/rhel7/profiles/common.xml
@@ -1,6 +1,6 @@
 <Profile id="common">
-<title>Common Profile for General-Purpose Systems</title>
-<description>This profile contains items common to general-purpose desktop and server installations.</description>
+<title override="true">Common Profile for General-Purpose Systems</title>
+<description override="true">This profile contains items common to general-purpose desktop and server installations.</description>
 <select idref="partition_for_var_log" selected="true"/>
 <select idref="partition_for_var_log_audit" selected="true"/>
 

--- a/rhel7/profiles/docker-host.xml
+++ b/rhel7/profiles/docker-host.xml
@@ -1,6 +1,6 @@
 <Profile id="docker-host">
-<title>Standard Docker Host Security Profile</title>
-<description>This profile contains rules to ensure standard security baseline
+<title override="true">Standard Docker Host Security Profile</title>
+<description override="true">This profile contains rules to ensure standard security baseline
 of Red Hat Enterprise Linux 7 system running the docker daemon. This discussion
 is currently being held on open-scap-list@redhat.com and 
 scap-security-guide@lists.fedorahosted.org.

--- a/rhel7/profiles/ospp-rhel7.xml
+++ b/rhel7/profiles/ospp-rhel7.xml
@@ -1,6 +1,6 @@
 <Profile id="ospp-rhel7">
-<title>United States Government Configuration Baseline (USGCB / STIG) - DRAFT</title>
-<description>This profile is developed in partnership with the 
+<title override="true">United States Government Configuration Baseline (USGCB / STIG) - DRAFT</title>
+<description override="true">This profile is developed in partnership with the 
 U.S. National Institute of Standards and Technology (NIST), U.S. Department of 
 Defense, the National Security Agency, and Red Hat. The USGCB is intended
 to be the core set of security related configuration settings by which all

--- a/rhel7/profiles/pci-dss.xml
+++ b/rhel7/profiles/pci-dss.xml
@@ -1,6 +1,6 @@
 <Profile id="pci-dss" xmlns="http://checklists.nist.gov/xccdf/1.1">
-<title>PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7</title>
-<description>This is a *draft* profile for PCI-DSS v3.</description>
+<title override="true">PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7</title>
+<description override="true">This is a *draft* profile for PCI-DSS v3.</description>
 
 <refine-value idref="var_password_pam_unix_remember" selector="4" />
 <refine-value idref="var_account_disable_post_pw_expiration" selector="90" />

--- a/rhel7/profiles/rht-ccp.xml
+++ b/rhel7/profiles/rht-ccp.xml
@@ -1,6 +1,6 @@
 <Profile id="rht-ccp" xmlns="http://checklists.nist.gov/xccdf/1.1">
-<title>Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)</title>
-<description>This is a *draft* SCAP profile for Red Hat Certified Cloud Providers.</description>
+<title override="true">Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)</title>
+<description override="true">This is a *draft* SCAP profile for Red Hat Certified Cloud Providers.</description>
 <!-- CONFIGURATION OPTIONS -->
 <refine-value idref="var_selinux_state" selector="enforcing"/>
 <refine-value idref="var_selinux_policy_name" selector="targeted"/>

--- a/rhel7/profiles/standard.xml
+++ b/rhel7/profiles/standard.xml
@@ -1,6 +1,6 @@
 <Profile id="standard">
-<title>Standard System Security Profile</title>
-<description>This profile contains rules to ensure standard security baseline
+<title override="true">Standard System Security Profile</title>
+<description override="true">This profile contains rules to ensure standard security baseline
 of Red Hat Enterprise Linux 7 system. Regardless of your system's workload
 all of these checks should pass.</description>
 

--- a/rhel7/profiles/stig-ansible-tower-upstream.xml
+++ b/rhel7/profiles/stig-ansible-tower-upstream.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-ansible-tower-upstream" extends="stig-http-disa">
-<title>Upstream DISA STIG for Red Hat Ansible Tower</title>
-<description>
+<title override="true">Upstream DISA STIG for Red Hat Ansible Tower</title>
+<description override="true">
 This is a *draft* profile for STIG. This profile is being
 developed under the DoD consensus model to become a STIG in
 coordination with DISA FSO.

--- a/rhel7/profiles/stig-http-disa.xml
+++ b/rhel7/profiles/stig-http-disa.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-http-disa">
-<title>DISA STIG for Apache HTTP on Red Hat Enterprise Linux 7</title>
-<description>
+<title override="true">DISA STIG for Apache HTTP on Red Hat Enterprise Linux 7</title>
+<description override="true">
 This profile contains configuration checks that align to the
 DISA STIG for Apache HTTP web server.
 </description>

--- a/rhel7/profiles/stig-ipa-server-upstream.xml
+++ b/rhel7/profiles/stig-ipa-server-upstream.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-ipa-server-upstream" extends="stig-http-disa">
-<title>Upstream DISA STIG for Red Hat IdM</title>
-<description>
+<title override="true">Upstream DISA STIG for Red Hat IdM</title>
+<description override="true">
 This is a *draft* profile for STIG. This profile is being
 developed under the DoD consensus model to become a STIG in
 coordination with DISA FSO.

--- a/rhel7/profiles/stig-rhel7-disa.xml
+++ b/rhel7/profiles/stig-rhel7-disa.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-rhel7-disa">
-<title>DISA STIG for Red Hat Enterprise Linux 7</title>
-<description>
+<title override="true">DISA STIG for Red Hat Enterprise Linux 7</title>
+<description override="true">
 This profile contains configuration checks that align to the 
 DISA STIG for Red Hat Enterprise Linux V1R1.
 

--- a/rhel7/profiles/stig-satellite-upstream.xml
+++ b/rhel7/profiles/stig-satellite-upstream.xml
@@ -1,6 +1,6 @@
 <Profile id="stig-satellite-upstream" extends="stig-http-disa">
-<title>Upstream DISA STIG for Red Hat Satellite</title>
-<description>
+<title override="true">Upstream DISA STIG for Red Hat Satellite</title>
+<description override="true">
 This is a *draft* profile for STIG. This profile is being
 developed under the DoD consensus model to become a STIG in
 coordination with DISA FSO.

--- a/rhevm3/profiles/stig-rhevm3.xml
+++ b/rhevm3/profiles/stig-rhevm3.xml
@@ -1,6 +1,6 @@
 <Profile id="common" xmlns="http://checklists.nist.gov/xccdf/1.1" >
-<title>Common Profile for General-Purpose Systems</title>
-<description>This profile contains items common to general-purpose desktop and server installations.</description>
+<title override="true">Common Profile for General-Purpose Systems</title>
+<description override="true">This profile contains items common to general-purpose desktop and server installations.</description>
 <!-- This is a hack because our tooling doesn't work well with profiles that have on selects!
      Remove this once you add any real select here -->
 <select idref="remediation_functions" selected="true"/>

--- a/rhosp7/profiles/stig-openstack.xml
+++ b/rhosp7/profiles/stig-openstack.xml
@@ -1,5 +1,5 @@
 <Profile id="stig-openstack">
-<title>RHEL OSP STIG</title>
+<title override="true">RHEL OSP STIG</title>
 <description override="true">Sample profile description.</description>
 
 <!-- Horizon Specific Rules -->

--- a/sle11/profiles/common.xml
+++ b/sle11/profiles/common.xml
@@ -1,6 +1,6 @@
 <Profile id="common">
-<title>Common Profile for General-Purpose Systems</title>
-<description>This profile contains items common to general-purpose desktop and server installations.</description>
+<title override="true">Common Profile for General-Purpose Systems</title>
+<description override="true">This profile contains items common to general-purpose desktop and server installations.</description>
 <!--<select idref="partition_for_tmp" selected="true"/>-->
 <!--<select idref="partition_for_var" selected="true"/>-->
 <!--<select idref="partition_for_var_log" selected="true"/>-->

--- a/sle11/profiles/standard.xml
+++ b/sle11/profiles/standard.xml
@@ -1,6 +1,6 @@
 <Profile id="standard">
-<title>Standard System Security Profile</title>
-<description>This profile contains rules to ensure standard security baseline of SUSE Linux Enterprise 11 system.
+<title override="true">Standard System Security Profile</title>
+<description override="true">This profile contains rules to ensure standard security baseline of SUSE Linux Enterprise 11 system.
 Regardless of your system's workload all of these checks should pass.</description>
 
 <!--<select idref="ensure_redhat_gpgkey_installed" selected="true" />-->

--- a/sle12/profiles/common.xml
+++ b/sle12/profiles/common.xml
@@ -1,6 +1,6 @@
 <Profile id="common">
-<title>Common Profile for General-Purpose Systems</title>
-<description>This profile contains items common to general-purpose desktop and server installations.</description>
+<title override="true">Common Profile for General-Purpose Systems</title>
+<description override="true">This profile contains items common to general-purpose desktop and server installations.</description>
 <!--<select idref="partition_for_tmp" selected="true"/>-->
 <!--<select idref="partition_for_var" selected="true"/>-->
 <!--<select idref="partition_for_var_log" selected="true"/>-->

--- a/sle12/profiles/standard.xml
+++ b/sle12/profiles/standard.xml
@@ -1,6 +1,6 @@
 <Profile id="standard">
-<title>Standard System Security Profile</title>
-<description>This profile contains rules to ensure standard security baseline of SUSE Linux Enterprise 11 system.
+<title override="true">Standard System Security Profile</title>
+<description override="true">This profile contains rules to ensure standard security baseline of SUSE Linux Enterprise 11 system.
 Regardless of your system's workload all of these checks should pass.</description>
 
 <!--<select idref="ensure_redhat_gpgkey_installed" selected="true" />-->

--- a/ubuntu14/profiles/anssi_np_nt28_minimal.xml
+++ b/ubuntu14/profiles/anssi_np_nt28_minimal.xml
@@ -1,6 +1,6 @@
 <Profile id="anssi_np_nt28_minimal">
-<title>Profile for ANSSI DAT-NT28 Minimal Level</title>
-<description>This profile contains items to be applied systematically.</description>
+<title override="true">Profile for ANSSI DAT-NT28 Minimal Level</title>
+<description override="true">This profile contains items to be applied systematically.</description>
 
 <!-- partitioning -->
 <!-- system -->

--- a/ubuntu14/profiles/common.xml
+++ b/ubuntu14/profiles/common.xml
@@ -1,6 +1,6 @@
 <Profile id="common">
-<title>Common Profile for General-Purpose Ubuntu Systems</title>
-<description>This profile contains items common to general-purpose Ubuntu 1404 installations.</description>
+<title override="true">Common Profile for General-Purpose Ubuntu Systems</title>
+<description override="true">This profile contains items common to general-purpose Ubuntu 1404 installations.</description>
 
 <!-- partitioning -->
 <select idref="partition_for_tmp" selected="true"/>

--- a/ubuntu16/profiles/anssi_np_nt28_minimal.xml
+++ b/ubuntu16/profiles/anssi_np_nt28_minimal.xml
@@ -1,6 +1,6 @@
 <Profile id="anssi_np_nt28_minimal">
-<title>Profile for ANSSI DAT-NT28 Minimal Level</title>
-<description>This profile contains items to be applied systematically.</description>
+<title override="true">Profile for ANSSI DAT-NT28 Minimal Level</title>
+<description override="true">This profile contains items to be applied systematically.</description>
 
 <!-- partitioning -->
 <!-- system -->

--- a/ubuntu16/profiles/common.xml
+++ b/ubuntu16/profiles/common.xml
@@ -1,6 +1,6 @@
 <Profile id="common">
-<title>Common Profile for General-Purpose Ubuntu Systems</title>
-<description>This profile contains items common to general-purpose Ubuntu 1604 installations.</description>
+<title override="true">Common Profile for General-Purpose Ubuntu Systems</title>
+<description override="true">This profile contains items common to general-purpose Ubuntu 1604 installations.</description>
 
 <!-- partitioning -->
 <select idref="partition_for_tmp" selected="true"/>

--- a/webmin/profiles/common.xml
+++ b/webmin/profiles/common.xml
@@ -1,6 +1,6 @@
 <Profile id="common" xmlns="http://checklists.nist.gov/xccdf/1.1" >
-<title>Common Profile for Webmin system administration tool</title>
-<description></description>
+<title override="true">Common Profile for Webmin system administration tool</title>
+<description override="true"></description>
 
 	<select idref="webmin_is_up_to_date" selected="true"/>
 	<select idref="module_useradmin_accounts_char_types" selected="true"/>

--- a/wrlinux/profiles/basic-embedded.xml
+++ b/wrlinux/profiles/basic-embedded.xml
@@ -1,6 +1,6 @@
 <Profile id="basic-embedded">
-<title>Basic Profile for Embedded Systems</title>
-<description>
+<title override="true">Basic Profile for Embedded Systems</title>
+<description override="true">
 This profile contains items common to many embedded Linux installations.
 Regardless of your system's deployment objective, all of these checks should pass.
 </description>


### PR DESCRIPTION
#### Description:

- Checks that all profile titles and descriptions in generated XCCDF files contain `override="true"` attribute.

#### Rationale:

- This check should prevent us from releasing SSG with profiles which are extending other profile but have no `override` attribute set for their `title` and `description` tags.
