### PR TITLE
Move debian8 and rhel6 system and services locally

### DIFF
--- a/debian8/guide.xslt
+++ b/debian8/guide.xslt
@@ -35,8 +35,8 @@
       <xsl:apply-templates select="document(concat($BUILD_RP, '/bash-remediation-functions.xml'))" />
 
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/intro/shared_intro_os.xml'))" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/system.xml'))" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/services.xml'))" />
+      <xsl:apply-templates select="document('xccdf/system/system.xml')" />
+      <xsl:apply-templates select="document('xccdf/services/services.xml')" />
     </xsl:copy>
   </xsl:template>
 

--- a/debian8/xccdf/services/services.xml
+++ b/debian8/xccdf/services/services.xml
@@ -1,0 +1,13 @@
+<Group id="services" prodtype="all">
+<title>Services</title>
+<description>
+The best protection against vulnerable software is running less software. This section describes how to review
+the software which <product-name-macro/> installs on a system and disable software which is not needed. It
+then enumerates the software packages installed on a default <product-name-macro/> system and provides guidance about which
+ones can be safely disabled.
+<br /><br />
+<product-name-macro/> provides a convenient minimal install option that essentially installs the bare necessities for a functional
+system. When building <product-name-macro/> systems, it is highly recommended to select the minimal packages and then build up
+the system from there.
+</description>
+</Group>

--- a/debian8/xccdf/system/system.xml
+++ b/debian8/xccdf/system/system.xml
@@ -1,0 +1,6 @@
+<Group id="system" prodtype="all">
+<title>System Settings</title>
+<description>Contains rules that check correct system settings.</description>
+
+</Group>
+

--- a/rhel6/guide.xslt
+++ b/rhel6/guide.xslt
@@ -43,8 +43,8 @@
       <xsl:apply-templates select="document(concat($BUILD_RP, '/bash-remediation-functions.xml'))" />
 
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/intro/shared_intro_os.xml'))" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/system.xml'))" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/services.xml'))" />
+      <xsl:apply-templates select="document('xccdf/system/system.xml')" />
+      <xsl:apply-templates select="document('xccdf/services/services.xml')" />
       <!-- the overlays Groups here will be removed prior to some outputs -->
       <xsl:apply-templates select="document('overlays/srg_support.xml')" />
     </xsl:copy>

--- a/rhel6/xccdf/services/services.xml
+++ b/rhel6/xccdf/services/services.xml
@@ -1,0 +1,13 @@
+<Group id="services" prodtype="all">
+<title>Services</title>
+<description>
+The best protection against vulnerable software is running less software. This section describes how to review
+the software which <product-name-macro/> installs on a system and disable software which is not needed. It
+then enumerates the software packages installed on a default <product-name-macro/> system and provides guidance about which
+ones can be safely disabled.
+<br /><br />
+<product-name-macro/> provides a convenient minimal install option that essentially installs the bare necessities for a functional
+system. When building <product-name-macro/> systems, it is highly recommended to select the minimal packages and then build up
+the system from there.
+</description>
+</Group>

--- a/rhel6/xccdf/system/system.xml
+++ b/rhel6/xccdf/system/system.xml
@@ -1,0 +1,6 @@
+<Group id="system" prodtype="all">
+<title>System Settings</title>
+<description>Contains rules that check correct system settings.</description>
+
+</Group>
+


### PR DESCRIPTION
#### Description:

- Copy shared system and services xccdf content used by debian8 and rhel6 to its local folders
- Build shorthand using local content only

#### Rationale:
- This will help untangle where the shortand XCCDF are sourced from to continue yaml work.
