### PR TITLE
Grub2 password fix

### DIFF
--- a/fedora/xccdf/system/accounts/physical.xml
+++ b/fedora/xccdf/system/accounts/physical.xml
@@ -78,20 +78,19 @@ parameters.
 <description>The grub2 boot loader should have a superuser account and password
 protection enabled to protect boot-time settings.
 <br /><br />
-To do so, select a superuser account and password and add them into the
-<tt>/etc/grub.d/01_users</tt> configuration file.
+To do so, select a superuser account name and password and and modify the
+<tt>/etc/grub.d/01_users</tt> configuration file with the new account name.
 <br /><br />
 Since plaintext passwords are a security risk, generate a hash for the pasword
 by running the following command:
-<pre>$ grub2-mkpasswd-pbkdf2</pre>
-When prompted, enter the password that was selected and insert the returned 
-password hash into the <tt>/etc/grub.d/01_users</tt> configuration file
-immediately after the superuser account.
-(Use the output from <tt>grub2-mkpasswd-pbkdf2</tt> as the value of 
-<b>password-hash</b>):
-<pre>password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+<pre>$ grub2-setpassword</pre>
+When prompted, enter the password that was selected. 
+<br /><br />
 NOTE: It is recommended not to use common administrator account names like root,
 admin, or administrator for the grub2 superuser account. 
+<br /><br />
+Change the superuser to a different username (The default is 'root').
+<pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>
 <br /><br />
 To meet FISMA Moderate, the bootloader superuser account and password MUST 
 differ from the root account and password.
@@ -107,6 +106,7 @@ been set, and the password encrypted, run the following command:
 <pre>sudo grep -A1 "superusers\|password" /etc/grub2.cfg</pre>
 The output should show the following:
 <pre>set superusers="<b>superusers-account</b>"
+export <b>superusers</b>
 password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
 </ocil>
 <rationale>
@@ -128,24 +128,23 @@ the grub2 superuser account and password, please refer to
 <description>The UEFI grub2 boot loader should have a superuser account and password
 protection enabled to protect boot-time settings.
 <br /><br />
-To do so, select a superuser account and password and add them into the
-<tt>/etc/grub.d/01_users</tt> configuration file.
+To do so, select a superuser account name and password and and modify the
+<tt>/etc/grub.d/01_users</tt> configuration file with the new account name.
 <br /><br />
 Since plaintext passwords are a security risk, generate a hash for the pasword
 by running the following command:
-<pre>$ grub2-mkpasswd-pbkdf2</pre>
-When prompted, enter the password that was selected and insert the returned
-password hash into the <tt>/etc/grub.d/01_users</tt> configuration file immediately
-after the superuser account.
-(Use the output from <tt>grub2-mkpasswd-pbkdf2</tt> as the value of
-<b>password-hash</b>):
-<pre>password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+<pre>$ grub2-setpassword</pre>
+When prompted, enter the password that was selected.
+<br /><br />
 NOTE: It is recommended not to use common administrator account names like root,
 admin, or administrator for the grub2 superuser account.
 <br /><br />
-To meet FISMA Moderate, the bootloader superuser account and password MUST
+Change the superuser to a different username (The default is 'root').
+<pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>
+<br /><br />
+To meet FISMA Moderate, the bootloader superuser account and password MUST 
 differ from the root account and password.
-Once the superuser account and password have been added, update the
+Once the superuser account and password have been added, update the 
 <tt>grub.cfg</tt> file by running:
 <pre>grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre>
 NOTE: Do NOT manually add the superuser account and password to the
@@ -157,6 +156,7 @@ been set, and the password encrypted, run the following command:
 <pre>sudo grep -A1 "superusers\|password" /etc/grub2-efi.cfg</pre>
 The output should show the following:
 <pre>set superusers="<b>superusers-account</b>"
+export <b>superusers</b>
 password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
 </ocil>
 <rationale>

--- a/shared/checks/oval/bootloader_password.xml
+++ b/shared/checks/oval/bootloader_password.xml
@@ -11,7 +11,7 @@
     <criteria operator="OR">
       <criterion comment="Pass if /boot/grub2/grub.cfg does not exist" test_ref="test_bootloader_grub_cfg" />
       <criteria operator="AND">
-        <criterion comment="make sure a password is defined in /boot/grub2/grub.cfg" test_ref="test_bootloader_password" />
+        <criterion comment="make sure a password is defined in /boot/grub2/user.cfg" test_ref="test_bootloader_password" />
         <criterion comment="make sure a superuser is defined in /boot/grub2/grub.cfg" test_ref="test_bootloader_superuser"/>
       </criteria>
     </criteria>
@@ -33,11 +33,11 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/grub2/grub.cfg" id="test_bootloader_password" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/grub2/user.cfg" id="test_bootloader_password" version="1">
     <ind:object object_ref="object_bootloader_password" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_password" version="1">
-    <ind:filepath>/boot/grub2/grub.cfg</ind:filepath>
+    <ind:filepath>/boot/grub2/user.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/checks/oval/bootloader_uefi_password.xml
+++ b/shared/checks/oval/bootloader_uefi_password.xml
@@ -12,7 +12,7 @@
     <criteria operator="OR">
       <criterion comment="Pass if /boot/efi/EFI/redhat/grub.cfg does not exist" test_ref="test_bootloader_uefi_grub_cfg" />
       <criteria operator="AND">
-        <criterion comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_uefi_password" />
+        <criterion comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" test_ref="test_bootloader_uefi_password" />
         <criterion comment="make sure a superuser is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_uefi_superuser"/>
       </criteria>
     </criteria>
@@ -34,11 +34,11 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" id="test_bootloader_uefi_password" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" id="test_bootloader_uefi_password" version="1">
     <ind:object object_ref="object_bootloader_uefi_password" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_uefi_password" version="1">
-    <ind:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/grub.cfg</ind:filepath>
+    <ind:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/user.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/references/disa-stig-rhel7-v1r1-xccdf-manual.xml
+++ b/shared/references/disa-stig-rhel7-v1r1-xccdf-manual.xml
@@ -764,54 +764,47 @@ If the "HostbasedAuthentication" keyword is not set to "no", is missing, or is c
 
 Generate an encrypted grub2 password for root with the following command:
 
-Note: The hash generated is an example.
-
-# grub-mkpasswd-pbkdf2
+# grub2-setpassword
 Enter Password:
 Reenter Password:
-PBKDF2 hash of your password is grub.pbkdf2.sha512.10000.F3A7CFAA5A51EED123BE8238C23B25B2A6909AFC9812F0D45
 
-Using this hash, modify the "/etc/grub.d/10_linux" file with the following commands to add the password to the root entry:
-
-# cat &lt;&lt; EOF
-&gt; set superusers="root" password_pbkdf2 smithj grub.pbkdf2.sha512.10000.F3A7CFAA5A51EED123BE8238C23B25B2A6909AFC9812F0D45
-&gt; EOF
+The hash of your password is is stored in /boot/grub2/user.cfg
 
 Generate a new "grub.conf" file with the new password with the following commands:
 
-# grub2-mkconfig --output=/tmp/grub2.cfg
-# mv /tmp/grub2.cfg /boot/grub2/grub.cfg</fixtext><fix id="F-78313r1_fix" /><check system="C-72193r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_RHEL_7_STIG.xml" /><check-content>Check to see if an encrypted root password is set. On systems that use a BIOS, use the following command:
+# grub2-mkconfig -o /boot/grub2/grub.cfg</fixtext><fix id="F-78313r1_fix" /><check system="C-72193r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_RHEL_7_STIG.xml" /><check-content>Check to see if an encrypted root password is set. On systems that use a BIOS, use the following commands:
 
 # grep -i password /boot/grub2/grub.cfg
-password_pbkdf2 superusers-account password-hash
+password_pbkdf2 root ${GRUB2_PASSWORD}
 
-If the root password entry does not begin with "password_pbkdf2", this is a finding.</check-content></check></Rule></Group><Group id="V-71963"><title>SRG-OS-000080-GPOS-00048</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-86587r1_rule" severity="high" weight="10.0"><version>RHEL-07-010490</version><title>Systems using Unified Extensible Firmware Interface (UEFI) must require authentication upon booting into single-user and maintenance modes.</title><description>&lt;VulnDiscussion&gt;If the system does not require valid root authentication before it boots into single-user or maintenance mode, anyone who invokes single-user or maintenance mode is granted privileged access to all files on the system. GRUB 2 is the default boot loader for RHEL 7 and is designed to require a password to boot into single-user mode or make modifications to the boot menu.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Red Hat 7</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Red Hat 7</dc:subject><dc:identifier>2777</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000213</ident><fixtext fixref="F-78315r1_fix">Configure the system to encrypt the boot password for root.
+# cat /boot/grub2/user.cfg
+GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.4D4691C59A015F3426D45A74972EE2AF042F0711F020F42A3F6989337A50E46399B2EC3C7000879C0EDCAF8C9484EE01B3D79F10003FAF15761688E6145E0ED1.336450B1DC48E6C0E38080709E1A67D80094A274A2486A296ECF8CA97D542FA55247F4B0384195361A96987C5936F9B64F0E0977B8EEDE6EA0DF0D3BD35D6D77
+
+Note: the above hash is an example and will be different than the returned hash.
+
+If the root password entry does not begin with "password_pbkdf2", or if /boot/grub2/user.cfg is either empty or missing, this is a finding.</check-content></check></Rule></Group><Group id="V-71963"><title>SRG-OS-000080-GPOS-00048</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-86587r1_rule" severity="high" weight="10.0"><version>RHEL-07-010490</version><title>Systems using Unified Extensible Firmware Interface (UEFI) must require authentication upon booting into single-user and maintenance modes.</title><description>&lt;VulnDiscussion&gt;If the system does not require valid root authentication before it boots into single-user or maintenance mode, anyone who invokes single-user or maintenance mode is granted privileged access to all files on the system. GRUB 2 is the default boot loader for RHEL 7 and is designed to require a password to boot into single-user mode or make modifications to the boot menu.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Red Hat 7</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Red Hat 7</dc:subject><dc:identifier>2777</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000213</ident><fixtext fixref="F-78315r1_fix">Configure the system to encrypt the boot password for root.
 
 Generate an encrypted grub2 password for root with the following command:
 
-Note: The hash generated is an example.
-
-# grub-mkpasswd-pbkdf2
+# grub2-setpassword
 Enter Password:
 Reenter Password:
 
-PBKDF2 hash of your password is grub.pbkdf2.sha512.10000.F3A7CFAA5A51EED123BE8238C23B25B2A6909AFC9812F0D45
-
-Using this hash, modify the "/etc/grub.d/10_linux" file with the following commands to add the password to the root entry:
-
-# cat &lt;&lt; EOF
-&gt; set superusers="root" password_pbkdf2 smithj grub.pbkdf2.sha512.10000.F3A7CFAA5A51EED123BE8238C23B25B2A6909AFC9812F0D45
-&gt; EOF
+The hash of your password is is stored in /boot/grub2/user.cfg
 
 Generate a new "grub.conf" file with the new password with the following commands:
 
-# grub2-mkconfig --output=/tmp/grub2.cfg
-# mv /tmp/grub2.cfg /boot/efi/EFI/redhat/grub.cfg</fixtext><fix id="F-78315r1_fix" /><check system="C-72195r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_RHEL_7_STIG.xml" /><check-content>Check to see if an encrypted root password is set. On systems that use UEFI, use the following command:
+# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</fixtext><fix id="F-78313r1_fix" /><check system="C-72195r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_RHEL_7_STIG.xml" /><check-content>Check to see if an encrypted root password is set. On systems that use UEFI, use the following commands:
 
 # grep -i password /boot/efi/EFI/redhat/grub.cfg
-password_pbkdf2 superusers-account password-hash
+password_pbkdf2 root ${GRUB2_PASSWORD}
 
-If the root password entry does not begin with "password_pbkdf2", this is a finding.</check-content></check></Rule></Group><Group id="V-71965"><title>SRG-OS-000104-GPOS-00051</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-86589r1_rule" severity="medium" weight="10.0"><version>RHEL-07-010500</version><title>The operating system must uniquely identify and must authenticate organizational users (or processes acting on behalf of organizational users) using multifactor authentication.</title><description>&lt;VulnDiscussion&gt;To assure accountability and prevent unauthenticated access, organizational users must be identified and authenticated to prevent potential misuse and compromise of the system.
+# cat /boot/efi/EFI/redhat/user.cfg
+GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.4D4691C59A015F3426D45A74972EE2AF042F0711F020F42A3F6989337A50E46399B2EC3C7000879C0EDCAF8C9484EE01B3D79F10003FAF15761688E6145E0ED1.336450B1DC48E6C0E38080709E1A67D80094A274A2486A296ECF8CA97D542FA55247F4B0384195361A96987C5936F9B64F0E0977B8EEDE6EA0DF0D3BD35D6D77
+
+Note: the above hash is an example and will be different than the returned hash.
+
+If the root password entry does not begin with "password_pbkdf2", or if /boot/efi/EFI/redhat/user.cfg is either empty or missing, this is a finding.</check-content></check></Rule></Group><Group id="V-71965"><title>SRG-OS-000104-GPOS-00051</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-86589r1_rule" severity="medium" weight="10.0"><version>RHEL-07-010500</version><title>The operating system must uniquely identify and must authenticate organizational users (or processes acting on behalf of organizational users) using multifactor authentication.</title><description>&lt;VulnDiscussion&gt;To assure accountability and prevent unauthenticated access, organizational users must be identified and authenticated to prevent potential misuse and compromise of the system.
 
 Organizational users include organizational employees or individuals the organization deems to have equivalent status of employees (e.g., contractors). Organizational users (and processes acting on behalf of users) must be uniquely identified and authenticated to all accesses, except for the following:
 

--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -143,20 +143,19 @@ parameters.
 <description>The grub2 boot loader should have a superuser account and password
 protection enabled to protect boot-time settings.
 <br /><br />
-To do so, select a superuser account and password and add them into the
-<tt>/etc/grub.d/01_users</tt> configuration file.
+To do so, select a superuser account name and password and and modify the
+<tt>/etc/grub.d/01_users</tt> configuration file with the new account name.
 <br /><br />
 Since plaintext passwords are a security risk, generate a hash for the pasword
 by running the following command:
-<pre>$ grub2-mkpasswd-pbkdf2</pre>
-When prompted, enter the password that was selected and insert the returned
-password hash into the <tt>/etc/grub.d/01_users</tt> configuration file
-immediately after the superuser account.
-(Use the output from <tt>grub2-mkpasswd-pbkdf2</tt> as the value of
-<b>password-hash</b>):
-<pre>password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+<pre>$ grub2-setpassword</pre>
+When prompted, enter the password that was selected.
+<br /><br />
 NOTE: It is recommended not to use common administrator account names like root,
 admin, or administrator for the grub2 superuser account.
+<br /><br />
+Change the superuser to a different username (The default is 'root').
+<pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>
 <br /><br />
 To meet FISMA Moderate, the bootloader superuser account and password MUST
 differ from the root account and password.
@@ -172,6 +171,7 @@ been set, and the password encrypted, run the following command:
 <pre>$ sudo grep -A1 "superusers\|password" /etc/grub2.cfg</pre>
 The output should show the following:
 <pre>set superusers="<b>superusers-account</b>"
+export <b>superusers</b>
 password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
 </ocil>
 <rationale>
@@ -200,20 +200,19 @@ must be automated as a component of machine provisioning, or followed manually a
 <description>The UEFI grub2 boot loader should have a superuser account and password
 protection enabled to protect boot-time settings.
 <br /><br />
-To do so, select a superuser account and password and add them into the
-<tt>/etc/grub.d/01_users</tt> configuration file.
+To do so, select a superuser account name and password and and modify the
+<tt>/etc/grub.d/01_users</tt> configuration file with the new account name.
 <br /><br />
 Since plaintext passwords are a security risk, generate a hash for the pasword
 by running the following command:
-<pre>$ grub2-mkpasswd-pbkdf2</pre>
-When prompted, enter the password that was selected and insert the returned
-password hash into the <tt>/etc/grub.d/01_users</tt> configuration file immediately
-after the superuser account.
-(Use the output from <tt>grub2-mkpasswd-pbkdf2</tt> as the value of
-<b>password-hash</b>):
-<pre>password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+<pre>$ grub2-setpassword</pre>
+When prompted, enter the password that was selected.
+<br /><br />
 NOTE: It is recommended not to use common administrator account names like root,
 admin, or administrator for the grub2 superuser account.
+<br /><br />
+Change the superuser to a different username (The default is 'root').
+<pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>
 <br /><br />
 To meet FISMA Moderate, the bootloader superuser account and password MUST
 differ from the root account and password.
@@ -229,6 +228,7 @@ been set, and the password encrypted, run the following command:
 <pre>sudo grep -A1 "superusers\|password" /etc/grub2-efi.cfg</pre>
 The output should show the following:
 <pre>set superusers="<b>superusers-account</b>"
+export <b>superusers</b>
 password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
 </ocil>
 <rationale>


### PR DESCRIPTION
#### Description:

- This is my first PR that I am attempting on my own - please let me know if I screwed anything up.  Red Hat documentation now uses the grub2-setpassword command to set the boot loader password.  This patch corrects the instructions for the DISA STIG as well as changes the OVAL content to check user.cfg for the presence to a configured password.

#### Rationale:

- Change was needed to be in line with Red Hat documentation on securing the boot loader with a password.  DISA Is making changes to their DoD STIG content as well.