### PR TITLE
audit_rules_privileged_commands: allow arbitrary key

### DIFF
--- a/shared/checks/oval/audit_rules_privileged_commands.xml
+++ b/shared/checks/oval/audit_rules_privileged_commands.xml
@@ -75,7 +75,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_arpc_suid_sgid_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F perm=[r|w]?x -F auid>=1000 -F auid!=4294967295 -k privileged[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F perm=[r|w]?x -F auid>=1000 -F auid!=4294967295[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
     <filter action="exclude">state_proper_audit_rule_but_for_unprivileged_command</filter>
   </ind:textfilecontent54_object>
@@ -99,7 +99,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_arpc_suid_sgid_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F perm=[r|w]?x -F auid>=1000 -F auid!=4294967295 -k privileged[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F perm=[r|w]?x -F auid>=1000 -F auid!=4294967295[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
     <filter action="exclude">state_proper_audit_rule_but_for_unprivileged_command</filter>
   </ind:textfilecontent54_object>


### PR DESCRIPTION
#### Description:

Allows using an arbitrary key in the audit rule.

#### Rationale:

- User should be able to choose an arbitrary key to tag the event.

- Fixes #2707 