### PR TITLE
Introduced draft of SSG Bash scripting guidelines.

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -730,11 +730,21 @@ Following, you can see an example of a bash remediation that sets the maximum nu
 populate var_accounts_maximum_age_login_defs
 
 grep -q ^PASS_MAX_DAYS /etc/login.defs && \
-  sed -i "s/PASS_MAX_DAYS.*/PASS_MAX_DAYS     $var_accounts_maximum_age_login_defs/g" /etc/login.defs
-if ! [ $? -eq 0 ]; then
+    sed -i "s/PASS_MAX_DAYS.*/PASS_MAX_DAYS     $var_accounts_maximum_age_login_defs/g" /etc/login.defs
+if [ $? -ne 0 ]; then
     echo "PASS_MAX_DAYS      $var_accounts_maximum_age_login_defs" >> /etc/login.defs
 fi
 ----
+
+When writing new bash remediations content, please follow the following guidelins:
+
+* Use tabs for indentation rather than spaces.
+* Prefer to use `sed` rather than `awk`.
+* Try to keep expressions simple, avoid double negations. Use link:http://tldp.org/LDP/abs/html/list-cons.html[compound lists] with moderation and only link:https://mywiki.wooledge.org/BashPitfalls#cmd1_.26.26_cmd2_.7C.7C_cmd3[if you understand them].
+* Test your script in the "strict mode" with `set -e -o pipefail` specified at the top of it. Make sure that the script doesn't end prematurely in the strict mode.
+* Beware of constructs such as `[ $x = 1 ] && echo "$x is one"` as they violate the previous point. `[ $x != 1 ] || echo "$x is one"` is OK.
+* Use the `die` function defined in `remediation_functions` to handle exceptions, such as `[ -f "$config_file" ] || die "Couldn't find the configuration file '$config_file'"`.
+* Run `shellcheck` over your remediation script. Make sure that you fix all warnings that are applicable. If you are not sure, mention those warnings in the pull request description.
 
 ==== Templating
 

--- a/shared/bash_remediation_functions/die.sh
+++ b/shared/bash_remediation_functions/die.sh
@@ -1,0 +1,8 @@
+# Print a message to stderr and exit the shell
+# $1: The message to print.
+# $2: The error code (optional, default is 1)
+function die {
+	local _message="$1" _rc="${2:-1}"
+	printf '%s\n' "$_message" >&2
+	exit "$_rc"
+}


### PR DESCRIPTION
As @OnceUponALoop  in #2617 noticed, it is not clear what style and approach to prefer when contributing to Bash remediations.
I have went to the existing remediations in the `shared/fixes/bash` folder and observed the prevalent existing style. I have found out two points which I believe that are not controversial at all:
* most scripts use tabs for indentation, so let's use tabs.
* usage of `sed` greatly surpasses `awk`, so let's encourage `sed`.

Next, I propose these:
* Use the `die` function [idiom](https://stackoverflow.com/q/7868818/592892) to handle possible errors (I have defined it and checked that it can be actually used).
* Run `shellcheck` over the snippet and try to fix all warnings.
* Avoid double negatives s.a. `if ! [ $x != 1 ]; then ...`

Finally, some points may be controversial:
* I have slightly encouraged usage of compound statements. I think that if they are used in moderation, they can make the code much shorter, without obscuring anything.
* I have suggested to write scripts in a way that they work if invoked in the "strict mode" e.g. by running them using `bash -e` or by writing `set -e` to the top of the script. This imposes greater requirements on error handling inside the script and therefore increases its robustness.