### PR TITLE
Make it possible to build SSG with python3

### DIFF
--- a/shared/utils/add_stig_references.py
+++ b/shared/utils/add_stig_references.py
@@ -7,7 +7,6 @@ try:
 except ImportError:
     import cElementTree as etree
 
-import re
 import sys
 import argparse
 
@@ -35,7 +34,7 @@ stig_references_beginning = 'http://iase.disa.mil/stigs/'
 try:
     reference_root = etree.parse(reference)
 except IOError as exception:
-    print 'INFO: DISA STIG Reference file not found for this platform'
+    print("INFO: DISA STIG Reference file not found for this platform")
     sys.exit(0)
 
 reference_rules = reference_root.findall('.//{%s}Rule' % xccdf_namespace)

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -260,7 +260,7 @@ def main():
                 index_select_options += "\n".join(index_options[benchmark_id])
                 index_select_options += "</optgroup>\n"
         else:
-            index_select_options += "\n".join(index_options.values()[0])
+            index_select_options += "\n".join(list(index_options.values())[0])
 
         index_source = "".join([
             "<!DOCTYPE html>\n",

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -16,7 +16,10 @@ except ImportError:
 import os.path
 import argparse
 import threading
-import Queue
+try:
+    import queue as Queue
+except ImportError:
+    import Queue
 import sys
 import multiprocessing
 

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -267,7 +267,7 @@ def main():
             "<html lang=\"en\">\n",
             "\t<head>\n",
             "\t\t<meta charset=\"utf-8\">\n",
-            "\t\t<title>%s</title>\n" % (benchmarks.itervalues().next()),
+            "\t\t<title>%s</title>\n" % (list(benchmarks.values())[0]),
             "\t\t<script>\n",
             "\t\t\tfunction change_profile(option_element)\n",
             "\t\t\t{\n",

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -216,7 +216,7 @@ def main():
                 guide_html = generate_guide_for_input_content(
                     input_path, benchmark_id, profile_id
                 )
-                with open(guide_path, "w") as f:
+                with open(guide_path, "wb") as f:
                     f.write(guide_html.encode("utf-8"))
 
                 queue.task_done()
@@ -329,7 +329,7 @@ def main():
     elif args.cmd == "list_outputs":
         print(index_path)
     elif args.cmd == "build":
-        with open(index_path, "w") as f:
+        with open(index_path, "wb") as f:
             f.write(index_source.encode("utf-8"))
 
 if __name__ == "__main__":

--- a/shared/utils/build-all-remediation-roles.py
+++ b/shared/utils/build-all-remediation-roles.py
@@ -16,7 +16,10 @@ import os.path
 import argparse
 
 import threading
-import Queue
+try:
+    import queue as Queue
+except ImportError:
+    import Queue
 import sys
 import multiprocessing
 

--- a/shared/utils/build-all-remediation-roles.py
+++ b/shared/utils/build-all-remediation-roles.py
@@ -137,7 +137,7 @@ def main():
     # TODO: [:1] is here because oscap generate fix can't handle multiple
     # benchmarks. This needs to be removed once
     # https://github.com/OpenSCAP/openscap/issues/722 is fixed
-    for benchmark_id in benchmarks.keys()[:1]:
+    for benchmark_id in list(benchmarks.keys())[:1]:
         profiles = xccdf_utils.get_profile_choices_for_input(
             input_tree, benchmark_id, None
         )

--- a/shared/utils/build-all-remediation-roles.py
+++ b/shared/utils/build-all-remediation-roles.py
@@ -227,7 +227,7 @@ def main():
                 if args.extension == "yml" and \
                    args.template == "urn:xccdf:fix:script:ansible":
                     role_src = add_minimum_ansible_version(role_src)
-                with open(role_path, "w") as f:
+                with open(role_path, "wb") as f:
                     f.write(role_src.encode("utf-8"))
 
                 queue.task_done()

--- a/shared/utils/combine-ovals.py
+++ b/shared/utils/combine-ovals.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python2
 
-import datetime
 import os
 import os.path
 import errno
-import platform
 import re
 import sys
 from copy import deepcopy

--- a/shared/utils/combine-ovals.py
+++ b/shared/utils/combine-ovals.py
@@ -9,6 +9,7 @@ import re
 import sys
 from copy import deepcopy
 import argparse
+import codecs
 
 
 try:
@@ -252,13 +253,13 @@ def check_oval_version_from_oval(xml_content, oval_version):
     oval_file_tree = ElementTree.fromstring(ssgcommon.oval_header + xml_content + footer)
     for defgroup in oval_file_tree.findall("./{%s}def-group" % oval_ns):
         file_oval_version = defgroup.get("oval_version")
-  
+
     if file_oval_version is None:
         # oval_version does not exist in <def-group/>
         # which means the OVAL is supported for any version.
         # By default, that version is 5.10
         file_oval_version = "5.10"
- 
+
     if tuple(oval_version.split(".")) >= tuple(file_oval_version.split(".")):
         return True
 
@@ -279,7 +280,8 @@ def checks(product, oval_version, oval_dirs):
             # sort the files to make output deterministic
             for filename in sorted(os.listdir(oval_dir)):
                 if filename.endswith(".xml"):
-                    with open(os.path.join(oval_dir, filename), 'r') as xml_file:
+                    with codecs.open(os.path.join(oval_dir, filename), "r",
+                                     encoding="utf-8") as xml_file:
                         xml_content = xml_file.read()
                         if not check_is_applicable_for_product(xml_content, product):
                             continue
@@ -312,7 +314,7 @@ def main():
                    help="Location of the oval.config file.")
     p.add_argument("--oval_version", required=True,
                    help="OVAL version to use. Example: 5.11, 5.10, ...")
-    p.add_argument("--output", type=argparse.FileType('w'), required=True)
+    p.add_argument("--output", type=argparse.FileType("wb"), required=True)
     p.add_argument("ovaldirs", metavar="OVAL_DIR", nargs="+",
                    help="Directory(ies) from which we will collect "
                    "OVAL definitions to combine. Order matters, latter "

--- a/shared/utils/combine-remediations.py
+++ b/shared/utils/combine-remediations.py
@@ -6,6 +6,7 @@ import os.path
 import re
 import errno
 import argparse
+import codecs
 
 try:
     from xml.etree import cElementTree as ElementTree
@@ -78,7 +79,7 @@ def get_available_remediation_functions(build_dir):
         sys.exit(1)
 
     remediation_functions = []
-    with open(xmlfilepath, "r") as xmlfile:
+    with codecs.open(xmlfilepath, "r", encoding="utf-8") as xmlfile:
         filestring = xmlfile.read()
         # This regex looks implementation dependent but we can rely on
         # ElementTree sorting XML attrs alphabetically. Hidden is guaranteed
@@ -402,7 +403,7 @@ def main():
     p.add_argument("--build_dir", required=True,
                    help="where is the cmake build directory. pass value of "
                    "$CMAKE_BINARY_DIR.")
-    p.add_argument("--output", type=argparse.FileType('w'), required=True)
+    p.add_argument("--output", type=argparse.FileType("wb"), required=True)
     p.add_argument("fixdirs", metavar="FIX_DIR", nargs="+",
                    help="directory(ies) from which we will collect "
                    "remediations to combine.")
@@ -435,7 +436,8 @@ def main():
 
                 mod_file = []
                 config = {}
-                with open(os.path.join(fixdir, filename), 'r') as fix_file:
+                with codecs.open(os.path.join(fixdir, filename), "r",
+                                 encoding="utf-8") as fix_file:
                     # Assignment automatically escapes shell characters for XML
                     for line in fix_file.readlines():
                         if line.startswith('#'):

--- a/shared/utils/cpe-generate.py
+++ b/shared/utils/cpe-generate.py
@@ -74,9 +74,9 @@ def collect_nodes(tree, reflist):
 
 def main():
     if len(sys.argv) < 2:
-        print "Provide an OVAL file that contains inventory definitions."
-        print ("This script extracts these definitions and writes them" +
-               " to STDOUT.")
+        print("Provide an OVAL file that contains inventory definitions.")
+        print("This script extracts these definitions and writes them "
+              "to STDOUT.")
         sys.exit(1)
 
     product = sys.argv[1]

--- a/shared/utils/enable-derivatives.py
+++ b/shared/utils/enable-derivatives.py
@@ -208,13 +208,16 @@ def main():
     parser.add_option("--enable-sl", dest="sl", default=False,
                       action="store_true", help="Enable Scientific Linux")
     parser.add_option("-i", "--input", dest="input_content", default=False,
-                      action="store", help="INPUT can be XCCDF or Source DataStream")
+                      action="store",
+                      help="INPUT can be XCCDF or Source DataStream")
     parser.add_option("-o", "--output", dest="output", default=False,
                       action="store", help="XML Tree content")
     (options, args) = parser.parse_args()
 
     if options.centos and options.sl:
-        print "Cannot enable two derivative OS(s) at the same time"
+        sys.stderr.write(
+            "Cannot enable two derivative OS(s) at the same time\n"
+        )
         parser.print_help()
         sys.exit(1)
 
@@ -261,16 +264,18 @@ def main():
     for namespace, benchmark in benchmarks:
         if not add_derivative_cpes(benchmark, namespace, mapping):
             raise RuntimeError(
-                "Could not add derivative OS CPEs to Benchmark '%s'." % (benchmark)
+                "Could not add derivative OS CPEs to Benchmark '%s'."
+                % (benchmark)
             )
 
         if not add_derivative_notice(benchmark, namespace, notice, warning):
             raise RuntimeError(
-                "Managed to add derivative OS CPEs but failed to add the notice to "
-                "affected XCCDF Benchmark '%s'." % (benchmark)
+                "Managed to add derivative OS CPEs but failed to add the "
+                "notice to affected XCCDF Benchmark '%s'." % (benchmark)
             )
 
     tree.write(options.output)
+
 
 if __name__ == "__main__":
     main()

--- a/shared/utils/generate-bash-remediation-functions.py
+++ b/shared/utils/generate-bash-remediation-functions.py
@@ -4,6 +4,7 @@ import sys
 import os
 import os.path
 import argparse
+import codecs
 
 try:
     from xml.etree import cElementTree as ElementTree
@@ -13,15 +14,15 @@ except ImportError:
 
 def preprocess_source(filepath):
     raw = ""
-    with open(filepath, "r") as f:
+    with codecs.open(filepath, "r", encoding="utf-8") as f:
         raw = f.read()
 
     source = ""
     for line in raw.splitlines(True):
         if line.startswith("source ") and line.endswith(".sh\n"):
             included_file = line.strip()[7:]  # skip "source "
-            with open(os.path.join(
-                os.path.dirname(filepath), included_file), "r"
+            with codecs.open(os.path.join(
+                os.path.dirname(filepath), included_file), "r", encoding="utf-8"
             ) as f:
                 source += f.read()
                 source += "\n"
@@ -34,7 +35,7 @@ def preprocess_source(filepath):
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("--input_dir", required=True)
-    p.add_argument("--output", type=argparse.FileType('w'), required=True)
+    p.add_argument("--output", type=argparse.FileType("wb"), required=True)
 
     args, unknown = p.parse_known_args()
     if unknown:

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -38,7 +38,11 @@ def add_sub_element(parent, tag, data):
     # and therefore it does not add child elements
     # we need to do a hack instead
     # TODO: Remove this function after we move to Markdown everywhere in SSG
-    ustr = unicode("<{0}>{1}</{0}>").format(tag, data)
+    try:
+        ustr = unicode("<{0}>{1}</{0}>").format(tag, data)
+    except NameError:
+        ustr = str("<{0}>{1}</{0}>").format(tag, data)
+
     element = ET.fromstring(ustr.encode("utf-8"))
     parent.append(element)
     return element


### PR DESCRIPTION
We need to be careful about treating text as bytes and vice-versa.

It's now possible to build SSG with python2 or python3. The port was pretty easy.