### PR TITLE
Remove disabling all usb devices in kernel for OSPP and HIPAA profile

### DIFF
--- a/rhel7/profiles/hipaa.profile
+++ b/rhel7/profiles/hipaa.profile
@@ -1,4 +1,4 @@
-documentation_complete: true
+documentation_complete: True
 
 title: 'Health Insurance Portability and Accountability Act (HIPAA)'
 
@@ -94,7 +94,6 @@ selections:
     - audit_rules_privileged_commands_sudo
     - audit_rules_privileged_commands_su
     - audit_rules_immutable
-    - bootloader_nousb_argument
     - kernel_module_usb-storage_disabled
     - service_autofs_disabled
     - auditd_audispd_syslog_plugin_activated

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -205,7 +205,6 @@ selections:
     - wireless_disable_interfaces
     - kernel_module_bluetooth_disabled
     - service_bluetooth_disabled
-    - bootloader_nousb_argument
     - kernel_module_usb-storage_disabled
     - service_autofs_disabled
     - disable_ctrlaltdel_reboot


### PR DESCRIPTION
#### Description:

- Remove disabling all usb devices in kernel for OSPP profile

#### Rationale:

- Breaks USB mice and keyboards
