### PR TITLE
Improve remediation of auditd_data_disk_full_action

### DIFF
--- a/shared/fixes/bash/auditd_data_disk_full_action.sh
+++ b/shared/fixes/bash/auditd_data_disk_full_action.sh
@@ -1,16 +1,8 @@
 # platform = multi_platform_rhel
+
+# Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
+
 populate var_auditd_disk_full_action
 
-#
-# If disk_full_action present in /etc/audit/auditd.conf, change value
-# to var_auditd_disk_full_action, else
-# add "disk_full_action = $var_auditd_disk_full_action" to /etc/audit/auditd.conf
-#
-
-if grep --silent ^disk_full_action /etc/audit/auditd.conf ; then
-        sed -i 's/^disk_full_action.*/disk_full_action = '"$var_auditd_disk_full_action"'/g' /etc/audit/auditd.conf
-else
-        echo -e "\n# Set disk_full_action to $var_auditd_disk_full_action per security requirements" >> /etc/audit/auditd.conf
-        echo "disk_full_action = $var_auditd_disk_full_action" >> /etc/audit/auditd.conf
-fi
+replace_or_append /etc/audit/auditd.conf '^disk_full_action' "$var_auditd_disk_full_action" "@CCENUM@"


### PR DESCRIPTION
So far, I have made the remediation to use our shared remediation functionality. However, the remediation is not included in the datastream. I have no idea why, renaming the bash file to `content_rule_auditd_data_disk_full_action.sh` didn't help. 
Any ideas?
