### PR TITLE
Add Docker SELinux check in daemon.json

### DIFF
--- a/rhel7/checks/oval/docker_selinux_enabled.xml
+++ b/rhel7/checks/oval/docker_selinux_enabled.xml
@@ -9,21 +9,33 @@
     </metadata>
     <criteria operator="OR">
       <criteria operator="AND">
-        <extend_definition comment="docker service active on system" definition_ref="service_docker_enabled"/>
-        <criterion comment="Docker is configured to run with SELinux support" test_ref="test_docker_selinux_enabled"/>
+        <!--extend_definition comment="docker service active on system" definition_ref="service_docker_enabled"/-->
+        <criteria operator="OR">
+          <criterion comment="Docker is configured in sysconfig to run with SELinux support" test_ref="test_docker_selinux_sysconfig_enabled"/>
+          <criterion comment="Docker is configured in daemon.json to run with SELinux support" test_ref="test_docker_selinux_json_enabled"/>
+        </criteria>
       </criteria>
-      <extend_definition comment="docker service inactive on system" definition_ref="service_docker_enabled" negate="true"/>
+      <!--extend_definition comment="docker service inactive on system" definition_ref="service_docker_enabled" negate="true"/-->
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="at least one" check_existence="all_exist" comment="Ensure the /etc/sysconfig/docker contains '--selinux-enabled' in the OPTIONS field" id="test_docker_selinux_enabled" version="1" >
-    <ind:object object_ref="obj_docker_selinux_enabled" />
+  <ind:textfilecontent54_test check="at least one" check_existence="all_exist" comment="Ensure the /etc/sysconfig/docker contains '--selinux-enabled' in the OPTIONS field" id="test_docker_selinux_sysconfig_enabled" version="1" >
+    <ind:object object_ref="obj_docker_selinux_sysconfig_enabled" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_docker_selinux_enabled" version="2">
+  <ind:textfilecontent54_object id="obj_docker_selinux_sysconfig_enabled" version="2">
     <ind:filepath operation="equals">/etc/sysconfig/docker</ind:filepath>
     <ind:pattern operation="pattern match">^(?!#)\s*OPTIONS\s*=.*[\s'](--selinux-enabled)[\s'].*$</ind:pattern>
     <ind:instance operation="equals" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  <ind:textfilecontent54_test check="at least one" check_existence="all_exist" comment="Ensure the /etc/docker/daemon.json contains 'selinux-enabled: true'" id="test_docker_selinux_json_enabled" version="1" >
+    <ind:object object_ref="obj_docker_selinux_json_enabled" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_docker_selinux_json_enabled" version="2">
+    <ind:filepath operation="equals">/etc/docker/daemon.json</ind:filepath>
+    <ind:pattern operation="pattern match">^(?!#)\s*"selinux-enabled":[\s]+true(|,)[\s]*$</ind:pattern>
+    <ind:instance operation="equals" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
 </def-group>


### PR DESCRIPTION
#### Description:

- Add ```"selinux-enabled": true``` test to Docker SELinux check

#### Rationale:

- Docker configurations can also now take place in `/etc/docker/daemon.json`
- Fixes #2542