### PR TITLE
Tests and OVAL fix for Rule sssd_enable_pam_services

### DIFF
--- a/shared/checks/oval/sssd_enable_pam_services.xml
+++ b/shared/checks/oval/sssd_enable_pam_services.xml
@@ -20,7 +20,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sssd_enable_pam_services" version="1">
     <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*\[sssd]([^\n]*\n+)+?[\s]*services.*pam.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*\[sssd]([^\n\[\]]*\n+)+?[\s]*services.*pam.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/shared/fixes/bash/sssd_enable_pam_services.sh
+++ b/shared/fixes/bash/sssd_enable_pam_services.sh
@@ -1,0 +1,19 @@
+# platform = multi_platform_rhel
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+SSSD_SERVICES_PAM_REGEX="^[[:space:]]*\[sssd]([^\n]*\n+)+?[[:space:]]*services.*pam.*$"
+SSSD_SERVICES_REGEX="^[[:space:]]*\[sssd]([^\n]*\n+)+?[[:space:]]*services.*$"
+SSSD_PAM_SERVICES="[sssd]
+services = pam"
+SSSD_CONF="/etc/sssd/sssd.conf"
+
+# If there is services line with pam, good
+# If there is services line without pam, append pam
+# If not echo services line with pam
+grep -q "$SSSD_SERVICES_PAM_REGEX" $SSSD_CONF || \
+	grep -q "$SSSD_SERVICES_REGEX" $SSSD_CONF && \
+	sed -i "s/$SSSD_SERVICES_REGEX/&, pam/" $SSSD_CONF || \
+	echo "$SSSD_PAM_SERVICES" >> $SSSD_CONF
+

--- a/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_missing.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_missing.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
-# remediation = none
 
 SSSD_PAM_SERVICES_REGEX="^[\s]*\[sssd]([^\n]*\n+)+?[\s]*services.*pam.*$"
 SSSD_PAM_SERVICES="[sssd]

--- a/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_missing.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_missing.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = none
+
+SSSD_PAM_SERVICES_REGEX="^[\s]*\[sssd]([^\n]*\n+)+?[\s]*services.*pam.*$"
+SSSD_PAM_SERVICES="[sssd]
+services pam"
+SSSD_CONF="/etc/sssd/sssd.conf"
+
+grep -q "$SSSD_PAM_SERVICES_REGEX" $SSSD_CONF && \
+	sed -i "/$SSSD_PAM_SERVICES_REGEX/d" $SSSD_CONF || \
+	true

--- a/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_wrong_section.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_wrong_section.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
-# remediation = none
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 cp wrong_sssd.conf $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_wrong_section.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_wrong_section.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = none
+
+SSSD_CONF="/etc/sssd/sssd.conf"
+cp wrong_sssd.conf $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/sssd_pam_services.pass.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/sssd_pam_services.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
-# remediation = none
 
 SSSD_PAM_SERVICES_REGEX="^[\s]*\[sssd]([^\n]*\n+)+?[\s]*services.*pam.*$"
 SSSD_PAM_SERVICES="[sssd]

--- a/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/sssd_pam_services.pass.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/sssd_pam_services.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = none
+
+SSSD_PAM_SERVICES_REGEX="^[\s]*\[sssd]([^\n]*\n+)+?[\s]*services.*pam.*$"
+SSSD_PAM_SERVICES="[sssd]
+services = pam"
+SSSD_CONF="/etc/sssd/sssd.conf"
+
+grep -q "$SSSD_PAM_SERVICES_REGEX" $SSSD_CONF && \
+	sed -i "s/$SSSD_PAM_SERVICES_REGEX/$SSD_PAM_SERVICES/" $SSSD_CONF || \
+	echo "$SSSD_PAM_SERVICES" >> $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/wrong_sssd.conf
+++ b/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/wrong_sssd.conf
@@ -1,0 +1,16 @@
+[sssd]
+services = nss
+domains = shadowutils
+
+[nss]
+
+[pam]
+services = pam
+
+[domain/shadowutils]
+id_provider = files
+
+auth_provider = proxy
+proxy_pam_target = sssd-shadowutils
+
+proxy_fast_alias = True


### PR DESCRIPTION
#### Description:

- Add tests for `sssd_enable_pam_services`
  - sssd_pam_services - pass - expected config line is present
  - services_pam_missing - fail - expected config line is missing
  - services_pam_wrong_section - fail - expected config line is put in wrong section file
- Regex in OVAL check made stricter, motivated by test that puts config line in wrong section.
- Add bash remediation for `sssd_enable_pam_services`
