### PR TITLE
Fix missing elements and description in var_auditd_admin_space_left_action and var_auditd_space_left_action

### DIFF
--- a/shared/guide/system/auditing/configure_auditd_data_retention/var_auditd_admin_space_left_action.var
+++ b/shared/guide/system/auditing/configure_auditd_data_retention/var_auditd_admin_space_left_action.var
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Action for auditd to take when disk space just starts to run low'
 
-description: 'The setting for space_left_action in /etc/audit/auditd.conf'
+description: 'The setting for admin_space_left_action in /etc/audit/auditd.conf'
 
 type: string
 
@@ -18,3 +18,4 @@ options:
     single: single
     suspend: suspend
     syslog: syslog
+    rotate: rotate

--- a/shared/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left_action.var
+++ b/shared/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left_action.var
@@ -18,3 +18,4 @@ options:
     single: single
     suspend: suspend
     syslog: syslog
+    rotate: rotate


### PR DESCRIPTION
#### Description:

Add missing element `rotate` to `var_auditd_admin_space_left_action` and `var_auditd_space_left_action`.
Change description in `var_auditd_admin_space_left_action`, which contained `space_left_action` instead of `admin_space_left_action`.


- Fixes #2700
