### PR TITLE
Make sure that dconf dirs exist

### DIFF
--- a/shared/bash_remediation_functions/dconf_lock.sh
+++ b/shared/bash_remediation_functions/dconf_lock.sh
@@ -19,10 +19,7 @@ function dconf_lock {
 	LOCKFILES=$(grep -r "^/${_key}/${_setting}$" "/etc/dconf/db/" | grep -v "distro\|ibus" | cut -d":" -f1)
 	LOCKSFOLDER="/etc/dconf/db/${_db}/locks"
 
-	if [ ! -d ${LOCKSFOLDER} ]
-	then
-		mkdir -p ${LOCKSFOLDER}
-	fi
+	mkdir -p "${LOCKSFOLDER}"
 
 	if [[ -z "${LOCKFILES}" ]]
 	then

--- a/shared/bash_remediation_functions/dconf_lock.sh
+++ b/shared/bash_remediation_functions/dconf_lock.sh
@@ -17,6 +17,12 @@ function dconf_lock {
 
 	# Check for setting in any of the DConf db directories
 	LOCKFILES=$(grep -r "^/${_key}/${_setting}$" "/etc/dconf/db/" | grep -v "distro\|ibus" | cut -d":" -f1)
+	LOCKSFOLDER="/etc/dconf/db/${_db}/locks"
+
+	if [ ! -d ${LOCKSFOLDER} ]
+	then
+		mkdir -p ${LOCKSFOLDER}
+	fi
 
 	if [[ -z "${LOCKFILES}" ]]
 	then

--- a/shared/bash_remediation_functions/dconf_settings.sh
+++ b/shared/bash_remediation_functions/dconf_settings.sh
@@ -20,10 +20,7 @@ function dconf_settings {
 	DCONFFILE="/etc/dconf/db/${_db}/${_settingFile}"
 	DBDIR="/etc/dconf/db/${_db}"
 
-	if [ ! -d ${DBDIR} ]
-	then
-		mkdir -p ${DBDIR}
-	fi
+	mkdir -p "${DBDIR}"
 
 	if [[ -z "${SETTINGSFILES[@]}" ]]
 	then

--- a/shared/bash_remediation_functions/dconf_settings.sh
+++ b/shared/bash_remediation_functions/dconf_settings.sh
@@ -18,6 +18,12 @@ function dconf_settings {
 	# Check for setting in any of the DConf db directories
 	SETTINGSFILES=($(grep -r "\[${_path}]" "/etc/dconf/db/" | grep -v "distro\|ibus" | cut -d":" -f1))
 	DCONFFILE="/etc/dconf/db/${_db}/${_settingFile}"
+	DBDIR="/etc/dconf/db/${_db}"
+
+	if [ ! -d ${DBDIR} ]
+	then
+		mkdir -p ${DBDIR}
+	fi
 
 	if [[ -z "${SETTINGSFILES[@]}" ]]
 	then


### PR DESCRIPTION
#### Description:

- Make sure that dconf dirs exist

#### Rationale:

- dconf directories may not exist and could cause a remediation failure.
