### PR TITLE
Minor in size, but substantial test suite improvements.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -51,7 +51,7 @@ An example invocation may look like this:
 ./test_suite.py profile --hypervisor qemu:///system --domain ssg-test-suite-centos --datastream ssg-centos7-ds.xml --xccdf-id xccdf-id profile-id
 ```
 
-Note that the `profile-id` is not matched by the suffix (as opposed to how the `oscap` tool works), so specify it literally (use `oscap info --profiles` to see available profiles).
+`profile-id` is matched by the suffix so it is the same as the `oscap` tool works (you can use `oscap info --profiles` to see available profiles).
 
 ### Rule-based testing
 In this mode, you specify the `rule` command and you supply part of the rule title as a positional argument.

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -259,7 +259,7 @@ class GenericRunner(object):
         self.results_path = ''
         self.stage = 'undefined'
 
-        self.clean_files = True
+        self.clean_files = False
         self._filenames_to_clean_afterwards = set()
 
         self.command_base = []

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -52,9 +52,7 @@ def get_viable_profiles(selected_profiles, datastream, benchmark):
             valid_profiles += [ds_profile]
             continue
         for sel_profile in selected_profiles:
-            # this means substring - we expect selected profile might be
-            # just a shorter version of proper datastream profile id
-            if sel_profile in ds_profile:
+            if ds_profile.endswith(sel_profile):
                 valid_profiles += [ds_profile]
     if not valid_profiles:
         logging.error('No profile matched with "{0}"'


### PR DESCRIPTION
* Don't clean HTML files by default - Fixes the issue when HTML reports of profile runs were wiped out.
* Match profile IDs by suffix as the rest of the ecosystem. - Helps when the ...C2S profile is selected, because the ...C2S-docker profile is the superstring of the former.