### PR TITLE
Remove ignore option for auditing configuration

### DIFF
--- a/shared/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action.rule
+++ b/shared/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action.rule
@@ -12,7 +12,6 @@ description: |-
     Possible values for <i>ACTION</i> are described in the <tt>auditd.conf</tt> man
     page. These include:
     <ul>
-    <li><tt>ignore</tt></li>
     <li><tt>syslog</tt></li>
     <li><tt>suspend</tt></li>
     <li><tt>rotate</tt></li>

--- a/shared/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action.rule
+++ b/shared/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action.rule
@@ -13,7 +13,6 @@ description: |-
     Possible values for <i>ACTION</i> are described in the <tt>auditd.conf</tt> man page.
     These include:
     <ul>
-    <li><tt>ignore</tt></li>
     <li><tt>syslog</tt></li>
     <li><tt>email</tt></li>
     <li><tt>exec</tt></li>

--- a/shared/guide/system/auditing/configure_auditd_data_retention/var_audispd_disk_full_action.var
+++ b/shared/guide/system/auditing/configure_auditd_data_retention/var_audispd_disk_full_action.var
@@ -15,7 +15,6 @@ options:
     email: email
     exec: exec
     halt: halt
-    ignore: ignore
     single: single
     suspend: suspend
     syslog: syslog

--- a/shared/guide/system/auditing/configure_auditd_data_retention/var_audispd_network_failure_action.var
+++ b/shared/guide/system/auditing/configure_auditd_data_retention/var_audispd_network_failure_action.var
@@ -15,7 +15,6 @@ options:
     email: email
     exec: exec
     halt: halt
-    ignore: ignore
     single: single
     suspend: suspend
     syslog: syslog

--- a/shared/guide/system/auditing/configure_auditd_data_retention/var_auditd_admin_space_left_action.var
+++ b/shared/guide/system/auditing/configure_auditd_data_retention/var_auditd_admin_space_left_action.var
@@ -15,7 +15,6 @@ options:
     email: email
     exec: exec
     halt: halt
-    ignore: ignore
     single: single
     suspend: suspend
     syslog: syslog

--- a/shared/guide/system/auditing/configure_auditd_data_retention/var_auditd_max_log_file_action.var
+++ b/shared/guide/system/auditing/configure_auditd_data_retention/var_auditd_max_log_file_action.var
@@ -12,7 +12,6 @@ interactive: false
 
 options:
     default: rotate
-    ignore: ignore
     keep_logs: keep_logs
     rotate: rotate
     suspend: suspend

--- a/shared/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left_action.var
+++ b/shared/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left_action.var
@@ -15,7 +15,6 @@ options:
     email: email
     exec: exec
     halt: halt
-    ignore: ignore
     single: single
     suspend: suspend
     syslog: syslog


### PR DESCRIPTION
#### Description:

- Remove ignore option for auditing configuration

#### Rationale:

- The ignore option is not really an acceptable security practice
