### PR TITLE
eaccess should actually be eacces

### DIFF
--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
@@ -14,14 +14,14 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules 32-bit file eaccess" test_ref="test_32bit_arufm_eaccess_%NAME%_augenrules" />
+        <criterion comment="audit augenrules 32-bit file eacces" test_ref="test_32bit_arufm_eacces_%NAME%_augenrules" />
         <criterion comment="audit augenrules 32-bit file eperm" test_ref="test_32bit_arufm_eperm_%NAME%_augenrules" />
         <criteria operator="OR">
-          <!-- System either isn't 64-bit => we just check presence of the 32-bit version of the EACCESS / EPERM rules-->
+          <!-- System either isn't 64-bit => we just check presence of the 32-bit version of the EACCES / EPERM rules-->
           <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
           <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit versions of the rules -->
           <criteria operator="AND">
-            <criterion comment="audit augenrules 64-bit file eaccess" test_ref="test_64bit_arufm_eaccess_%NAME%_augenrules" />
+            <criterion comment="audit augenrules 64-bit file eacces" test_ref="test_64bit_arufm_eacces_%NAME%_augenrules" />
             <criterion comment="audit augenrules 64-bit file eperm" test_ref="test_64bit_arufm_eperm_%NAME%_augenrules" />
           </criteria>
         </criteria>
@@ -30,14 +30,14 @@
       <!-- OR test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl 32-bit file eaccess" test_ref="test_32bit_arufm_eaccess_%NAME%_auditctl" />
+        <criterion comment="audit auditctl 32-bit file eacces" test_ref="test_32bit_arufm_eacces_%NAME%_auditctl" />
         <criterion comment="audit auditctl 32-bit file eperm" test_ref="test_32bit_arufm_eperm_%NAME%_auditctl" />
         <criteria operator="OR">
-          <!-- System either isn't 64-bit => we just check presence of the 32-bit version of the EACCESS / EPERM rules -->
+          <!-- System either isn't 64-bit => we just check presence of the 32-bit version of the EACCES / EPERM rules -->
           <extend_definition comment="64-bit_system" definition_ref="system_info_architecture_64bit" negate="true" />
           <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit versions of the rules -->
           <criteria operator="AND">
-            <criterion comment="audit auditctl 64-bit file eaccess" test_ref="test_64bit_arufm_eaccess_%NAME%_auditctl" />
+            <criterion comment="audit auditctl 64-bit file eacces" test_ref="test_64bit_arufm_eacces_%NAME%_auditctl" />
             <criterion comment="audit auditctl 64-bit file eperm" test_ref="test_64bit_arufm_eperm_%NAME%_auditctl" />
           </criteria>
         </criteria>
@@ -46,10 +46,10 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit file eaccess" id="test_32bit_arufm_eaccess_%NAME%_augenrules" version="1">
-    <ind:object object_ref="object_32bit_arufm_eaccess_%NAME%_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit file eacces" id="test_32bit_arufm_eacces_%NAME%_augenrules" version="1">
+    <ind:object object_ref="object_32bit_arufm_eacces_%NAME%_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_32bit_arufm_eaccess_%NAME%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_32bit_arufm_eacces_%NAME%_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
@@ -64,10 +64,10 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit file eaccess" id="test_64bit_arufm_eaccess_%NAME%_augenrules" version="1">
-    <ind:object object_ref="object_64bit_arufm_eaccess_%NAME%_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit file eacces" id="test_64bit_arufm_eacces_%NAME%_augenrules" version="1">
+    <ind:object object_ref="object_64bit_arufm_eacces_%NAME%_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_64bit_arufm_eaccess_%NAME%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_64bit_arufm_eacces_%NAME%_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
@@ -82,10 +82,10 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit file eaccess" id="test_32bit_arufm_eaccess_%NAME%_auditctl" version="1">
-    <ind:object object_ref="object_32bit_arufm_eaccess_%NAME%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit file eacces" id="test_32bit_arufm_eacces_%NAME%_auditctl" version="1">
+    <ind:object object_ref="object_32bit_arufm_eacces_%NAME%_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_32bit_arufm_eaccess_%NAME%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_32bit_arufm_eacces_%NAME%_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
@@ -100,10 +100,10 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit file eaccess" id="test_64bit_arufm_eaccess_%NAME%_auditctl" version="1">
-    <ind:object object_ref="object_64bit_arufm_eaccess_%NAME%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit file eacces" id="test_64bit_arufm_eacces_%NAME%_auditctl" version="1">
+    <ind:object object_ref="object_64bit_arufm_eacces_%NAME%_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_64bit_arufm_eaccess_%NAME%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_64bit_arufm_eacces_%NAME%_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>


### PR DESCRIPTION
#### Description:

eaccess should be eacces. See `man audit.rules`

#### Rationale:

I guess this was a typo :wink: 
