### PR TITLE
Add override to C2S-docker Profile

### DIFF
--- a/rhel7/profiles/C2S-docker.xml
+++ b/rhel7/profiles/C2S-docker.xml
@@ -1,6 +1,6 @@
 <Profile id="C2S-docker">
-<title>C2S for Docker</title>
-<description>This profile demonstrates compliance against the
+<title override="true">C2S for Docker</title>
+<description override="true">This profile demonstrates compliance against the
 U.S. Government Commercial Cloud Services (C2S) baseline.
 
 This baseline was inspired by the Center for Internet Security


### PR DESCRIPTION
#### Description:

- Override title and description of C2S Docker Profile.

#### Rationale:

- Default is to override these fields in all Profiles, so that Profiles that extend another don't forget to do so.
- There is no harm in overriding even if not extending any Profile.
