### PR TITLE
Fix a mismatched tag issue in RHEL6 sudo.xml

### DIFF
--- a/rhel6/xccdf/system/software/sudo.xml
+++ b/rhel6/xccdf/system/software/sudo.xml
@@ -15,7 +15,7 @@ For more information on <tt>Sudo</tt> and addition <tt>Sudo</tt> configuration o
 <description>
 The sudo <tt>NOPASSWD</tt> and <tt>!authenticate</tt> option, when specified, allows a
 user to execute commands using sudo without having to authenticate. This should be
-disabled by making sure that <tt>NOPASSWD</tt> and/or tt>!authenticate</tt> do not exist
+disabled by making sure that <tt>NOPASSWD</tt> and/or <tt>!authenticate</tt> do not exist
 in <tt>/etc/sudoers</tt> configuration file or 
 any sudo configuration snippets in <tt>/etc/sudoers.d/</tt>.
 </description>


### PR DESCRIPTION
The mismatched tag prevents the yaml dump script from working.

This is clearly a typo. I am puzzled how no part of our build system / test system spotted this until now.