### PR TITLE
update references to RHEL7 STIG release to V1R4

### DIFF
--- a/docs/scap-security-guide.8
+++ b/docs/scap-security-guide.8
@@ -210,7 +210,7 @@ Regardless of your system's workload all of these checks should pass.
 
 .I stig-rhel7-disa
 .RS
-The DISA STIG for Red Hat Enterprise Linux 7 Server V1R1.
+The DISA STIG for Red Hat Enterprise Linux 7 Server V1R4.
 
 The Security Technical Implementation Guides (STIGs) and the NSA Guides are the
 configuration standards for DOD IA and IA-enabled devices/systems. Since 1998,

--- a/rhel7/profiles/stig-rhel7-disa.profile
+++ b/rhel7/profiles/stig-rhel7-disa.profile
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'DISA STIG for Red Hat Enterprise Linux 7'
 
-description: "This profile contains configuration checks that align to the \nDISA STIG for Red Hat Enterprise Linux V1R1.\n\
+description: "This profile contains configuration checks that align to the \nDISA STIG for Red Hat Enterprise Linux V1R4.\n\
     \nIn addition to being applicable to RHEL7, DISA recognizes this \nconfiguration baseline as applicable to the operating\
     \ system\ntier of Red Hat technologies that are based off RHEL7, such as RHEL\nServer,  RHV-H, RHEL for HPC, RHEL Workstation,\
     \ and Red Hat \nStorage deployments."


### PR DESCRIPTION
#### Description:

Update DISA STIG version/release references in the manual page and stig-rhel7-disa.profile.

#### Rationale:

I believe these changes were missed in OpenSCAP/scap-security-guide#2728.