### PR TITLE
Fix sudo audit rules

### DIFF
--- a/shared/templates/template_BASH_audit_rules_privileged_commands
+++ b/shared/templates/template_BASH_audit_rules_privileged_commands
@@ -3,7 +3,7 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-PATTERN="-a always,exit -F path=%PATH%.*"
+PATTERN="-a always,exit -F path=%PATH%\\s*.*"
 GROUP="privileged"
 FULL_RULE="-a always,exit -F path=%PATH% -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged"
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'


### PR DESCRIPTION
#### Description:

- Handle space after word in template_BASH_audit_rules_privileged_commands

#### Rationale:

- Fix was overwriting expanded words e.g. sudo with sudoedit in audit rules 
- Fixes #2507
