### PR TITLE
Fixes #2607 - audit_rules_login_events

### DIFF
--- a/shared/templates/create_audit_rules_login_events.py
+++ b/shared/templates/create_audit_rules_login_events.py
@@ -14,7 +14,7 @@ import re
 class AuditRulesLoginEventsGenerator(FilesGenerator):
     def generate(self, target, args):
         path = args[0]
-        name = re.sub('[-\./]', '_', os.path.basename(path))
+        name = re.sub('[-\./]', '_', os.path.basename(os.path.normpath(path)))
         if target == "oval":
             self.file_from_template(
                 "./template_OVAL_audit_rules_login_events",

--- a/shared/templates/csv/audit_rules_login_events.csv
+++ b/shared/templates/csv/audit_rules_login_events.csv
@@ -1,3 +1,3 @@
-/var/run/faillock
+/var/run/faillock/
 /var/log/lastlog
 /var/log/tallylog


### PR DESCRIPTION
#### Description:

Regex for audit rules verification generated from `shared/templates/csv/audit_rules_login_events.csv` was failing because it did not account for the `/` at the end of faillock. 

Fixing that breaks the xml generation since `os.path.basename('/var/run/faillock/')` returns blank. 
Use path normalization to handle the case of `faillock/`. 

#### Rationale:

- The audit rules verification for logon/logout events fails for faillock,

- Fixes #2607
