### PR TITLE
Add anssi reference to rsyslog_service_enabled

### DIFF
--- a/shared/xccdf/system/logging.xml
+++ b/shared/xccdf/system/logging.xml
@@ -49,7 +49,7 @@ logging services, which are essential to system administration.
 </rationale>
 <ident prodtype="rhel7" cce="80188-6" />
 <oval id="service_rsyslog_enabled" />
-<ref nist="AU-4(1),AU-12" disa="1311,1312,1557,1851" cis="4.2.1.1" />
+<ref nist="AU-4(1),AU-12" disa="1311,1312,1557,1851" cis="4.2.1.1" anssi="NT28(R5),NT28(R46)"/>
 </Rule>
 
 <Group id="ensure_rsyslog_log_file_configuration">


### PR DESCRIPTION
#### Description:

- Added reference to `rsyslog_service_enabled`
#### Rationale:

- Enabling rsyslog service is same requirement as installing rsyslog


