### PR TITLE
Enable correct ansible templte for file modification audit rules

### DIFF
--- a/shared/templates/create_audit_rules_unsuccessful_file_modification.py
+++ b/shared/templates/create_audit_rules_unsuccessful_file_modification.py
@@ -32,7 +32,7 @@ class AuditRulesUnsuccessfulFileModificationGenerator(FilesGenerator):
 
         elif target == "ansible":
             self.file_from_template(
-                "./template_ANSIBLE_audit_rules_privileged_commands",
+                "./template_ANSIBLE_audit_rules_unsuccessful_file_modification",
                 {
                     "%NAME%":	name
                 },


### PR DESCRIPTION
#### Description:

This updates the "ansible" target to use the correct template to generate remediation for the "Record Unauthorized Access Attempts Events to Files (unsuccessful)" set of rules.

Correction allowed for these six rules to be successfully remediated on a local RHEL 7 test system.
#### Rationale:

Previous version built remediation from a template designed for use of privileged commands.

- Fixes https://github.com/OpenSCAP/scap-security-guide/issues/2609
