### PR TITLE
Update Contributors list for release v0.1.38

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,6 +1,6 @@
 <!---
 This file is generated using the generate-contributors.py script. DO NOT MANUALLY EDIT!!!!
-Last Modified: 2018-01-03 15:03
+Last Modified: 2018-03-01 16:18
 --->
 
 The following people have contributed to the SCAP Security Guide project
@@ -9,6 +9,7 @@ The following people have contributed to the SCAP Security Guide project
 * Frank J Cameron (CAM1244) <cameron@ctc.com>
 * 0x66656c6978 <0x66656c6978@users.noreply.github.com>
 * Gabe Alford <redhatrises@gmail.com>
+* Firas AlShafei <firas.alshafei@us.abb.com>
 * Christopher Anderson <cba@fedoraproject.org>
 * Chuck Atkins <chuck.atkins@kitware.com>
 * Ryan Ballanger <root@rballang-admin-2.fastenal.com>
@@ -38,7 +39,7 @@ The following people have contributed to the SCAP Security Guide project
 * Rebekah Hayes <rhayes@corp.rivierautilities.com>
 * Trey Henefield <thenefield@gmail.com>
 * hex2a <hex2a@users.noreply.github.com>
-* John Hooks <jhooks@starscream.pa.jhbcomputers.com>
+* John Hooks <hooksie11@gmail.com>
 * Robin Price II <robin@redhat.com>
 * Jeremiah Jahn <jeremiah@goodinassociates.com>
 * Stephan Joerrens <Stephan.Joerrens@fiduciagad.de>
@@ -55,6 +56,7 @@ The following people have contributed to the SCAP Security Guide project
 * Michael McConachie <michael@redhat.com>
 * Khary Mendez <kharyam@gmail.com>
 * Rodney Mercer <rmercer@harris.com>
+* Matt Micene <nzwulfin@gmail.com>
 * Brian Millett <bmillett@gmail.com>
 * mmosel <mmosel@kde.example.com>
 * Zbynek Moravec <zmoravec@redhat.com>
@@ -63,12 +65,13 @@ The following people have contributed to the SCAP Security Guide project
 * Joe Nall <joe@nall.com>
 * Neiloy <neiloy@redhat.com>
 * Michele Newman <mnewman@redhat.com>
+* OnceUponALoop <firas.alshafei@gmail.com>
 * Kaustubh Padegaonkar <theTuxRacer@gmail.com>
 * Michael Palmiotto <mpalmiotto@tresys.com>
 * Max R.D. Parmer <maxp@trystero.is>
 * pcactr <paul.c.arnold4.ctr@mail.mil>
 * Kenneth Peeples <kennethwpeeples@gmail.com>
-* Nathan Peters <petna01@ca.com>
+* Nathan Peters <Nathaniel.Peters@ca.com>
 * Frank Lin PIAT <fpiat@klabs.be>
 * Stefan Pietsch <mail.ipv4v6+gh@gmail.com>
 * Martin Preisler <mpreisle@redhat.com>
@@ -78,6 +81,7 @@ The following people have contributed to the SCAP Security Guide project
 * Rick Renshaw <Richard_Renshaw@xtoenergy.com>
 * Chris Reynolds <c.reynolds82@gmail.com>
 * Pat Riehecky <riehecky@fnal.gov>
+* rlucente-se-jboss <rlucente@redhat.com>
 * Joshua Roys <roysjosh@gmail.com>
 * rrenshaw <bofh69@yahoo.com>
 * Chris Ruffalo <chris.ruffalo@gmail.com>

--- a/Contributors.xml
+++ b/Contributors.xml
@@ -1,12 +1,13 @@
 <!--
 This file is generated using the generate-contributors.py script. DO NOT MANUALLY EDIT!!!!
-Last Modified: 2018-01-03 15:03
+Last Modified: 2018-03-01 16:18
 -->
 
 <text>
 <contributor>Frank J Cameron (CAM1244) &lt;cameron@ctc.com&gt;</contributor>
 <contributor>0x66656c6978 &lt;0x66656c6978@users.noreply.github.com&gt;</contributor>
 <contributor>Gabe Alford &lt;redhatrises@gmail.com&gt;</contributor>
+<contributor>Firas AlShafei &lt;firas.alshafei@us.abb.com&gt;</contributor>
 <contributor>Christopher Anderson &lt;cba@fedoraproject.org&gt;</contributor>
 <contributor>Chuck Atkins &lt;chuck.atkins@kitware.com&gt;</contributor>
 <contributor>Ryan Ballanger &lt;root@rballang-admin-2.fastenal.com&gt;</contributor>
@@ -36,7 +37,7 @@ Last Modified: 2018-01-03 15:03
 <contributor>Rebekah Hayes &lt;rhayes@corp.rivierautilities.com&gt;</contributor>
 <contributor>Trey Henefield &lt;thenefield@gmail.com&gt;</contributor>
 <contributor>hex2a &lt;hex2a@users.noreply.github.com&gt;</contributor>
-<contributor>John Hooks &lt;jhooks@starscream.pa.jhbcomputers.com&gt;</contributor>
+<contributor>John Hooks &lt;hooksie11@gmail.com&gt;</contributor>
 <contributor>Robin Price II &lt;robin@redhat.com&gt;</contributor>
 <contributor>Jeremiah Jahn &lt;jeremiah@goodinassociates.com&gt;</contributor>
 <contributor>Stephan Joerrens &lt;Stephan.Joerrens@fiduciagad.de&gt;</contributor>
@@ -53,6 +54,7 @@ Last Modified: 2018-01-03 15:03
 <contributor>Michael McConachie &lt;michael@redhat.com&gt;</contributor>
 <contributor>Khary Mendez &lt;kharyam@gmail.com&gt;</contributor>
 <contributor>Rodney Mercer &lt;rmercer@harris.com&gt;</contributor>
+<contributor>Matt Micene &lt;nzwulfin@gmail.com&gt;</contributor>
 <contributor>Brian Millett &lt;bmillett@gmail.com&gt;</contributor>
 <contributor>mmosel &lt;mmosel@kde.example.com&gt;</contributor>
 <contributor>Zbynek Moravec &lt;zmoravec@redhat.com&gt;</contributor>
@@ -61,12 +63,13 @@ Last Modified: 2018-01-03 15:03
 <contributor>Joe Nall &lt;joe@nall.com&gt;</contributor>
 <contributor>Neiloy &lt;neiloy@redhat.com&gt;</contributor>
 <contributor>Michele Newman &lt;mnewman@redhat.com&gt;</contributor>
+<contributor>OnceUponALoop &lt;firas.alshafei@gmail.com&gt;</contributor>
 <contributor>Kaustubh Padegaonkar &lt;theTuxRacer@gmail.com&gt;</contributor>
 <contributor>Michael Palmiotto &lt;mpalmiotto@tresys.com&gt;</contributor>
 <contributor>Max R.D. Parmer &lt;maxp@trystero.is&gt;</contributor>
 <contributor>pcactr &lt;paul.c.arnold4.ctr@mail.mil&gt;</contributor>
 <contributor>Kenneth Peeples &lt;kennethwpeeples@gmail.com&gt;</contributor>
-<contributor>Nathan Peters &lt;petna01@ca.com&gt;</contributor>
+<contributor>Nathan Peters &lt;Nathaniel.Peters@ca.com&gt;</contributor>
 <contributor>Frank Lin PIAT &lt;fpiat@klabs.be&gt;</contributor>
 <contributor>Stefan Pietsch &lt;mail.ipv4v6+gh@gmail.com&gt;</contributor>
 <contributor>Martin Preisler &lt;mpreisle@redhat.com&gt;</contributor>
@@ -76,6 +79,7 @@ Last Modified: 2018-01-03 15:03
 <contributor>Rick Renshaw &lt;Richard_Renshaw@xtoenergy.com&gt;</contributor>
 <contributor>Chris Reynolds &lt;c.reynolds82@gmail.com&gt;</contributor>
 <contributor>Pat Riehecky &lt;riehecky@fnal.gov&gt;</contributor>
+<contributor>rlucente-se-jboss &lt;rlucente@redhat.com&gt;</contributor>
 <contributor>Joshua Roys &lt;roysjosh@gmail.com&gt;</contributor>
 <contributor>rrenshaw &lt;bofh69@yahoo.com&gt;</contributor>
 <contributor>Chris Ruffalo &lt;chris.ruffalo@gmail.com&gt;</contributor>

--- a/shared/misc/generate-contributors.py
+++ b/shared/misc/generate-contributors.py
@@ -26,6 +26,9 @@ email_mappings = {
     "dahaic@users.noreply.github.com": "mhaicman@redhat.com",
     # Martin Preisler
     "martin@preisler.me": "mpreisle@redhat.com",
+    # Nathan Peters
+    "nathan@nathanpeters.com": "Nathaniel.Peters@ca.com",
+    "petna01@ca.com": "Nathaniel.Peters@ca.com",
     # Philippe Thierry
     "phil@internal.reseau-libre.net": "phil@reseau-libre.net",
     "philippe.thierry@reseau-libre.net": "phil@reseau-libre.net",
@@ -54,7 +57,8 @@ email_mappings = {
 }
 
 name_mappings = {
-    "Gabe": "Gabe Alford"
+    "Gabe": "Gabe Alford",
+    "Olivier": "Olivier Bonhomme",
 }
 
 


### PR DESCRIPTION
#### Description:

- As we are approaching release date (02.03.2018) of version 0.1.38, update list of contributors.
- Thank you:
  - @OnceUponALoop 
  - @ptitoliv 
  - @hooksie1 
  - @nzwulfin 
  - @rlucente-se-jboss 

#### Rationale:

- Proposing this to check with new contributors name and email to use in list.

