### PR TITLE
Fix #2618

### DIFF
--- a/shared/checks/oval/bootloader_password.xml
+++ b/shared/checks/oval/bootloader_password.xml
@@ -11,7 +11,10 @@
     <criteria operator="OR">
       <criterion comment="Pass if /boot/grub2/grub.cfg does not exist" test_ref="test_bootloader_grub_cfg" />
       <criteria operator="AND">
-        <criterion comment="make sure a password is defined in /boot/grub2/user.cfg" test_ref="test_bootloader_password" />
+        <criteria comment="check both files to account for procedure change in documenation" operator="OR">
+            <criterion comment="make sure a password is defined in /boot/grub2/user.cfg" test_ref="test_bootloader_password_usercfg" />
+            <criterion comment="make sure a password is defined in /boot/grub2/grub.cfg" test_ref="test_bootloader_password_grubcfg" />
+        </criteria>
         <criterion comment="make sure a superuser is defined in /boot/grub2/grub.cfg" test_ref="test_bootloader_superuser"/>
       </criteria>
     </criteria>
@@ -33,12 +36,23 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/grub2/user.cfg" id="test_bootloader_password" version="1">
-    <ind:object object_ref="object_bootloader_password" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/grub2/user.cfg" id="test_bootloader_password_usercfg" version="1">
+    <ind:object object_ref="object_bootloader_password_usercfg" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_bootloader_password" version="1">
+  <ind:textfilecontent54_object id="object_bootloader_password_usercfg" version="1">
     <ind:filepath>/boot/grub2/user.cfg</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*GRUB2_PASSWORD=grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/grub2/grub.cfg" id="test_bootloader_password_grubcfg" version="1">
+    <ind:object object_ref="object_bootloader_password_grubcfg" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_bootloader_password_grubcfg" version="1">
+    <ind:filepath>/boot/grub2/grub.cfg</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>  
+
 </def-group>
+

--- a/shared/checks/oval/bootloader_password.xml
+++ b/shared/checks/oval/bootloader_password.xml
@@ -12,8 +12,8 @@
       <criterion comment="Pass if /boot/grub2/grub.cfg does not exist" test_ref="test_bootloader_grub_cfg" />
       <criteria operator="AND">
         <criteria comment="check both files to account for procedure change in documenation" operator="OR">
-            <criterion comment="make sure a password is defined in /boot/grub2/user.cfg" test_ref="test_bootloader_password_usercfg" />
-            <criterion comment="make sure a password is defined in /boot/grub2/grub.cfg" test_ref="test_bootloader_password_grubcfg" />
+          <criterion comment="make sure a password is defined in /boot/grub2/user.cfg" test_ref="test_bootloader_password_usercfg" />
+          <criterion comment="make sure a password is defined in /boot/grub2/grub.cfg" test_ref="test_bootloader_password_grubcfg" />
         </criteria>
         <criterion comment="make sure a superuser is defined in /boot/grub2/grub.cfg" test_ref="test_bootloader_superuser"/>
       </criteria>

--- a/shared/checks/oval/bootloader_uefi_password.xml
+++ b/shared/checks/oval/bootloader_uefi_password.xml
@@ -12,7 +12,10 @@
     <criteria operator="OR">
       <criterion comment="Pass if /boot/efi/EFI/redhat/grub.cfg does not exist" test_ref="test_bootloader_uefi_grub_cfg" />
       <criteria operator="AND">
-        <criterion comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" test_ref="test_bootloader_uefi_password" />
+        <criteria comment="check both files to account for procedure change in documenation" operator="OR">
+          <criterion comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" test_ref="test_bootloader_uefi_password_usercfg" />
+          <criterion comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_uefi_password_grubcfg" />
+        </criteria>
         <criterion comment="make sure a superuser is defined in /boot/efi/EFI/redhat/grub.cfg" test_ref="test_bootloader_uefi_superuser"/>
       </criteria>
     </criteria>
@@ -34,11 +37,20 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" id="test_bootloader_uefi_password" version="1">
-    <ind:object object_ref="object_bootloader_uefi_password" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" id="test_bootloader_uefi_password_usercfg" version="1">
+    <ind:object object_ref="object_bootloader_uefi_password_usercfg" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_bootloader_uefi_password" version="1">
+  <ind:textfilecontent54_object id="object_bootloader_uefi_password_usercfg" version="1">
     <ind:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/user.cfg</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*GRUB2_PASSWORD=grub\.pbkdf2\.sha512.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" id="test_bootloader_uefi_password_grubcfg" version="1">
+    <ind:object object_ref="object_bootloader_uefi_password_grubcfg" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_bootloader_uefi_password_grubcfg" version="1">
+    <ind:filepath operation="pattern match">/boot/efi/EFI/(redhat|fedora)/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>


### PR DESCRIPTION
#### Description:

Update the check to verify if password exists in either `/boot/grub2/grub.cfg` or `/boot/grub2/user.cfg`.
They're both valid configurations, the documented remediation was recently updated from modifying `/boot/grub.d/01_users` to using the `grub2-setpassword` tool.

#### Rationale:

Documented remediation process conflicts with previously recommended remediation. This left us with 2 valid configurations. 

Fixes #2618 
