### PR TITLE
Clarify references to make it easier to understand which references map to the difference compliance organizations

### DIFF
--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -504,6 +504,19 @@
           <xsl:when test="name() = 'stigid'">
             <xsl:value-of select="normalize-space(concat($os-stigid-concat, .))" />
           </xsl:when>
+          <xsl:when test="name() = 'cis'">
+            <xsl:value-of select="normalize-space(concat('CIS ', $refitem))" />
+          </xsl:when>
+          <xsl:when test="name() = 'cjis'">
+            <xsl:value-of select="normalize-space(concat('CJIS ', $refitem))" />
+          </xsl:when>
+          <xsl:when test="name() = 'cui'">
+            <xsl:value-of select="normalize-space(concat('NIST 800-171 ', $refitem))" />
+          </xsl:when>
+          <xsl:when test="name() = 'hipaa'">
+            <xsl:value-of select="normalize-space(concat('HIPAA ', $refitem))" />
+          </xsl:when>
+          
           <xsl:otherwise>
             <xsl:choose>
               <xsl:when test="name() = 'disa'">


### PR DESCRIPTION
#### Description:

- Clarify references to make it easier to understand which references map to the difference compliance organizations

#### Rationale:

- A lot of compliance organizations use a similar number/decimal scheme e.g. 1.1.1 or 2.1.3 which makes it confusing on which benchmark (HIPAA, NIST 800-171, etc.) reference the rule applies. This hopefully fixes that issue.
