### PR TITLE
Change ID of Rule that checks for IPV6 disabled

### DIFF
--- a/rhel7/profiles/C2S.xml
+++ b/rhel7/profiles/C2S.xml
@@ -341,7 +341,7 @@ baseline.
 <select idref="sysctl_net_ipv6_conf_default_accept_redirects" selected="true" />
 
 <!-- 3.3.3 Ensure IPv6 is disabled (Not Scored) -->
-<select idref="sysctl_kernel_ipv6_disable" selected="true" />
+<select idref="sysctl_net_ipv6_conf_all_disable_ipv6" selected="true" />
 
 <!-- 3.4 TCP Wrappers -->
 <!-- 3.4.1 Ensure TCP Wrappers is installed (Scored) -->

--- a/rhel7/profiles/ospp-rhel7.xml
+++ b/rhel7/profiles/ospp-rhel7.xml
@@ -115,7 +115,7 @@ the consensus process.
 <select idref="service_firewalld_enabled" selected="true" />
 <select idref="set_firewalld_default_zone" selected="true" />
 <select idref="firewalld_sshd_port_enabled" selected="true"/>
-<select idref="sysctl_kernel_ipv6_disable" selected="true" />
+<select idref="sysctl_net_ipv6_conf_all_disable_ipv6" selected="true" />
 <select idref="sysctl_net_ipv4_conf_all_accept_redirects" selected="true" />
 <select idref="sysctl_net_ipv4_conf_all_accept_source_route" selected="true" />
 <select idref="sysctl_net_ipv4_conf_all_log_martians" selected="true" />

--- a/rhel7/profiles/rht-ccp.xml
+++ b/rhel7/profiles/rht-ccp.xml
@@ -95,7 +95,7 @@
 
 <!-- <select idref="sysctl_kernel_randomize_va_space" selected="true"/>
 <select idref="enable_execshield" selected="true"/>
-<select idref="sysctl_kernel_ipv6_disable" selected="true"/>
+<select idref="sysctl_net_ipv6_conf_all_disable_ipv6" selected="true"/>
 <select idref="service_ip6tables_enabled" selected="true"/>
 
 This requirement does not apply against Red Hat Enterprise Linux 7:

--- a/shared/xccdf/system/network/ipv6.xml
+++ b/shared/xccdf/system/network/ipv6.xml
@@ -16,7 +16,7 @@ effectively prevent execution of the IPv6 networking stack is to
 instruct the system not to activate the IPv6 kernel module.
 </description>
 
-<Rule id="sysctl_kernel_ipv6_disable" prodtype="rhel7,fedora" severity="medium">
+<Rule id="sysctl_net_ipv6_conf_all_disable_ipv6" prodtype="rhel7,fedora" severity="medium">
 <title>Disable IPv6 Networking Support Automatic Loading</title>
 <description>To disable support for (<tt>ipv6</tt>) add the following line to
 <tt>/etc/sysctl.d/ipv6.conf</tt> (or another file in
@@ -46,7 +46,7 @@ the vulnerability to exploitation.
 </rationale>
 <platform idref="cpe:/a:machine" />
 <ident cce="80175-3" prodtype="rhel7" />
-<oval id="sysctl_kernel_ipv6_disable" />
+<oval id="sysctl_net_ipv6_conf_all_disable_ipv6" />
 <ref cis="3.3.3" cui="3.1.20" disa="1551" nist="CM-7" />
 </Rule>
 


### PR DESCRIPTION
#### Description:

- Change ID of Rule `sysctl_kernel_ipv6_disable` to `sysctl_net_ipv6_conf_all_disable_ipv6`.

#### Rationale:
* The Rule is not following expected pattern. The sysctrl in question is
`net.ipv6.conf.all.disable_ipv6`, so exptected Rule id is
`syctl_net_ivp6_conf_all_disable_ipv6`.
* This is causing template generated remediation to not be picked up by
build system.
* The used pattern would be for a sysctl with name  `kernel.ipv6_disabled`, witch
doesn't exist.

- Changing ID of a Rule can break existing tailoring, but I'm not fan of keeping static remediation for this Rule.

* Fixes #2515 
* Fixes #2576