### PR TITLE
Add support for Oracle Linux 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ option(SSG_PRODUCT_SUSE12 "If enabled, the SLE12 SCAP content will be built" TRU
 option(SSG_PRODUCT_UBUNTU14 "If enabled, the Ubuntu14 SCAP content will be built" TRUE)
 option(SSG_PRODUCT_UBUNTU16 "If enabled, the Ubuntu16 SCAP content will be built" TRUE)
 option(SSG_PRODUCT_WRLINUX "If enabled, the WRLinux SCAP content will be built" TRUE)
+option(SSG_PRODUCT_OL7 "If enabled, the Oracle Linux 7 SCAP content will be built" TRUE)
 
 option(SSG_CENTOS_DERIVATIVES_ENABLED "If enabled, CentOS derivative content will be built from the RHEL content" TRUE)
 option(SSG_SCIENTIFIC_LINUX_DERIVATIVES_ENABLED "If enabled, Scientific Linux derivative content will be built from the RHEL content" TRUE)
@@ -153,6 +154,7 @@ message(STATUS "SUSE 12: ${SSG_PRODUCT_SUSE12}")
 message(STATUS "Ubuntu 14: ${SSG_PRODUCT_UBUNTU14}")
 message(STATUS "Ubuntu 16: ${SSG_PRODUCT_UBUNTU16}")
 message(STATUS "WRLinux: ${SSG_PRODUCT_WRLINUX}")
+message(STATUS "Oracle Linux 7: ${SSG_PRODUCT_OL7}")
 
 message(STATUS " ")
 
@@ -230,6 +232,11 @@ endif()
 if (SSG_PRODUCT_WRLINUX)
     add_subdirectory("wrlinux")
 endif()
+
+if (SSG_PRODUCT_OL7)
+    add_subdirectory("ol7")
+endif()
+
 
 ssg_define_guide_and_table_tests()
 

--- a/ol7/CMakeLists.txt
+++ b/ol7/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Sometimes our users will try to do: "cd wrlinux; cmake ." That needs to error in a nice way.
+# Sometimes our users will try to do: "cd ol7; cmake ." That needs to error in a nice way.
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     message(FATAL_ERROR "cmake has to be used on the root CMakeLists.txt, see BUILD.md for more details!")
 endif()

--- a/ol7/CMakeLists.txt
+++ b/ol7/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Sometimes our users will try to do: "cd wrlinux; cmake ." That needs to error in a nice way.
+if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+    message(FATAL_ERROR "cmake has to be used on the root CMakeLists.txt, see BUILD.md for more details!")
+endif()
+
+ssg_build_product("ol7")

--- a/ol7/checks/oval/file_permissions_unauthorized_sgid.xml
+++ b/ol7/checks/oval/file_permissions_unauthorized_sgid.xml
@@ -3,7 +3,6 @@
     <metadata>
       <title>Find setgid files system packages</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Oracle Linux 7</platform>
       </affected>
       <description>All files with setgid should be owned by a base system package</description>
@@ -29,7 +28,7 @@
     <unix:sgid datatype="boolean">true</unix:sgid>
   </unix:file_state>
 
-  <!-- list of all setgid files included with base RHEL7 system -->
+  <!-- list of all setgid files included with base OL7 system -->
   <unix:file_state id="state_sgid_whitelist" version="1">
     <unix:filepath var_ref="var_sgid_whitelist" var_check="at least one" />
   </unix:file_state>

--- a/ol7/checks/oval/file_permissions_unauthorized_sgid.xml
+++ b/ol7/checks/oval/file_permissions_unauthorized_sgid.xml
@@ -1,0 +1,79 @@
+<def-group>
+  <definition class="compliance" id="file_permissions_unauthorized_sgid" version="2">
+    <metadata>
+      <title>Find setgid files system packages</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Oracle Linux 7</platform>
+      </affected>
+      <description>All files with setgid should be owned by a base system package</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Check all setgid files" test_ref="check_setgid_files" />
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="none_exist" comment="setgid files outside system RPMs" id="check_setgid_files" version="1">
+    <unix:object object_ref="object_file_permissions_unauthorized_sgid" />
+  </unix:file_test>
+
+  <unix:file_object comment="files with sgid set" id="object_file_permissions_unauthorized_sgid" version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
+    <unix:path operation="equals">/</unix:path>
+    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <filter action="include">state_file_permissions_unauthorized_sgid</filter>
+    <filter action="exclude">state_sgid_whitelist</filter>
+  </unix:file_object>
+
+  <unix:file_state id="state_file_permissions_unauthorized_sgid" version="1">
+    <unix:sgid datatype="boolean">true</unix:sgid>
+  </unix:file_state>
+
+  <!-- list of all setgid files included with base RHEL7 system -->
+  <unix:file_state id="state_sgid_whitelist" version="1">
+    <unix:filepath var_ref="var_sgid_whitelist" var_check="at least one" />
+  </unix:file_state>
+
+  <constant_variable id="var_sgid_whitelist" version="1" datatype="string" comment="sgid whitelist">
+    <value>/usr/bin/cgclassify</value>
+    <value>/usr/bin/cgexec</value>
+    <value>/usr/sbin/netreport</value>
+    <value>/usr/bin/crontab</value>
+    <value>/usr/bin/gnomine</value>
+    <value>/usr/bin/iagno</value>
+    <value>/usr/bin/locate</value>
+    <value>/usr/bin/lockfile</value>
+    <value>/usr/bin/same-gnome</value>
+    <value>/usr/bin/screen</value>
+    <value>/usr/bin/ssh-agent</value>
+    <value>/usr/bin/wall</value>
+    <value>/usr/bin/write</value>
+    <value>/usr/lib/vte/gnome-pty-helper</value>
+    <value>/usr/lib/vte-2.90/gnome-pty-helper</value>
+    <value>/usr/lib/vte-2.91/gnome-pty-helper</value>
+    <value>/usr/lib64/vte/gnome-pty-helper</value>
+    <value>/usr/lib64/vte-2.90/gnome-pty-helper</value>
+    <value>/usr/lib64/vte-2.91/gnome-pty-helper</value>
+    <value>/usr/libexec/abrt-action-install-debuginfo-to-abrt-cache</value>
+    <value>/usr/libexec/kde4/kdesud</value>
+    <value>/usr/libexec/openssh/ssh-keysign</value>
+    <value>/usr/libexec/utempter/utempter</value>
+    <value>/usr/lib/mailman/cgi-bin/admindb</value>
+    <value>/usr/lib/mailman/cgi-bin/admin</value>
+    <value>/usr/lib/mailman/cgi-bin/confirm</value>
+    <value>/usr/lib/mailman/cgi-bin/create</value>
+    <value>/usr/lib/mailman/cgi-bin/edithtml</value>
+    <value>/usr/lib/mailman/cgi-bin/listinfo</value>
+    <value>/usr/lib/mailman/cgi-bin/options</value>
+    <value>/usr/lib/mailman/cgi-bin/private</value>
+    <value>/usr/lib/mailman/cgi-bin/rmlist</value>
+    <value>/usr/lib/mailman/cgi-bin/roster</value>
+    <value>/usr/lib/mailman/cgi-bin/subscribe</value>
+    <value>/usr/lib/mailman/mail/mailman</value>
+    <value>/usr/sbin/lockdev</value>
+    <value>/usr/sbin/postdrop</value>
+    <value>/usr/sbin/postqueue</value>
+    <value>/usr/sbin/sendmail.sendmail</value>
+  </constant_variable>
+
+</def-group>

--- a/ol7/checks/oval/file_permissions_unauthorized_suid.xml
+++ b/ol7/checks/oval/file_permissions_unauthorized_suid.xml
@@ -1,0 +1,94 @@
+<def-group>
+  <definition class="compliance" id="file_permissions_unauthorized_suid" version="1">
+    <metadata>
+      <title>Find setuid files from system packages</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Oracle Linux 7</platform>
+      </affected>
+      <description>All files with setuid should be owned by a base system package</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Check all setuid files" test_ref="check_setuid_files" />
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="none_exist" comment="setuid files outside system RPMs" id="check_setuid_files" version="1">
+    <unix:object object_ref="object_file_permissions_unauthorized_suid" />
+  </unix:file_test>
+
+  <unix:file_object comment="files with suid set" id="object_file_permissions_unauthorized_suid" version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
+    <unix:path operation="equals">/</unix:path>
+    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <filter action="include">state_file_permissions_unauthorized_suid</filter>
+    <filter action="exclude">state_suid_whitelist</filter>
+  </unix:file_object>
+
+  <unix:file_state id="state_file_permissions_unauthorized_suid" version="1">
+    <unix:suid datatype="boolean">true</unix:suid>
+  </unix:file_state>
+
+<!-- List of all setuid files included with base OL7 system -->
+<!-- KEEP THE LIST BELOW SORTED !!! -->
+  <unix:file_state id="state_suid_whitelist" version="1">
+    <unix:filepath var_ref="var_suid_whitelist" var_check="at least one" />
+  </unix:file_state>
+
+  <constant_variable id="var_suid_whitelist" version="1" datatype="string" comment="suid whitelist">
+    <value>/usr/bin/abrt-action-install-debuginfo-to-abrt-cache</value>
+    <value>/usr/bin/at</value>
+    <value>/usr/bin/chage</value>
+    <value>/usr/bin/chfn</value>
+    <value>/usr/bin/chsh</value>
+    <value>/usr/bin/crontab</value>
+    <value>/usr/bin/fusermount</value>
+    <value>/usr/bin/gpasswd</value>
+    <value>/usr/bin/ksu</value>
+    <value>/usr/bin/mount</value>
+    <value>/usr/bin/newgrp</value>
+    <value>/usr/bin/passwd</value>
+    <value>/usr/bin/pkexec</value>
+    <value>/usr/bin/staprun</value>
+    <value>/usr/bin/sudoedit</value>
+    <value>/usr/bin/sudo</value>
+    <value>/usr/bin/su</value>
+    <value>/usr/bin/umount</value>
+    <value>/usr/bin/Xorg</value>
+    <value>/usr/lib64/amanda/application/amgtar</value>
+    <value>/usr/lib64/amanda/application/amstar</value>
+    <value>/usr/lib64/amanda/calcsize</value>
+    <value>/usr/lib64/amanda/dumper</value>
+    <value>/usr/lib64/amanda/killpgrp</value>
+    <value>/usr/lib64/amanda/planner</value>
+    <value>/usr/lib64/amanda/rundump</value>
+    <value>/usr/lib64/amanda/runtar</value>
+    <value>/usr/lib64/dbus-1/dbus-daemon-launch-helper</value>
+    <value>/usr/lib/amanda/application/amgtar</value>
+    <value>/usr/lib/amanda/application/amstar</value>
+    <value>/usr/lib/amanda/calcsize</value>
+    <value>/usr/lib/amanda/dumper</value>
+    <value>/usr/lib/amanda/killpgrp</value>
+    <value>/usr/lib/amanda/planner</value>
+    <value>/usr/lib/amanda/rundump</value>
+    <value>/usr/lib/amanda/runtar</value>
+    <value>/usr/lib/dbus-1/dbus-daemon-launch-helper</value>
+    <value>/usr/libexec/abrt-action-install-debuginfo-to-abrt-cache</value>
+    <value>/usr/libexec/kde4/kpac_dhcp_helper</value>
+    <value>/usr/libexec/qemu-bridge-helper</value>
+    <value>/usr/libexec/spice-gtk-x86_64/spice-client-glib-usb-acl-helper</value>
+    <value>/usr/libexec/sssd/krb5_child</value>
+    <value>/usr/libexec/sssd/ldap_child</value>
+    <value>/usr/libexec/sssd/proxy_child</value>
+    <value>/usr/libexec/sssd/selinux_child</value>
+    <value>/usr/lib/polkit-1/polkit-agent-helper-1</value>
+    <value>/usr/sbin/amcheck</value>
+    <value>/usr/sbin/amservice</value>
+    <value>/usr/sbin/mount.nfs</value>
+    <value>/usr/sbin/pam_timestamp_check</value>
+    <value>/usr/sbin/unix_chkpwd</value>
+    <value>/usr/sbin/userhelper</value>
+    <value>/usr/sbin/usernetctl</value>
+  </constant_variable>
+
+</def-group>

--- a/ol7/checks/oval/file_permissions_unauthorized_suid.xml
+++ b/ol7/checks/oval/file_permissions_unauthorized_suid.xml
@@ -3,7 +3,6 @@
     <metadata>
       <title>Find setuid files from system packages</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Oracle Linux 7</platform>
       </affected>
       <description>All files with setuid should be owned by a base system package</description>

--- a/ol7/cpe/ol7-cpe-dictionary.xml
+++ b/ol7/cpe/ol7-cpe-dictionary.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd">
+      <cpe-item name="cpe:/o:oracle:linux:7">
+            <title xml:lang="en-us">Oracle Linux 7</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_ol7_family</check>
+      </cpe-item>
+
+</cpe-list>

--- a/ol7/guide.xslt
+++ b/ol7/guide.xslt
@@ -1,0 +1,146 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+<!-- This transform assembles all fragments into one "shorthand" XCCDF document
+     Accepts the following parameters:
+
+     * SHARED_RP    (required)  Holds the resolved ABSOLUTE path
+                    to the SSG's "shared/" directory.
+     * BUILD_RP     (required)  Holds the resolved ABSOLUTE path
+                    to the SSG's build directory - $CMAKE_BINARY_PATH
+-->
+
+<!-- Define the default value of the required "SHARED_RP" parameter -->
+<xsl:param name="SHARED_RP" select='undef' />
+<xsl:param name="BUILD_RP" select='undef' />
+
+  <xsl:template match="Benchmark">
+    <xsl:copy>
+      <xsl:copy-of select="@*|node()" />
+
+      <!-- Adding profiles here -->
+      <xsl:apply-templates select="document('profiles/standard.xml')" />
+
+
+      <!-- Adding 'conditional_clause' placeholder <xccdf:Value> here -->
+      <Value id="conditional_clause" type="string" operator="equals">
+        <title>A conditional clause for check statements.</title>
+        <description>A conditional clause for check statements.</description>
+        <value>This is a placeholder.</value>
+      </Value>
+      <xsl:apply-templates select="document(concat($BUILD_RP, '/bash-remediation-functions.xml'))" />
+
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/intro/shared_intro_os.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/system.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/services.xml'))" />
+
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Copy Group templates from ../shared/xccdf/shared_guide.xslt -->
+  <xsl:template match="Group[@id='system']">
+    <xsl:copy>
+      <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/software.xml'))" /> 
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/permissions.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/selinux.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/accounts.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/network/network.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/logging.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/auditing.xml'))" />
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="Group[@id='software']">
+    <xsl:copy>
+      <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/disk_partitioning.xml'))" />
+      <xsl:apply-templates select="document('xccdf/system/software/updating.xml')" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/integrity.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/gnome.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/sudo.xml'))" />
+    </xsl:copy>
+  </xsl:template>
+
+
+  <xsl:template match="Group[@id='accounts']">
+    <xsl:copy>
+      <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/restrictions/restrictions.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/pam.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/session.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/physical.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/banners.xml'))" />
+    </xsl:copy>
+  </xsl:template>
+
+
+  <xsl:template match="Group[@id='accounts-restrictions']">
+    <xsl:copy>
+      <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/restrictions/root_logins.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/restrictions/password_storage.xml'))" /> 
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/restrictions/password_expiration.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/restrictions/account_expiration.xml'))" />
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="Group[@id='permissions']">
+    <xsl:copy>
+      <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/partitions.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/mounting.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/files.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/execution.xml'))" /> 
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="Group[@id='network']">
+    <xsl:copy>
+      <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/network/kernel.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/network/wireless.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/network/ipv6.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/network/firewalld.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/network/ssl.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/network/uncommon.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/network/ipsec.xml'))" />
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="Group[@id='services']">
+    <xsl:copy>
+      <xsl:copy-of select="@*|node()" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/obsolete.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/base.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/cron.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/docker.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/ssh.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/sssd.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/xorg.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/avahi.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/printing.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/dhcp.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/ntp.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/mail.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/ldap.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/nfs.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/dns.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/ftp.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/http.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/imap.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/quagga.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/smb.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/squid.xml'))" />
+      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/snmp.xml'))" />
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- copy everything else through to final output -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>
+

--- a/ol7/profiles/standard.xml
+++ b/ol7/profiles/standard.xml
@@ -1,0 +1,37 @@
+<Profile id="standard">
+<title override="true">Standard System Security Profile</title>
+<description override="true">This profile contains rules to ensure standard security baseline
+of Oracle Linux 7 system. Regardless of your system's workload
+all of these checks should pass.</description>
+
+<!-- Verify list of standard profile rules applicable on Oracle Linux 7 -->
+
+<select idref="ensure_oracle_gpgkey_installed" selected="true" />
+<select idref="ensure_gpgcheck_globally_activated" selected="true" />
+<!-- <select idref="rpm_verify_permissions" selected="true" /> -->
+<!-- <select idref="rpm_verify_hashes" selected="true" /> -->
+<!-- <select idref="security_patches_up_to_date" selected="true"/> -->
+<!-- <select idref="no_empty_passwords" selected="true"/> -->
+<!-- <select idref="file_permissions_unauthorized_sgid" selected="true"/> -->
+
+<!-- <select idref="file_permissions_unauthorized_suid" selected="true"/> -->
+<!-- <select idref="file_permissions_unauthorized_world_writable" selected="true"/> -->
+<!-- <select idref="accounts_root_path_dirs_no_write" selected="true"/> -->
+<!-- <select idref="dir_perms_world_writable_sticky_bits" selected="true" /> -->
+
+<!-- The following rules currently returns 'notapplicable' on RHEL-7 container -->
+<!-- Investigate why, fix the issues, and re-enable back once fixed -->
+
+<!-- The OVAL check for root_path_no_dot uses environmentvariable58_test -->
+<!-- which may be the cause of 'notapplicable' results for offline scanning -->
+<!-- <select idref="root_path_no_dot" selected="true"/> -->
+
+<!-- Password and shadow probes are disabled for offline scanning. -->
+<!-- See https://github.com/OpenSCAP/openscap/pull/327 and -->
+<!-- https://github.com/OpenSCAP/openscap/pull/344 -->
+<!-- <select idref="accounts_password_all_shadowed" selected="true"/> -->
+
+<!-- <select idref="mount_option_dev_shm_nodev" selected="true" /> -->
+<!-- <select idref="mount_option_dev_shm_nosuid" selected="true" /> -->
+
+</Profile>

--- a/ol7/profiles/standard.xml
+++ b/ol7/profiles/standard.xml
@@ -8,30 +8,23 @@ all of these checks should pass.</description>
 
 <select idref="ensure_oracle_gpgkey_installed" selected="true" />
 <select idref="ensure_gpgcheck_globally_activated" selected="true" />
-<!-- <select idref="rpm_verify_permissions" selected="true" /> -->
-<!-- <select idref="rpm_verify_hashes" selected="true" /> -->
-<!-- <select idref="security_patches_up_to_date" selected="true"/> -->
-<!-- <select idref="no_empty_passwords" selected="true"/> -->
-<!-- <select idref="file_permissions_unauthorized_sgid" selected="true"/> -->
-
-<!-- <select idref="file_permissions_unauthorized_suid" selected="true"/> -->
-<!-- <select idref="file_permissions_unauthorized_world_writable" selected="true"/> -->
-<!-- <select idref="accounts_root_path_dirs_no_write" selected="true"/> -->
-<!-- <select idref="dir_perms_world_writable_sticky_bits" selected="true" /> -->
-
-<!-- The following rules currently returns 'notapplicable' on RHEL-7 container -->
-<!-- Investigate why, fix the issues, and re-enable back once fixed -->
+<select idref="rpm_verify_permissions" selected="true" />
+<select idref="rpm_verify_hashes" selected="true" />
+<select idref="security_patches_up_to_date" selected="true"/>
+<select idref="no_empty_passwords" selected="true"/>
+<select idref="file_permissions_unauthorized_sgid" selected="true"/>
+<select idref="file_permissions_unauthorized_suid" selected="true"/>
+<select idref="file_permissions_unauthorized_world_writable" selected="true"/>
+<select idref="accounts_root_path_dirs_no_write" selected="true"/>
+<select idref="dir_perms_world_writable_sticky_bits" selected="true" />
 
 <!-- The OVAL check for root_path_no_dot uses environmentvariable58_test -->
 <!-- which may be the cause of 'notapplicable' results for offline scanning -->
-<!-- <select idref="root_path_no_dot" selected="true"/> -->
+<select idref="root_path_no_dot" selected="true"/>
 
 <!-- Password and shadow probes are disabled for offline scanning. -->
 <!-- See https://github.com/OpenSCAP/openscap/pull/327 and -->
 <!-- https://github.com/OpenSCAP/openscap/pull/344 -->
-<!-- <select idref="accounts_password_all_shadowed" selected="true"/> -->
-
-<!-- <select idref="mount_option_dev_shm_nodev" selected="true" /> -->
-<!-- <select idref="mount_option_dev_shm_nosuid" selected="true" /> -->
+<select idref="accounts_password_all_shadowed" selected="true"/>
 
 </Profile>

--- a/ol7/templates/csv/oval_5.11/services_disabled.csv
+++ b/ol7/templates/csv/oval_5.11/services_disabled.csv
@@ -1,0 +1,2 @@
+# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+sshd,,

--- a/ol7/templates/csv/packages_installed.csv
+++ b/ol7/templates/csv/packages_installed.csv
@@ -1,0 +1,1 @@
+openssh-server

--- a/ol7/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/ol7/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -1,0 +1,53 @@
+<def-group>
+  <definition class="compliance" id="service_%SERVICENAME%_disabled" version="1">
+    <metadata>
+      <title>Service %SERVICENAME% Disabled</title>
+      <affected family="unix">
+        <platform>Oracle Linux 7</platform>
+      </affected>
+      <description>The %SERVICENAME% service should be disabled if possible.</description>
+    </metadata>
+    <criteria comment="package %PACKAGENAME% removed or service %SERVICENAME% is not configured to start" operator="OR">
+      <extend_definition comment="%PACKAGENAME% removed" definition_ref="package_%PACKAGENAME%_removed" />
+      <criteria operator="AND" comment="service %SERVICENAME% is not configured to start">
+        <criterion comment="%SERVICENAME% not wanted by multi-user.target" test_ref="test_%SERVICENAME%_not_wanted_by_multi_user_target" />
+        <criterion comment="%SERVICENAME% socket not wanted by multi-user.target" test_ref="test_%SERVICENAME%_socket_not_wanted_by_multi_user_target" />
+        <criterion comment="%SERVICENAME% is not running" test_ref="test_service_not_running_%SERVICENAME%" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_%SERVICENAME%_not_wanted_by_multi_user_target" version="1">
+    <linux:object object_ref="object_multi_user_target_for_%SERVICENAME%_disabled" />
+    <linux:state state_ref="state_systemd_%SERVICENAME%_off"/>
+  </linux:systemdunitdependency_test>
+  <linux:systemdunitdependency_object id="object_multi_user_target_for_%SERVICENAME%_disabled" comment="list of dependencies of multi-user.target" version="1">
+    <linux:unit>multi-user.target</linux:unit>
+  </linux:systemdunitdependency_object>
+  <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_off" comment="%SERVICENAME% service is not listed in the dependencies" version="1">
+    <linux:dependency entity_check="none satisfy">%SERVICENAME%.service</linux:dependency>
+  </linux:systemdunitdependency_state>
+
+  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_%SERVICENAME%_socket_not_wanted_by_multi_user_target" version="1">
+    <linux:object object_ref="object_multi_user_target_for_%SERVICENAME%_socket_disabled" />
+    <linux:state state_ref="state_systemd_%SERVICENAME%_socket_off"/>
+  </linux:systemdunitdependency_test>
+  <linux:systemdunitdependency_object id="object_multi_user_target_for_%SERVICENAME%_socket_disabled" comment="list of dependencies of multi-user.target" version="1">
+    <linux:unit>multi-user.target</linux:unit>
+  </linux:systemdunitdependency_object>
+  <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_socket_off" comment="%SERVICENAME% socket is not listed in the dependencies" version="1">
+    <linux:dependency entity_check="none satisfy">%SERVICENAME%.socket</linux:dependency>
+  </linux:systemdunitdependency_state>
+
+  <linux:systemdunitproperty_test id="test_service_not_running_%SERVICENAME%" check="all" check_existence="any_exist" comment="Test that the %SERVICENAME% service is not running" version="1">
+    <linux:object object_ref="obj_service_not_running_%SERVICENAME%"/>
+    <linux:state state_ref="state_service_not_running_%SERVICENAME%"/>
+  </linux:systemdunitproperty_test>
+  <linux:systemdunitproperty_object id="obj_service_not_running_%SERVICENAME%" comment="Retrieve the ActiveState property of %SERVICENAME%" version="1">
+    <linux:unit operation="pattern match">%SERVICENAME%\.(service|socket)</linux:unit>
+    <linux:property>ActiveState</linux:property>
+  </linux:systemdunitproperty_object>
+  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running">
+      <linux:value>inactive</linux:value>
+  </linux:systemdunitproperty_state>
+</def-group>

--- a/ol7/templates/template_OVAL_kernel_module_disabled
+++ b/ol7/templates/template_OVAL_kernel_module_disabled
@@ -1,0 +1,83 @@
+<def-group>
+  <definition class="compliance"
+  id="kernel_module_%KERNMODULE%_disabled" version="1">
+    <metadata>
+      <title>Disable %KERNMODULE% Kernel Module</title>
+      <affected family="unix">
+        <platform>Oracle Linux 7</platform>
+      </affected>
+      <description>The kernel module %KERNMODULE% should be disabled.</description>
+    </metadata>
+    <criteria operator="OR">
+      <criterion test_ref="test_kernmod_%KERNMODULE%_disabled" comment="kernel module %KERNMODULE% disabled in /etc/modprobe.d" />
+      <criterion test_ref="test_kernmod_%KERNMODULE%_modprobeconf" comment="kernel module %KERNMODULE% disabled in /etc/modprobe.conf" />
+      <criterion test_ref="test_kernmod_%KERNMODULE%_etcmodules-load" comment="kernel module %KERNMODULE% disabled in /etc/modules-load.d" />
+      <criterion test_ref="test_kernmod_%KERNMODULE%_runmodules-load" comment="kernel module %KERNMODULE% disabled in /run/modules-load.d" />
+      <criterion test_ref="test_kernmod_%KERNMODULE%_libmodules-load" comment="kernel module %KERNMODULE% disabled in /usr/lib/modules-load.d" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_disabled" version="1" check="all"
+  comment="kernel module %KERNMODULE% disabled">
+    <ind:object object_ref="obj_kernmod_%KERNMODULE%_disabled" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_modprobeconf" version="1" check="all"
+  comment="kernel module %KERNMODULE% disabled in /etc/modprobe.conf">
+    <ind:object object_ref="obj_kernmod_%KERNMODULE%_modprobeconf" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_etcmodules-load" version="1" check="all"
+  comment="kernel module %KERNMODULE% disabled in /etc/modules-load.d">
+    <ind:object object_ref="obj_kernmod_%KERNMODULE%_etcmodules-load" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_runmodules-load" version="1" check="all"
+  comment="kernel module %KERNMODULE% disabled in /run/modules-load.d">
+    <ind:object object_ref="obj_kernmod_%KERNMODULE%_runmodules-load" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_libmodules-load" version="1" check="all"
+  comment="kernel module %KERNMODULE% disabled in /usr/lib/modules-load.d">
+    <ind:object object_ref="obj_kernmod_%KERNMODULE%_libmodules-load" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_disabled"
+  version="1" comment="kernel module %KERNMODULE% disabled">
+    <ind:path>/etc/modprobe.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_modprobeconf"
+  version="1" comment="Check deprecated /etc/modprobe.conf for disablement of %KERNMODULE%">
+    <ind:filepath>/etc/modprobe.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_etcmodules-load"
+  version="1" comment="kernel module %KERNMODULE% disabled in /etc/modules-load.d">
+    <ind:path>/etc/modules-load.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_runmodules-load"
+  version="1" comment="kernel module %KERNMODULE% disabled in /run/modules-load.d">
+    <ind:path>/run/modules-load.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_libmodules-load"
+  version="1" comment="kernel module %KERNMODULE% disabled in /usr/lib/modules-load.d">
+    <ind:path>/usr/lib/modules-load.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/ol7/templates/template_OVAL_package_installed
+++ b/ol7/templates/template_OVAL_package_installed
@@ -1,0 +1,24 @@
+<def-group>
+  <definition class="compliance" id="package_%PKGNAME%_installed"
+  version="1">
+    <metadata>
+      <title>Package %PKGNAME% Installed</title>
+      <affected family="unix">
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>The RPM package %PKGNAME% should be installed.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="package %PKGNAME% is installed"
+      test_ref="test_package_%PKGNAME%_installed" />
+    </criteria>
+  </definition>
+  <linux:rpminfo_test check="all" check_existence="all_exist"
+  id="test_package_%PKGNAME%_installed" version="1"
+  comment="package %PKGNAME% is installed">
+    <linux:object object_ref="obj_package_%PKGNAME%_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_%PKGNAME%_installed" version="1">
+    <linux:name>%PKGNAME%</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/ol7/templates/template_OVAL_package_removed
+++ b/ol7/templates/template_OVAL_package_removed
@@ -1,0 +1,24 @@
+<def-group>
+  <definition class="compliance" id="package_%PKGNAME%_removed"
+  version="1">
+    <metadata>
+      <title>Package %PKGNAME% Removed</title>
+      <affected family="unix">
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>The RPM package %PKGNAME% should be removed.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="package %PKGNAME% is removed"
+      test_ref="test_package_%PKGNAME%_removed" />
+    </criteria>
+  </definition>
+  <linux:rpminfo_test check="all" check_existence="none_exist"
+  id="test_package_%PKGNAME%_removed" version="1"
+  comment="package %PKGNAME% is removed">
+    <linux:object object_ref="obj_package_%PKGNAME%_removed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_%PKGNAME%_removed" version="1">
+    <linux:name>%PKGNAME%</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/ol7/transforms/constants.xslt
+++ b/ol7/transforms/constants.xslt
@@ -1,0 +1,22 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:include href="../../shared/transforms/shared_constants.xslt"/>
+
+<xsl:variable name="product_long_name">Oracle Linux 7</xsl:variable>
+<xsl:variable name="product_short_name">OL7</xsl:variable>
+<xsl:variable name="product_stig_id_name">>OL_7_STIG</xsl:variable>
+<xsl:variable name="prod_type">ol7</xsl:variable>
+
+<xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Oracle_Linux_7_Benchmark_v2.1.0.pdf</xsl:variable>
+<xsl:variable name="product_guide_id_name">OL-7</xsl:variable>
+<xsl:variable name="platform_cpes">cpe:/o:oracle:linux:7</xsl:variable>
+<xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
+<xsl:variable name="os-stigid-concat" >OL-07-</xsl:variable>
+
+<!-- Define URI for custom CCE identifier which can be used for mapping to corporate policy -->
+<!--xsl:variable name="custom-cce-uri">https://www.example.org</xsl:variable-->
+
+<!-- Define URI for custom policy reference which can be used for linking to corporate policy -->
+<!--xsl:variable name="custom-ref-uri">https://www.example.org</xsl:variable-->
+
+</xsl:stylesheet>

--- a/ol7/transforms/shorthand2xccdf.xslt
+++ b/ol7/transforms/shorthand2xccdf.xslt
@@ -1,0 +1,9 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:import href="../../shared/transforms/shared_shorthand2xccdf.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:param name="ssg_version">unknown</xsl:param>
+<xsl:variable name="ovalfile">unlinked-ol7-oval.xml</xsl:variable>
+
+</xsl:stylesheet>

--- a/ol7/xccdf/system/software/updating.xml
+++ b/ol7/xccdf/system/software/updating.xml
@@ -88,4 +88,46 @@ Authority (CA).
 pcidss="Req-6.2" cis="1.2.2" cjis="5.10.4.1" cui="3.4.8" />
 </Rule>
 
+<Rule id="security_patches_up_to_date" severity="high" prodtype="ol7">
+<title>Ensure Software Patches Installed</title>
+<description>If the system is joined to the ULN or a yum server, run the following command to install updates:
+<pre>$ sudo yum update</pre>
+If the system is not configured to use one of these sources, updates (in the form of RPM packages)
+can be manually downloaded from the ULN and installed using <tt>rpm</tt>.
+<br /><br />
+NOTE: U.S. Defense systems are required to be patched within 30 days or sooner as local policy
+dictates.
+</description>
+<!-- Directly define remotely located OVAL to be executed when scanning this rule -->
+<check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+  <check-content-ref href="https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2" />
+</check>
+<ocil clause="updates are not installed">
+If the system is joined to the ULN or a yum server which provides updates, invoking the following command will
+indicate if updates are available:
+<pre>$ sudo yum check-update</pre>
+<br /><br />
+If the system is not configured to update from one of these sources,
+run the following command to list when each package was last updated:
+<pre>$ rpm -qa -last</pre>
+<br /><br />
+Compare this to Oracle Linux Security Advisories (ELSA) listed at
+<weblink-macro link="https://linux.oracle.com/pls/apex/f?p=105:21:::NO:RP::"/>
+to determine if the system is missing applicable updates.
+</ocil>
+<rationale>
+Installing software updates is a fundamental mitigation against
+the exploitation of publicly-known vulnerabilities. If the most
+recent security patches and updates are not installed, unauthorized
+users may take advantage of weaknesses in the unpatched software. The
+lack of prompt attention to patching could result in a system compromise.
+</rationale>
+<ident prodtype="rhel7" cce="26895-3" />
+<!-- Particular OVAL check is defined directly via <check> element above -->
+<!-- DO NOT REFERENCE an OVAL id here !!! -->
+<ref prodtype="rhel7" stigid="020260" />
+<ref nist="SI-2,SI-2(c),MA-1(b)" disa="366" pcidss="Req-6.2" cis="1.8" srg="SRG-OS-000480-GPOS-00227" cjis="5.10.4.1" />
+</Rule>
+
+
 </Group>

--- a/ol7/xccdf/system/software/updating.xml
+++ b/ol7/xccdf/system/software/updating.xml
@@ -39,7 +39,6 @@ the software has not been tampered with and that it has been provided
 by a trusted vendor. The Oracle GPG key is necessary to
 cryptographically verify packages are from Oracle.
 </rationale>
-<ident prodtype="rhel7" cce="26957-1" />
 <oval id="ensure_oracle_gpgkey_installed" />
 <ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" ossrg="366" pcidss="Req-6.2" cis="1.2.2" />
 </Rule>
@@ -47,7 +46,7 @@ cryptographically verify packages are from Oracle.
 <!-- REMINDER: Before telling people to update their systems
      via the security_patches_up_to_date rule, we must
      ensure they have configured an update source! -->
-<Rule id="ensure_gpgcheck_globally_activated" severity="high" prodtype="rhel7, ol7">
+<Rule id="ensure_gpgcheck_globally_activated" severity="high" prodtype="ol7">
 <title>Ensure gpgcheck Enabled In Main Yum Configuration</title>
 <description>The <tt>gpgcheck</tt> option controls whether
 RPM packages' signatures are always checked prior to installation.
@@ -81,9 +80,7 @@ certificates are disallowed by this requirement. Certificates
 used to verify the software must be from an approved Certificate
 Authority (CA).
 </rationale>
-<ident prodtype="rhel7" cce="26989-4" />
 <oval id="ensure_gpgcheck_globally_activated" />
-<ref prodtype="rhel7" stigid="020050" />
 <ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" srg="SRG-OS-000366-GPOS-00153"
 pcidss="Req-6.2" cis="1.2.2" cjis="5.10.4.1" cui="3.4.8" />
 </Rule>
@@ -122,10 +119,8 @@ recent security patches and updates are not installed, unauthorized
 users may take advantage of weaknesses in the unpatched software. The
 lack of prompt attention to patching could result in a system compromise.
 </rationale>
-<ident prodtype="rhel7" cce="26895-3" />
 <!-- Particular OVAL check is defined directly via <check> element above -->
 <!-- DO NOT REFERENCE an OVAL id here !!! -->
-<ref prodtype="rhel7" stigid="020260" />
 <ref nist="SI-2,SI-2(c),MA-1(b)" disa="366" pcidss="Req-6.2" cis="1.8" srg="SRG-OS-000480-GPOS-00227" cjis="5.10.4.1" />
 </Rule>
 

--- a/ol7/xccdf/system/software/updating.xml
+++ b/ol7/xccdf/system/software/updating.xml
@@ -1,0 +1,91 @@
+<Group id="updating">
+<title>Updating Software</title>
+<description>The <tt>yum</tt> command line tool is used to install and
+update software packages. The system also provides a graphical
+software update tool in the <b>System</b> menu, in the <b>Administration</b> submenu,
+called <b>Software Update</b>.
+<br /><br />
+Oracle Linux system contain an installed software catalog called
+the RPM database, which records metadata of installed packages. Consistently using
+<tt>yum</tt> or the graphical <b>Software Update</b> for all software installation
+allows for insight into the current inventory of installed software on the system.
+</description>
+
+<Rule id="ensure_oracle_gpgkey_installed" severity="high" prodtype="ol7">
+<title>Ensure Oracle Linux GPG Key Installed</title>
+<description>
+To ensure the system can cryptographically verify base software
+packages come from Oracle (and to connect to the Unbreakable Linux Network to
+receive them), the Oracle GPG key must properly be installed.
+To install the Oracle GPG key, run:
+<pre>$ sudo uln_register</pre>
+If the system is not connected to the Internet,
+then install the Oracle GPG key from trusted media such as
+the Oracle installation CD-ROM or DVD. Assuming the disc is mounted
+in <tt>/media/cdrom</tt>, use the following command as the root user to import
+it into the keyring:
+<pre>$ sudo rpm --import /media/cdrom/RPM-GPG-KEY</pre>
+</description>
+<ocil clause="the Oracle GPG Key is not installed">
+To ensure that the GPG key is installed, run:
+<pre>$ rpm -q --queryformat "%{SUMMARY}\n" gpg-pubkey</pre>
+The command should return the string below:
+<pre>gpg(Oracle OSS group (Open Source Software group) &lt;build@oss.oracle.com&gt;</pre>
+</ocil>
+<rationale>
+Changes to software components can have significant effects on the
+overall security of the operating system. This requirement ensures
+the software has not been tampered with and that it has been provided
+by a trusted vendor. The Oracle GPG key is necessary to
+cryptographically verify packages are from Oracle.
+</rationale>
+<ident prodtype="rhel7" cce="26957-1" />
+<oval id="ensure_oracle_gpgkey_installed" />
+<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" ossrg="366" pcidss="Req-6.2" cis="1.2.2" />
+</Rule>
+
+<!-- REMINDER: Before telling people to update their systems
+     via the security_patches_up_to_date rule, we must
+     ensure they have configured an update source! -->
+<Rule id="ensure_gpgcheck_globally_activated" severity="high" prodtype="rhel7, ol7">
+<title>Ensure gpgcheck Enabled In Main Yum Configuration</title>
+<description>The <tt>gpgcheck</tt> option controls whether
+RPM packages' signatures are always checked prior to installation.
+To configure yum to check package signatures before installing
+them, ensure the following line appears in <tt>/etc/yum.conf</tt> in
+the <tt>[main]</tt> section:
+<pre>gpgcheck=1</pre>
+</description>
+<ocil clause="GPG checking is not enabled">
+To determine whether <tt>yum</tt> is configured to use <tt>gpgcheck</tt>,
+inspect <tt>/etc/yum.conf</tt> and ensure the following appears in the
+<tt>[main]</tt> section:
+<pre>gpgcheck=1</pre>
+A value of <tt>1</tt> indicates that <tt>gpgcheck</tt> is enabled. Absence of a
+<tt>gpgcheck</tt> line or a setting of <tt>0</tt> indicates that it is
+disabled.
+</ocil>
+<rationale>
+Changes to any software components can have significant effects on the overall security 
+of the operating system. This requirement ensures the software has not been tampered with
+and that it has been provided by a trusted vendor.
+<br />
+Accordingly, patches, service packs, device drivers, or operating system components must
+be signed with a certificate recognized and approved by the organization.
+<br />
+Verifying the authenticity of the software prior to installation
+validates the integrity of the patch or upgrade received from
+a vendor. This ensures the software has not been tampered with and
+that it has been provided by a trusted vendor. Self-signed
+certificates are disallowed by this requirement. Certificates
+used to verify the software must be from an approved Certificate
+Authority (CA).
+</rationale>
+<ident prodtype="rhel7" cce="26989-4" />
+<oval id="ensure_gpgcheck_globally_activated" />
+<ref prodtype="rhel7" stigid="020050" />
+<ref nist="CM-5(3),SI-7,MA-1(b)" disa="1749" srg="SRG-OS-000366-GPOS-00153"
+pcidss="Req-6.2" cis="1.2.2" cjis="5.10.4.1" cui="3.4.8" />
+</Rule>
+
+</Group>

--- a/oval.config.in
+++ b/oval.config.in
@@ -21,7 +21,7 @@
 # Note: this file uses .ini style formatting
 #
 [Platform]
-multi_platform_oval = multi_platform_fedora, multi_platform_rhel, multi_platform_debian, multi_platform_buntu, multi_platform_wrlinux
+multi_platform_oval = multi_platform_fedora, multi_platform_rhel, multi_platform_debian, multi_platform_buntu, multi_platform_wrlinux, multi_platform_ol
 multi_platform_fedora = 24,23
 multi_platform_debian = 8
 multi_platform_ubuntu = 1604,1404
@@ -30,3 +30,4 @@ multi_platform_rhel = 6,7
 multi_platform_openstack = 
 multi_platform_opensuse = 42.0,42.1
 multi_platform_sle = 11,12
+multi_platform_ol = 7

--- a/shared/checks/oval/dir_perms_world_writable_sticky_bits.xml
+++ b/shared/checks/oval/dir_perms_world_writable_sticky_bits.xml
@@ -4,6 +4,7 @@
       <title>Verify that All World-Writable Directories Have Sticky Bits Set</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The sticky bit should be set for all world-writable directories.</description>
     </metadata>

--- a/shared/checks/oval/ensure_oracle_gpgkey_installed.xml
+++ b/shared/checks/oval/ensure_oracle_gpgkey_installed.xml
@@ -6,7 +6,6 @@
         <platform>multi_platform_ol</platform>
       </affected>
       <description>The Oracle Linux key packages are required to be installed.</description>
-      <reference source="galford" ref_id="20151006" ref_url="test_attestation" />
     </metadata>
     <criteria comment="Vendor GPG keys" operator="OR">
       <criteria comment="Oracle Vendor Keys" operator="AND">

--- a/shared/checks/oval/ensure_oracle_gpgkey_installed.xml
+++ b/shared/checks/oval/ensure_oracle_gpgkey_installed.xml
@@ -1,0 +1,40 @@
+<def-group>
+  <definition class="compliance" id="ensure_oracle_gpgkey_installed" version="1">
+    <metadata>
+      <title>Oracle Linux gpg-pubkey Package Installed</title>
+      <affected family="unix">
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>The Oracle Linux key packages are required to be installed.</description>
+      <reference source="galford" ref_id="20151006" ref_url="test_attestation" />
+    </metadata>
+    <criteria comment="Vendor GPG keys" operator="OR">
+      <criteria comment="Oracle Vendor Keys" operator="AND">
+        <criteria comment="Oracle Installed" operator="OR">
+          <extend_definition comment="Oracle Linux 6 installed" definition_ref="installed_OS_is_ol6_family" />
+          <extend_definition comment="Oracle Linux 7 installed" definition_ref="installed_OS_is_ol7_family" />
+        </criteria>
+        <criterion comment="package gpg-pubkey-ec551f03-53619141 is installed"
+        test_ref="test_package_gpgkey-ec551f03-53619141_installed" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <!-- First define global "object_package_gpg-pubkey" to be shared (reused) across multiple tests -->
+  <linux:rpminfo_object id="object_package_gpg-pubkey" version="1">
+    <linux:name>gpg-pubkey</linux:name>
+  </linux:rpminfo_object>
+
+  <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
+  id="test_package_gpgkey-ec551f03-53619141_installed" version="1"
+  comment="Oracle Linux key package is installed">
+    <linux:object object_ref="object_package_gpg-pubkey" />
+    <linux:state state_ref="state_package_gpg-pubkey-ec551f03-53619141" />
+  </linux:rpminfo_test>
+
+  <linux:rpminfo_state id="state_package_gpg-pubkey-ec551f03-53619141" version="1">
+    <linux:release>53619141</linux:release>
+    <linux:version>ec551f03</linux:version>
+  </linux:rpminfo_state>
+
+</def-group>

--- a/shared/checks/oval/file_permissions_unauthorized_world_writable.xml
+++ b/shared/checks/oval/file_permissions_unauthorized_world_writable.xml
@@ -6,6 +6,7 @@
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_wrlinux</platform>
         <platform>multi_platform_opensuse</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The world-write permission should be disabled for all files.</description>
     </metadata>

--- a/shared/checks/oval/installed_OS_is_ol6_family.xml
+++ b/shared/checks/oval/installed_OS_is_ol6_family.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_ol6_family" version="1">
+    <metadata>
+      <title>Oracle Linux 6</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:oracle:linux:6"
+      source="CPE" />
+
+      <description>The operating system installed on the system is
+      Oracle Linux 6</description>
+    </metadata>
+    <criteria>
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
+      <criteria operator="OR">
+          <criterion comment="Oracle Linux 6 System is installed"
+            test_ref="test_ol6_system" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="oraclelinux-release is version 6" id="test_ol6_system" version="1">
+    <linux:object object_ref="obj_ol6_system" />
+    <linux:state state_ref="state_ol6_system" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_ol6_system" version="1">
+    <linux:version operation="pattern match">^6Server$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_ol6_system" version="1">
+    <linux:name>oraclelinux-release</linux:name>
+  </linux:rpminfo_object>
+
+</def-group>

--- a/shared/checks/oval/installed_OS_is_ol7_family.xml
+++ b/shared/checks/oval/installed_OS_is_ol7_family.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_ol7_family" version="1">
+    <metadata>
+      <title>Oracle Linux 7</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:oracle:linux:7"
+      source="CPE" />
+
+      <description>The operating system installed on the system is
+      Oracle Linux 7</description>
+    </metadata>
+    <criteria>
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
+      <criteria operator="OR">
+          <criterion comment="Oracle Linux 7 System is installed"
+            test_ref="test_ol7_system" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="oraclelinux-release is version 7" id="test_ol7_system" version="1">
+    <linux:object object_ref="obj_ol7_system" />
+    <linux:state state_ref="state_ol7_system" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_ol7_system" version="1">
+    <linux:version operation="pattern match">^7.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_ol7_system" version="1">
+    <linux:name>oraclelinux-release</linux:name>
+  </linux:rpminfo_object>
+
+</def-group>

--- a/shared/checks/oval/package_openssh-server_removed.xml
+++ b/shared/checks/oval/package_openssh-server_removed.xml
@@ -9,6 +9,7 @@
         <platform>multi_platform_sle</platform>
         <platform>multi_platform_wrlinux</platform>
         <platform>multi_platform_opensuse</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The RPM package openssh-server should be removed.</description>
     </metadata>

--- a/shared/checks/oval/root_path_no_dot.xml
+++ b/shared/checks/oval/root_path_no_dot.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_wrlinux</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The environment variable PATH should be set correctly for
       the root user.</description>

--- a/shared/checks/oval/rpm_verify_hashes.xml
+++ b/shared/checks/oval/rpm_verify_hashes.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Verify the RPM digests of system binaries using the RPM database.</description>
     </metadata>

--- a/shared/checks/oval/rpm_verify_permissions.xml
+++ b/shared/checks/oval/rpm_verify_permissions.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Verify the permissions of installed packages
       by comparing the installed files with information about the

--- a/shared/fixes/ansible/accounts_root_path_dirs_no_write.yml
+++ b/shared/fixes/ansible/accounts_root_path_dirs_no_write.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/shared/fixes/ansible/no_empty_passwords.yml
+++ b/shared/fixes/ansible/no_empty_passwords.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/shared/fixes/bash/ensure_gpgcheck_globally_activated.sh
+++ b/shared/fixes/bash/ensure_gpgcheck_globally_activated.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 replace_or_append '/etc/yum.conf' '^gpgcheck' '1' '@CCENUM@'

--- a/shared/fixes/bash/ensure_oracle_gpgkey_installed.sh
+++ b/shared/fixes/bash/ensure_oracle_gpgkey_installed.sh
@@ -1,0 +1,32 @@
+# platform = multi_platform_ol
+# OL fingerprints below retrieved from "Oracle Linux Unbreakable Linux Network User's Guide"
+# https://docs.oracle.com/cd/E37670_01/E39381/html/ol_import_gpg.html
+readonly OL_FINGERPRINT="4214 4123 FECF C55B 9086 313D 72F9 7B74 EC55 1F03"
+# Location of the key we would like to import (once it's integrity verified)
+readonly OL_RELEASE_KEY="/etc/pki/rpm-gpg/RPM-GPG-KEY-oracle"
+
+RPM_GPG_DIR_PERMS=$(stat -c %a "$(dirname "$OL_RELEASE_KEY")")
+
+# Verify /etc/pki/rpm-gpg directory permissions are safe
+if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]
+then
+  # If they are safe, try to obtain fingerprints from the key file
+  # (to ensure there won't be e.g. CRC error)
+  IFS=$'\n' GPG_OUT=($(gpg --with-fingerprint "${OL_RELEASE_KEY}"))
+  GPG_RESULT=$?
+  # No CRC error, safe to proceed
+  if [ "${GPG_RESULT}" -eq "0" ]
+  then
+    for ITEM in "${GPG_OUT[@]}"
+    do
+      # Filter just hexadecimal fingerprints from gpg's output from
+      # processing of a key file
+      RESULT=$(echo ${ITEM} | sed -n "s/[[:space:]]*Key fingerprint = \(.*\)/\1/p" | tr -s '[:space:]')
+      # If fingerprint matches Oracle Linux 6 and 7 key import the key
+      if [[ ${RESULT} ]] && [[ ${RESULT} = "${OL_FINGERPRINT}" ]] 
+      then
+        rpm --import "${OL_RELEASE_KEY}"
+      fi
+    done
+  fi
+fi

--- a/shared/fixes/bash/no_empty_passwords.sh
+++ b/shared/fixes/bash/no_empty_passwords.sh
@@ -1,3 +1,3 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 sed --follow-symlinks -i 's/\<nullok\>//g' /etc/pam.d/system-auth
 sed --follow-symlinks -i 's/\<nullok\>//g' /etc/pam.d/password-auth

--- a/shared/fixes/bash/security_patches_up_to_date.sh
+++ b/shared/fixes/bash/security_patches_up_to_date.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel, multi_platform_ol
 # reboot = true
 # strategy = patch
 # complexity = low

--- a/shared/modules/map_product_module.py
+++ b/shared/modules/map_product_module.py
@@ -13,9 +13,10 @@ FUSE = 'JBoss Fuse'
 OPENSUSE = 'OpenSUSE'
 SUSE = 'SUSE Linux Enterprise'
 WRLINUX = 'Wind River Linux'
+OL = 'Oracle Linux'
 
 multi_product_list = ["rhel", "fedora", "rhel-osp", "debian", "ubuntu",
-                      "wrlinux", "opensuse", "sle"]
+                      "wrlinux", "opensuse", "sle", "ol"]
 
 PRODUCT_NAME_PARSER = re.compile("([a-zA-Z\-]+)([0-9]+)")
 
@@ -71,6 +72,9 @@ def map_product(version):
         return SUSE
     if version.startswith("wrlinux"):
         return WRLINUX
+    if version.startswith("ol"):
+        return OL
+
 
     raise RuntimeError("Can't map version '%s' to any known product!"
                        % (version))

--- a/shared/xccdf/intro/shared_intro_os.xml
+++ b/shared/xccdf/intro/shared_intro_os.xml
@@ -43,7 +43,7 @@ machines.
 <description>
 The simplest way to avoid vulnerabilities in software is to avoid
 installing that software. On <product-name-macro/>,
-<os-type-macro type="rhel7,rhel6,fedora,opensuse,sle11,sle12,osp7,eap6,fuse6,wrlinux">the RPM Package Manager (originally Red Hat
+<os-type-macro type="rhel7,rhel6,fedora,opensuse,sle11,sle12,osp7,eap6,fuse6,wrlinux,ol7">the RPM Package Manager (originally Red Hat
 Package Manager, abbreviated RPM)</os-type-macro><os-type-macro type="debian">
 the Package Manager (originally
 <weblink-macro link="https://www.debian.org/doc/manuals/debian-faq/ch-pkgtools.en.html" text="apt" />)</os-type-macro>

--- a/shared/xccdf/services/ssh.xml
+++ b/shared/xccdf/services/ssh.xml
@@ -74,7 +74,7 @@ A value of 2 indicates that OpenSSH server package is required by the policy.<br
 <value selector="yes">2</value>
 </Value>
 
-<Rule id="package_openssh-server_installed" prodtype="rhel7" severity="medium">
+<Rule id="package_openssh-server_installed" prodtype="rhel7,ol7" severity="medium">
 <title>Install the OpenSSH Server Package</title>
 <description>
 The <tt>openssh-server</tt> package should be installed.
@@ -119,7 +119,7 @@ of interception and modification.
 <oval id="service_sshd_enabled" />
 </Rule>
 
-<Rule id="service_sshd_disabled" prodtype="rhel7">
+<Rule id="service_sshd_disabled" prodtype="rhel7,ol7">
 <title>Disable SSH Server If Possible (Unusual)</title>
 <description>The SSH server service, sshd, is commonly needed.
 However, if it can be disabled, do so.

--- a/shared/xccdf/system/accounts/restrictions/password_storage.xml
+++ b/shared/xccdf/system/accounts/restrictions/password_storage.xml
@@ -16,7 +16,7 @@ Using system-provided tools for password change/creation
 should allow administrators to avoid such misconfiguration.
 </description>
 
-<Rule id="no_empty_passwords" prodtype="rhel7,fedora" severity="high">
+<Rule id="no_empty_passwords" prodtype="rhel7,fedora,ol7" severity="high">
 <title>Prevent Log In to Accounts With Empty Password</title>
 <description>If an account is configured for password authentication
 but does not have an assigned password, it may be possible to log
@@ -42,7 +42,7 @@ empty passwords should never be used in operational environments.
 <ref cjis="5.5.2" cui="3.1.1, 3.1.5" disa="366" hipaa="164.308(a)(1)(ii)(B),164.308(a)(7)(i),164.308(a)(7)(ii)(A),164.310(a)(1),164.310(a)(2)(i),164.310(a)(2)(ii),164.310(a)(2)(iii),164.310(b),164.310(c),164.310(d)(1),164.310(d)(2)(iii)" nist="AC-6,IA-5(b),IA-5(c),IA-5(1)(a)" pcidss="Req-8.2.3" srg="SRG-OS-000480-GPOS-00227" />
 </Rule>
 
-<Rule id="accounts_password_all_shadowed" prodtype="rhel7,fedora" severity="medium">
+<Rule id="accounts_password_all_shadowed" prodtype="rhel7,fedora,ol7" severity="medium">
 <title>Verify All Account Password Hashes are Shadowed</title>
 <description>
 If any password hashes are stored in <tt>/etc/passwd</tt> (in the second field,

--- a/shared/xccdf/system/accounts/session.xml
+++ b/shared/xccdf/system/accounts/session.xml
@@ -172,7 +172,7 @@ It is a good practice for administrators to always execute
 privileged commands by typing the full path to the
 command.</description>
 
-<Rule id="root_path_no_dot" prodtype="rhel7,fedora">
+<Rule id="root_path_no_dot" prodtype="rhel7,fedora,ol7">
 <title>Ensure that Root's Path Does Not Include Relative Paths or Null Directories</title>
 <description>
 Ensure that none of the directories in root's path is equal to a single
@@ -194,7 +194,7 @@ execute code from an untrusted location.
 <ref disa="366" nist="CM-6(b)" />
 </Rule>
 
-<Rule id="accounts_root_path_dirs_no_write" prodtype="rhel7,fedora">
+<Rule id="accounts_root_path_dirs_no_write" prodtype="rhel7,fedora,ol7">
 <title>Ensure that Root's Path Does Not Include World or Group-Writable Directories</title>
 <description>
 For each element in root's path, run:

--- a/shared/xccdf/system/permissions/files.xml
+++ b/shared/xccdf/system/permissions/files.xml
@@ -325,7 +325,7 @@ execution of these programs cannot be co-opted.
 
 </Group>
 
-<Rule id="dir_perms_world_writable_sticky_bits" prodtype="rhel7,fedora">
+<Rule id="dir_perms_world_writable_sticky_bits" prodtype="rhel7,fedora,ol7">
 <title>Verify that All World-Writable Directories Have Sticky Bits Set</title>
 <description>When the so-called 'sticky bit' is set on a directory,
 only the owner of a given file may remove that file from the
@@ -359,7 +359,7 @@ requiring global read/write access.
 <ref cis="1.1.21" nist="AC-6" />
 </Rule>
 
-<Rule id="file_permissions_unauthorized_world_writable" prodtype="rhel7,opensuse,fedora" severity="medium">
+<Rule id="file_permissions_unauthorized_world_writable" prodtype="rhel7,opensuse,fedora,ol7" severity="medium">
 <title>Ensure No World-Writable Files Exist</title>
 <description>It is generally a good idea to remove global (other) write
 access to a file when it is discovered. However, check with
@@ -383,7 +383,7 @@ caused by world-writable files.</rationale>
 <oval id="file_permissions_unauthorized_world_writable" />
 </Rule>
 
-<Rule id="file_permissions_unauthorized_sgid" prodtype="rhel7,fedora">
+<Rule id="file_permissions_unauthorized_sgid" prodtype="rhel7,fedora,ol7">
 <title>Ensure All SGID Executables Are Authorized</title>
 <description>The SGID (set group id) bit should be set only on files that were
 installed via authorized means. A straightforward means of identifying
@@ -404,7 +404,7 @@ strictly controlled on the system.</rationale>
 <ref cis="6.1.14" nist="AC-6(1)" />
 </Rule>
 
-<Rule id="file_permissions_unauthorized_suid" prodtype="rhel7,fedora">
+<Rule id="file_permissions_unauthorized_suid" prodtype="rhel7,fedora,ol7">
 <title>Ensure All SUID Executables Are Authorized</title>
 <description>The SUID (set user id) bit should be set only on files that were
 installed via authorized means. A straightforward means of identifying

--- a/shared/xccdf/system/software/integrity.xml
+++ b/shared/xccdf/system/software/integrity.xml
@@ -261,7 +261,7 @@ modification of important files. To list which files on the system differ from w
 See the man page for <tt>rpm</tt> to see a complete explanation of each column.
 </description>
 
-<Rule id="rpm_verify_permissions" prodtype="rhel7,fedora" severity="high">
+<Rule id="rpm_verify_permissions" prodtype="rhel7,fedora,ol7" severity="high">
 <title>Verify and Correct File Permissions with RPM</title>
 <description>
 The RPM package management system can check file access permissions
@@ -338,7 +338,7 @@ Bugzilla #1275532.
 <ref cis="1.2.6,6.1.3,6.1.4,6.1.5,6.1.6,6.1.7,6.1.8,6.1.9,6.2.3" cjis="5.10.4.1" cui="3.3.8,3.4.1" disa="1494,1496" nist="AC-6,AU-9(1),AU-9(3),CM-6(d),CM-6(3)" pcidss="Req-11.5" srg="SRG-OS-000257-GPOS-00098,SRG-OS-000278-GPOS-00108" />
 </Rule>
 
-<Rule id="rpm_verify_hashes" prodtype="rhel7,fedora" severity="high">
+<Rule id="rpm_verify_hashes" prodtype="rhel7,fedora,ol7" severity="high">
 <title>Verify File Hashes with RPM</title>
 <description>Without cryptographic integrity protections, system
 executables and files can be altered by unauthorized users without

--- a/shared/xccdf/system/software/updating.xml
+++ b/shared/xccdf/system/software/updating.xml
@@ -45,7 +45,7 @@ cryptographically verify packages are from Red Hat.
 </Rule>
 
 
-<Rule id="ensure_gpgcheck_globally_activated" prodtype="rhel7,fedora" severity="high">
+<Rule id="ensure_gpgcheck_globally_activated" prodtype="rhel7,fedora,ol7" severity="high">
 <title>Ensure gpgcheck Enabled In Main Yum Configuration</title>
 <description>The <tt>gpgcheck</tt> option controls whether
 RPM packages' signatures are always checked prior to installation.


### PR DESCRIPTION
#### Description:

Suggested initial support for Oracle Linux 7 product.

Existing rhel7 and shared content reused as much as possible to cover standard profile content and make ol7 project to pass build and build tests.

Affected changes:
- Added ol7 product build structure and Oracle Linux 7 cpe content
- Created ol7 'standard' profile reflecting rhel7 'standard' profile rules set
- Added ensure_oracle_gpgkey_installed oval, xccdf and fix content, other definitions and templates copied from rhel7 product without changes due to RHEL7 and OL7 compatibility
- Added ol7 product platform to affected shared oval, xccfd rules and fix scripts
- Checked build and tests to pass, using oscap tool validated generated ssg-ol7-* xml files, also checked generated guide content and evaluation results for 'standard' profile.

#### Rationale:

- Add Oracle Linux platform specific SCAP profiles support.

