### PR TITLE
Generalized the 'not running' state of a service in OVAL check.

### DIFF
--- a/debian8/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/debian8/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -47,7 +47,7 @@
     <linux:unit operation="pattern match">%DAEMONNAME%\.(service|socket)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running">
-      <linux:value>inactive</linux:value>
+  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running, either because nobody tried, service has been stopped, or because it terminated unexpectedly">
+      <linux:value operation="pattern match">(inactive|failed)</linux:value>
   </linux:systemdunitproperty_state>
 </def-group>

--- a/fedora/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/fedora/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -47,7 +47,7 @@
     <linux:unit operation="pattern match">%SERVICENAME%\.(service|socket)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running">
-      <linux:value>inactive</linux:value>
+  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running, either because nobody tried, service has been stopped, or because it terminated unexpectedly">
+      <linux:value operation="pattern match">(inactive|failed)</linux:value>
   </linux:systemdunitproperty_state>
 </def-group>

--- a/ol7/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/ol7/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -47,7 +47,7 @@
     <linux:unit operation="pattern match">%SERVICENAME%\.(service|socket)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running">
-      <linux:value>inactive</linux:value>
+  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running, either because nobody tried, service has been stopped, or because it terminated unexpectedly">
+      <linux:value operation="pattern match">(inactive|failed)</linux:value>
   </linux:systemdunitproperty_state>
 </def-group>

--- a/opensuse/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/opensuse/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -47,7 +47,7 @@
     <linux:unit operation="pattern match">%SERVICENAME%\.(service|socket)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running">
-      <linux:value>inactive</linux:value>
+  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running, either because nobody tried, service has been stopped, or because it terminated unexpectedly">
+      <linux:value operation="pattern match">(inactive|failed)</linux:value>
   </linux:systemdunitproperty_state>
 </def-group>

--- a/rhel7/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/rhel7/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -47,7 +47,7 @@
     <linux:unit operation="pattern match">%SERVICENAME%\.(service|socket)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running">
-      <linux:value>inactive</linux:value>
+  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running, either because nobody tried, service has been stopped, or because it terminated unexpectedly">
+      <linux:value operation="pattern match">(inactive|failed)</linux:value>
   </linux:systemdunitproperty_state>
 </def-group>

--- a/rhosp7/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/rhosp7/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -47,7 +47,7 @@
     <linux:unit operation="pattern match">%SERVICENAME%\.(service|socket)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running">
-      <linux:value>inactive</linux:value>
+  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running, either because nobody tried, service has been stopped, or because it terminated unexpectedly">
+      <linux:value operation="pattern match">(inactive|failed)</linux:value>
   </linux:systemdunitproperty_state>
 </def-group>

--- a/sle12/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/sle12/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -47,7 +47,7 @@
     <linux:unit operation="pattern match">%SERVICENAME%\.(service|socket)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running">
-      <linux:value>inactive</linux:value>
+  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running, either because nobody tried, service has been stopped, or because it terminated unexpectedly">
+      <linux:value operation="pattern match">(inactive|failed)</linux:value>
   </linux:systemdunitproperty_state>
 </def-group>

--- a/ubuntu14/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/ubuntu14/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -47,7 +47,7 @@
     <linux:unit operation="pattern match">%SERVICENAME%\.(service|socket)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running">
-      <linux:value>inactive</linux:value>
+  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running, either because nobody tried, service has been stopped, or because it terminated unexpectedly">
+      <linux:value operation="pattern match">(inactive|failed)</linux:value>
   </linux:systemdunitproperty_state>
 </def-group>

--- a/ubuntu16/templates/oval_5.11_templates/template_OVAL_service_disabled
+++ b/ubuntu16/templates/oval_5.11_templates/template_OVAL_service_disabled
@@ -47,7 +47,7 @@
     <linux:unit operation="pattern match">%SERVICENAME%\.(service|socket)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running">
-      <linux:value>inactive</linux:value>
+  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running, either because nobody tried, service has been stopped, or because it terminated unexpectedly">
+      <linux:value operation="pattern match">(inactive|failed)</linux:value>
   </linux:systemdunitproperty_state>
 </def-group>


### PR DESCRIPTION
Before, a service was acknowledged as "not running" only if it was in "inactive" state. However, some services tend to end up in the "failed" state, which is also a "not running" state.

For example, the `kdump` service fails on a default RHEL7 installation on a VM with this error:

```
... kdumpctl[1102]: No memory reserved for crash kernel
... kdumpctl[1102]: Starting kdump: [FAILED]
```