### PR TITLE
Do not fail aide_scan_notification with other email adresses

### DIFF
--- a/shared/checks/oval/aide_scan_notification.xml
+++ b/shared/checks/oval/aide_scan_notification.xml
@@ -23,7 +23,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="notify personnel when aide completes" id="object_test_aide_scan_notification" version="1">
     <ind:filepath>/etc/crontab</ind:filepath>
-    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*root@.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*.*@.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -32,7 +32,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="notify personnel when aide completes" id="object_aide_var_cron_notification" version="1">
     <ind:filepath>/var/spool/cron/root</ind:filepath>
-    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*root@.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*.*@.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -42,7 +42,7 @@
   <ind:textfilecontent54_object comment="notify personnel when aide completes in cron.(d|daily|weekly|monthly)" id="object_aide_crontabs_notification" version="1">
     <ind:path operation="pattern match">/etc/cron.(d|daily|weekly|monthly)</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*root@.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*.*@.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
    

--- a/shared/checks/oval/aide_scan_notification.xml
+++ b/shared/checks/oval/aide_scan_notification.xml
@@ -23,7 +23,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="notify personnel when aide completes" id="object_test_aide_scan_notification" version="1">
     <ind:filepath>/etc/crontab</ind:filepath>
-    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*.*@.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*.+@.+$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -32,7 +32,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="notify personnel when aide completes" id="object_aide_var_cron_notification" version="1">
     <ind:filepath>/var/spool/cron/root</ind:filepath>
-    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*.*@.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*.+@.+$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -42,7 +42,7 @@
   <ind:textfilecontent54_object comment="notify personnel when aide completes in cron.(d|daily|weekly|monthly)" id="object_aide_crontabs_notification" version="1">
     <ind:path operation="pattern match">/etc/cron.(d|daily|weekly|monthly)</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*.*@.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^.*/usr/sbin/aide[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*.+@.+$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
    


### PR DESCRIPTION



#### Description:

The rule aide_scan_notification says that AIDE should notify appropriate
personnel of the details of an AIDE scan. The check currently requires
that the email address of the appropriate personnel starts with 'root@'.
In practice, the email address could be any email address. The check
should match any email address.

#### Rationale:
Fixes RHBZ#1540505
