### PR TITLE
Add tests for accounts_passwords_pam_faillock_deny

### DIFF
--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/config_without_skip.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/config_without_skip.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+
+cp pam_config_without_skip /etc/pam.d/system-auth
+cp pam_config_without_skip /etc/pam.d/password-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/default_die_pam_unix.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/default_die_pam_unix.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = none
+# Remediation for accounts_passwords_pam_faillock_deny cannot remediate this scenario
+# The remediation would need to detect and remove default=die from pam_unix.so module
+
+cp pam_config_default_die_pam_unix  /etc/pam.d/system-auth
+cp pam_config_default_die_pam_unix  /etc/pam.d/password-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/disablefaillock_authconfig.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/disablefaillock_authconfig.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+
+authconfig --disablefaillock --updateall

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_default_die_pam_unix
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_default_die_pam_unix
@@ -1,0 +1,27 @@
+# This pam config allows pam_unix.so to die
+# This way pam_faillock authfail will never log authentication failures
+
+auth        required      pam_env.so
+auth        required      pam_faildelay.so delay=2000000
+auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
+auth        [success=done ignore=ignore default=die]    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        sufficient    pam_sss.so forward_pass
+auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200
+auth        required      pam_deny.so
+
+account     required      pam_faillock.so
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_correctly
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_correctly
@@ -1,0 +1,27 @@
+# This pam config is an example of a pam_faillock and pam_unix configured correctly
+# while skipping modules when pam_unix fails to authenticate
+
+auth        required      pam_env.so
+auth        required      pam_faildelay.so delay=2000000
+auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
+auth        [success=done ignore=ignore default=2]    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        sufficient    pam_sss.so forward_pass
+auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200
+auth        required      pam_deny.so
+
+account     required      pam_faillock.so
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_correctly_short
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_correctly_short
@@ -1,5 +1,5 @@
-# This pam config is an example of a pam_faillock and pam_unix configured correctly
-# while skipping modules when pam_unix fails to authenticate
+# This pam config is an example of a faillock and unix configured correctly
+# skipping into between unix and faillock
 
 auth        required      pam_env.so
 auth        required      pam_faildelay.so delay=2000000

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_correctly_short
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_correctly_short
@@ -1,0 +1,27 @@
+# This pam config is an example of a pam_faillock and pam_unix configured correctly
+# while skipping modules when pam_unix fails to authenticate
+
+auth        required      pam_env.so
+auth        required      pam_faildelay.so delay=2000000
+auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
+auth        [success=done ignore=ignore default=1]    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        sufficient    pam_sss.so forward_pass
+auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200
+auth        required      pam_deny.so
+
+account     required      pam_faillock.so
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_longer
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_longer
@@ -1,5 +1,5 @@
-# This pam config allows pam_unix to skip past pam_faillock
-# This way pam_faillock authfail will never log authentication failures
+# This pam config allows unix to skip past faillock
+# This way faillock authfail will never log authentication failures
 
 auth        required      pam_env.so
 auth        required      pam_faildelay.so delay=2000000

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_longer
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_longer
@@ -1,0 +1,27 @@
+# This pam config allows pam_unix to skip past pam_faillock
+# This way pam_faillock authfail will never log authentication failures
+
+auth        required      pam_env.so
+auth        required      pam_faildelay.so delay=2000000
+auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
+auth        [success=done ignore=ignore default=3]    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        sufficient    pam_sss.so forward_pass
+auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200
+auth        required      pam_deny.so
+
+account     required      pam_faillock.so
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_longer_comment
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_longer_comment
@@ -1,10 +1,11 @@
-# This pam config is an example of a faillock and unix configured correctly
-# skipping right on faillock
+# This pam config allows pam_unix to skip past pam_faillock
+# But by mentioning pam_unix in the comment here, it triggers
+# https://bugzilla.redhat.com/show_bug.cgi?id=1549671
 
 auth        required      pam_env.so
 auth        required      pam_faildelay.so delay=2000000
 auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
-auth        [success=done ignore=ignore default=2]    pam_unix.so nullok try_first_pass
+auth        [success=done ignore=ignore default=3]    pam_unix.so nullok try_first_pass
 auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient    pam_sss.so forward_pass
 auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_without_skip
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_without_skip
@@ -1,0 +1,26 @@
+# This pam config is an example of a pam_faillock and pam_unix configured correctly
+# without skipping any module
+
+auth        required      pam_env.so
+auth        required      pam_faildelay.so delay=2000000
+auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
+auth        sufficient    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200
+auth        required      pam_deny.so
+
+account     required      pam_faillock.so
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_correctly.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_correctly.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+
+cp pam_config_skip_correctly /etc/pam.d/system-auth
+cp pam_config_skip_correctly /etc/pam.d/password-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_correctly_short.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_correctly_short.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+
+cp pam_config_skip_correctly_short /etc/pam.d/system-auth
+cp pam_config_skip_correctly_short /etc/pam.d/password-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_longer.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_longer.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
+# remediation = none
+# Remediation for accounts_passwords_pam_faillock_deny cannot remediate this scenario
+# The remediation would need to calculate number of modules to skip
+
+cp pam_config_skip_longer /etc/pam.d/system-auth
+cp pam_config_skip_longer /etc/pam.d/password-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_longer_comment.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_longer_comment.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
+# remediation = none
+# Remediation for accounts_passwords_pam_faillock_deny cannot remediate this scenario
+# The remediation would need to calculate number of modules to skip
+
+cp pam_config_skip_longer_comment /etc/pam.d/system-auth
+cp pam_config_skip_longer_comment /etc/pam.d/password-auth


### PR DESCRIPTION
#### Description:

- Test scenarios for Rule `accounts_passwords_pam_faillock_deny`

#### Rationale:

- Tests for fixes proposed in #2171