### PR TITLE
OL7 standard profile extra rules

### DIFF
--- a/ol7/profiles/standard.profile
+++ b/ol7/profiles/standard.profile
@@ -20,3 +20,5 @@ selections:
     - dir_perms_world_writable_sticky_bits
     - root_path_no_dot
     - accounts_password_all_shadowed
+    - mount_option_dev_shm_nodev
+    - mount_option_dev_shm_nosuid

--- a/ol7/templates/csv/mount_options.csv
+++ b/ol7/templates/csv/mount_options.csv
@@ -1,0 +1,2 @@
+/dev/shm,nodev
+/dev/shm,nosuid

--- a/shared/fixes/ansible/rpm_verify_hashes.yml
+++ b/shared/fixes/ansible/rpm_verify_hashes.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = high
@@ -13,7 +13,7 @@
 - name: "Set fact: Package manager reinstall command (yum)"
   set_fact:
     package_manager_reinstall_cmd: yum reinstall -y
-  when: ansible_distribution == "RedHat"
+  when: ansible_distribution == "RedHat" or ansible_distribution == "OracleLinux"
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/fixes/bash/rpm_verify_permissions.sh
+++ b/shared/fixes/bash/rpm_verify_permissions.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = high

--- a/shared/fixes/bash/rpm_verify_permissions.sh
+++ b/shared/fixes/bash/rpm_verify_permissions.sh
@@ -22,7 +22,7 @@ do
 done
 
 # Remove duplicate mention of same RPM in $SETPERMS_RPM_LIST (if any)
-SETPERMS_RPM_LIST=( $(echo "${SETPERMS_RPM_LIST[@]}" | sort -n | uniq) )
+SETPERMS_RPM_LIST=( $(echo "${SETPERMS_RPM_LIST[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ') )
 
 # For each of the RPM packages left in the list -- reset its permissions to the
 # correct values

--- a/shared/guide/system/permissions/partitions/mount_option_dev_shm_nodev.rule
+++ b/shared/guide/system/permissions/partitions/mount_option_dev_shm_nodev.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Add nodev Option to /dev/shm'
 

--- a/shared/guide/system/permissions/partitions/mount_option_dev_shm_nosuid.rule
+++ b/shared/guide/system/permissions/partitions/mount_option_dev_shm_nosuid.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Add nosuid Option to /dev/shm'
 

--- a/shared/templates/template_ANACONDA_mount_options
+++ b/shared/templates/template_ANACONDA_mount_options
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = enable
 # complexity = low


### PR DESCRIPTION
#### Description:

Extended Oracle Linux 7 standard profile

- Added missing ol7 standard profile rules mount_option_dev_shm_nodev and mount_option_dev_shm_nosuid.
- Added ol7 specific values for mount_options templates. 
- Adopted rpm_verify_hashes and rpm_verify_permissions fixes.
- Fixed SETPERMS_RPM_LIST duplicates removal in shared rpm_verify_permissions.sh script.

#### Rationale:
ol7 standard profile aligned with existing rhel7 standard profile content

#### Testing:
- Verified ol7 and all projects builds and tests to pass
- Generated 'standard' profile guide and verified evaluation scan reports on ol7 with expected results and added content
- Checked rpm_verify_permissions.sh to work


