### PR TITLE
rhel7: fix titles/descriptions, indicate draft status (rebase of #2717)

### DIFF
--- a/rhel7/profiles/C2S-docker.profile
+++ b/rhel7/profiles/C2S-docker.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: 'C2S for Docker'
+title: '[DRAFT] C2S for Docker'
 
 description: |-
     This profile demonstrates compliance against the

--- a/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: 'ANSSI DAT-NT28 (enhanced)'
+title: '[DRAFT] ANSSI DAT-NT28 (enhanced)'
 
 description: 'Draft profile for ANSSI compliance at the enhanced level. ANSSI stands for Agence nationale de la sécurité des
     systèmes d''information. Based on https://www.ssi.gouv.fr/.'

--- a/rhel7/profiles/anssi_nt28_high.profile
+++ b/rhel7/profiles/anssi_nt28_high.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: 'ANSSI DAT-NT28 (high)'
+title: '[DRAFT] ANSSI DAT-NT28 (high)'
 
 description: 'Draft profile for ANSSI compliance at the high level. ANSSI stands for Agence nationale de la sécurité des systèmes
     d''information. Based on https://www.ssi.gouv.fr/.'

--- a/rhel7/profiles/anssi_nt28_intermediary.profile
+++ b/rhel7/profiles/anssi_nt28_intermediary.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: 'ANSSI DAT-NT28 (intermediary)'
+title: '[DRAFT] ANSSI DAT-NT28 (intermediary)'
 
 description: 'Draft profile for ANSSI compliance at the intermediary level. ANSSI stands for Agence nationale de la sécurité
     des systèmes d''information. Based on https://www.ssi.gouv.fr/.'

--- a/rhel7/profiles/anssi_nt28_minimal.profile
+++ b/rhel7/profiles/anssi_nt28_minimal.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: 'ANSSI DAT-NT28 (minimal)'
+title: '[DRAFT] ANSSI DAT-NT28 (minimal)'
 
 description: 'Draft profile for ANSSI compliance at the minimal level. ANSSI stands for Agence nationale de la sécurité des
     systèmes d''information. Based on https://www.ssi.gouv.fr/.'

--- a/rhel7/profiles/docker-host.profile
+++ b/rhel7/profiles/docker-host.profile
@@ -1,9 +1,12 @@
 documentation_complete: false
 
-title: 'Standard Docker Host Security Profile'
+title: '[DRAFT] Standard Docker Host Security Profile'
 
-description: "This profile contains rules to ensure standard security baseline\nof Red Hat Enterprise Linux 7 system running\
-    \ the docker daemon. This discussion\nis currently being held on open-scap-list@redhat.com and \nscap-security-guide@lists.fedorahosted.org."
+description: "This profile contains rules to ensure standard security \n
+    \ baseline of Red Hat Enterprise Linux 7 system running the docker \n
+    \ \n
+    \ This discussion is currently being held on open-scap-list@redhat.com \n
+    \ and scap-security-guide@lists.fedorahosted.org."
 
 selections:
     - service_docker_enabled

--- a/rhel7/profiles/ospp42-draft.profile
+++ b/rhel7/profiles/ospp42-draft.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: 'Protection Profile for General Purpose Operating Systems'
+title: '[DRAFT] Protection Profile for General Purpose Operating Systems'
 
 description: "This profile reflects mandatory configuration controls identified\nin the NIAP Configuration Annex to the Protection\
     \ Profile for General Purpose Operating\nSystems (Protection Profile Version 4.2 draft). \n\nThis Annex is consistent\

--- a/rhel7/profiles/pci-dss.profile
+++ b/rhel7/profiles/pci-dss.profile
@@ -1,8 +1,9 @@
 documentation_complete: true
 
-title: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7'
+title: '[DRAFT] PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7'
 
-description: 'This is a *draft* profile for PCI-DSS v3.'
+description: 'Ensures PCI-DSS v3 related security configuration settings \n
+    \ are applied.'
 
 selections:
     - var_password_pam_unix_remember=4

--- a/rhel7/profiles/rht-ccp.profile
+++ b/rhel7/profiles/rht-ccp.profile
@@ -2,7 +2,10 @@ documentation_complete: true
 
 title: 'Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)'
 
-description: 'This is a *draft* SCAP profile for Red Hat Certified Cloud Providers.'
+description: 'This profile contains the minimum security relevant \n
+    \ configuration settings recommended by Red Hat, Inc for \n
+    \ Red Hat Enterprise Linux 7 instances deployed by Red Hat Certified \n
+    \ Cloud Providers.'
 
 selections:
     - var_selinux_state=enforcing

--- a/rhel7/profiles/stig-ansible-tower-upstream.profile
+++ b/rhel7/profiles/stig-ansible-tower-upstream.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: 'Upstream DISA STIG for Red Hat Ansible Tower'
+title: '[DRAFT] DISA STIG for Red Hat Ansible Tower'
 
 description: |-
     This is a *draft* profile for STIG. This profile is being

--- a/rhel7/profiles/stig-http-disa.profile
+++ b/rhel7/profiles/stig-http-disa.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: 'DISA STIG for Apache HTTP on Red Hat Enterprise Linux 7'
+title: '[DRAFT] DISA STIG for Apache HTTP on Red Hat Enterprise Linux 7'
 
 description: |-
     This profile contains configuration checks that align to the

--- a/rhel7/profiles/stig-ipa-server-upstream.profile
+++ b/rhel7/profiles/stig-ipa-server-upstream.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: 'Upstream DISA STIG for Red Hat IdM'
+title: '[DRAFT] DISA STIG for Red Hat IdM'
 
 description: |-
     This is a *draft* profile for STIG. This profile is being

--- a/rhel7/profiles/stig-rhel7-disa.profile
+++ b/rhel7/profiles/stig-rhel7-disa.profile
@@ -2,10 +2,17 @@ documentation_complete: true
 
 title: 'DISA STIG for Red Hat Enterprise Linux 7'
 
-description: "This profile contains configuration checks that align to the \nDISA STIG for Red Hat Enterprise Linux V1R4.\n\
-    \nIn addition to being applicable to RHEL7, DISA recognizes this \nconfiguration baseline as applicable to the operating\
-    \ system\ntier of Red Hat technologies that are based off RHEL7, such as RHEL\nServer,  RHV-H, RHEL for HPC, RHEL Workstation,\
-    \ and Red Hat \nStorage deployments."
+description: "This profile contains configuration checks that align to the \n
+    \ DISA STIG for Red Hat Enterprise Linux V1R4. \n
+    \ \n
+    \ In addition to being applicable to RHEL7, DISA recognizes this \n
+    \ configuration baseline as applicable to the operating system tier of \n
+    \ Red Hat technologies that are based off RHEL7, such as: \n
+    \ - Red Hat Enterprise Linux Server \n
+    \ - Red Hat Enterprise Linux Workstation and Desktop \n
+    \ - Red Hat Virtualization Hypervisor (RHV-H) \n
+    \ - Red Hat Enterprise Linux for HPC \n
+    \ - Red Hat Storage"
 
 selections:
     - login_banner_text=dod_banners

--- a/rhel7/profiles/stig-rhvh-upstream.profile
+++ b/rhel7/profiles/stig-rhvh-upstream.profile
@@ -1,16 +1,10 @@
 documentation_complete: false
 
-title: 'STIG for Red Hat Virtualization Hypervisor'
+title: '[DRAFT] STIG for Red Hat Virtualization Hypervisor'
 
-description: "This is a *draft* profile for STIG. This profile is being developed under the DoD consensus model to become\
-    \ a STIG in coordination with DISA FSO.<br /><br />\n\n<p>\n    <strong>Where is the RHV-H STIG?</strong>\n    <ul>\n\
-    \        <li>Question: May I deploy a product if no STIG exists?<br />\n            Answer: Yes, based on mission need\
-    \ and with DAA approval.\n        </li>\n        <li>Question: What do I use if there is no STIG?<br />\n            Answer:\
-    \ DISA FSO developed Security Requirement Guides (SRGs) to address technology areas. In the absence of a STIG, an SRG\
-    \ can be used to determine compliance with DoD policies. If there is no applicable SRG or STIG, industry or vendor recommended\
-    \ practices may be used. Examples include Center for Internet Security Benchmarks, Payment Card Industry requirements\
-    \ or the vendor's own security documentation.\n        </li>\n    </ul>\n    <small>Source: http://iase.disa.mil/stigs/Pages/faqs.aspx#STIG</small>\n\
-    </p>"
+description: "This is a *draft* profile for STIG. This profile is being \n
+    \ developed under the DISA Vendor STIG model in coordination with \n
+    \ DISA FSO."
 
 extends: stig-rhel7-disa
 

--- a/rhel7/profiles/stig-satellite-upstream.profile
+++ b/rhel7/profiles/stig-satellite-upstream.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: 'Upstream DISA STIG for Red Hat Satellite'
+title: '[DRAFT] DISA STIG for Red Hat Satellite'
 
 description: |-
     This is a *draft* profile for STIG. This profile is being


### PR DESCRIPTION
#### Description:

- This is a rebase of #2717 by @shawndwells 
- rhel7: update to STIG profile description
  - I updated the commit message because it didn't update the title, just the description.
- rhel7: update RHV-H profile title/desc
- rhel7: docker profile title/desc
- rhel7: update various titles to indicate draft status


#### Rationale:

- rebased so the changes didn't get lost in time
- Fixes #2568
- Fixes #2570 
- Fixes #2717


Here's a diff of an intermediate rebase showing resolved conflicts:
```
$ git diff fixup2717 pr2717
diff --git a/rhel7/guide.xslt b/rhel7/guide.xslt
index 5420f58..affe36e 100644
--- a/rhel7/guide.xslt
+++ b/rhel7/guide.xslt
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/">

 <!-- This transform assembles all fragments into one "shorthand" XCCDF document
-     Accepts the following parameters:
+          Accepts the following parameters:

      * SHARED_RP    (required)  Holds the resolved ABSOLUTE path
                     to the SSG's "shared/" directory.
      * BUILD_RP     (required)  Holds the resolved ABSOLUTE path
                     to the SSG's build directory - $CMAKE_BINARY_PATH
 -->

 <!-- Define the default value of the required "SHARED_RP" parameter -->
diff --git a/rhel7/profiles/stig-rhel7-disa.profile b/rhel7/profiles/stig-rhel7-disa.profile
index c8bf528..b0a519b 100644
--- a/rhel7/profiles/stig-rhel7-disa.profile
+++ b/rhel7/profiles/stig-rhel7-disa.profile
@@ -1,14 +1,14 @@
 documentation_complete: true

 title: 'DISA STIG for Red Hat Enterprise Linux 7'

 description: "This profile contains configuration checks that align to the \n
-    \ DISA STIG for Red Hat Enterprise Linux V1R4. \n
+    \ DISA STIG for Red Hat Enterprise Linux V1R3. \n
     \ \n
     \ In addition to being applicable to RHEL7, DISA recognizes this \n
     \ configuration baseline as applicable to the operating system tier of \n
     \ Red Hat technologies that are based off RHEL7, such as: \n
     \ - Red Hat Enterprise Linux Server \n
     \ - Red Hat Enterprise Linux Workstation and Desktop \n
     \ - Red Hat Virtualization Hypervisor (RHV-H) \n
     \ - Red Hat Enterprise Linux for HPC \n
$
```