### PR TITLE
remediation functions xml is no longer in shared

### DIFF
--- a/chromium/guide.xslt
+++ b/chromium/guide.xslt
@@ -29,7 +29,6 @@
 
       <xsl:apply-templates select="document(concat($BUILD_RP, '/bash-remediation-functions.xml'))" />
 
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/intro/shared_intro_app.xml'))" />
       <xsl:apply-templates select="document('xccdf/chromium.xml')" />
     </xsl:copy>

--- a/firefox/guide.xslt
+++ b/firefox/guide.xslt
@@ -29,7 +29,6 @@
 
       <xsl:apply-templates select="document(concat($BUILD_RP, '/bash-remediation-functions.xml'))" />
 
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/intro/shared_intro_app.xml'))" />
       <xsl:apply-templates select="document('xccdf/firefox.xml')" />
     </xsl:copy>

--- a/jre/guide.xslt
+++ b/jre/guide.xslt
@@ -29,7 +29,6 @@
 
       <xsl:apply-templates select="document(concat($BUILD_RP, '/bash-remediation-functions.xml'))" />
 
-      <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/remediation_functions.xml'))" />
       <xsl:apply-templates select="document(concat($SHARED_RP, '/xccdf/intro/shared_intro_app.xml'))" />
       <xsl:apply-templates select="document('xccdf/java.xml')" />
     </xsl:copy>


### PR DESCRIPTION
These cause:
warning: failed to load external entity "/home/jenkins/workspace/
scap-security-guide-pull-requests/label/ssg_new/shared/xccdf/
remediation_functions.xml"

I am trying to figure out all errors and warnings for the yaml work in #2592