### PR TITLE
Add remediation for ldap_client_start_tls

### DIFF
--- a/shared/fixes/bash/ldap_client_start_tls.sh
+++ b/shared/fixes/bash/ldap_client_start_tls.sh
@@ -1,0 +1,10 @@
+# platform = multi_platform_rhel
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+# Use LDAP for authentication
+replace_or_append '/etc/sysconfig/authconfig' 'USELDAPAUTH' 'yes' '@CCENUM@' '%s=%s'
+
+# Configure client to use TLS for all authentications
+replace_or_append '/etc/nslcd.conf' 'ssl' 'start_tls' '@CCENUM@' '%s %s'

--- a/tests/data/group_services/group_ldap/group_openldap_client/rule_ldap_client_start_tls/ldap_auth_and_start_tls.pass.sh
+++ b/tests/data/group_services/group_ldap/group_openldap_client/rule_ldap_client_start_tls/ldap_auth_and_start_tls.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+AUTHCONFIG_REGEX="^[[:space:]]*USELDAPAUTH=yes[[:space:]]*$"
+grep -q "$AUTHCONFIG_REGEX" /etc/sysconfig/authconfig && \
+	sed -i "s/$AUTHCONFIG_REGEX/USELDAPAUTH=yes/" /etc/sysconfig/authconfig || \
+	echo "USELDAPAUTH=yes" >> /etc/sysconfig/authconfig
+
+yum install -y nss-pam-ldapd
+
+START_TLS_REGEX="^[[:space:]]*ssl[[:space:]]*start_tls[[:space:]]*$"
+grep -q "$START_TLS_REGEX" /etc/nslcd.conf && \
+	sed -i "s/$START_TLS_REGEX/ssl start_tls/" /etc/nslcd.conf || \
+	echo "ssl start_tls" >> /etc/nslcd.conf

--- a/tests/data/group_services/group_ldap/group_openldap_client/rule_ldap_client_start_tls/not_using_ldap.fail.sh
+++ b/tests/data/group_services/group_ldap/group_openldap_client/rule_ldap_client_start_tls/not_using_ldap.fail.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+yum install -y nss-pam-ldapd
+
+AUTHCONFIG_REGEX="^[[:space:]]*USELDAPAUTH=yes[[:space:]]*$"
+grep -q "$AUTHCONFIG_REGEX" /etc/sysconfig/authconfig && \
+	sed -i "s/$AUTHCONFIG_REGEX//" /etc/sysconfig/authconfig
+
+yum install -y nss-pam-ldapd
+
+START_TLS_REGEX="^[[:space:]]*ssl[[:space:]]*start_tls[[:space:]]*$"
+grep -q "$START_TLS_REGEX" /etc/nslcd.conf && \
+	sed -i "s/$START_TLS_REGEX/ssl start_tls/" /etc/nslcd.conf || \
+	echo "ssl start_tls" >> /etc/nslcd.conf

--- a/tests/data/group_services/group_ldap/group_openldap_client/rule_ldap_client_start_tls/tls_not_starting.fail.sh
+++ b/tests/data/group_services/group_ldap/group_openldap_client/rule_ldap_client_start_tls/tls_not_starting.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp-rhel7
+
+yum install -y nss-pam-ldapd
+
+sed -i "/$START_TLS_REGEX/d" /etc/nslcd.conf || true


### PR DESCRIPTION
#### Description:

- Add test scenario: ldap_auth_and_start_tls pass - LDAP and TLS configured for auths
- Add test scenario: not_using_ldap fail - not configured to use LDAP for authentication
- Add test scenario: tls_not_starting fail - not configured to use TLS for authentications
- Add remediation for ldap_client_start_tls 

#### Rationale:

- Fixes #2587 