### PR TITLE
Add test scenarios for aide_scan_notification

### DIFF
--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/cron_weekly_configured.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/cron_weekly_configured.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+# ensure aide is installed
+yum install -y aide
+
+# configured in crontab
+echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "SSG Test Suite - AIDE Integrity Check" admin@ssgtestsuite' > /etc/cron.weekly/aidescan

--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/crontab_configured.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/crontab_configured.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+# ensure aide is installed
+yum install -y aide
+
+# configured in crontab
+echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "SSG Test Suite - AIDE Integrity Check" admin@ssgtestsuite' >> /etc/crontab

--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/crontab_just_periodic_checking.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/crontab_just_periodic_checking.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+# ensure aide is installed
+yum install -y aide
+
+# configured in crontab
+echo '0 5 * * * root /usr/sbin/aide  --check' >> /etc/crontab

--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/default.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/default.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+# ensure aide is installed
+yum install -y aide
+
+# default instalation
+true

--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/var_cron_configured.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/var_cron_configured.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+# ensure aide is installed
+yum install -y aide
+
+# configured in crontab
+echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "SSG Test Suite - AIDE Integrity Check" admin@ssgtestsuite' >> /var/spool/cron/root


### PR DESCRIPTION
#### Description:
- crontab_configured pass - notification configured in /etc/crontab
- cron_weekly_configured pass - notification configured in cron.weekly
- var_cron_configured pass - notification configure in /var/cron/spool
- crontab_just_periodic_checking fail - crontab already doing periodic
checking
- default fail - default installation config

#### Rationale:

- Helps assure that OVAL definition and Bash remediation for Rule `aide_scan_notification` is working
