### PR TITLE
shorthand.xml target should depend on the yaml-to-shorthand script

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -97,6 +97,7 @@ macro(ssg_build_shorthand_xml PRODUCT)
         DEPENDS ${SHORTHAND_INPUTS}
         DEPENDS generate-internal-bash-remediation-functions.xml
         DEPENDS "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml"
+        DEPENDS "${SSG_SHARED_UTILS}/yaml-to-shorthand.py"
         COMMENT "[${PRODUCT}-content] generating shorthand.xml"
     )
     add_custom_target(


### PR DESCRIPTION
That way, when you change the script it will auto-rebuild the shorthand
and everything depending on it.

Not a big deal but we do it for every other target and it makes sense IMO.