### PR TITLE
This is a shorthand XCCDF, not the actual XCCDF 1.1, the xmlns makes …

### DIFF
--- a/chromium/profiles/stig-chromium-upstream.xml
+++ b/chromium/profiles/stig-chromium-upstream.xml
@@ -1,4 +1,4 @@
-<Profile id="stig-chromium-upstream" xmlns="http://checklists.nist.gov/xccdf/1.1" >
+<Profile id="stig-chromium-upstream">
 <title override="true">Upstream STIG for Google Chromium</title>
 <description override="true">This profile is developed under the DoD consensus model and DISA FSO Vendor STIG process,
 serving as the upstream development environment for the Google Chromium STIG.

--- a/firefox/profiles/stig-firefox-upstream.xml
+++ b/firefox/profiles/stig-firefox-upstream.xml
@@ -1,4 +1,4 @@
-<Profile id="stig-firefox-upstream" xmlns="http://checklists.nist.gov/xccdf/1.1" >
+<Profile id="stig-firefox-upstream">
 <title override="true">Upstream Firefox STIG</title>
 <description override="true">This profile is developed under the DoD consensus model and DISA FSO Vendor STIG process,
 serving as the upstream development environment for the Firefox STIG.

--- a/jre/profiles/stig-java-upstream.xml
+++ b/jre/profiles/stig-java-upstream.xml
@@ -1,4 +1,4 @@
-<Profile id="stig-java-upstream" xmlns="http://checklists.nist.gov/xccdf/1.1" >
+<Profile id="stig-java-upstream">
 <title override="true">Java Runtime Environment (JRE) STIG</title>
 <description override="true">The Java Runtime Environment (JRE) is a bundle developed
 and offered by Oracle Corporation which includes the Java Virtual Machine

--- a/rhel6/profiles/pci-dss.xml
+++ b/rhel6/profiles/pci-dss.xml
@@ -1,4 +1,4 @@
-<Profile id="pci-dss" xmlns="http://checklists.nist.gov/xccdf/1.1">
+<Profile id="pci-dss">
 <title override="true">PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 6</title>
 <description override="true">This is a *draft* profile for PCI-DSS v3.</description>
 

--- a/rhel6/profiles/rht-ccp.xml
+++ b/rhel6/profiles/rht-ccp.xml
@@ -1,4 +1,4 @@
-<Profile id="rht-ccp" xmlns="http://checklists.nist.gov/xccdf/1.1">
+<Profile id="rht-ccp">
 <title override="true">Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)</title>
 <description override="true">This is a *draft* SCAP profile for Red Hat Certified Cloud Providers</description>
 <!-- CONFIGURATION OPTIONS -->

--- a/rhel7/profiles/pci-dss.xml
+++ b/rhel7/profiles/pci-dss.xml
@@ -1,4 +1,4 @@
-<Profile id="pci-dss" xmlns="http://checklists.nist.gov/xccdf/1.1">
+<Profile id="pci-dss">
 <title override="true">PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7</title>
 <description override="true">This is a *draft* profile for PCI-DSS v3.</description>
 

--- a/rhel7/profiles/rht-ccp.xml
+++ b/rhel7/profiles/rht-ccp.xml
@@ -1,4 +1,4 @@
-<Profile id="rht-ccp" xmlns="http://checklists.nist.gov/xccdf/1.1">
+<Profile id="rht-ccp">
 <title override="true">Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)</title>
 <description override="true">This is a *draft* SCAP profile for Red Hat Certified Cloud Providers.</description>
 <!-- CONFIGURATION OPTIONS -->

--- a/rhevm3/profiles/stig-rhevm3.xml
+++ b/rhevm3/profiles/stig-rhevm3.xml
@@ -1,4 +1,4 @@
-<Profile id="common" xmlns="http://checklists.nist.gov/xccdf/1.1" >
+<Profile id="common">
 <title override="true">Common Profile for General-Purpose Systems</title>
 <description override="true">This profile contains items common to general-purpose desktop and server installations.</description>
 <!-- This is a hack because our tooling doesn't work well with profiles that have on selects!

--- a/webmin/profiles/common.xml
+++ b/webmin/profiles/common.xml
@@ -1,4 +1,4 @@
-<Profile id="common" xmlns="http://checklists.nist.gov/xccdf/1.1" >
+<Profile id="common">
 <title override="true">Common Profile for Webmin system administration tool</title>
 <description override="true"></description>
 


### PR DESCRIPTION
…no sense

#### Description:

Most of our shorthand sources don't have xmlns, however these few files do. This is most likely a mistake, so let's keep things consistent.

#### Rationale:

- This is blocking the yaml work in #2592 because technically with xmlns all the elements are different from the elements without xmlns.
