### PR TITLE
Add regex handling for SRG and STIG reference versions in CMake

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -922,8 +922,8 @@ macro(ssg_build_html_cce_table PRODUCT)
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
 endmacro()
 
-macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE DISA_SRG_VERSION)
-    FILE(GLOB DISA_SRG_REF "${SSG_SHARED_REFS}/disa-${DISA_SRG_TYPE}-srg-${DISA_SRG_VERSION}.xml")
+macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE)
+    file(GLOB DISA_SRG_REF "${SSG_SHARED_REFS}/disa-${DISA_SRG_TYPE}-srg-v[0-9]*r[0-9]*.xml")
     # we have to encode spaces in paths before passing them as stringparams to xsltproc
     string(REPLACE " " "%20" CMAKE_CURRENT_BINARY_DIR_NO_SPACES "${CMAKE_CURRENT_BINARY_DIR}")
     add_custom_command(
@@ -964,8 +964,8 @@ macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE DISA_SRG_VERSION)
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
 endmacro()
 
-macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
-    FILE(GLOB DISA_STIG_REF "${SSG_SHARED_REFS}/disa-stig-${PRODUCT}-${DISA_STIG_VERSION}-xccdf-manual.xml")
+macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE)
+    file(GLOB DISA_STIG_REF "${SSG_SHARED_REFS}/disa-stig-${PRODUCT}-v[0-9]*r[0-9]*-xccdf-manual.xml")
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -923,16 +923,17 @@ macro(ssg_build_html_cce_table PRODUCT)
 endmacro()
 
 macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE DISA_SRG_VERSION)
+    FILE(GLOB DISA_SRG_REF "${SSG_SHARED_REFS}/disa-${DISA_SRG_TYPE}-srg-${DISA_SRG_VERSION}.xml")
     # we have to encode spaces in paths before passing them as stringparams to xsltproc
     string(REPLACE " " "%20" CMAKE_CURRENT_BINARY_DIR_NO_SPACES "${CMAKE_CURRENT_BINARY_DIR}")
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
         # We need to use xccdf-linked.xml because ssg-${PRODUCT}-xccdf.xml has the srg_support Group removed
-        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${SSG_SHARED_REFS}/disa-${DISA_SRG_TYPE}-srg-${DISA_SRG_VERSION}.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${DISA_SRG_REF}"
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-        DEPENDS "${SSG_SHARED_REFS}/disa-${DISA_SRG_TYPE}-srg-${DISA_SRG_VERSION}.xml"
+        DEPENDS "${DISA_SRG_REF}"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt"
         COMMENT "[${PRODUCT}-tables] generating HTML SRG map table (flat=no)"
     )
@@ -940,10 +941,10 @@ macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE DISA_SRG_VERSION)
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
         # We need to use xccdf-linked.xml because ssg-${PRODUCT}-xccdf.xml has the srg_support Group removed
-        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam flat "y" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${SSG_SHARED_REFS}/disa-${DISA_SRG_TYPE}-srg-${DISA_SRG_VERSION}.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam flat "y" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${DISA_SRG_REF}"
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-        DEPENDS "${SSG_SHARED_REFS}/disa-${DISA_SRG_TYPE}-srg-${DISA_SRG_VERSION}.xml"
+        DEPENDS "${DISA_SRG_REF}"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt"
         COMMENT "[${PRODUCT}-tables] generating HTML SRG map table (flat=yes)"
     )
@@ -964,11 +965,12 @@ macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE DISA_SRG_VERSION)
 endmacro()
 
 macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE DISA_STIG_VERSION)
+    FILE(GLOB DISA_STIG_REF "${SSG_SHARED_REFS}/disa-stig-${PRODUCT}-${DISA_STIG_VERSION}-xccdf-manual.xml")
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
-        COMMAND "${XSLTPROC_EXECUTABLE}" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-stig.xslt" "${SSG_SHARED_REFS}/disa-stig-${PRODUCT}-${DISA_STIG_VERSION}-xccdf-manual.xml"
-        DEPENDS "${SSG_SHARED_REFS}/disa-stig-${PRODUCT}-${DISA_STIG_VERSION}-xccdf-manual.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-stig.xslt" "${DISA_STIG_REF}"
+        DEPENDS "${DISA_STIG_REF}"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-stig.xslt"
         COMMENT "[${PRODUCT}-tables] generating HTML MANUAL STIG table"
     )

--- a/eap6/CMakeLists.txt
+++ b/eap6/CMakeLists.txt
@@ -4,8 +4,8 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 set(PRODUCT "eap6")
-set(DISA_SRG_VERSION "v2r1")
-set(DISA_STIG_VERSION "v1r2")
+set(DISA_SRG_VERSION "v[0-9]*r[0-9]*")
+set(DISA_STIG_VERSION "v[0-9]*r[0-9]*")
 set(DISA_SRG_TYPE "application")
 
 ssg_build_product(${PRODUCT})

--- a/eap6/CMakeLists.txt
+++ b/eap6/CMakeLists.txt
@@ -4,8 +4,6 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 set(PRODUCT "eap6")
-set(DISA_SRG_VERSION "v[0-9]*r[0-9]*")
-set(DISA_STIG_VERSION "v[0-9]*r[0-9]*")
 set(DISA_SRG_TYPE "application")
 
 ssg_build_product(${PRODUCT})
@@ -14,7 +12,7 @@ ssg_build_html_nistrefs_table(${PRODUCT} "stig-${PRODUCT}-disa")
 
 ssg_build_html_cce_table(${PRODUCT})
 
-ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE} ${DISA_SRG_VERSION})
+ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE})
 
-ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-disa" ${DISA_STIG_VERSION})
+ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-disa")
 

--- a/ocp3/CMakeLists.txt
+++ b/ocp3/CMakeLists.txt
@@ -4,8 +4,6 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 set(PRODUCT "ocp3")
-#set(DISA_SRG_VERSION "v[0-9]*r[0-9]*")
-#set(DISA_STIG_VERSION "v[0-9]*r[0-9]*")
 #set(DISA_SRG_TYPE "os")
 
 #ssg_build_product(${PRODUCT})
@@ -22,7 +20,7 @@ set(PRODUCT "ocp3")
 
 #ssg_build_html_cce_table(${PRODUCT})
 
-#ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE} ${DISA_SRG_VERSION})
+#ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE})
 
-#ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-disa" ${DISA_STIG_VERSION})
+#ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-disa")
 

--- a/ocp3/CMakeLists.txt
+++ b/ocp3/CMakeLists.txt
@@ -4,8 +4,8 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 set(PRODUCT "ocp3")
-#set(DISA_SRG_VERSION "v1r4")
-#set(DISA_STIG_VERSION "v1r1")
+#set(DISA_SRG_VERSION "v[0-9]*r[0-9]*")
+#set(DISA_STIG_VERSION "v[0-9]*r[0-9]*")
 #set(DISA_SRG_TYPE "os")
 
 #ssg_build_product(${PRODUCT})

--- a/rhel6/CMakeLists.txt
+++ b/rhel6/CMakeLists.txt
@@ -4,8 +4,8 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 set(PRODUCT "rhel6")
-set(DISA_SRG_VERSION "v1r4")
-set(DISA_STIG_VERSION "v1r18")
+set(DISA_SRG_VERSION "v[0-9]*r[0-9]*")
+set(DISA_STIG_VERSION "v[0-9]*r[0-9]*")
 set(DISA_SRG_TYPE "os")
 
 ssg_build_product(${PRODUCT})

--- a/rhel6/CMakeLists.txt
+++ b/rhel6/CMakeLists.txt
@@ -4,8 +4,6 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 set(PRODUCT "rhel6")
-set(DISA_SRG_VERSION "v[0-9]*r[0-9]*")
-set(DISA_STIG_VERSION "v[0-9]*r[0-9]*")
 set(DISA_SRG_TYPE "os")
 
 ssg_build_product(${PRODUCT})
@@ -19,9 +17,9 @@ ssg_build_html_nistrefs_table(${PRODUCT} "C2S")
 
 ssg_build_html_cce_table(${PRODUCT})
 
-ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE} ${DISA_SRG_VERSION})
+ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE})
 
-ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-disa" ${DISA_STIG_VERSION})
+ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-disa")
 
 if (SSG_CENTOS_DERIVATIVES_ENABLED)
     ssg_build_derivative_product(${PRODUCT} "centos" "centos6")

--- a/rhel7/CMakeLists.txt
+++ b/rhel7/CMakeLists.txt
@@ -4,8 +4,8 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 set(PRODUCT "rhel7")
-set(DISA_SRG_VERSION "v1r4")
-set(DISA_STIG_VERSION "v1r4")
+set(DISA_SRG_VERSION "v[0-9]*r[0-9]*")
+set(DISA_STIG_VERSION "v[0-9]*r[0-9]*")
 set(DISA_SRG_TYPE "os")
 
 ssg_build_product(${PRODUCT})

--- a/rhel7/CMakeLists.txt
+++ b/rhel7/CMakeLists.txt
@@ -4,8 +4,6 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 set(PRODUCT "rhel7")
-set(DISA_SRG_VERSION "v[0-9]*r[0-9]*")
-set(DISA_STIG_VERSION "v[0-9]*r[0-9]*")
 set(DISA_SRG_TYPE "os")
 
 ssg_build_product(${PRODUCT})
@@ -28,9 +26,9 @@ ssg_build_html_anssirefs_table(${PRODUCT} "nt28_high")
 
 ssg_build_html_cce_table(${PRODUCT})
 
-ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE} ${DISA_SRG_VERSION})
+ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE})
 
-ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-disa" ${DISA_STIG_VERSION})
+ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-disa")
 
 if (SSG_CENTOS_DERIVATIVES_ENABLED)
     ssg_build_derivative_product(${PRODUCT} "centos" "centos7")


### PR DESCRIPTION
#### Description:

- Add regex handling for SRG and STIG versions in CMake

#### Rationale:

- While SRG and STIG references may not be updated often, this makes it easier to update the reference file. If a specific version is needed, the version can still me manually entered.
