### PR TITLE
aide cron flex

### DIFF
--- a/shared/checks/oval/aide_periodic_cron_checking.xml
+++ b/shared/checks/oval/aide_periodic_cron_checking.xml
@@ -13,46 +13,46 @@
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <criteria operator="OR">
-        <criterion comment="run aide periodically with cron" test_ref="test_aide_periodic_cron_checking" />
-        <criterion comment="run aide periodically with cron" test_ref="test_aide_crond_checking" />
-        <criterion comment="run aide periodically with cron" test_ref="test_aide_var_cron_checking" />
-        <criterion comment="run aide periodically with cron.(daily|weekly|monthly)" test_ref="test_aide_crontabs_checking" />
+        <criterion comment="run aide with cron" test_ref="test_aide_periodic_cron_checking" />
+        <criterion comment="run aide with cron" test_ref="test_aide_crond_checking" />
+        <criterion comment="run aide with cron" test_ref="test_aide_var_cron_checking" />
+        <criterion comment="run aide with cron.(daily|weekly|monthly)" test_ref="test_aide_crontabs_checking" />
       </criteria>
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide periodically with cron" id="test_aide_periodic_cron_checking" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide with cron" id="test_aide_periodic_cron_checking" version="1">
     <ind:object object_ref="object_test_aide_periodic_cron_checking" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="run aide periodically with cron" id="object_test_aide_periodic_cron_checking" version="1">
+  <ind:textfilecontent54_object comment="run aide with cron" id="object_test_aide_periodic_cron_checking" version="1">
     <ind:filepath>/etc/crontab</ind:filepath>
     <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide periodically with cron" id="test_aide_crond_checking" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide with cron" id="test_aide_crond_checking" version="1">
     <ind:object object_ref="object_test_aide_crond_checking" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="run aide periodically with cron" id="object_test_aide_crond_checking" version="1">
+  <ind:textfilecontent54_object comment="run aide with cron" id="object_test_aide_crond_checking" version="1">
     <ind:path>/etc/cron.d</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
     <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide periodically with cron" id="test_aide_var_cron_checking" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide with cron" id="test_aide_var_cron_checking" version="1">
     <ind:object object_ref="object_aide_var_cron_checking" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="run aide periodically with cron" id="object_aide_var_cron_checking" version="1">
+  <ind:textfilecontent54_object comment="run aide with cron" id="object_aide_var_cron_checking" version="1">
     <ind:filepath>/var/spool/cron/root</ind:filepath>
     <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide periodically with cron.(daily|weekly|monthly)" id="test_aide_crontabs_checking" version="2">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide with cron.(daily|weekly|monthly)" id="test_aide_crontabs_checking" version="2">
     <ind:object object_ref="object_aide_crontabs_checking" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="run aide periodically with cron.(daily|weekly|monthly)" id="object_aide_crontabs_checking" version="1">
+  <ind:textfilecontent54_object comment="run aide with cron.(daily|weekly|monthly)" id="object_aide_crontabs_checking" version="1">
     <ind:path operation="pattern match">/etc/cron.(daily|weekly|monthly)</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
     <ind:pattern operation="pattern match">^\s*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>

--- a/shared/checks/oval/aide_periodic_cron_checking.xml
+++ b/shared/checks/oval/aide_periodic_cron_checking.xml
@@ -26,7 +26,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="run aide periodically with cron" id="object_test_aide_periodic_cron_checking" version="1">
     <ind:filepath>/etc/crontab</ind:filepath>
-    <ind:pattern operation="pattern match">^[0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -36,7 +36,7 @@
   <ind:textfilecontent54_object comment="run aide periodically with cron" id="object_test_aide_crond_checking" version="1">
     <ind:path>/etc/cron.d</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^[0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -45,7 +45,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="run aide periodically with cron" id="object_aide_var_cron_checking" version="1">
     <ind:filepath>/var/spool/cron/root</ind:filepath>
-    <ind:pattern operation="pattern match">^[0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*[\s]*(root|)/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/checks/oval/aide_periodic_cron_checking.xml
+++ b/shared/checks/oval/aide_periodic_cron_checking.xml
@@ -13,46 +13,46 @@
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <criteria operator="OR">
-        <criterion comment="run aide daily with cron" test_ref="test_aide_periodic_cron_checking" />
-        <criterion comment="run aide daily with cron" test_ref="test_aide_crond_checking" />
-        <criterion comment="run aide daily with cron" test_ref="test_aide_var_cron_checking" />
-        <criterion comment="run aide daily with cron.(daily|weekly|monthly)" test_ref="test_aide_crontabs_checking" />
+        <criterion comment="run aide periodically with cron" test_ref="test_aide_periodic_cron_checking" />
+        <criterion comment="run aide periodically with cron" test_ref="test_aide_crond_checking" />
+        <criterion comment="run aide periodically with cron" test_ref="test_aide_var_cron_checking" />
+        <criterion comment="run aide periodically with cron.(daily|weekly|monthly)" test_ref="test_aide_crontabs_checking" />
       </criteria>
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide daily with cron" id="test_aide_periodic_cron_checking" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide periodically with cron" id="test_aide_periodic_cron_checking" version="1">
     <ind:object object_ref="object_test_aide_periodic_cron_checking" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="run aide daily with cron" id="object_test_aide_periodic_cron_checking" version="1">
+  <ind:textfilecontent54_object comment="run aide periodically with cron" id="object_test_aide_periodic_cron_checking" version="1">
     <ind:filepath>/etc/crontab</ind:filepath>
     <ind:pattern operation="pattern match">^[0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide daily with cron" id="test_aide_crond_checking" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide periodically with cron" id="test_aide_crond_checking" version="1">
     <ind:object object_ref="object_test_aide_crond_checking" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="run aide daily with cron" id="object_test_aide_crond_checking" version="1">
+  <ind:textfilecontent54_object comment="run aide periodically with cron" id="object_test_aide_crond_checking" version="1">
     <ind:path>/etc/cron.d</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
     <ind:pattern operation="pattern match">^[0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide daily with cron" id="test_aide_var_cron_checking" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide periodically with cron" id="test_aide_var_cron_checking" version="1">
     <ind:object object_ref="object_aide_var_cron_checking" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="run aide daily with cron" id="object_aide_var_cron_checking" version="1">
+  <ind:textfilecontent54_object comment="run aide periodically with cron" id="object_aide_var_cron_checking" version="1">
     <ind:filepath>/var/spool/cron/root</ind:filepath>
     <ind:pattern operation="pattern match">^[0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*[\s]*(root|)/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide daily with cron.(daily|weekly|monthly)" id="test_aide_crontabs_checking" version="2">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide periodically with cron.(daily|weekly|monthly)" id="test_aide_crontabs_checking" version="2">
     <ind:object object_ref="object_aide_crontabs_checking" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="run aide daily with cron.(daily|weekly|monthly)" id="object_aide_crontabs_checking" version="1">
+  <ind:textfilecontent54_object comment="run aide periodically with cron.(daily|weekly|monthly)" id="object_aide_crontabs_checking" version="1">
     <ind:path operation="pattern match">/etc/cron.(daily|weekly|monthly)</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
     <ind:pattern operation="pattern match">^\s*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>


### PR DESCRIPTION
#### Description:

- Allow usage of cron special times in the periodic execution of `aide --check`

#### Rationale:

- It is good to avoid warning for compliant configurations.

- Fixes #2708
