### PR TITLE
Add missing rpm_verify_ownership bash script

### DIFF
--- a/shared/fixes/bash/rpm_verify_ownership.sh
+++ b/shared/fixes/bash/rpm_verify_ownership.sh
@@ -5,7 +5,7 @@
 # disruption = medium
 
 # Declare array to hold list of RPM packages we need to correct permissions for
-declare -a SETPERMS_RPM_LIST
+SETPERMS_RPM_LIST=()
 
 # Create a list of files on the system having permissions different from what
 # is expected by the RPM database
@@ -18,11 +18,11 @@ FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep "^.*\(G\|U\)" | cut 
 for FILE_PATH in "${FILES_WITH_INCORRECT_PERMS[@]}"
 do
         RPM_PACKAGE=$(rpm -qf "$FILE_PATH")
-        SETPERMS_RPM_LIST=("${SETPERMS_RPM_LIST[@]}" "$RPM_PACKAGE")
+	SETPERMS_RPM_LIST+=("$RPM_PACKAGE")
 done
 
 # Remove duplicate mention of same RPM in $SETPERMS_RPM_LIST (if any)
-SETPERMS_RPM_LIST=( $(echo "${SETPERMS_RPM_LIST[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ') )
+SETPERMS_RPM_LIST=( $(printf "%s\n" "${SETPERMS_RPM_LIST[@]}" | sort -u) )
 
 # For each of the RPM packages left in the list -- reset its permissions to the
 # correct values

--- a/shared/fixes/bash/rpm_verify_ownership.sh
+++ b/shared/fixes/bash/rpm_verify_ownership.sh
@@ -1,0 +1,32 @@
+# platform = multi_platform_rhel,multi_platform_ol
+# reboot = false
+# strategy = restrict
+# complexity = high
+# disruption = medium
+
+# Declare array to hold list of RPM packages we need to correct permissions for
+declare -a SETPERMS_RPM_LIST
+
+# Create a list of files on the system having permissions different from what
+# is expected by the RPM database
+FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep "^.*\(G\|U\)" | cut -d ' ' -f4-))
+
+# For each file path from that list:
+# * Determine the RPM package the file path is shipped by,
+# * Include it into SETPERMS_RPM_LIST array
+
+for FILE_PATH in "${FILES_WITH_INCORRECT_PERMS[@]}"
+do
+        RPM_PACKAGE=$(rpm -qf "$FILE_PATH")
+        SETPERMS_RPM_LIST=("${SETPERMS_RPM_LIST[@]}" "$RPM_PACKAGE")
+done
+
+# Remove duplicate mention of same RPM in $SETPERMS_RPM_LIST (if any)
+SETPERMS_RPM_LIST=( $(echo "${SETPERMS_RPM_LIST[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ') )
+
+# For each of the RPM packages left in the list -- reset its permissions to the
+# correct values
+for RPM_PACKAGE in "${SETPERMS_RPM_LIST[@]}"
+do
+        rpm --setugids "${RPM_PACKAGE}"
+done


### PR DESCRIPTION
#### Description:

- Add missing rpm_verify_ownership bash script

#### Rationale:

- Script was accidentally removed and missing from older PRs on this topic
