### PR TITLE
Tests for ctrlaltdel burstaction and audit rules time

### DIFF
--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_disable_ctrlaltdel_burstaction/correct_value.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_disable_ctrlaltdel_burstaction/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+if grep -q "^CtrlAltDelBurstAction=" /etc/systemd/system.conf; then
+	sed -i "s/^CtrlAltDelBurstAction.*/CtrlAltDelBurstAction=none/" /etc/systemd/system.conf
+else
+	echo "CtrlAltDelBurstAction=none" >> /etc/systemd/system.conf
+fi

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_disable_ctrlaltdel_burstaction/line_not_there.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_disable_ctrlaltdel_burstaction/line_not_there.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+sed -i "/^CtrlAltDelBurstAction.*/d" /etc/systemd/system.conf

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_disable_ctrlaltdel_burstaction/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_disable_ctrlaltdel_burstaction/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+if grep -q "^CtrlAltDelBurstAction=" /etc/systemd/system.conf; then
+	sed -i "s/^CtrlAltDelBurstAction.*/CtrlAltDelBurstAction=poweroff-immediate/" /etc/systemd/system.conf
+else
+	echo "CtrlAltDelBurstAction=poweroff-immediate" >> /etc/systemd/system.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_adjtimex/correct_value.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_adjtimex/correct_value.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+adjtimex[\s]+|([\s]+|[,])adjtimex([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then
+	echo "-a always,exit -F arch=b32 -S adjtimex -k audit_time_rules" >> /etc/audit/rules.d/time.rules
+	echo "-a always,exit -F arch=b64 -S adjtimex -k audit_time_rules" >> /etc/audit/rules.d/time.rules
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_adjtimex/line_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_adjtimex/line_not_there.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+adjtimex[\s]+|([\s]+|[,])adjtimex([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_settimeofday/correct_value.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_settimeofday/correct_value.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+settimeofday[\s]+|([\s]+|[,])settimeofday([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then
+	echo "-a always,exit -F arch=b32 -S settimeofday -k audit_time_rules" >> /etc/audit/rules.d/time.rules
+	echo "-a always,exit -F arch=b64 -S settimeofday -k audit_time_rules" >> /etc/audit/rules.d/time.rules
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_settimeofday/line_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_settimeofday/line_not_there.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+settimeofday[\s]+|([\s]+|[,])settimeofday([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_stime/correct_value.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_stime/correct_value.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+stime[\s]+|([\s]+|[,])stime([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then
+	echo "-a always,exit -F arch=b32 -S stime -k audit_time_rules" >> /etc/audit/rules.d/time.rules
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_stime/line_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_time_rules/rule_audit_rules_time_stime/line_not_there.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+stime[\s]+|([\s]+|[,])stime([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules


### PR DESCRIPTION
#### Description:

Test scenarios for Rules:
- xccdf_org.ssgproject.content_rule_disable_ctrlaltdel_burstaction
- xccdf_org.ssgproject.content_rule_audit_rules_time_adjtimex 
- xccdf_org.ssgproject.content_rule_audit_rules_time_settimeofday
- xccdf_org.ssgproject.content_rule_audit_rules_time_stime

#### Rationale:

- Tests for fixes proposed in https://github.com/OpenSCAP/scap-security-guide/pull/2484
