### PR TITLE
Improved replace_or_append.

### DIFF
--- a/shared/bash_remediation_functions/replace_or_append.sh
+++ b/shared/bash_remediation_functions/replace_or_append.sh
@@ -25,34 +25,27 @@
 #     replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' $var_selinux_state '@CCENUM@' '%s=%s'
 #
 function replace_or_append {
+  local default_format='%s = %s'
   local config_file=$1
   local key=$2
   local value=$3
   local cce=$4
   local format=$5
 
+  [ -n "$format" ] || format="$default_format"
   # Check sanity of the input
-  if [ $# -lt "3" ]
-  then
-        echo "Usage: replace_or_append 'config_file_location' 'key_to_search' 'new_value'"
-        echo
-        echo "If symlinks need to be taken into account, add yes/no to the last argument"
-        echo "to allow to 'follow_symlinks'."
-        echo "Aborting."
-        exit 1
-  fi
+  [ $# -ge "3" ] || die "Usage: replace_or_append <config_file_location> <key_to_search> <new_value> [<CCE number or literal '@CCENUM@' if unknown>] [printf-like format, default is '$default_format']"
 
   # Test if the config_file is a symbolic link. If so, use --follow-symlinks with sed.
   # Otherwise, regular sed command will do.
-  if test -L $config_file; then
-    sed_command="sed -i --follow-symlinks"
-  else
-    sed_command="sed -i"
+  sed_command=('sed' '-i')
+  if test -L "$config_file"; then
+    sed_command+=('--follow-symlinks')
   fi
 
   # Test that the cce arg is not empty or does not equal @CCENUM@.
   # If @CCENUM@ exists, it means that there is no CCE assigned.
-  if ! [ "x$cce" = x ] && [ "$cce" != '@CCENUM@' ]; then
+  if [ -n "$cce" ] && [ "$cce" != '@CCENUM@' ]; then
     cce="CCE-${cce}"
   else
     cce="CCE"
@@ -60,22 +53,16 @@ function replace_or_append {
 
   # Strip any search characters in the key arg so that the key can be replaced without
   # adding any search characters to the config file.
-  stripped_key=$(sed "s/[\^=\$,;+]*//g" <<< $key)
+  stripped_key=$(sed 's/[\^=\$,;+]*//g' <<< "$key")
 
-  # If there is no print format specified in the last arg, use the default format.
-  if ! [ "x$format" = x ] ; then
-    printf -v formatted_output "$format" "$stripped_key" "$value"
-  else
-    formatted_output="$stripped_key = $value"
-  fi
+  printf -v formatted_output "$format" "$stripped_key" "$value"
 
   # If the key exists, change it. Otherwise, add it to the config_file.
-  if `grep -qi "$key" $config_file` ; then
-    eval '$sed_command "s/$key.*/$formatted_output/g" $config_file'
+  if grep -qi "$key" "$config_file"; then
+    "${sed_command[@]}" "s/$key.*/$formatted_output/g" "$config_file"
   else
     # \n is precaution for case where file ends without trailing newline
-    echo -e "\n# Per $cce: Set $formatted_output in $config_file" >> $config_file
-    echo -e "$formatted_output" >> $config_file
+    printf '\n# Per %s: Set %s in %s\n' "$cce" "$formatted_output" "$config_file" >> "$config_file"
+    printf '%s\n' "$formatted_output" >> "$config_file"
   fi
-
 }


### PR DESCRIPTION
* Removed misleading usage message when not enough args were specified.
* Made the sed command an array, avoiding usage of eval.
* Added double quotes when applicable.
* Removed echo -e in [favor of printf](https://unix.stackexchange.com/questions/65803/why-is-printf-better-than-echo).
* Achieved function compliance with shellcheck.