### PR TITLE
Create test scenarios for rules in group_configure_auditd_data_retention

### DIFF
--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_hostname.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_hostname.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = profile_not_found
+
+yum install -y audit audispd-plugins
+
+REMOTE_SERVER_REGEX="^remote_server[[:space:]]*=.*$"
+if grep -q "$REMOTE_SERVER_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$REMOTE_SERVER_REGEX/remote_server = some.resolvable-hostname.com/" /etc/audisp/audisp-remote.conf
+else
+        echo "remote_server = some.resolvable-hostname.com" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_not_there.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = profile_not_found
+
+yum install -y audit audispd-plugins
+
+sed -i "/^remote_server[[:space:]]*=/d" /etc/audisp/audisp-remote.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_numeric_address.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_numeric_address.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = profile_not_found
+
+yum install -y audit audispd-plugins
+
+REMOTE_SERVER_REGEX="^remote_server[[:space:]]*=.*$"
+if grep -q "$REMOTE_SERVER_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$REMOTE_SERVER_REGEX/remote_server = 10.10.10.10/" /etc/audisp/audisp-remote.conf
+else
+        echo "remote_server = 10.10.10.10" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_exec.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_exec.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+DISK_FULL_ACTION_REGEX="^disk_full_action[[:space:]]*=.*$"
+if grep -q "$DISK_FULL_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$DISK_FULL_ACTION_REGEX/disk_full_action = exec \/path-to-script/" /etc/audisp/audisp-remote.conf
+else
+        echo "disk_full_action = exec /path-to-script" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_halt.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_halt.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+DISK_FULL_ACTION_REGEX="^disk_full_action[[:space:]]*=.*$"
+if grep -q "$DISK_FULL_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$DISK_FULL_ACTION_REGEX/disk_full_action = halt/" /etc/audisp/audisp-remote.conf
+else
+        echo "disk_full_action = halt" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_ignore.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_ignore.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+DISK_FULL_ACTION_REGEX="^disk_full_action[[:space:]]*=.*$"
+if grep -q "$DISK_FULL_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$DISK_FULL_ACTION_REGEX/disk_full_action = ignore/" /etc/audisp/audisp-remote.conf
+else
+        echo "disk_full_action = ignore" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+sed -i "/^disk_full_action[[:space:]]*=.*$/d" /etc/audisp/audisp-remote.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_single.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_single.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+DISK_FULL_ACTION_REGEX="^disk_full_action[[:space:]]*=.*$"
+if grep -q "$DISK_FULL_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$DISK_FULL_ACTION_REGEX/disk_full_action = single/" /etc/audisp/audisp-remote.conf
+else
+        echo "disk_full_action = single" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_stop.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_stop.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+DISK_FULL_ACTION_REGEX="^disk_full_action[[:space:]]*=.*$"
+if grep -q "$DISK_FULL_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$DISK_FULL_ACTION_REGEX/disk_full_action = stop/" /etc/audisp/audisp-remote.conf
+else
+        echo "disk_full_action = stop" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_suspend.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_suspend.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+DISK_FULL_ACTION_REGEX="^disk_full_action[[:space:]]*=.*$"
+if grep -q "$DISK_FULL_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$DISK_FULL_ACTION_REGEX/disk_full_action = suspend/" /etc/audisp/audisp-remote.conf
+else
+        echo "disk_full_action = suspend" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_syslog.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_syslog.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+DISK_FULL_ACTION_REGEX="^disk_full_action[[:space:]]*=.*$"
+if grep -q "$DISK_FULL_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$DISK_FULL_ACTION_REGEX/disk_full_action = syslog/" /etc/audisp/audisp-remote.conf
+else
+        echo "disk_full_action = syslog" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_warm_once.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_warm_once.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+DISK_FULL_ACTION_REGEX="^disk_full_action[[:space:]]*=.*$"
+if grep -q "$DISK_FULL_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$DISK_FULL_ACTION_REGEX/disk_full_action = warm_once/" /etc/audisp/audisp-remote.conf
+else
+        echo "disk_full_action = warm_once" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_warm_once_continue.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_disk_full_action/disk_full_action_warm_once_continue.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+DISK_FULL_ACTION_REGEX="^disk_full_action[[:space:]]*=.*$"
+if grep -q "$DISK_FULL_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$DISK_FULL_ACTION_REGEX/disk_full_action = warm_once_continue/" /etc/audisp/audisp-remote.conf
+else
+        echo "disk_full_action = warm_once_continue" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+ENABLE_KRB5_REGEX="^enable_krb5[[:space:]]*=.*$"
+if grep -q "$ENABLE_KRB5_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$ENABLE_KRB5_REGEX/enable_krb5 = yes/" /etc/audisp/audisp-remote.conf
+else
+        echo "enable_krb5 = yes" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_activated.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_activated.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+ENABLE_KRB5_REGEX="^enable_krb5[[:space:]]*=.*$"
+if grep -q "$ENABLE_KRB5_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$ENABLE_KRB5_REGEX/enable_krb5 = no/" /etc/audisp/audisp-remote.conf
+else
+        echo "enable_krb5 = no" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+sed -i "/^enable_krb5[[:space:]]*=.*$/d" /etc/audisp/audisp-remote.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_exec.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_exec.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+NETWORK_FAILURE_ACTION_REGEX="^network_failure_action[[:space:]]*=.*$"
+if grep -q "$NETWORK_FAILURE_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$NETWORK_FAILURE_ACTION_REGEX/network_failure_action = exec \/path-to-script/" /etc/audisp/audisp-remote.conf
+else
+        echo "network_failure_action = exec /path-to-script" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_halt.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_halt.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+NETWORK_FAILURE_ACTION_REGEX="^network_failure_action[[:space:]]*=.*$"
+if grep -q "$NETWORK_FAILURE_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$NETWORK_FAILURE_ACTION_REGEX/network_failure_action = halt/" /etc/audisp/audisp-remote.conf
+else
+        echo "network_failure_action = halt" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_ignore.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_ignore.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+NETWORK_FAILURE_ACTION_REGEX="^network_failure_action[[:space:]]*=.*$"
+if grep -q "$NETWORK_FAILURE_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$NETWORK_FAILURE_ACTION_REGEX/network_failure_action = ignore/" /etc/audisp/audisp-remote.conf
+else
+        echo "network_failure_action = ignore" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+sed -i "/^network_failure_action[[:space:]]*=.*$/d" /etc/audisp/audisp-remote.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_single.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_single.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+NETWORK_FAILURE_ACTION_REGEX="^network_failure_action[[:space:]]*=.*$"
+if grep -q "$NETWORK_FAILURE_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$NETWORK_FAILURE_ACTION_REGEX/network_failure_action = single/" /etc/audisp/audisp-remote.conf
+else
+        echo "network_failure_action = single" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_stop.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_stop.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+NETWORK_FAILURE_ACTION_REGEX="^network_failure_action[[:space:]]*=.*$"
+if grep -q "$NETWORK_FAILURE_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$NETWORK_FAILURE_ACTION_REGEX/network_failure_action = stop/" /etc/audisp/audisp-remote.conf
+else
+        echo "network_failure_action = stop" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_suspend.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_suspend.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+NETWORK_FAILURE_ACTION_REGEX="^network_failure_action[[:space:]]*=.*$"
+if grep -q "$NETWORK_FAILURE_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$NETWORK_FAILURE_ACTION_REGEX/network_failure_action = suspend/" /etc/audisp/audisp-remote.conf
+else
+        echo "network_failure_action = suspend" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_syslog.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_syslog.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+NETWORK_FAILURE_ACTION_REGEX="^network_failure_action[[:space:]]*=.*$"
+if grep -q "$NETWORK_FAILURE_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$NETWORK_FAILURE_ACTION_REGEX/network_failure_action = syslog/" /etc/audisp/audisp-remote.conf
+else
+        echo "network_failure_action = syslog" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_warm_once.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_warm_once.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+NETWORK_FAILURE_ACTION_REGEX="^network_failure_action[[:space:]]*=.*$"
+if grep -q "$NETWORK_FAILURE_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$NETWORK_FAILURE_ACTION_REGEX/network_failure_action = warm_once/" /etc/audisp/audisp-remote.conf
+else
+        echo "network_failure_action = warm_once" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_warm_once_continue.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_network_failure_action/network_failure_action_warm_once_continue.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+NETWORK_FAILURE_ACTION_REGEX="^network_failure_action[[:space:]]*=.*$"
+if grep -q "$NETWORK_FAILURE_ACTION_REGEX" /etc/audisp/audisp-remote.conf; then
+        sed -i "s/$NETWORK_FAILURE_ACTION_REGEX/network_failure_action = warm_once_continue/" /etc/audisp/audisp-remote.conf
+else
+        echo "network_failure_action = warm_once_continue" >> /etc/audisp/audisp-remote.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_activated.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_activated.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit audispd-plugins
+
+ACTIVE_REGEX="^active[[:space:]]*=.*$"
+if grep -q "$ACTIVE_REGEX" /etc/audisp/plugins.d/syslog.conf; then
+        sed -i "s/$ACTIVE_REGEX/active = yes/" /etc/audisp/plugins.d/syslog.conf
+else
+        echo "active = yes" >> /etc/audisp/plugins.d/syslog.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_activated_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_activated_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+# remediation = bash
+
+yum install -y audit audispd-plugins
+
+sed -i "/^active[[:space:]]*=/d" /etc/audisp/plugins.d/syslog.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_not_activated.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_not_activated.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit audispd-plugins
+
+ACTIVE_REGEX="^active[[:space:]]*=.*$"
+if grep -q "$ACTIVE_REGEX" /etc/audisp/plugins.d/syslog.conf; then
+        sed -i "s/$ACTIVE_REGEX/active = no/" /etc/audisp/plugins.d/syslog.conf
+else
+        echo "active = no" >> /etc/audisp/plugins.d/syslog.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_action_mail_acct/action_mail_acct_alias.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_action_mail_acct/action_mail_acct_alias.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = bash
+
+yum install -y audit
+
+ACTION_MAIL_ACCT_REGEX="^action_mail_acct[[:space:]]*=.*$"
+if grep -q "$ACTION_MAIL_ACCT_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/^action_mail_acct[[:space:]]*=.*$/action_mail_acct = some_alias/" /etc/audit/auditd.conf
+else
+        echo "action_mail_acct = some_alias" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_action_mail_acct/action_mail_acct_email.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_action_mail_acct/action_mail_acct_email.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = bash
+
+yum install -y audit
+
+ACTION_MAIL_ACCT_REGEX="^action_mail_acct[[:space:]]*=.*$"
+if grep -q "$ACTION_MAIL_ACCT_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/^action_mail_acct[[:space:]]*=.*$/action_mail_acct = some@email.com/" /etc/audit/auditd.conf
+else
+        echo "action_mail_acct = some@email.com" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_action_mail_acct/action_mail_acct_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_action_mail_acct/action_mail_acct_not_there.fail.sh
@@ -2,4 +2,6 @@
 # profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
 # remediation = bash
 
-sed -i "/^space_left_action = /d" /etc/audit/auditd.conf
+yum install -y audit
+
+sed -i "/^action_mail_acct[[:space:]]*=/d" /etc/audit/auditd.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_action_mail_acct/action_mail_acct_root.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_action_mail_acct/action_mail_acct_root.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = bash
+
+yum install -y audit
+
+ACTION_MAIL_ACCT_REGEX="^action_mail_acct[[:space:]]*=.*$"
+if grep -q "$ACTION_MAIL_ACCT_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/^action_mail_acct[[:space:]]*=.*$/action_mail_acct = root/" /etc/audit/auditd.conf
+else
+        echo "action_mail_acct = root" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_email.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_email.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+yum install -y audit
+
+ADMIN_SPACE_LEFT_ACTION_REGEX="^admin_space_left_action[[:space:]]*=.*$"
+if grep -q "$ADMIN_SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+    sed -i "s/$ADMIN_SPACE_LEFT_ACTION_REGEX/admin_space_left_action = email/" /etc/audit/auditd.conf
+else
+    echo "admin_space_left_action = email" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_exec.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_exec.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+yum install -y audit
+
+ADMIN_SPACE_LEFT_ACTION_REGEX="^admin_space_left_action[[:space:]]*=.*$"
+if grep -q "$ADMIN_SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+    sed -i "s/$ADMIN_SPACE_LEFT_ACTION_REGEX/admin_space_left_action = exec \/path-to-script/" /etc/audit/auditd.conf
+else
+    echo "admin_space_left_action = /path-to-script" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_halt.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_halt.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+yum install -y audit
+
+ADMIN_SPACE_LEFT_ACTION_REGEX="^admin_space_left_action[[:space:]]*=.*$"
+if grep -q "$ADMIN_SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+    sed -i "s/$ADMIN_SPACE_LEFT_ACTION_REGEX/admin_space_left_action = halt/" /etc/audit/auditd.conf
+else
+    echo "admin_space_left_action = halt" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_ignore.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_ignore.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+yum install -y audit
+
+ADMIN_SPACE_LEFT_ACTION_REGEX="^admin_space_left_action[[:space:]]*=.*$"
+if grep -q "$ADMIN_SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+    sed -i "s/$ADMIN_SPACE_LEFT_ACTION_REGEX/admin_space_left_action = ignore/" /etc/audit/auditd.conf
+else
+    echo "admin_space_left_action = ignore" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+yum install -y audit
+
+sed -i "/^admin_space_left_action[[:space:]]*=/d" /etc/audit/auditd.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_rotate.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_rotate.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+yum install -y audit
+
+ADMIN_SPACE_LEFT_ACTION_REGEX="^admin_space_left_action[[:space:]]*=.*$"
+if grep -q "$ADMIN_SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+    sed -i "s/$ADMIN_SPACE_LEFT_ACTION_REGEX/admin_space_left_action = rotate/" /etc/audit/auditd.conf
+else
+    echo "admin_space_left_action = rotate" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_single.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_single.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+yum install -y audit
+
+ADMIN_SPACE_LEFT_ACTION_REGEX="^admin_space_left_action[[:space:]]*=.*$"
+if grep -q "$ADMIN_SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+    sed -i "s/$ADMIN_SPACE_LEFT_ACTION_REGEX/admin_space_left_action = single/" /etc/audit/auditd.conf
+else
+    echo "admin_space_left_action = single" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_suspend.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_suspend.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+yum install -y audit
+
+ADMIN_SPACE_LEFT_ACTION_REGEX="^admin_space_left_action[[:space:]]*=.*$"
+if grep -q "$ADMIN_SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+    sed -i "s/$ADMIN_SPACE_LEFT_ACTION_REGEX/admin_space_left_action = suspend/" /etc/audit/auditd.conf
+else
+    echo "admin_space_left_action = suspend" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_syslog.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_admin_space_left_action/admin_space_left_action_syslog.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+yum install -y audit
+
+ADMIN_SPACE_LEFT_ACTION_REGEX="^admin_space_left_action[[:space:]]*=.*$"
+if grep -q "$ADMIN_SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+    sed -i "s/$ADMIN_SPACE_LEFT_ACTION_REGEX/admin_space_left_action = syslog/" /etc/audit/auditd.conf
+else
+    echo "admin_space_left_action = syslog" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_data.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_data.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = profile_not_found
+
+yum install -y audit
+
+FLUSH_REGEX="^flush[[:space:]]*=.*$"
+if grep -q "$FLUSH_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$FLUSH_REGEX/flush = data/" /etc/audit/auditd.conf
+else
+        echo "flush = data" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = profile_not_found
+
+yum install -y audit
+
+FLUSH_REGEX="^flush[[:space:]]*=.*$"
+if grep -q "$FLUSH_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$FLUSH_REGEX/flush = incremental/" /etc/audit/auditd.conf
+else
+        echo "flush = incremental" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental_async.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental_async.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = profile_not_found
+
+yum install -y audit
+
+FLUSH_REGEX="^flush[[:space:]]*=.*$"
+if grep -q "$FLUSH_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$FLUSH_REGEX/flush = incremental_async/" /etc/audit/auditd.conf
+else
+        echo "flush = incremental_async" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_none.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_none.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = profile_not_found
+
+yum install -y audit
+
+FLUSH_REGEX="^flush[[:space:]]*=.*$"
+if grep -q "$FLUSH_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$FLUSH_REGEX/flush = none/" /etc/audit/auditd.conf
+else
+        echo "flush = none" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = profile_not_found
+# remediation = bash
+
+yum install -y audit
+
+sed -i "/^flush[[:space:]]*=/d" /etc/audit/auditd.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_sync.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_flush/flush_sync.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = profile_not_found
+
+yum install -y audit
+
+FLUSH_REGEX="^flush[[:space:]]*=.*$"
+if grep -q "$FLUSH_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$FLUSH_REGEX/flush = sync/" /etc/audit/auditd.conf
+else
+        echo "flush = sync" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file/max_log_file_greater_than_minimum_value.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file/max_log_file_greater_than_minimum_value.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+MAX_LOG_FILE="^max_log_file[[:space:]]*=.*$"
+if grep -q "$MAX_LOG_FILE" /etc/audit/auditd.conf; then
+        sed -i "s/$MAX_LOG_FILE/max_log_file = 10/" /etc/audit/auditd.conf
+else
+        echo "max_log_file = 10" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file/max_log_file_minimum_value.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file/max_log_file_minimum_value.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+MAX_LOG_FILE="^max_log_file[[:space:]]*=.*$"
+if grep -q "$MAX_LOG_FILE" /etc/audit/auditd.conf; then
+        sed -i "s/$MAX_LOG_FILE/max_log_file = 6/" /etc/audit/auditd.conf
+else
+        echo "max_log_file = 6" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file/max_log_file_not_enough.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file/max_log_file_not_enough.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+MAX_LOG_FILE="^max_log_file[[:space:]]*=.*$"
+if grep -q "$MAX_LOG_FILE" /etc/audit/auditd.conf; then
+        sed -i "s/$MAX_LOG_FILE/max_log_file = 5/" /etc/audit/auditd.conf
+else
+        echo "max_log_file = 5" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file/max_log_file_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file/max_log_file_not_there.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+sed -i "/^max_log_file[[:space:]]*=/d" /etc/audit/auditd.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_ignore.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_ignore.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+MAX_LOG_FILE_ACTION="^max_log_file_action[[:space:]]*=.*$"
+if grep -q "$MAX_LOG_FILE_ACTION" /etc/audit/auditd.conf; then
+        sed -i "s/$MAX_LOG_FILE_ACTION/max_log_file_action = ignore/" /etc/audit/auditd.conf
+else
+        echo "max_log_file_action = ignore" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_keep_logs.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_keep_logs.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+MAX_LOG_FILE_ACTION="^max_log_file_action[[:space:]]*=.*$"
+if grep -q "$MAX_LOG_FILE_ACTION" /etc/audit/auditd.conf; then
+        sed -i "s/$MAX_LOG_FILE_ACTION/max_log_file_action = keep_logs/" /etc/audit/auditd.conf
+else
+        echo "max_log_file_action = keep_logs" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_not_there.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+sed -i "/^max_log_file_action[[:space:]]*=/d" /etc/audit/auditd.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_rotate.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_rotate.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+MAX_LOG_FILE_ACTION="^max_log_file_action[[:space:]]*=.*$"
+if grep -q "$MAX_LOG_FILE_ACTION" /etc/audit/auditd.conf; then
+        sed -i "s/$MAX_LOG_FILE_ACTION/max_log_file_action = rotate/" /etc/audit/auditd.conf
+else
+        echo "max_log_file_action = rotate" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_suspend.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_suspend.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+MAX_LOG_FILE_ACTION="^max_log_file_action[[:space:]]*=.*$"
+if grep -q "$MAX_LOG_FILE_ACTION" /etc/audit/auditd.conf; then
+        sed -i "s/$MAX_LOG_FILE_ACTION/max_log_file_action = suspend/" /etc/audit/auditd.conf
+else
+        echo "max_log_file_action = suspend" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_syslog.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_max_log_file_action/max_log_file_action_syslog.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+MAX_LOG_FILE_ACTION="^max_log_file_action[[:space:]]*=.*$"
+if grep -q "$MAX_LOG_FILE_ACTION" /etc/audit/auditd.conf; then
+        sed -i "s/$MAX_LOG_FILE_ACTION/max_log_file_action = syslog/" /etc/audit/auditd.conf
+else
+        echo "max_log_file_action = syslog" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_greater_than_minimum.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_greater_than_minimum.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+NUM_LOGS_REGEX="^num_logs[[:space:]]*=.*$"
+if grep -q "$NUM_LOGS_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$NUM_LOGS_REGEX/num_logs = 10/" /etc/audit/auditd.conf
+else
+        echo "num_logs = 10" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_minimum_value.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_minimum_value.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+NUM_LOGS_REGEX="^num_logs[[:space:]]*=.*$"
+if grep -q "$NUM_LOGS_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/^num_logs[[:space:]]=.*$/num_logs = 5/" /etc/audit/auditd.conf
+else
+        echo "num_logs = 5" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_not_enough.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_not_enough.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+NUM_LOGS_REGEX="^num_logs[[:space:]]*=.*$"
+if grep -q "$NUM_LOGS_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$NUM_LOGS_REGEX/num_logs = 1/" /etc/audit/auditd.conf
+else
+        echo "num_logs = 1" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_not_there.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audit
+
+sed -i "/^num_logs[[:space:]]*=/d" /etc/audit/auditd.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_greater_than_minimum.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_greater_than_minimum.pass.sh
@@ -2,9 +2,11 @@
 # profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
 # remediation = bash
 
+yum install -y audit
+
 SPACE_LEFT_REGEX="^space_left[[:space:]]*=.*$"
 if grep -q "$SPACE_LEFT_REGEX" /etc/audit/auditd.conf; then
-	sed -i "s/$SPACE_LEFT_REGEX/space_left = 100/" /etc/audit/auditd.conf
+        sed -i "s/$SPACE_LEFT_REGEX/space_left = 250/" /etc/audit/auditd.conf
 else
-	echo "space_left = 100" >> /etc/audit/auditd.conf
+        echo "space_left = 250" >> /etc/audit/auditd.conf
 fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_minimum_value.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_minimum_value.pass.sh
@@ -6,7 +6,7 @@ yum install -y audit
 
 SPACE_LEFT_REGEX="^space_left[[:space:]]*=.*$"
 if grep -q "$SPACE_LEFT_REGEX" /etc/audit/auditd.conf; then
-        sed -i "s/$SPACE_LEFT_REGEX/space_left = 15/" /etc/audit/auditd.conf
+        sed -i "s/$SPACE_LEFT_REGEX/space_left = 100/" /etc/audit/auditd.conf
 else
-        echo "space_left = 15" >> /etc/audit/auditd.conf
+        echo "space_left = 100" >> /etc/audit/auditd.conf
 fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_not_there.fail.sh
@@ -2,4 +2,6 @@
 # profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
 # remediation = bash
 
-sed -i "/^space_left = /d" /etc/audit/auditd.conf
+yum install -y audit
+
+sed -i "/^space_left[[:space:]]*=.*$/d" /etc/audit/auditd.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_email.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_email.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = bash
+
+yum install -y audit
+
+SPACE_LEFT_ACTION_REGEX="^space_left_action[[:space:]]*=.*$"
+if grep -q "$SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$SPACE_LEFT_ACTION_REGEX/space_left_action = email/" /etc/audit/auditd.conf
+else
+        echo "space_left_action = email" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_exec.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_exec.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = bash
+
+yum install -y audit
+
+SPACE_LEFT_ACTION_REGEX="^space_left_action[[:space:]]*=.*$"
+if grep -q "$SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$SPACE_LEFT_ACTION_REGEX/space_left_action = exec \/path-to-script/" /etc/audit/auditd.conf
+else
+        echo "space_left_action = exec /path-to-script" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_halt.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_halt.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = bash
+
+yum install -y audit
+
+SPACE_LEFT_ACTION_REGEX="^space_left_action[[:space:]]*=.*$"
+if grep -q "$SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$SPACE_LEFT_ACTION_REGEX/space_left_action = halt/" /etc/audit/auditd.conf
+else
+        echo "space_left_action = halt" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_ignore.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_ignore.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = bash
+
+yum install -y audit
+
+SPACE_LEFT_ACTION_REGEX="^space_left_action[[:space:]]*=.*$"
+if grep -q "$SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$SPACE_LEFT_ACTION_REGEX/space_left_action = ignore/" /etc/audit/auditd.conf
+else
+        echo "space_left_action = ignore" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_not_there.fail.sh
@@ -2,4 +2,6 @@
 # profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
 # remediation = bash
 
-sed -i "s/^space_left_action = .*$/space_left_action = email/" /etc/audit/auditd.conf
+yum install -y audit
+
+sed -i "/^space_left_action[[:space:]]*=/d" /etc/audit/auditd.conf

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_single.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_single.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = bash
+
+yum install -y audit
+
+SPACE_LEFT_ACTION_REGEX="^space_left_action[[:space:]]*=.*$"
+if grep -q "$SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$SPACE_LEFT_ACTION_REGEX/space_left_action = single/" /etc/audit/auditd.conf
+else
+        echo "space_left_action = single" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_suspend.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_suspend.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = bash
+
+yum install -y audit
+
+SPACE_LEFT_ACTION_REGEX="^space_left_action[[:space:]]*=.*$"
+if grep -q "$SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$SPACE_LEFT_ACTION_REGEX/space_left_action = suspend/" /etc/audit/auditd.conf
+else
+        echo "space_left_action = suspend" >> /etc/audit/auditd.conf
+fi

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_syslog.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_syslog.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# remediation = bash
+
+yum install -y audit
+
+SPACE_LEFT_ACTION_REGEX="^space_left_action[[:space:]]*=.*$"
+if grep -q "$SPACE_LEFT_ACTION_REGEX" /etc/audit/auditd.conf; then
+        sed -i "s/$SPACE_LEFT_ACTION_REGEX/space_left_action = syslog/" /etc/audit/auditd.conf
+else
+        echo "space_left_action = syslog" >> /etc/audit/auditd.conf
+fi


### PR DESCRIPTION
#### Description:

Add new tests for auditd settings rules:
- Configure auditd Number of Logs Retained
- Configure auditd Max Log File Size
- Configure auditd max_log_file_action Upon Reaching Maximum Log Size
- Configure auditd admin_space_left Action on Low Disk Space
- Configure auditd mail_acct Action on Low Disk Space
- Configure auditd flush priority
- Configure auditd to use audispd's syslog plugin
- Configure audispd's Plugin network_failure_action On Network Failure
- Configure audispd's Plugin disk_full_action When Disk Is Full
- Encrypt Audit Records Sent With audispd Plugin
- Configure audispd Plugin To Send Logs To Remote Server

Changes tests for (fix some regular expressions or changes tests scenarios):
- Configure auditd space_left Action on Low Disk Space
- Configure auditd admin_space_left Action on Low Disk Space

These tests check values (number of logs, size of logs, action when low disk space etc.) in `/etc/audit/auditd.conf` or `/etc/audisp/audisp-remote.conf`