### PR TITLE
ftp_present_banner: update pattern in oval file and add remediation

### DIFF
--- a/shared/checks/oval/ftp_present_banner.xml
+++ b/shared/checks/oval/ftp_present_banner.xml
@@ -21,7 +21,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="Banner for FTP Users" id="object_test_ftp_present_banner" version="1">
     <ind:filepath>/etc/vsftpd/vsftpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*banner_file[\s]*=[\s]*/etc/issue*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*banner_file=/etc/issue[\s]*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/shared/fixes/bash/ftp_present_banner.sh
+++ b/shared/fixes/bash/ftp_present_banner.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_wrlinux
+
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '/etc/vsftpd.conf' '^banner_file' '/etc/issue' '@CCENUM@' '%s=%s'


### PR DESCRIPTION

#### Description:

- update pattern in oval file ftp_present_banner.xml and add bash remediation

#### Rationale:

- No space is allowed between the option, = and value in vsftpd.conf. See man vsftpd.conf.
