### PR TITLE
Glob source xccdf files recursively

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -110,7 +110,8 @@ endmacro()
 macro(ssg_build_shorthand_xml PRODUCT)
     file(GLOB OVERLAYS_DEPS "${CMAKE_CURRENT_SOURCE_DIR}/overlays/*.xml")
     file(GLOB PROFILE_DEPS "${CMAKE_CURRENT_SOURCE_DIR}/profiles/*.xml")
-    file(GLOB XCCDF_RULE_DEPS "${CMAKE_CURRENT_SOURCE_DIR}/xccdf/**/*.xml")
+    file(GLOB_RECURSE XCCDF_RULE_DEPS "${CMAKE_CURRENT_SOURCE_DIR}/xccdf/*.xml")
+    file(GLOB_RECURSE SHARED_XCCDF_RULE_DEPS "${SSG_SHARED}/xccdf/*.xml")
 
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
@@ -124,6 +125,7 @@ macro(ssg_build_shorthand_xml PRODUCT)
         DEPENDS ${OVERLAYS_DEPS}
         DEPENDS ${PROFILE_DEPS}
         DEPENDS ${XCCDF_RULE_DEPS}
+        DEPENDS ${SHARED_XCCDF_RULE_DEPS}
         COMMENT "[${PRODUCT}-content] generating shorthand.xml"
     )
     add_custom_target(


### PR DESCRIPTION
#### Description:

- glob product specific xccdf source files recursively
- glob shared xccdf source files recursively
- depend on shared xccdf source files recursively

#### Rationale:
- Input XCCDF xml files are layed out in a multi level directory structure
- When building shorthand file:
  - glob for xccdf xml files worked fine for files in first level of directory (e.g.: `rhel6/xccdf/system/auditing.xml`).
  - glob for files in deeper levels did not work (e.g: `rhel6/xccdf/system/software/gnome.xml`)

- Fixes #2389
- Note, XCCDF files added or remove will still require CMake to regenerate