### PR TITLE
Don't load yaml booleans as python booleans

### DIFF
--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -16,7 +16,17 @@ except ImportError:
     import cElementTree as ET
 
 
+def bool_constructor(self, node):
+    value = self.construct_yaml_bool(node)
+    if value == False:
+        return 'false'
+    else:
+        return 'true'
+
 def open_yaml(yaml_file):
+    # Don't follow python bool case
+    yaml.Loader.add_constructor(u'tag:yaml.org,2002:bool', bool_constructor)
+
     with codecs.open(yaml_file, "r", "utf8") as stream:
         yaml_contents = yaml.load(stream)
         if "documentation_complete" in yaml_contents and \

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -17,16 +17,8 @@ except ImportError:
     import cElementTree as ET
 
 
-def construct_yaml_bool(self, node):
-    value = self.construct_scalar(node)
-
-    return value
-
-
 def bool_constructor(self, node):
-    value = construct_yaml_bool(self, node)
-
-    return value
+    return self.construct_scalar(node)
 
 
 def open_yaml(yaml_file):

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -10,18 +10,24 @@ import datetime
 import codecs
 import sys
 
+
 try:
     from xml.etree import cElementTree as ET
 except ImportError:
     import cElementTree as ET
 
 
+def construct_yaml_bool(self, node):
+    value = self.construct_scalar(node)
+
+    return value
+
+
 def bool_constructor(self, node):
-    value = self.construct_yaml_bool(node)
-    if value == False:
-        return 'false'
-    else:
-        return 'true'
+    value = construct_yaml_bool(self, node)
+
+    return value
+
 
 def open_yaml(yaml_file):
     # Don't follow python bool case

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -258,7 +258,8 @@ class Benchmark(object):
         version.text = self.version
 
         for profile in self.profiles:
-            root.append(profile.to_xml_element())
+            if profile is not None:
+                root.append(profile.to_xml_element())
 
         for v in self.values.values():
             root.append(v.to_xml_element())


### PR DESCRIPTION
#### Description:

- Don't load yaml booleans as python booleans

#### Rationale:

- Booleans were being loaded as `True`, `False`, etc. 
