### PR TITLE
Update build instructions to include PyYAML

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,7 +4,7 @@
 
 1. On Red Hat Enterprise Linux and Fedora make sure the packages `cmake`, `openscap-utils`, and their dependencies are installed. We require version `1.0.8` or later of `openscap-utils` (available in Red Hat Enterprise Linux) as well as `git`.
 
- `# yum -y install cmake openscap-utils git`
+ `# yum -y install cmake openscap-utils git PyYAML`
 
  On Ubuntu make sure the packages `expat`, `libopenscap8`, `libxml2-utils`, `xsltproc`, and their dependencies are installed as well as `git`.
 


### PR DESCRIPTION
Needed for builds. If not present, get errors:

`````
ImportError: No module named yaml
-- Scanning for dependencies of chromium fixes (bash, ansible, puppet and anaconda)...
mak-- Scanning for dependencies of chromium checks (OVAL)...
e Traceback (most recent call last):
  File "/var/www/html/github/openscap/scap-security-guide/shared/utils/yaml-to-shorthand.py", line 6, in <module>
    import yaml
ImportError: No module named yaml
-- Scanning for dependencies of debian8 fixes (bash, ansible, puppet and anaconda)...
-- Scanning for dependencies of debian8 checks (OVAL)...
Traceback (most recent call last):
  File "/var/www/html/github/openscap/scap-security-guide/shared/utils/yaml-to-shorthand.py", line 6, in <module>
    import yaml
ImportError: No module named yaml
-- Scanning for dependencies of fedora fixes (bash, ansible, puppet and anaconda)...
-- Scanning for dependencies of fedora checks (OVAL)...
Traceback (most recent call last):
`````
