### PR TITLE
Further improved replace_or_append

### DIFF
--- a/shared/bash_remediation_functions/replace_or_append.sh
+++ b/shared/bash_remediation_functions/replace_or_append.sh
@@ -65,8 +65,10 @@ function replace_or_append {
   printf -v formatted_output "$format" "$stripped_key" "$value"
 
   # If the key exists, change it. Otherwise, add it to the config_file.
-  if grep -q $grep_case_insensitive_option "${key}" "$config_file"; then
-    "${sed_command[@]}" "s/${key}.*/$formatted_output/g$sed_case_insensitive_option" "$config_file"
+  # We search for the key string followed by a word boundary (matched by \>),
+  # so if we search for 'setting', 'setting2' won't match.
+  if grep -q $grep_case_insensitive_option "${key}\\>" "$config_file"; then
+    "${sed_command[@]}" "s/${key}\\>.*/$formatted_output/g$sed_case_insensitive_option" "$config_file"
   else
     # \n is precaution for case where file ends without trailing newline
     printf '\n# Per %s: Set %s in %s\n' "$cce" "$formatted_output" "$config_file" >> "$config_file"

--- a/shared/bash_remediation_functions/replace_or_append.sh
+++ b/shared/bash_remediation_functions/replace_or_append.sh
@@ -1,12 +1,14 @@
 # Function to replace configuration setting in config file or add the configuration setting if
 # it does not exist.
 #
-# Expects four arguments:
+# Expects arguments:
 #
 # config_file:		Configuration file that will be modified
 # key:			Configuration option to change
 # value:		Value of the configuration option to change
 # cce:			The CCE identifier or '@CCENUM@' if no CCE identifier exists
+# format:		The printf-like format string that will be given stripped key and value as arguments,
+#			so e.g. '%s=%s' will result in key=value subsitution (i.e. without spaces around =)
 #
 # Optional arugments:
 #
@@ -25,13 +27,17 @@
 #     replace_or_append '/etc/sysconfig/selinux' '^SELINUX=' $var_selinux_state '@CCENUM@' '%s=%s'
 #
 function replace_or_append {
-  local default_format='%s = %s'
+  local default_format='%s = %s' case_insensitive_mode=yes sed_case_insensitive_option='' grep_case_insensitive_option=''
   local config_file=$1
   local key=$2
   local value=$3
   local cce=$4
   local format=$5
 
+  if [ "$case_insensitive_mode" = yes ]; then
+    sed_case_insensitive_option="i"
+    grep_case_insensitive_option="-i"
+  fi
   [ -n "$format" ] || format="$default_format"
   # Check sanity of the input
   [ $# -ge "3" ] || { echo "Usage: replace_or_append <config_file_location> <key_to_search> <new_value> [<CCE number or literal '@CCENUM@' if unknown>] [printf-like format, default is '$default_format']" >&2; exit 1; }
@@ -55,11 +61,12 @@ function replace_or_append {
   # adding any search characters to the config file.
   stripped_key=$(sed 's/[\^=\$,;+]*//g' <<< "$key")
 
+  # shellcheck disable=SC2059
   printf -v formatted_output "$format" "$stripped_key" "$value"
 
   # If the key exists, change it. Otherwise, add it to the config_file.
-  if grep -qi "$key" "$config_file"; then
-    "${sed_command[@]}" "s/$key.*/$formatted_output/g" "$config_file"
+  if grep -q $grep_case_insensitive_option "${key}" "$config_file"; then
+    "${sed_command[@]}" "s/${key}.*/$formatted_output/g$sed_case_insensitive_option" "$config_file"
   else
     # \n is precaution for case where file ends without trailing newline
     printf '\n# Per %s: Set %s in %s\n' "$cce" "$formatted_output" "$config_file" >> "$config_file"


### PR DESCRIPTION
Further improvements to the function:

- Harmless improvement: Synchronized the case sensitivity option of `grep` and `sed` commands. In cases where the provided and actual keys differed by case, the substitution would fail.
The modification is backwards-compatible (c-insensitivity is on by default) and controlled from a single point.

- Potentially controversial, but needed improvement: I have appended the word boundary right after the key for the matching.
Although this change alters behavior of the function, remediations that are not broken already shouldn't break, as this change just prevents longer strings that begin with the substring that happens to be the ky to be mistaken for it. For example, `space_left_action` begins with substring `space_left`, so remediation for `auditd_data_retention_space_left` rule could break the `auditd_data_retention_space_left_action` rule.