### PR TITLE
Simplify display_login_attempts remediation script logic

### DIFF
--- a/shared/fixes/bash/display_login_attempts.sh
+++ b/shared/fixes/bash/display_login_attempts.sh
@@ -1,10 +1,8 @@
 # platform = Red Hat Enterprise Linux 7
 
-if ! `grep -q "^session.*pam_lastlog.so" /etc/pam.d/postlogin` ; then
-	echo "session     [default=1]   pam_lastlog.so nowtmp showfailed" >> /etc/pam.d/postlogin
-	echo "session     optional      pam_lastlog.so silent noupdate showfailed" >> /etc/pam.d/postlogin
-else
+if $(grep -q "^session.*pam_lastlog.so" /etc/pam.d/postlogin) ; then
 	sed -i --follow-symlinks "/pam_lastlog.so/d" /etc/pam.d/postlogin
-	echo "session     [default=1]   pam_lastlog.so nowtmp showfailed" >> /etc/pam.d/postlogin
-        echo "session     optional      pam_lastlog.so silent noupdate showfailed" >> /etc/pam.d/postlogin
 fi
+
+echo "session     [default=1]   pam_lastlog.so nowtmp showfailed" >> /etc/pam.d/postlogin
+echo "session     optional      pam_lastlog.so silent noupdate showfailed" >> /etc/pam.d/postlogin

--- a/shared/fixes/bash/display_login_attempts.sh
+++ b/shared/fixes/bash/display_login_attempts.sh
@@ -1,14 +1,10 @@
 # platform = Red Hat Enterprise Linux 7
 
-if ! `grep -q ^[^#].*pam_succeed_if.*showfailed /etc/pam.d/postlogin` ; then
-  if ! grep `^session.*pam_succeed_if.so /etc/pam.d/postlogin` ; then
-    echo "session     [default=1]   pam_lastlog.so nowtmp showfailed" >> /etc/pam.d/postlogin
-    echo "session     optional      pam_lastlog.so silent noupdate showfailed" >> /etc/pam.d/postlogin
-  else
-    sed -i --follow-symlinks '/^session.*pam_succeed_if.so/a session\t    optional\t  pam_lastlog.so silent noupdate showfailed' /etc/pam.d/postlogin
-    sed -i --follow-symlinks '/^session.*pam_succeed_if.so/a session\t    [default=1]\t  pam_lastlog.so nowtmp showfailed' /etc/pam.d/postlogin
-  fi
+if ! `grep -q "^session.*pam_lastlog.so" /etc/pam.d/postlogin` ; then
+	echo "session     [default=1]   pam_lastlog.so nowtmp showfailed" >> /etc/pam.d/postlogin
+	echo "session     optional      pam_lastlog.so silent noupdate showfailed" >> /etc/pam.d/postlogin
 else
-  sed -i --follow-symlinks "s/session[ ]*\[default=1][ ]*pam_lastlog.so.*/session     [default=1]   pam_lastlog.so nowtmp showfailed/g" /etc/pam.d/postlogin
-  sed -i --follow-symlinks "s/session[ ]*optional[ ]*pam_lastlog.so.*/session     optional      pam_lastlog.so silent noupdate showfailed/g" /etc/pam.d/postlogin
+	sed -i --follow-symlinks "/pam_lastlog.so/d" /etc/pam.d/postlogin
+	echo "session     [default=1]   pam_lastlog.so nowtmp showfailed" >> /etc/pam.d/postlogin
+        echo "session     optional      pam_lastlog.so silent noupdate showfailed" >> /etc/pam.d/postlogin
 fi


### PR DESCRIPTION
#### Description:

- Simplify display_login_attempts remediation script logic

#### Rationale:

- Logic was for an outdated version of RHEL

- Fixes #2483
