### PR TITLE
Document minimum Ansible version in User/Developer Guides

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -689,6 +689,8 @@ Remediations also carry metadata that should be present at the beginning of the 
 
 ==== Ansible
 
+IMPORTANT: The minimum version of Ansible must be at least version 2.3
+
 Ansible remediations are stored as yml files in directory _/template/static/ansible_ under the targeted platform. They are meant to be executed by Ansible itself when requested by openscap, so they are
 written using link:ttp://docs.ansible.com/ansible/latest/intro.html[Ansible's own language] with the following exceptions:
 

--- a/docs/manual/user_guide.adoc
+++ b/docs/manual/user_guide.adoc
@@ -251,6 +251,8 @@ XML Results
 |===
 
 === Remediation
+
+==== Bash Scripts
 SCAP Security Guide embeds bash remediation scripts into the SCAP content. This allows for SCAP compatible tools to extract these remediation scripts to aide in potential remediation of system misconfigurations.
 OpenSCAP, the CLI delivered with Fedora and Red Hat Enterprise Linux systems, contains the ability to transform XML results into an executable script. The syntax to generate a remediation script is:
 
@@ -312,6 +314,13 @@ fi
 ----
 
 This output could be redirected to a bash script, or built into your RHEL6 provisioning process (e.g. the %post section of a kickstart).
+
+#### Ansible Playbooks
+
+SCAP Security Guide embeds ansible remediation scripts into the SCAP content. This allows for SCAP compatible tools to extract these remediation scripts to aide in potential remediation of system misconfigurations. When using OpenSCAP with
+Ansible, it is advisable to use the playbooks from https://github.com/Ansible-Security-Compliance. These playbooks are generated from the SCAP Security Guide project and are also available on Ansible Galaxy.
+
+IMPORTANT: The minimum version of Ansible must be at least version 2.3
 
 ## Deprecated Content
 


### PR DESCRIPTION
#### Description:

- Document minimum Ansible version in User/Developer Guides

#### Rationale:

- Need to document minimum ansible version for users and developers as some users have used
  versions of Ansible that do not work with the playbooks that are generated.

- Fixes #2467
