### PR TITLE
Removed duplicate sudo related selects in rhel7's HIPAA

### DIFF
--- a/rhel7/profiles/hipaa.xml
+++ b/rhel7/profiles/hipaa.xml
@@ -251,8 +251,6 @@ Rule identified for securing of electronic protected health information.
 <select idref="audit_rules_privileged_commands_postqueue" selected="true" />
 <select idref="audit_rules_privileged_commands_ssh_keysign" selected="true" />
 <select idref="audit_rules_privileged_commands_sudoedit" selected="true" />
-<select idref="audit_rules_privileged_commands_sudo" selected="true" />
-<select idref="audit_rules_privileged_commands_su" selected="true" />
 <select idref="audit_rules_privileged_commands_umount" selected="true" />
 <select idref="audit_rules_privileged_commands_unix_chkpwd" selected="true" />
 <select idref="audit_rules_privileged_commands_userhelper" selected="true" />


### PR DESCRIPTION
#### Description:

- Somehow we accidentally merged a build breaking PR. This remedies the situation.

```
File '/home/jenkins/workspace/scap-security-guide-pull-requests/label/ssg_new/build/rhel7/xccdf-unlinked-resolved.xml' line 2595: Element '{http://checklists.nist.gov/xccdf/1.1}select': Duplicate key-sequence ['audit_rules_privileged_commands_sudo'] in unique identity-constraint '{http://checklists.nist.gov/xccdf/1.1}itemSelectKey'.
File '/home/jenkins/workspace/scap-security-guide-pull-requests/label/ssg_new/build/rhel7/xccdf-unlinked-resolved.xml' line 2596: Element '{http://checklists.nist.gov/xccdf/1.1}select': Duplicate key-sequence ['audit_rules_privileged_commands_su'] in unique identity-constraint '{http://checklists.nist.gov/xccdf/1.1}itemSelectKey'.
```

Regression happened in #2650

#### Rationale:

- SSG not building makes everybody sad and it also blocks all PRs because nothing builds.
