### PR TITLE
Require the python yaml module, fatal error if it's not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 # This is set to silence GNUInstallDirs warning about no language being used with cmake
 set(CMAKE_INSTALL_LIBDIR "/nowhere")
 include(GNUInstallDirs)
+include(FindPythonModule)
+
 set(SSG_CONTENT_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/xml/scap/ssg/content")
 set(SSG_GUIDE_INSTALL_DIR "${CMAKE_INSTALL_DOCDIR}/guides")
 set(SSG_TABLE_INSTALL_DIR "${CMAKE_INSTALL_DOCDIR}/tables")
@@ -69,6 +71,7 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 endif()
 
 find_package(PythonInterp 2 REQUIRED)
+find_python_module(yaml REQUIRED)
 
 find_package(OpenSCAP REQUIRED)
 
@@ -121,6 +124,7 @@ message(STATUS " ")
 
 message(STATUS "Tools:")
 message(STATUS "python: ${PYTHON_EXECUTABLE} (version: ${PYTHON_VERSION_STRING})")
+message(STATUS "python yaml module: ${PY_YAML}")
 message(STATUS "oscap: ${OPENSCAP_OSCAP_EXECUTABLE} (version: ${OSCAP_VERSION})")
 message(STATUS "xsltproc: ${XSLTPROC_EXECUTABLE}")
 message(STATUS "xmllint: ${XMLLINT_EXECUTABLE}")

--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -5,7 +5,7 @@ function(find_python_module module)
 	string(TOUPPER ${module} module_upper)
 	if(NOT PY_${module_upper})
 		if(ARGC GREATER 1 AND ARGV1 STREQUAL "REQUIRED")
-			set(${module}_FIND_REQUIRED TRUE)
+			set(PY_${module}_FIND_REQUIRED TRUE)
 		endif()
 		# A module's location is usually a directory, but for binary modules
 		# it's a .so file.

--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -1,0 +1,24 @@
+# Find if a Python module is installed
+# Found at http://www.cmake.org/pipermail/cmake/2011-January/041666.html
+# To use do: find_python_module(PyQt4 REQUIRED)
+function(find_python_module module)
+	string(TOUPPER ${module} module_upper)
+	if(NOT PY_${module_upper})
+		if(ARGC GREATER 1 AND ARGV1 STREQUAL "REQUIRED")
+			set(${module}_FIND_REQUIRED TRUE)
+		endif()
+		# A module's location is usually a directory, but for binary modules
+		# it's a .so file.
+		execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+			"import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+			RESULT_VARIABLE _${module}_status
+			OUTPUT_VARIABLE _${module}_location
+			ERROR_QUIET
+			OUTPUT_STRIP_TRAILING_WHITESPACE)
+		if(NOT _${module}_status)
+			set(PY_${module_upper} ${_${module}_location} CACHE STRING
+				"Location of Python module ${module}")
+		endif(NOT _${module}_status)
+	endif(NOT PY_${module_upper})
+	find_package_handle_standard_args(PY_${module} DEFAULT_MSG PY_${module_upper})
+endfunction(find_python_module)


### PR DESCRIPTION
`yaml` is a critical requirement since our move to yaml. It is not included in python's standard distribution. It only makes sense to look for it at configure time and tell the user at that time before the build even starts. I plan to use the same mechanism for `jinja2` module.