### PR TITLE
Don't exit with 0 when product.yml loading fails

### DIFF
--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -550,10 +550,6 @@ def main():
         print(args.output)
         sys.exit(0)
 
-    # TODO: Remove this once all products are ported over
-    if not os.path.isfile(args.product_yaml):
-        sys.exit(0)
-
     product_yaml = open_yaml(args.product_yaml)
     base_dir = os.path.dirname(args.product_yaml)
     benchmark_root = required_yaml_key(product_yaml, "benchmark_root")


### PR DESCRIPTION
Previously this was done to slowly port everything over to yaml, now
that it is ported we want to fail hard in case product.yml loading
fails.

Oh well..