### PR TITLE
Grub2 password fix

### DIFF
--- a/fedora/xccdf/system/accounts/physical.xml
+++ b/fedora/xccdf/system/accounts/physical.xml
@@ -154,7 +154,7 @@ To meet FISMA Moderate, the bootloader superuser account and password MUST
 differ from the root account and password.
 Once the superuser account and password have been added, update the
 <tt>grub.cfg</tt> file by running:
-<pre>grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre>
+<pre>grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre>
 NOTE: Do NOT manually add the superuser account and password to the
 <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 </description>
@@ -168,7 +168,7 @@ export superusers
 password_pbkdf2 <b>superusers-account</b> <b>${GRUB2_PASSWORD}</b></pre>
 To verify the boot loader superuser account password has been set,
 and the password encrypted, run the following command:
-<pre>sudo cat /boot/efi/EFI/redhat/user.cfg</pre>
+<pre>sudo cat /boot/efi/EFI/fedora/user.cfg</pre>
 The output should show the following (NOTE: the hash will be different):
 <pre>GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
 2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0

--- a/fedora/xccdf/system/accounts/physical.xml
+++ b/fedora/xccdf/system/accounts/physical.xml
@@ -143,12 +143,6 @@ after the superuser account.
 NOTE: It is recommended not to use common administrator account names like root,
 admin, or administrator for the grub2 superuser account.
 <br /><br />
-<<<<<<< HEAD
-<<<<<<< HEAD
-To meet FISMA Moderate, the bootloader superuser account and password MUST
-=======
-=======
->>>>>>> fa8e79ca4dc6447d0aea25af217c4717e50c056e
 Change the superuser to a different username.  In the below command, bootuser
 is used for the new superuser account name. (The default is 'root').
 <pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>

--- a/fedora/xccdf/system/accounts/physical.xml
+++ b/fedora/xccdf/system/accounts/physical.xml
@@ -78,36 +78,44 @@ parameters.
 <description>The grub2 boot loader should have a superuser account and password
 protection enabled to protect boot-time settings.
 <br /><br />
-To do so, select a superuser account and password and add them into the
-<tt>/etc/grub.d/01_users</tt> configuration file.
+To do so, select a superuser account name and password and and modify the
+<tt>/etc/grub.d/01_users</tt> configuration file with the new account name.
 <br /><br />
 Since plaintext passwords are a security risk, generate a hash for the pasword
 by running the following command:
-<pre>$ grub2-mkpasswd-pbkdf2</pre>
-When prompted, enter the password that was selected and insert the returned 
-password hash into the <tt>/etc/grub.d/01_users</tt> configuration file
-immediately after the superuser account.
-(Use the output from <tt>grub2-mkpasswd-pbkdf2</tt> as the value of 
-<b>password-hash</b>):
-<pre>password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
-NOTE: It is recommended not to use common administrator account names like root,
-admin, or administrator for the grub2 superuser account. 
+<pre>$ grub2-setpassword</pre>
+When prompted, enter the password that was selected.
 <br /><br />
-To meet FISMA Moderate, the bootloader superuser account and password MUST 
+NOTE: It is recommended not to use common administrator account names like root,
+admin, or administrator for the grub2 superuser account.
+<br /><br />
+Change the superuser to a different username (The default is 'root').
+<pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>
+<br /><br />
+To meet FISMA Moderate, the bootloader superuser account and password MUST
 differ from the root account and password.
-Once the superuser account and password have been added, update the 
+Once the superuser account and password have been added, update the
 <tt>grub.cfg</tt> file by running:
 <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
-NOTE: Do NOT manually add the superuser account and password to the 
+NOTE: Do NOT manually add the superuser account and password to the
 <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 </description>
 <ocil clause="it does not">
-To verify the boot loader superuser account and superuser account password have
-been set, and the password encrypted, run the following command:
+To verify the boot loader superuser account has been set, run the following
+command:
 <pre>sudo grep -A1 "superusers\|password" /etc/grub2.cfg</pre>
 The output should show the following:
 <pre>set superusers="<b>superusers-account</b>"
-password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+export superusers
+password_pbkdf2 <b>superusers-account</b> <b>${GRUB2_PASSWORD}</b></pre>
+To verify the boot loader superuser account password has been set,
+and the password encrypted, run the following command:
+<pre>sudo cat /boot/grub2/user.cfg</pre>
+The output should show the following (NOTE: the hash will be different):
+<pre>GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
+2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0
+916F7AB46E0D.1302284FCCC52CD73BA3671C6C12C26FF50BA873293B24EE2A96EE3B57963E6D7
+0C83964B473EC8F93B07FE749AA6710269E904A9B08A6BBACB00A2D242AD828</pre>
 </ocil>
 <rationale>
 Password protection on the boot loader configuration ensures
@@ -125,44 +133,47 @@ the grub2 superuser account and password, please refer to
 
 <Rule id="bootloader_uefi_password" severity="medium">
 <title>Set the UEFI Boot Loader Password</title>
-<description>The UEFI grub2 boot loader should have a superuser account and password
+<description>The grub2 boot loader should have a superuser account and password
 protection enabled to protect boot-time settings.
 <br /><br />
-To do so, select a superuser account and password and add them into the
-<tt>/etc/grub.d/01_users</tt> configuration file.
+To do so, select a superuser account name and password and and modify the
+<tt>/etc/grub.d/01_users</tt> configuration file with the new account name.
 <br /><br />
 Since plaintext passwords are a security risk, generate a hash for the pasword
 by running the following command:
-<pre>$ grub2-mkpasswd-pbkdf2</pre>
-When prompted, enter the password that was selected and insert the returned
-password hash into the <tt>/etc/grub.d/01_users</tt> configuration file immediately
-after the superuser account.
-(Use the output from <tt>grub2-mkpasswd-pbkdf2</tt> as the value of
-<b>password-hash</b>):
-<pre>password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+<pre>$ grub2-setpassword</pre>
+When prompted, enter the password that was selected.
+<br /><br />
 NOTE: It is recommended not to use common administrator account names like root,
 admin, or administrator for the grub2 superuser account.
 <br /><br />
-Change the superuser to a different username.  In the below command, bootuser
-is used for the new superuser account name. (The default is 'root').
+Change the superuser to a different username (The default is 'root').
 <pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>
 <br /><br />
-To meet FISMA Moderate, the bootloader superuser account and password MUST 
->>>>>>> fix grub2 boot loader password so that is aligns with documentation.
+To meet FISMA Moderate, the bootloader superuser account and password MUST
 differ from the root account and password.
 Once the superuser account and password have been added, update the
 <tt>grub.cfg</tt> file by running:
-<pre>grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre>
+<pre>grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre>
 NOTE: Do NOT manually add the superuser account and password to the
 <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 </description>
 <ocil clause="it does not">
-To verify the boot loader superuser account and superuser account password have
-been set, and the password encrypted, run the following command:
+To verify the boot loader superuser account has been set, run the following
+command:
 <pre>sudo grep -A1 "superusers\|password" /etc/grub2-efi.cfg</pre>
 The output should show the following:
 <pre>set superusers="<b>superusers-account</b>"
-password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+export superusers
+password_pbkdf2 <b>superusers-account</b> <b>${GRUB2_PASSWORD}</b></pre>
+To verify the boot loader superuser account password has been set,
+and the password encrypted, run the following command:
+<pre>sudo cat /boot/efi/EFI/redhat/user.cfg</pre>
+The output should show the following (NOTE: the hash will be different):
+<pre>GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
+2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0
+916F7AB46E0D.1302284FCCC52CD73BA3671C6C12C26FF50BA873293B24EE2A96EE3B57963E6D7
+0C83964B473EC8F93B07FE749AA6710269E904A9B08A6BBACB00A2D242AD828</pre>
 </ocil>
 <rationale>
 Password protection on the boot loader configuration ensures

--- a/fedora/xccdf/system/accounts/physical.xml
+++ b/fedora/xccdf/system/accounts/physical.xml
@@ -143,7 +143,15 @@ after the superuser account.
 NOTE: It is recommended not to use common administrator account names like root,
 admin, or administrator for the grub2 superuser account.
 <br /><br />
+<<<<<<< HEAD
 To meet FISMA Moderate, the bootloader superuser account and password MUST
+=======
+Change the superuser to a different username.  In the below command, bootuser
+is used for the new superuser account name. (The default is 'root').
+<pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>
+<br /><br />
+To meet FISMA Moderate, the bootloader superuser account and password MUST 
+>>>>>>> fix grub2 boot loader password so that is aligns with documentation.
 differ from the root account and password.
 Once the superuser account and password have been added, update the
 <tt>grub.cfg</tt> file by running:

--- a/shared/checks/oval/bootloader_password.xml
+++ b/shared/checks/oval/bootloader_password.xml
@@ -11,7 +11,7 @@
     <criteria operator="OR">
       <criterion comment="Pass if /boot/grub2/grub.cfg does not exist" test_ref="test_bootloader_grub_cfg" />
       <criteria operator="AND">
-        <criterion comment="make sure a password is defined in /boot/grub2/grub.cfg" test_ref="test_bootloader_password" />
+        <criterion comment="make sure a password is defined in /boot/grub2/user.cfg" test_ref="test_bootloader_password" />
         <criterion comment="make sure a superuser is defined in /boot/grub2/grub.cfg" test_ref="test_bootloader_superuser"/>
       </criteria>
     </criteria>
@@ -33,11 +33,11 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/grub2/grub.cfg" id="test_bootloader_password" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/grub2/user.cfg" id="test_bootloader_password" version="1">
     <ind:object object_ref="object_bootloader_password" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_password" version="1">
-    <ind:filepath>/boot/grub2/grub.cfg</ind:filepath>
+    <ind:filepath>/boot/grub2/user.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/checks/oval/bootloader_uefi_password.xml
+++ b/shared/checks/oval/bootloader_uefi_password.xml
@@ -12,7 +12,7 @@
     <criteria operator="OR">
       <criterion comment="Pass if /boot/efi/EFI/redhat/grub.cfg does not exist" test_ref="test_bootloader_uefi_grub_cfg" />
       <criteria operator="AND">
-        <criterion comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_uefi_password" />
+        <criterion comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" test_ref="test_bootloader_uefi_password" />
         <criterion comment="make sure a superuser is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_uefi_superuser"/>
       </criteria>
     </criteria>
@@ -34,11 +34,11 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" id="test_bootloader_uefi_password" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" id="test_bootloader_uefi_password" version="1">
     <ind:object object_ref="object_bootloader_uefi_password" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_uefi_password" version="1">
-    <ind:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/grub.cfg</ind:filepath>
+    <ind:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/user.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -158,17 +158,10 @@ immediately after the superuser account.
 NOTE: It is recommended not to use common administrator account names like root,
 admin, or administrator for the grub2 superuser account.
 <br /><br />
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
 Change the superuser to a different username.  In the below command, bootuser
-=======
-Change the superuser to a different username.  In the below command, bootuser 
->>>>>>> fa8e79ca4dc6447d0aea25af217c4717e50c056e
 is used for the new superuser account name. (The default is 'root').
 <pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>
 <br /><br />
->>>>>>> fix grub2 boot loader password so that is aligns with documentation.
 To meet FISMA Moderate, the bootloader superuser account and password MUST
 differ from the root account and password.
 Once the superuser account and password have been added, update the

--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -158,6 +158,13 @@ immediately after the superuser account.
 NOTE: It is recommended not to use common administrator account names like root,
 admin, or administrator for the grub2 superuser account.
 <br /><br />
+<<<<<<< HEAD
+=======
+Change the superuser to a different username.  In the below command, bootuser
+is used for the new superuser account name. (The default is 'root').
+<pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>
+<br /><br />
+>>>>>>> fix grub2 boot loader password so that is aligns with documentation.
 To meet FISMA Moderate, the bootloader superuser account and password MUST
 differ from the root account and password.
 Once the superuser account and password have been added, update the

--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -176,7 +176,7 @@ password_pbkdf2 <b>superusers-account</b> <b>${GRUB2_PASSWORD}</b></pre>
 To verify the boot loader superuser account password has been set,
 and the password encrypted, run the following command:
 <pre>sudo cat /boot/grub2/user.cfg</pre>
-The output should show the following (NOTE: the hash will be different):
+The output should be similar to:
 <pre>GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
 2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0
 916F7AB46E0D.1302284FCCC52CD73BA3671C6C12C26FF50BA873293B24EE2A96EE3B57963E6D7
@@ -241,7 +241,7 @@ password_pbkdf2 <b>superusers-account</b> <b>${GRUB2_PASSWORD}</b></pre>
 To verify the boot loader superuser account password has been set,
 and the password encrypted, run the following command:
 <pre>sudo cat /boot/efi/EFI/redhat/user.cfg</pre>
-The output should show the following (NOTE: the hash will be different):
+The output should be similar to:
 <pre>GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
 2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0
 916F7AB46E0D.1302284FCCC52CD73BA3671C6C12C26FF50BA873293B24EE2A96EE3B57963E6D7

--- a/shared/xccdf/system/accounts/physical.xml
+++ b/shared/xccdf/system/accounts/physical.xml
@@ -143,40 +143,44 @@ parameters.
 <description>The grub2 boot loader should have a superuser account and password
 protection enabled to protect boot-time settings.
 <br /><br />
-To do so, select a superuser account and password and add them into the
-<tt>/etc/grub.d/01_users</tt> configuration file.
+To do so, select a superuser account name and password and and modify the
+<tt>/etc/grub.d/01_users</tt> configuration file with the new account name.
 <br /><br />
 Since plaintext passwords are a security risk, generate a hash for the pasword
 by running the following command:
-<pre>$ grub2-mkpasswd-pbkdf2</pre>
-When prompted, enter the password that was selected and insert the returned
-password hash into the <tt>/etc/grub.d/01_users</tt> configuration file
-immediately after the superuser account.
-(Use the output from <tt>grub2-mkpasswd-pbkdf2</tt> as the value of
-<b>password-hash</b>):
-<pre>password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
-NOTE: It is recommended not to use common administrator account names like root,
-admin, or administrator for the grub2 superuser account.
+<pre>$ grub2-setpassword</pre>
+When prompted, enter the password that was selected. 
 <br /><br />
-Change the superuser to a different username.  In the below command, bootuser
-is used for the new superuser account name. (The default is 'root').
+NOTE: It is recommended not to use common administrator account names like root,
+admin, or administrator for the grub2 superuser account. 
+<br /><br />
+Change the superuser to a different username (The default is 'root').
 <pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>
 <br /><br />
-To meet FISMA Moderate, the bootloader superuser account and password MUST
+To meet FISMA Moderate, the bootloader superuser account and password MUST 
 differ from the root account and password.
-Once the superuser account and password have been added, update the
+Once the superuser account and password have been added, update the 
 <tt>grub.cfg</tt> file by running:
 <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
-NOTE: Do NOT manually add the superuser account and password to the
+NOTE: Do NOT manually add the superuser account and password to the 
 <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 </description>
 <ocil clause="it does not">
-To verify the boot loader superuser account and superuser account password have
-been set, and the password encrypted, run the following command:
-<pre>$ sudo grep -A1 "superusers\|password" /etc/grub2.cfg</pre>
+To verify the boot loader superuser account has been set, run the following
+command:
+<pre>sudo grep -A1 "superusers\|password" /etc/grub2.cfg</pre>
 The output should show the following:
 <pre>set superusers="<b>superusers-account</b>"
-password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+export superusers
+password_pbkdf2 <b>superusers-account</b> <b>${GRUB2_PASSWORD}</b></pre>
+To verify the boot loader superuser account password has been set,
+and the password encrypted, run the following command:
+<pre>sudo cat /boot/grub2/user.cfg</pre>
+The output should show the following (NOTE: the hash will be different):
+<pre>GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
+2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0
+916F7AB46E0D.1302284FCCC52CD73BA3671C6C12C26FF50BA873293B24EE2A96EE3B57963E6D7
+0C83964B473EC8F93B07FE749AA6710269E904A9B08A6BBACB00A2D242AD828</pre>
 </ocil>
 <rationale>
 Password protection on the boot loader configuration ensures
@@ -201,39 +205,47 @@ must be automated as a component of machine provisioning, or followed manually a
 
 <Rule id="bootloader_uefi_password" severity="medium" prodtype="rhel7">
 <title>Set the UEFI Boot Loader Password</title>
-<description>The UEFI grub2 boot loader should have a superuser account and password
+<description>The grub2 boot loader should have a superuser account and password
 protection enabled to protect boot-time settings.
 <br /><br />
-To do so, select a superuser account and password and add them into the
-<tt>/etc/grub.d/01_users</tt> configuration file.
+To do so, select a superuser account name and password and and modify the
+<tt>/etc/grub.d/01_users</tt> configuration file with the new account name.
 <br /><br />
 Since plaintext passwords are a security risk, generate a hash for the pasword
 by running the following command:
-<pre>$ grub2-mkpasswd-pbkdf2</pre>
-When prompted, enter the password that was selected and insert the returned
-password hash into the <tt>/etc/grub.d/01_users</tt> configuration file immediately
-after the superuser account.
-(Use the output from <tt>grub2-mkpasswd-pbkdf2</tt> as the value of
-<b>password-hash</b>):
-<pre>password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
-NOTE: It is recommended not to use common administrator account names like root,
-admin, or administrator for the grub2 superuser account.
+<pre>$ grub2-setpassword</pre>
+When prompted, enter the password that was selected. 
 <br /><br />
-To meet FISMA Moderate, the bootloader superuser account and password MUST
+NOTE: It is recommended not to use common administrator account names like root,
+admin, or administrator for the grub2 superuser account. 
+<br /><br />
+Change the superuser to a different username (The default is 'root').
+<pre>$ sed -i s/root/bootuser/g /etc/grub.d/01_users</pre>
+<br /><br />
+To meet FISMA Moderate, the bootloader superuser account and password MUST 
 differ from the root account and password.
-Once the superuser account and password have been added, update the
+Once the superuser account and password have been added, update the 
 <tt>grub.cfg</tt> file by running:
 <pre>grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre>
-NOTE: Do NOT manually add the superuser account and password to the
+NOTE: Do NOT manually add the superuser account and password to the 
 <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 </description>
 <ocil clause="it does not">
-To verify the boot loader superuser account and superuser account password have
-been set, and the password encrypted, run the following command:
+To verify the boot loader superuser account has been set, run the following
+command:
 <pre>sudo grep -A1 "superusers\|password" /etc/grub2-efi.cfg</pre>
 The output should show the following:
 <pre>set superusers="<b>superusers-account</b>"
-password_pbkdf2 <b>superusers-account</b> <b>password-hash</b></pre>
+export superusers
+password_pbkdf2 <b>superusers-account</b> <b>${GRUB2_PASSWORD}</b></pre>
+To verify the boot loader superuser account password has been set,
+and the password encrypted, run the following command:
+<pre>sudo cat /boot/efi/EFI/redhat/user.cfg</pre>
+The output should show the following (NOTE: the hash will be different):
+<pre>GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
+2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0
+916F7AB46E0D.1302284FCCC52CD73BA3671C6C12C26FF50BA873293B24EE2A96EE3B57963E6D7
+0C83964B473EC8F93B07FE749AA6710269E904A9B08A6BBACB00A2D242AD828</pre>
 </ocil>
 <rationale>
 Password protection on the boot loader configuration ensures


### PR DESCRIPTION
#### Description:

- Fix checks associated with grub2 boot password to align them with documentation

#### Rationale:

- Documentation now directs the use of grub2-setpassword to create a grub2 boot loader password.  The new command stores the password in /boot/grub2/user.cfg with 0600 permissions on BIOS systems (/boot/efi/EFI/redhat/user.cfg on UEFI systems).  Changing to this method is easier to implement and more secure.