### PR TITLE
Add test scenarios and remediation for network ipv6 {disable rpc|privacy extensions} 

### DIFF
--- a/shared/fixes/bash/network_ipv6_disable_rpc.sh
+++ b/shared/fixes/bash/network_ipv6_disable_rpc.sh
@@ -1,0 +1,10 @@
+# platform = multi_platform_rhel
+
+# Drop 'tcp6' and 'udp6' entries from /etc/netconfig to prevent RPC
+# services for NFSv4 from attempting to start IPv6 network listeners
+declare -a IPV6_RPC_ENTRIES=("tcp6" "udp6")
+
+for rpc_entry in ${IPV6_RPC_ENTRIES[@]}
+do
+	sed -i "/^$rpc_entry[[:space:]]\+tpi\_.*inet6.*/d" /etc/netconfig
+done

--- a/shared/fixes/bash/network_ipv6_disable_rpc.sh
+++ b/shared/fixes/bash/network_ipv6_disable_rpc.sh
@@ -2,9 +2,8 @@
 
 # Drop 'tcp6' and 'udp6' entries from /etc/netconfig to prevent RPC
 # services for NFSv4 from attempting to start IPv6 network listeners
-declare -a IPV6_RPC_ENTRIES=("tcp6" "udp6")
 
-for rpc_entry in ${IPV6_RPC_ENTRIES[@]}
+for rpc_entry in "tcp6" "udp6"
 do
 	sed -i "/^$rpc_entry[[:space:]]\+tpi\_.*inet6.*/d" /etc/netconfig
 done

--- a/shared/fixes/bash/network_ipv6_disable_rpc.sh
+++ b/shared/fixes/bash/network_ipv6_disable_rpc.sh
@@ -5,5 +5,5 @@
 
 for rpc_entry in "tcp6" "udp6"
 do
-	sed -i "/^$rpc_entry[[:space:]]\+tpi\_.*inet6.*/d" /etc/netconfig
+	sed -i "/^$rpc_entry[[:space:]]\+tpi_.*inet6.*/d" /etc/netconfig
 done

--- a/shared/fixes/bash/network_ipv6_privacy_extensions.sh
+++ b/shared/fixes/bash/network_ipv6_privacy_extensions.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_rhel
+
+# enable randomness in ipv6 address generation
+for interface in $(ls /etc/sysconfig/network-scripts/ifcfg-*)
+do
+    echo "IPV6_PRIVACY=rfc3041" >> $interface
+done

--- a/shared/fixes/bash/network_ipv6_privacy_extensions.sh
+++ b/shared/fixes/bash/network_ipv6_privacy_extensions.sh
@@ -1,7 +1,7 @@
 # platform = multi_platform_rhel
 
 # enable randomness in ipv6 address generation
-for interface in $(ls /etc/sysconfig/network-scripts/ifcfg-*)
+for interface in /etc/sysconfig/network-scripts/ifcfg-*
 do
     echo "IPV6_PRIVACY=rfc3041" >> $interface
 done

--- a/tests/data/group_system/group_network/group_network-ipv6/group_configuring_ipv6/rule_network_ipv6_privacy_extensions/default.fail.sh
+++ b/tests/data/group_system/group_network/group_network-ipv6/group_configuring_ipv6/rule_network_ipv6_privacy_extensions/default.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+sed -i "/^IPV6_PRIVACY=rfc3041$/d" /etc/sysconfig/network-scripts/ifcfg-*

--- a/tests/data/group_system/group_network/group_network-ipv6/group_configuring_ipv6/rule_network_ipv6_privacy_extensions/ipv6_privacy_enabled.pass.sh
+++ b/tests/data/group_system/group_network/group_network-ipv6/group_configuring_ipv6/rule_network_ipv6_privacy_extensions/ipv6_privacy_enabled.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+for file in $(ls /etc/sysconfig/network-scripts/ifcfg-*)
+do
+    echo "IPV6_PRIVACY=rfc3041" >> $file
+done

--- a/tests/data/group_system/group_network/group_network-ipv6/group_configuring_ipv6/rule_network_ipv6_privacy_extensions/ipv6_privacy_enabled.pass.sh
+++ b/tests/data/group_system/group_network/group_network-ipv6/group_configuring_ipv6/rule_network_ipv6_privacy_extensions/ipv6_privacy_enabled.pass.sh
@@ -2,7 +2,7 @@
 #
 # profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
 
-for file in $(ls /etc/sysconfig/network-scripts/ifcfg-*)
+for interface in /etc/sysconfig/network-scripts/ifcfg-*
 do
-    echo "IPV6_PRIVACY=rfc3041" >> $file
+    echo "IPV6_PRIVACY=rfc3041" >> $interface
 done

--- a/tests/data/group_system/group_network/group_network-ipv6/group_disabling_ipv6/rule_network_ipv6_disable_rpc/default.fail.sh
+++ b/tests/data/group_system/group_network/group_network-ipv6/group_disabling_ipv6/rule_network_ipv6_disable_rpc/default.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7, xccdf_org.ssgproject.content_profile_ospp-rhel7
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
 # remediation = bash
 
 # default config has rpc enabled

--- a/tests/data/group_system/group_network/group_network-ipv6/group_disabling_ipv6/rule_network_ipv6_disable_rpc/default.fail.sh
+++ b/tests/data/group_system/group_network/group_network-ipv6/group_disabling_ipv6/rule_network_ipv6_disable_rpc/default.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7, xccdf_org.ssgproject.content_profile_ospp-rhel7
+# remediation = bash
+
+# default config has rpc enabled
+true

--- a/tests/data/group_system/group_network/group_network-ipv6/group_disabling_ipv6/rule_network_ipv6_disable_rpc/rpc_disabled.pass.sh
+++ b/tests/data/group_system/group_network/group_network-ipv6/group_disabling_ipv6/rule_network_ipv6_disable_rpc/rpc_disabled.pass.sh
@@ -3,5 +3,5 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7, xccdf_org.ssgproject.content_profile_ospp-rhel7
 # remediation = bash
 
-sed -i "/^tcp6[[:space:]]\+tpi\_.*inet6.*/d" /etc/netconfig
-sed -i "/^udp6[[:space:]]\+tpi\_.*inet6.*/d" /etc/netconfig
+sed -i "/^tcp6[[:space:]]\+tpi_.*inet6.*/d" /etc/netconfig
+sed -i "/^udp6[[:space:]]\+tpi_.*inet6.*/d" /etc/netconfig

--- a/tests/data/group_system/group_network/group_network-ipv6/group_disabling_ipv6/rule_network_ipv6_disable_rpc/rpc_disabled.pass.sh
+++ b/tests/data/group_system/group_network/group_network-ipv6/group_disabling_ipv6/rule_network_ipv6_disable_rpc/rpc_disabled.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7, xccdf_org.ssgproject.content_profile_ospp-rhel7
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
 # remediation = bash
 
 sed -i "/^tcp6[[:space:]]\+tpi_.*inet6.*/d" /etc/netconfig

--- a/tests/data/group_system/group_network/group_network-ipv6/group_disabling_ipv6/rule_network_ipv6_disable_rpc/rpc_disabled.pass.sh
+++ b/tests/data/group_system/group_network/group_network-ipv6/group_disabling_ipv6/rule_network_ipv6_disable_rpc/rpc_disabled.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7, xccdf_org.ssgproject.content_profile_ospp-rhel7
+# remediation = bash
+
+sed -i "/^tcp6[[:space:]]\+tpi\_.*inet6.*/d" /etc/netconfig
+sed -i "/^udp6[[:space:]]\+tpi\_.*inet6.*/d" /etc/netconfig


### PR DESCRIPTION
#### Description:

- Add test scenarios and bash remediation for `network_ipv6_disable_rpc` 
- Add test scenarios and bash remediation for `network_ipv6_privacy_extensions` 

#### Rationale:

- Cited rules are missing bash remediation
- Tests help ensure that remediations work

- Fixes #2577 
