### PR TITLE
OVAL: audit_rules_login_events optional trailing slash

### DIFF
--- a/shared/templates/create_audit_rules_login_events.py
+++ b/shared/templates/create_audit_rules_login_events.py
@@ -20,7 +20,7 @@ class AuditRulesLoginEventsGenerator(FilesGenerator):
                 "./template_OVAL_audit_rules_login_events",
                 {
                     "%NAME%":	name,
-                    "%PATH%":	path.replace("/", "\\/")
+                    "%PATH%":	re.sub('/$', '/?', path).replace("/", "\\/")
                 },
                 "./oval/audit_rules_login_events_{0}.xml", name
             )


### PR DESCRIPTION
#### Description:

Makes the trailing slash optional for the directory watch.

Fixes #2709 

#### Rationale:

It should not matter whether the audit watch on a directory is specified with or without a trailing slash.  The RHEL 7 STIG V1R4 shows it without a trailing slash.  This change makes both options pass.