### PR TITLE
[WIP] Fix #2445

### DIFF
--- a/shared/checks/oval/dconf_gnome_banner_enabled.xml
+++ b/shared/checks/oval/dconf_gnome_banner_enabled.xml
@@ -10,6 +10,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="gdm installed" definition_ref="package_gdm_installed" negate="true" />
       <criteria comment="Enable GUI banner and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Enable GUI banner" test_ref="test_banner_gui_enabled" />

--- a/shared/checks/oval/dconf_gnome_disable_automount.xml
+++ b/shared/checks/oval/dconf_gnome_disable_automount.xml
@@ -13,6 +13,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="gnome-desktop3 installed" definition_ref="package_gnome-desktop3_installed" negate="true" />
       <criteria comment="Disable GNOME3 automount/autorun and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Disable automount in GNOME3" test_ref="test_dconf_gnome_disable_automount" />

--- a/shared/checks/oval/dconf_gnome_disable_ctrlaltdel_reboot.xml
+++ b/shared/checks/oval/dconf_gnome_disable_ctrlaltdel_reboot.xml
@@ -10,6 +10,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="gnome-desktop3 installed" definition_ref="package_gnome-desktop3_installed" negate="true" />
       <criteria operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Disable Ctrl-Alt-Del" test_ref="test_disable_gnome_ctrlaltdel" />

--- a/shared/checks/oval/dconf_gnome_disable_geolocation.xml
+++ b/shared/checks/oval/dconf_gnome_disable_geolocation.xml
@@ -10,6 +10,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="gnome-desktop3 installed" definition_ref="package_gnome-desktop3_installed" negate="true" />
       <criteria operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Disable system geolocation" test_ref="test_disable_sys_geolocation" />

--- a/shared/checks/oval/dconf_gnome_disable_power_settings.xml
+++ b/shared/checks/oval/dconf_gnome_disable_power_settings.xml
@@ -10,6 +10,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="gnome-desktop3 installed" definition_ref="package_gnome-desktop3_installed" negate="true" />
       <criteria operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Disable power settings" test_ref="test_disable_gnome_power_setting" />

--- a/shared/checks/oval/dconf_gnome_disable_restart_shutdown.xml
+++ b/shared/checks/oval/dconf_gnome_disable_restart_shutdown.xml
@@ -10,6 +10,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- Check if gdm installed since dconf is a dependency of emacs -->
+      <extend_definition comment="gdm installed" definition_ref="package_gdm_installed" negate="true" />
       <criteria comment="Disable GUI shutdown and restart buttons and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Disable restart and shutdown buttons" test_ref="test_disable_restart_buttons" />

--- a/shared/checks/oval/dconf_gnome_disable_thumbnailers.xml
+++ b/shared/checks/oval/dconf_gnome_disable_thumbnailers.xml
@@ -13,6 +13,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="gnome-desktop3 installed" definition_ref="package_gnome-desktop3_installed" negate="true" />
       <criteria comment="Disable Gnome3 Thumbnailers and prevent user from enabling" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Disable thumbnailers in GNOME3" test_ref="test_gnome_disable_thumbnailers" />

--- a/shared/checks/oval/dconf_gnome_disable_user_admin.xml
+++ b/shared/checks/oval/dconf_gnome_disable_user_admin.xml
@@ -10,6 +10,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="gnome-desktop3 installed" definition_ref="package_gnome-desktop3_installed" negate="true" />
       <criteria operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Disable user administration" test_ref="test_disable_gnome_user_admin" />

--- a/shared/checks/oval/dconf_gnome_disable_user_list.xml
+++ b/shared/checks/oval/dconf_gnome_disable_user_list.xml
@@ -10,6 +10,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- Check if gdm installed since dconf is a dependency of emacs -->
+      <extend_definition comment="gdm installed" definition_ref="package_gdm_installed" negate="true" />
       <criteria comment="Disable GUI listing of known users and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Disable user list" test_ref="test_disable_user_list" />

--- a/shared/checks/oval/dconf_gnome_disable_wifi_create.xml
+++ b/shared/checks/oval/dconf_gnome_disable_wifi_create.xml
@@ -10,6 +10,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="nm-connection-editor installed" definition_ref="package_nm-connection-editor_installed" negate="true" />
       <criteria operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Disable wifi creation" test_ref="test_disable_wifi_creation" />

--- a/shared/checks/oval/dconf_gnome_disable_wifi_notification.xml
+++ b/shared/checks/oval/dconf_gnome_disable_wifi_notification.xml
@@ -10,6 +10,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="nm-connection-editor installed" definition_ref="package_nm-connection-editor_installed" negate="true" />
       <criteria operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Disable wifi notification" test_ref="test_disable_wifi_notification" />

--- a/shared/checks/oval/dconf_gnome_enable_smartcard_auth.xml
+++ b/shared/checks/oval/dconf_gnome_enable_smartcard_auth.xml
@@ -10,6 +10,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- Check if gdm installed since dconf is a dependency of emacs -->
+      <extend_definition comment="gdm installed" definition_ref="package_gdm_installed" negate="true" />
       <criteria comment="Enable smartcard authentication and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Enable smartcard authentication" test_ref="test_enable_gnome_smartcard" />

--- a/shared/checks/oval/dconf_gnome_login_banner_text.xml
+++ b/shared/checks/oval/dconf_gnome_login_banner_text.xml
@@ -10,6 +10,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="gdm installed" definition_ref="package_gdm_installed" negate="true" />
       <criteria comment="Enable GUI banner and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Prevent user from changing banner" test_ref="test_prevent_user_banner_change" />

--- a/shared/checks/oval/dconf_gnome_login_retries.xml
+++ b/shared/checks/oval/dconf_gnome_login_retries.xml
@@ -10,6 +10,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- Check if gdm installed since dconf is a dependency of emacs -->
+      <extend_definition comment="gdm installed" definition_ref="package_gdm_installed" negate="true" />
       <criteria comment="Set number of login attempts and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Set number of login tries" test_ref="test_configure_allowed_failures" />

--- a/shared/checks/oval/dconf_gnome_remote_access_credential_prompt.xml
+++ b/shared/checks/oval/dconf_gnome_remote_access_credential_prompt.xml
@@ -10,6 +10,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="vino installed" definition_ref="package_vino_installed" negate="true" />
       <criteria operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="configure remote access credentials" test_ref="test_configure_remote_access_creds" />

--- a/shared/checks/oval/dconf_gnome_remote_access_encryption.xml
+++ b/shared/checks/oval/dconf_gnome_remote_access_encryption.xml
@@ -10,6 +10,7 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <extend_definition comment="vino installed" definition_ref="package_vino_installed" negate="true" />
       <criteria operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="configure remote access encryption" test_ref="test_configure_remote_access_encryption" />

--- a/shared/checks/oval/dconf_gnome_screensaver_idle_activation_enabled.xml
+++ b/shared/checks/oval/dconf_gnome_screensaver_idle_activation_enabled.xml
@@ -10,6 +10,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- gnome-screensaver is not available in rhel7, gnome-shell handles power saving and security features instead -->
+      <extend_definition comment="gnome-shell installed" definition_ref="package_gnome-shell_installed" negate="true" />
       <criteria comment="check screensaver idle activation and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="idle activation has been configured" test_ref="test_screensaver_idle_activation_enabled" />

--- a/shared/checks/oval/dconf_gnome_screensaver_idle_delay.xml
+++ b/shared/checks/oval/dconf_gnome_screensaver_idle_delay.xml
@@ -10,6 +10,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- gnome-screensaver is not available in rhel7, gnome-shell handles power saving and security features instead -->
+      <extend_definition comment="gnome-shell installed" definition_ref="package_gnome-shell_installed" negate="true" />
       <criteria comment="check screensaver idle delay and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="idle delay has been configured" test_ref="test_screensaver_idle_delay" />

--- a/shared/checks/oval/dconf_gnome_screensaver_lock_delay.xml
+++ b/shared/checks/oval/dconf_gnome_screensaver_lock_delay.xml
@@ -11,6 +11,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- gnome-screensaver is not available in rhel7, gnome-shell handles power saving and security features instead -->
+      <extend_definition comment="gnome-shell installed" definition_ref="package_gnome-shell_installed" negate="true" />
       <criteria comment="Enable screensaver lock and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="screensaver lock delay is configured" test_ref="test_screensaver_lock_delay" />

--- a/shared/checks/oval/dconf_gnome_screensaver_lock_enabled.xml
+++ b/shared/checks/oval/dconf_gnome_screensaver_lock_enabled.xml
@@ -10,6 +10,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- gnome-screensaver is not available in rhel7, gnome-shell handles power saving and security features instead -->
+      <extend_definition comment="gnome-shell installed" definition_ref="package_gnome-shell_installed" negate="true" />
       <criteria comment="Enable screensaver lock and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <extend_definition comment="Check screensaver lock delay settings" definition_ref="dconf_gnome_screensaver_lock_delay" />

--- a/shared/checks/oval/dconf_gnome_screensaver_mode_blank.xml
+++ b/shared/checks/oval/dconf_gnome_screensaver_mode_blank.xml
@@ -10,6 +10,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- gnome-screensaver is not available in rhel7, gnome-shell handles power saving and security features instead -->
+      <extend_definition comment="gnome-shell installed" definition_ref="package_gnome-shell_installed" negate="true" />
       <criteria comment="Enable blank screensaver and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="screensaver is blank" test_ref="test_screensaver_mode_blank" />

--- a/shared/checks/oval/dconf_gnome_screensaver_user_info.xml
+++ b/shared/checks/oval/dconf_gnome_screensaver_user_info.xml
@@ -10,6 +10,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- gnome-screensaver is not available in rhel7, gnome-shell handles power saving and security features instead -->
+      <extend_definition comment="gnome-shell installed" definition_ref="package_gnome-shell_installed" negate="true" />
       <criteria comment="Disable screensaver user info and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="screensaver user info is disabled" test_ref="test_screensaver_disable_user_info" />

--- a/shared/checks/oval/dconf_gnome_screensaver_user_locks.xml
+++ b/shared/checks/oval/dconf_gnome_screensaver_user_locks.xml
@@ -10,6 +10,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- gnome-screensaver is not available in rhel7, gnome-shell handles power saving and security features instead -->
+      <extend_definition comment="gnome-shell installed" definition_ref="package_gnome-shell_installed" negate="true" />
       <criteria comment="check screensaver idle delay and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="prevent user from changing screensaver lock delay" test_ref="test_user_change_lock_delay_lock" />

--- a/shared/checks/oval/dconf_gnome_session_idle_user_locks.xml
+++ b/shared/checks/oval/dconf_gnome_session_idle_user_locks.xml
@@ -10,6 +10,8 @@
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <!-- gnome-screensaver is not available in rhel7, gnome-shell handles power saving and security features instead -->
+      <extend_definition comment="gnome-shell installed" definition_ref="package_gnome-shell_installed" negate="true" />
       <criteria comment="check screensaver idle delay and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="prevent user from changing idle delay" test_ref="test_user_change_idle_delay_lock" />

--- a/shared/checks/oval/package_gnome-desktop3_installed.xml
+++ b/shared/checks/oval/package_gnome-desktop3_installed.xml
@@ -1,0 +1,25 @@
+<def-group>
+  <definition class="compliance" id="package_gnome-desktop3_installed"
+  version="1">
+    <metadata>
+      <title>Package gnome-desktop3 Installed</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>The RPM package gnome-desktop3 should be installed.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="package gnome-desktop3 is installed"
+      test_ref="test_package_gnome-desktop3_installed" />
+    </criteria>
+  </definition>
+  <linux:rpminfo_test check="all" check_existence="all_exist"
+  id="test_package_gnome-desktop3_installed" version="1"
+  comment="package gnome-desktop3 is installed">
+    <linux:object object_ref="obj_package_gnome-desktop3_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_gnome-desktop3_installed" version="1">
+    <linux:name>gnome-desktop3</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/shared/checks/oval/package_gnome-shell_installed.xml
+++ b/shared/checks/oval/package_gnome-shell_installed.xml
@@ -1,0 +1,25 @@
+<def-group>
+  <definition class="compliance" id="package_gnome-shell_installed"
+  version="1">
+    <metadata>
+      <title>Package gnome-shell Installed</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>The RPM package gnome-shell should be installed.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="package gnome-shell is installed"
+      test_ref="test_package_gnome-shell_installed" />
+    </criteria>
+  </definition>
+  <linux:rpminfo_test check="all" check_existence="all_exist"
+  id="test_package_gnome-shell_installed" version="1"
+  comment="package gnome-shell is installed">
+    <linux:object object_ref="obj_package_gnome-shell_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_gnome-shell_installed" version="1">
+    <linux:name>gnome-shell</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/shared/checks/oval/package_nm-connection-editor_installed.xml
+++ b/shared/checks/oval/package_nm-connection-editor_installed.xml
@@ -1,0 +1,25 @@
+<def-group>
+  <definition class="compliance" id="package_nm-connection-editor_installed"
+  version="1">
+    <metadata>
+      <title>Package nm-connection-editor Installed</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>The RPM package nm-connection-editor should be installed.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="package nm-connection-editor is installed"
+      test_ref="test_package_nm-connection-editor_installed" />
+    </criteria>
+  </definition>
+  <linux:rpminfo_test check="all" check_existence="all_exist"
+  id="test_package_nm-connection-editor_installed" version="1"
+  comment="package nm-connection-editor is installed">
+    <linux:object object_ref="obj_package_nm-connection-editor_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_nm-connection-editor_installed" version="1">
+    <linux:name>nm-connection-editor</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/shared/checks/oval/package_vino_installed.xml
+++ b/shared/checks/oval/package_vino_installed.xml
@@ -1,0 +1,25 @@
+<def-group>
+  <definition class="compliance" id="package_vino_installed"
+  version="1">
+    <metadata>
+      <title>Package vino Installed</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>The RPM package vino should be installed.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="package vino is installed"
+      test_ref="test_package_vino_installed" />
+    </criteria>
+  </definition>
+  <linux:rpminfo_test check="all" check_existence="all_exist"
+  id="test_package_vino_installed" version="1"
+  comment="package vino is installed">
+    <linux:object object_ref="obj_package_vino_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_vino_installed" version="1">
+    <linux:name>vino</linux:name>
+  </linux:rpminfo_object>
+</def-group>


### PR DESCRIPTION
#### Description:
Added a checks for the following gnome packages
- gnome-desktop3
- gnome-shell
- nm-connection-editor
- vino

Updated the following checks to verify that the required package(s) exist to avoid false failures

| Check                                           | Additional Package Check |
| ----------------------------------------------- | ------------------------ |
| dconf_gnome_disable_ctrlaltdel_reboot           |  gnome-desktop3          |
| dconf_gnome_disable_geolocation                 |  gnome-desktop3          |
| dconf_gnome_disable_power_settings              |  gnome-desktop3          |
| dconf_gnome_disable_restart_shutdown            |  gdm                     |
| dconf_gnome_disable_user_admin                  |  gnome-desktop3          |
| dconf_gnome_disable_user_list                   |  gdm                     |
| dconf_gnome_disable_wifi_create                 |  nm-connection-editor    |
| dconf_gnome_disable_wifi_notification           |  nm-connection-editor    |
| dconf_gnome_enable_smartcard_auth               |  gdm                     |
| dconf_gnome_login_retries                       |  gdm                     |
| dconf_gnome_remote_access_credential_prompt     |  vino                    |
| dconf_gnome_remote_access_encryption            |  vino                    |
| dconf_gnome_screensaver_idle_activation_enabled |  gnome-shell             |
| dconf_gnome_screensaver_idle_delay              |  gnome-shell             |
| dconf_gnome_screensaver_lock_delay              |  gnome-shell             |
| dconf_gnome_screensaver_lock_enabled            |  gnome-shell             |
| dconf_gnome_screensaver_mode_blank              |  gnome-shell             |
| dconf_gnome_screensaver_user_info               |  gnome-shell             |
| dconf_gnome_screensaver_user_locks              |  gnome-shell             |
| dconf_gnome_session_idle_user_locks             |  gnome-shell             |
| dconf_gnome_banner_enabled                      |  gdm                     |
| dconf_gnome_disable_thumbnailers                |  gdm                     |
| dconf_gnome_login_banner_text                   |  gnome-desktop3          |
| dconf_gnome_disable_automount                   |  gnome-desktop3          |


#### Rationale:

Running gnome checks against a machine without gnome installed results in a number of false failures.

Check `gnome-shell` for screensaver per [RHEL Solution 1201153](https://access.redhat.com/solutions/1201153)
Check `nm-network-editor` and `vino` since they can be installed independently of gnome.

Fixes #2445 
