### PR TITLE
Made Ubuntu14 and Ubuntu16 to use local content.

### DIFF
--- a/ubuntu14/guide.xslt
+++ b/ubuntu14/guide.xslt
@@ -34,9 +34,9 @@
       <xsl:apply-templates select="document(concat($BUILD_RP, '/bash-remediation-functions.xml'))" />
 
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/intro/shared_intro_os.xml'))" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/system.xml'))" />
+      <xsl:apply-templates select="document('xccdf/system/system.xml')" />
 
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/services.xml'))" />
+      <xsl:apply-templates select="document('xccdf/services/services.xml')" />
     </xsl:copy>
   </xsl:template>
 
@@ -44,19 +44,19 @@
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
       <xsl:apply-templates select="document('xccdf/system/hardware.xml')" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/software.xml'))" /> 
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/permissions.xml'))" />
+      <xsl:apply-templates select="document('xccdf/system/software/software.xml')" />
+      <xsl:apply-templates select="document('xccdf/system/permissions/permissions.xml')" />
       <xsl:apply-templates select="document('xccdf/system/partitions.xml')" />
       <xsl:apply-templates select="document('xccdf/system/access.xml')" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/accounts.xml'))" />
+      <xsl:apply-templates select="document('xccdf/system/accounts/accounts.xml')" />
       <xsl:apply-templates select="document('xccdf/system/logging.xml')" />
     </xsl:copy>
   </xsl:template>
-  
+
   <xsl:template match="Group[@id='accounts']">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/restrictions/restrictions.xml'))" />
+      <xsl:apply-templates select="document('xccdf/system/accounts/restrictions/restrictions.xml')" />
     </xsl:copy>
   </xsl:template>
 

--- a/ubuntu14/xccdf/services/services.xml
+++ b/ubuntu14/xccdf/services/services.xml
@@ -1,0 +1,13 @@
+<Group id="services" prodtype="all">
+<title>Services</title>
+<description>
+The best protection against vulnerable software is running less software. This section describes how to review
+the software which <product-name-macro/> installs on a system and disable software which is not needed. It
+then enumerates the software packages installed on a default <product-name-macro/> system and provides guidance about which
+ones can be safely disabled.
+<br /><br />
+<product-name-macro/> provides a convenient minimal install option that essentially installs the bare necessities for a functional
+system. When building <product-name-macro/> systems, it is highly recommended to select the minimal packages and then build up
+the system from there.
+</description>
+</Group>

--- a/ubuntu14/xccdf/system/accounts/accounts.xml
+++ b/ubuntu14/xccdf/system/accounts/accounts.xml
@@ -1,0 +1,11 @@
+<Group id="accounts" prodtype="all">
+<title>Account and Access Control</title>
+<description>In traditional Unix security, if an attacker gains
+shell access to a certain login account, they can perform any action
+or access any file to which that account has access. Therefore,
+making it more difficult for unauthorized people to gain shell
+access to accounts, particularly to privileged accounts, is a
+necessary part of securing a system. This section introduces
+mechanisms for restricting access to accounts under
+<product-name-macro/>.</description>
+</Group>

--- a/ubuntu14/xccdf/system/accounts/restrictions/restrictions.xml
+++ b/ubuntu14/xccdf/system/accounts/restrictions/restrictions.xml
@@ -1,0 +1,13 @@
+<Group id="accounts-restrictions" prodtype="all">
+<title>Protect Accounts by Restricting Password-Based Login</title>
+<description>Conventionally, Unix shell accounts are accessed by
+providing a username and password to a login program, which tests
+these values for correctness using the <tt>/etc/passwd</tt> and
+<tt>/etc/shadow</tt> files. Password-based login is vulnerable to
+guessing of weak passwords, and to sniffing and man-in-the-middle
+attacks against passwords entered over a network or at an insecure
+console. Therefore, mechanisms for accessing accounts by entering
+usernames and passwords should be restricted to those which are
+operationally necessary.</description>
+
+</Group>

--- a/ubuntu14/xccdf/system/permissions/permissions.xml
+++ b/ubuntu14/xccdf/system/permissions/permissions.xml
@@ -1,0 +1,21 @@
+<Group id="permissions" prodtype="all">
+<title>File Permissions and Masks</title>
+<description>Traditional Unix security relies heavily on file and
+directory permissions to prevent unauthorized users from reading or
+modifying files to which they should not have access.
+<br /><br />
+Several of the commands in this section search filesystems
+for files or directories with certain characteristics, and are
+intended to be run on every local partition on a given system.
+When the variable <i>PART</i> appears in one of the commands below,
+it means that the command is intended to be run repeatedly, with the
+name of each local partition substituted for <i>PART</i> in turn.
+<br /><br />
+The following command prints a list of all xfs partitions on the local
+system, which is the default filesystem for Red Hat Enterprise Linux
+7 installations:
+<pre>$ mount -t xfs | awk '{print $3}'</pre>
+For any systems that use a different
+local filesystem type, modify this command as appropriate.
+</description>
+</Group>

--- a/ubuntu14/xccdf/system/software/software.xml
+++ b/ubuntu14/xccdf/system/software/software.xml
@@ -1,0 +1,8 @@
+<Group id="software" prodtype="all">
+<title>Installing and Maintaining Software</title>
+<description>The following sections contain information on
+security-relevant choices during the initial operating system
+installation process and the setup of software
+updates.</description>
+
+</Group>

--- a/ubuntu14/xccdf/system/system.xml
+++ b/ubuntu14/xccdf/system/system.xml
@@ -1,0 +1,6 @@
+<Group id="system" prodtype="all">
+<title>System Settings</title>
+<description>Contains rules that check correct system settings.</description>
+
+</Group>
+

--- a/ubuntu16/guide.xslt
+++ b/ubuntu16/guide.xslt
@@ -34,9 +34,9 @@
       <xsl:apply-templates select="document(concat($BUILD_RP, '/bash-remediation-functions.xml'))" />
 
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/intro/shared_intro_os.xml'))" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/system.xml'))" />
+      <xsl:apply-templates select="document('xccdf/system/system.xml')" />
 
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/services/services.xml'))" />
+      <xsl:apply-templates select="document('xccdf/services/services.xml')" />
     </xsl:copy>
   </xsl:template>
 
@@ -44,19 +44,19 @@
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
       <xsl:apply-templates select="document('xccdf/system/hardware.xml')" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/software/software.xml'))" /> 
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/permissions/permissions.xml'))" />
+      <xsl:apply-templates select="document('xccdf/system/software/software.xml')" />
+      <xsl:apply-templates select="document('xccdf/system/permissions/permissions.xml')" />
       <xsl:apply-templates select="document('xccdf/system/partitions.xml')" />
       <xsl:apply-templates select="document('xccdf/system/access.xml')" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/accounts.xml'))" />
+      <xsl:apply-templates select="document('xccdf/system/accounts/accounts.xml')" />
       <xsl:apply-templates select="document('xccdf/system/logging.xml')" />
     </xsl:copy>
   </xsl:template>
-  
+
   <xsl:template match="Group[@id='accounts']">
     <xsl:copy>
       <xsl:copy-of select="@*|node()" />
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/system/accounts/restrictions/restrictions.xml'))" />
+      <xsl:apply-templates select="document('xccdf/system/accounts/restrictions/restrictions.xml')" />
     </xsl:copy>
   </xsl:template>
 

--- a/ubuntu16/xccdf/services/services.xml
+++ b/ubuntu16/xccdf/services/services.xml
@@ -1,0 +1,13 @@
+<Group id="services" prodtype="all">
+<title>Services</title>
+<description>
+The best protection against vulnerable software is running less software. This section describes how to review
+the software which <product-name-macro/> installs on a system and disable software which is not needed. It
+then enumerates the software packages installed on a default <product-name-macro/> system and provides guidance about which
+ones can be safely disabled.
+<br /><br />
+<product-name-macro/> provides a convenient minimal install option that essentially installs the bare necessities for a functional
+system. When building <product-name-macro/> systems, it is highly recommended to select the minimal packages and then build up
+the system from there.
+</description>
+</Group>

--- a/ubuntu16/xccdf/system/accounts/accounts.xml
+++ b/ubuntu16/xccdf/system/accounts/accounts.xml
@@ -1,0 +1,12 @@
+<Group id="accounts" prodtype="all">
+<title>Account and Access Control</title>
+<description>In traditional Unix security, if an attacker gains
+shell access to a certain login account, they can perform any action
+or access any file to which that account has access. Therefore,
+making it more difficult for unauthorized people to gain shell
+access to accounts, particularly to privileged accounts, is a
+necessary part of securing a system. This section introduces
+mechanisms for restricting access to accounts under
+<product-name-macro/>.</description>
+</Group>
+

--- a/ubuntu16/xccdf/system/accounts/restrictions/restrictions.xml
+++ b/ubuntu16/xccdf/system/accounts/restrictions/restrictions.xml
@@ -1,0 +1,13 @@
+<Group id="accounts-restrictions" prodtype="all">
+<title>Protect Accounts by Restricting Password-Based Login</title>
+<description>Conventionally, Unix shell accounts are accessed by
+providing a username and password to a login program, which tests
+these values for correctness using the <tt>/etc/passwd</tt> and
+<tt>/etc/shadow</tt> files. Password-based login is vulnerable to
+guessing of weak passwords, and to sniffing and man-in-the-middle
+attacks against passwords entered over a network or at an insecure
+console. Therefore, mechanisms for accessing accounts by entering
+usernames and passwords should be restricted to those which are
+operationally necessary.</description>
+
+</Group>

--- a/ubuntu16/xccdf/system/permissions/permissions.xml
+++ b/ubuntu16/xccdf/system/permissions/permissions.xml
@@ -1,0 +1,21 @@
+<Group id="permissions" prodtype="all">
+<title>File Permissions and Masks</title>
+<description>Traditional Unix security relies heavily on file and
+directory permissions to prevent unauthorized users from reading or
+modifying files to which they should not have access.
+<br /><br />
+Several of the commands in this section search filesystems
+for files or directories with certain characteristics, and are
+intended to be run on every local partition on a given system.
+When the variable <i>PART</i> appears in one of the commands below,
+it means that the command is intended to be run repeatedly, with the
+name of each local partition substituted for <i>PART</i> in turn.
+<br /><br />
+The following command prints a list of all xfs partitions on the local
+system, which is the default filesystem for Red Hat Enterprise Linux
+7 installations:
+<pre>$ mount -t xfs | awk '{print $3}'</pre>
+For any systems that use a different
+local filesystem type, modify this command as appropriate.
+</description>
+</Group>

--- a/ubuntu16/xccdf/system/software/software.xml
+++ b/ubuntu16/xccdf/system/software/software.xml
@@ -1,0 +1,8 @@
+<Group id="software" prodtype="all">
+<title>Installing and Maintaining Software</title>
+<description>The following sections contain information on
+security-relevant choices during the initial operating system
+installation process and the setup of software
+updates.</description>
+
+</Group>

--- a/ubuntu16/xccdf/system/system.xml
+++ b/ubuntu16/xccdf/system/system.xml
@@ -1,0 +1,6 @@
+<Group id="system" prodtype="all">
+<title>System Settings</title>
+<description>Contains rules that check correct system settings.</description>
+
+</Group>
+


### PR DESCRIPTION
Similar to #2662, the Ubuntu local files couldn't be moved to shared, so shared functionality had to be moved local.
For future reference, after I have determined what shared files to transfer, this shell snippet assisted me in copyting and reviewing it:
```
STEMS=software permissions accounts accounts/restrictions
for stem in $STEMS
do
mkdir -p xccdf/system/$stem \
  && cp ../shared/xccdf/system/$stem/${stem##*/}.xml xccdf/system/$stem/ \
  && vim xccdf/system/$stem/${stem##*/}.xml
done
```