### PR TITLE
Use yaml.safe_load for build related yaml files

### DIFF
--- a/shared/modules/ssgcommon.py
+++ b/shared/modules/ssgcommon.py
@@ -255,7 +255,7 @@ def open_yaml(yaml_file, product_yaml=None):
 
     if product_yaml is None:
         with codecs.open(yaml_file, "r", "utf8") as stream:
-            yaml_contents = yaml.load(stream)
+            yaml_contents = yaml.safe_load(stream)
     else:
         yaml_contents = yaml.load(
             process_file_with_jinja(yaml_file, product_yaml)

--- a/shared/modules/ssgcommon.py
+++ b/shared/modules/ssgcommon.py
@@ -257,7 +257,7 @@ def open_yaml(yaml_file, product_yaml=None):
         with codecs.open(yaml_file, "r", "utf8") as stream:
             yaml_contents = yaml.safe_load(stream)
     else:
-        yaml_contents = yaml.load(
+        yaml_contents = yaml.safe_load(
             process_file_with_jinja(yaml_file, product_yaml)
         )
 


### PR DESCRIPTION
There is no real danger of somebody trying to exploit their own machine
but on the other hand we don't use any of the unsafe facilities of
yaml.load so we might as well use safe_load.
