### PR TITLE
updated rhel7/fixes/ansible/service_avahi-daemon_disabled.yml to match template_ANSIBLE_service_disabled

### DIFF
--- a/rhel7/fixes/ansible/service_avahi-daemon_disabled.yml
+++ b/rhel7/fixes/ansible/service_avahi-daemon_disabled.yml
@@ -4,6 +4,8 @@
     name="{{item}}"
     enabled="no"
     state="stopped"
+  register: service_result
+  failed_when: "service_result|failed and ('Could not find the requested service' not in service_result.msg)"
   with_items:
     - avahi-daemon
   tags:
@@ -14,6 +16,8 @@
     name="{{item}}"
     enabled="no"
     state="stopped"
+  register: service_result
+  failed_when: "service_result|failed and ('Could not find the requested service' not in service_result.msg)"
   with_items:
     - avahi-socket
   tags:


### PR DESCRIPTION
#### Description:

- updated rhel7/fixes/ansible/service_avahi-daemon_disabled.yml to match template_ANSIBLE_service_disabled

#### Rationale:

- Disabling avahi-daemon & avahi-socket services results in a failure when "Could not find the requested service".
