### PR TITLE
Audit kernel module arches

### DIFF
--- a/rhel6/fixes/bash/audit_rules_kernel_module_loading.sh
+++ b/rhel6/fixes/bash/audit_rules_kernel_module_loading.sh
@@ -5,11 +5,11 @@
 
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system
-# Note: 32-bit kernel modules can't be loaded / unloaded on 64-bit kernel =>
-#       it's not required on a 64-bit system to check also for the presence
-#       of 32-bit's equivalent of the corresponding rule. Therefore for
-#       each system it's enought to check presence of system's native rule form.
-[ $(getconf LONG_BIT) = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b64")
+# If the system has a 32-bit processor, only the 32-bit rule is needed.
+# If the system has a 64-bit processor, both arch 32 and 64 need to be included in
+# the audit file because it is not possible to know if the computer will be booted
+# in 64 or 32 bit mode or for which architecture a binary is compiled.
+[ $(getconf LONG_BIT) = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
 for ARCH in "${RULE_ARCHS[@]}"
 do

--- a/rhel6/xccdf/system/auditing.xml
+++ b/rhel6/xccdf/system/auditing.xml
@@ -1510,6 +1510,10 @@ stigid="RHEL-06-000201" srg="SRG-OS-000064" />
 <title>Ensure <tt>auditd</tt> Collects Information on Kernel Module Loading and Unloading</title>
 <description>Add the following to <tt>/etc/audit/audit.rules</tt> in order
 to capture kernel module loading and unloading events, setting ARCH to either b32 or b64 as appropriate for your system:
+If the system has a 32-bit processor, only the 32-bit rule is needed.
+If the system has a 64-bit processor, both arch 32 and 64 rules are needed because it is
+not possible to know if the computer will be booted in 64 or 32 bit mode or for which architecture
+a binary is compiled.
 <pre>-w /sbin/insmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
 -w /sbin/modprobe -p x -k modules

--- a/shared/fixes/bash/audit_rules_kernel_module_loading.sh
+++ b/shared/fixes/bash/audit_rules_kernel_module_loading.sh
@@ -5,11 +5,11 @@
 
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system
-# Note: 32-bit kernel modules can't be loaded / unloaded on 64-bit kernel =>
-#       it's not required on a 64-bit system to check also for the presence
-#       of 32-bit's equivalent of the corresponding rule. Therefore for
-#       each system it's enought to check presence of system's native rule form.
-[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b64")
+# If the system has a 32-bit processor, only the 32-bit rule is needed.
+# If the system has a 64-bit processor, both arch 32 and 64 need to be included in
+# the audit file because it is not possible to know if the computer will be booted
+# in 64 or 32 bit mode or for which architecture a binary is compiled.
+[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
 for ARCH in "${RULE_ARCHS[@]}"
 do

--- a/shared/xccdf/system/auditing.xml
+++ b/shared/xccdf/system/auditing.xml
@@ -3426,6 +3426,10 @@ If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt> utility
 rules during daemon startup, add the following lines to <tt>/etc/audit/audit.rules</tt> file
 in order to capture kernel module loading and unloading events, setting ARCH to either b32 or
 b64 as appropriate for your system:
+If the system has a 32-bit processor, only the 32-bit rule is needed.
+If the system has a 64-bit processor, both arch 32 and 64 rules are needed because it is
+not possible to know if the computer will be booted in 64 or 32 bit mode or for which architecture
+a binary is compiled.
 <pre>-w /usr/sbin/insmod -p x -k modules
 -w /usr/sbin/rmmod -p x -k modules
 -w /usr/sbin/modprobe -p x -k modules
@@ -3455,6 +3459,10 @@ If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt> utility
 rules during daemon startup, add the following lines to <tt>/etc/audit/audit.rules</tt> file
 in order to capture kernel module loading and unloading events, setting ARCH to either b32 or
 b64 as appropriate for your system:
+If the system has a 32-bit processor, only the 32-bit rule is needed.
+If the system has a 64-bit processor, both arch 32 and 64 rules are needed because it is
+not possible to know if the computer will be booted in 64 or 32 bit mode or for which architecture
+a binary is compiled.
 <pre>-a always,exit -F arch=<i>ARCH</i> -S init_module -F key=modules</pre>
 </description>
 <ocil>
@@ -3481,6 +3489,10 @@ If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt> utility
 rules during daemon startup, add the following lines to <tt>/etc/audit/audit.rules</tt> file
 in order to capture kernel module loading and unloading events, setting ARCH to either b32 or
 b64 as appropriate for your system:
+If the system has a 32-bit processor, only the 32-bit rule is needed.
+If the system has a 64-bit processor, both arch 32 and 64 rules are needed because it is
+not possible to know if the computer will be booted in 64 or 32 bit mode or for which architecture
+a binary is compiled.
 <pre>-a always,exit -F arch=<i>ARCH</i> -S delete_module -F key=modules</pre>
 </description>
 <ocil>


### PR DESCRIPTION
#### Description:

- Update fix for `audit_rules_kernel_module_loading` to follow same pattern as `audit_rules_kernel_module_loading_init` and `audit_rules_kernel_module_loading_delete` done in #2532.
- Update description of rules below to make clear that 32 bit kernel modules need to be checked on 64bit systems.
  - `audit_rules_kernel_module_loading`
  - `audit_rules_kernel_module_loading_init`
  - `audit_rules_kernel_module_loading_delete`

#### Rationale:

- There is often confusion regarding which kernel module related syscalls to audit in 64 bit systems.
- Check for `audit_rules_kernel_module_loading` extends definition of `audit_rules_kernel_module_loading_init` and `audit_rules_kernel_module_loading_delete` but their remediations are out of sync.
