### PR TITLE
Find shadowed files

### DIFF
--- a/shared/misc/find_shadowed_files.py
+++ b/shared/misc/find_shadowed_files.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python3
+
+import os
+import argparse
+import sys
+
+
+SSG_DIR = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))
+)
+
+
+def safe_listdir(path):
+    try:
+        return os.listdir(path)
+    except:
+        return []
+
+
+def print_shadows(resource, language, product):
+    source_paths = [
+        # shared templated checks
+        os.path.join("build", product, resource, "shared", language),
+        # shared checks
+        os.path.join("shared", resource, language),
+        # product templated checks
+        os.path.join("build", product, resource, language),
+        # product checks
+        os.path.join(product, resource, language),
+    ]
+
+    source_files = [
+        set(safe_listdir(os.path.join(SSG_DIR, path))) for path in source_paths
+    ]
+
+    all_source_files = set.union(*source_files)
+
+    for source_file in all_source_files:
+        i = 0
+        while i < len(source_paths):
+            if source_file in source_files[i]:
+                break
+            i += 1
+
+        assert(i < len(source_paths))
+
+        shadows = set()
+        j = i + 1
+        while j < len(source_paths):
+            if source_file in source_files[j]:
+                shadows.add(j)
+            j += 1
+
+        if shadows:
+            msg = os.path.relpath(
+                os.path.join(source_paths[i], source_file), SSG_DIR
+            )
+
+            for shadow in shadows:
+                msg += " <- " + os.path.relpath(
+                    os.path.join(source_paths[shadow], source_file), SSG_DIR
+                )
+
+            print(msg)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--product", default="rhel7",
+                   help="Which product we should examine for shadowed checks "
+                   "and fixes.")
+
+    args, unknown = p.parse_known_args()
+    if unknown:
+        sys.stderr.write(
+            "Unknown positional arguments " + ",".join(unknown) + ".\n"
+        )
+        sys.exit(1)
+
+    check_languages = ["oval"]
+    fix_languages = ["bash", "ansible", "anaconda", "puppet"]
+
+    for product in [args.product]:
+        for check_lang in check_languages:
+            print("%s %s check shadows" % (product, check_lang))
+            print_shadows("checks", check_lang, product)
+            print()
+
+        print()
+
+        for fix_lang in fix_languages:
+            print("%s %s fix shadows" % (product, fix_lang))
+            print_shadows("fixes", fix_lang, product)
+            print()
+
+
+if __name__ == "__main__":
+    main()

--- a/shared/misc/find_shadowed_files.py
+++ b/shared/misc/find_shadowed_files.py
@@ -65,7 +65,12 @@ def print_shadows(resource, language, product):
 
 
 def main():
-    p = argparse.ArgumentParser()
+    p = argparse.ArgumentParser(
+        description="Looks through both source files and built files of the "
+        "product and finds shadowed files. Outputs them in the format of "
+        "shadowing. For example if D ends up being used and C, B and A are "
+        "shadowed it will output A <- B <- C <- D."
+    )
     p.add_argument("--product", default="rhel7",
                    help="Which product we should examine for shadowed checks "
                    "and fixes.")


### PR DESCRIPTION
This should help us get rid of all the duplicate and shadowed files. With jinja2 there is no reason to shadow anything anymore.

Example of output:
```
$ ./shared/misc/find_shadowed_files.py --product rhel7
rhel7 oval check shadows
shared/checks/oval/sysctl_kernel_randomize_va_space.xml <- build/rhel7/checks/oval/sysctl_kernel_randomize_va_space.xml
shared/checks/oval/package_vsftpd_removed.xml <- build/rhel7/checks/oval/package_vsftpd_removed.xml
build/rhel7/checks/shared/oval/package_talk_removed.xml <- shared/checks/oval/package_talk_removed.xml <- build/rhel7/checks/oval/package_talk_removed.xml
shared/checks/oval/sysctl_runtime_net_ipv6_conf_all_disable_ipv6.xml <- build/rhel7/checks/oval/sysctl_runtime_net_ipv6_conf_all_disable_ipv6.xml
build/rhel7/checks/shared/oval/package_vsftpd_installed.xml <- shared/checks/oval/package_vsftpd_installed.xml <- build/rhel7/checks/oval/package_vsftpd_installed.xml
shared/checks/oval/kernel_module_usb-storage_disabled.xml <- build/rhel7/checks/oval/kernel_module_usb-storage_disabled.xml
build/rhel7/checks/shared/oval/package_aide_installed.xml <- shared/checks/oval/package_aide_installed.xml <- build/rhel7/checks/oval/package_aide_installed.xml
shared/checks/oval/package_dhcp_removed.xml <- build/rhel7/checks/oval/package_dhcp_removed.xml
shared/checks/oval/package_telnet-server_removed.xml <- build/rhel7/checks/oval/package_telnet-server_removed.xml
shared/checks/oval/service_dovecot_disabled.xml <- build/rhel7/checks/oval/service_dovecot_disabled.xml
build/rhel7/checks/shared/oval/package_net-snmp_removed.xml <- shared/checks/oval/package_net-snmp_removed.xml <- build/rhel7/checks/oval/package_net-snmp_removed.xml
build/rhel7/checks/shared/oval/package_talk-server_removed.xml <- shared/checks/oval/package_talk-server_removed.xml <- build/rhel7/checks/oval/package_talk-server_removed.xml
shared/checks/oval/package_tftp_removed.xml <- build/rhel7/checks/oval/package_tftp_removed.xml
shared/checks/oval/sshd_use_approved_macs.xml <- rhel7/checks/oval/sshd_use_approved_macs.xml
build/rhel7/checks/shared/oval/package_audit_installed.xml <- shared/checks/oval/package_audit_installed.xml <- build/rhel7/checks/oval/package_audit_installed.xml
shared/checks/oval/package_firewalld_installed.xml <- build/rhel7/checks/oval/package_firewalld_installed.xml
shared/checks/oval/package_dconf_installed.xml <- build/rhel7/checks/oval/package_dconf_installed.xml
build/rhel7/checks/shared/oval/package_rsh-server_removed.xml <- shared/checks/oval/package_rsh-server_removed.xml <- build/rhel7/checks/oval/package_rsh-server_removed.xml
shared/checks/oval/sysctl_static_kernel_randomize_va_space.xml <- build/rhel7/checks/oval/sysctl_static_kernel_randomize_va_space.xml
build/rhel7/checks/shared/oval/package_dovecot_removed.xml <- shared/checks/oval/package_dovecot_removed.xml <- build/rhel7/checks/oval/package_dovecot_removed.xml
shared/checks/oval/package_screen_installed.xml <- build/rhel7/checks/oval/package_screen_installed.xml
shared/checks/oval/package_openssh-server_removed.xml <- build/rhel7/checks/oval/package_openssh-server_removed.xml
shared/checks/oval/package_rsyslog_installed.xml <- build/rhel7/checks/oval/package_rsyslog_installed.xml
shared/checks/oval/package_prelink_removed.xml <- build/rhel7/checks/oval/package_prelink_removed.xml
shared/checks/oval/package_chrony_installed.xml <- build/rhel7/checks/oval/package_chrony_installed.xml
shared/checks/oval/sysctl_static_net_ipv6_conf_all_disable_ipv6.xml <- build/rhel7/checks/oval/sysctl_static_net_ipv6_conf_all_disable_ipv6.xml
shared/checks/oval/kernel_module_dccp_disabled.xml <- build/rhel7/checks/oval/kernel_module_dccp_disabled.xml
shared/checks/oval/package_ntp_installed.xml <- build/rhel7/checks/oval/package_ntp_installed.xml
shared/checks/oval/package_squid_removed.xml <- build/rhel7/checks/oval/package_squid_removed.xml
build/rhel7/checks/shared/oval/package_httpd_removed.xml <- shared/checks/oval/package_httpd_removed.xml <- build/rhel7/checks/oval/package_httpd_removed.xml
shared/checks/oval/package_bind_removed.xml <- build/rhel7/checks/oval/package_bind_removed.xml
shared/checks/oval/package_tftp-server_removed.xml <- build/rhel7/checks/oval/package_tftp-server_removed.xml
shared/checks/oval/package_ypserv_removed.xml <- build/rhel7/checks/oval/package_ypserv_removed.xml
shared/checks/oval/package_xinetd_removed.xml <- build/rhel7/checks/oval/package_xinetd_removed.xml
build/rhel7/checks/shared/oval/package_ypbind_removed.xml <- shared/checks/oval/package_ypbind_removed.xml <- build/rhel7/checks/oval/package_ypbind_removed.xml
build/rhel7/checks/shared/oval/package_telnet_removed.xml <- shared/checks/oval/package_telnet_removed.xml <- build/rhel7/checks/oval/package_telnet_removed.xml
shared/checks/oval/file_permissions_etc_shadow.xml <- build/rhel7/checks/oval/file_permissions_etc_shadow.xml
build/rhel7/checks/oval/service_sshd_disabled.xml <- rhel7/checks/oval/service_sshd_disabled.xml
shared/checks/oval/package_cronie_installed.xml <- build/rhel7/checks/oval/package_cronie_installed.xml
build/rhel7/checks/shared/oval/package_dracut-fips_installed.xml <- shared/checks/oval/package_dracut-fips_installed.xml
shared/checks/oval/package_libreswan_installed.xml <- build/rhel7/checks/oval/package_libreswan_installed.xml
build/rhel7/checks/shared/oval/package_rsh_removed.xml <- shared/checks/oval/package_rsh_removed.xml <- build/rhel7/checks/oval/package_rsh_removed.xml
build/rhel7/checks/shared/oval/package_samba-common_installed.xml <- shared/checks/oval/package_samba-common_installed.xml
shared/checks/oval/mount_option_var_tmp_bind.xml <- build/rhel7/checks/oval/mount_option_var_tmp_bind.xml
shared/checks/oval/sysctl_runtime_kernel_randomize_va_space.xml <- build/rhel7/checks/oval/sysctl_runtime_kernel_randomize_va_space.xml


rhel7 bash fix shadows
shared/fixes/bash/auditd_data_retention_space_left_action.sh <- rhel7/fixes/bash/auditd_data_retention_space_left_action.sh
build/rhel7/fixes/bash/service_rpcidmapd_disabled.sh <- rhel7/fixes/bash/service_rpcidmapd_disabled.sh
shared/fixes/bash/sshd_use_approved_macs.sh <- rhel7/fixes/bash/sshd_use_approved_macs.sh
build/rhel7/fixes/shared/bash/package_net-snmp_removed.sh <- build/rhel7/fixes/bash/package_net-snmp_removed.sh
build/rhel7/fixes/shared/bash/package_talk-server_removed.sh <- build/rhel7/fixes/bash/package_talk-server_removed.sh
shared/fixes/bash/bootloader_audit_argument.sh <- rhel7/fixes/bash/bootloader_audit_argument.sh
build/rhel7/fixes/bash/service_nfslock_disabled.sh <- rhel7/fixes/bash/service_nfslock_disabled.sh
build/rhel7/fixes/shared/bash/package_httpd_removed.sh <- build/rhel7/fixes/bash/package_httpd_removed.sh
shared/fixes/bash/sshd_set_keepalive.sh <- rhel7/fixes/bash/sshd_set_keepalive.sh
build/rhel7/fixes/bash/service_bluetooth_disabled.sh <- rhel7/fixes/bash/service_bluetooth_disabled.sh
shared/fixes/bash/rsyslog_files_permissions.sh <- rhel7/fixes/bash/rsyslog_files_permissions.sh
build/rhel7/fixes/bash/service_telnet_disabled.sh <- rhel7/fixes/bash/service_telnet_disabled.sh
build/rhel7/fixes/shared/bash/package_rsh-server_removed.sh <- build/rhel7/fixes/bash/package_rsh-server_removed.sh
build/rhel7/fixes/bash/service_avahi-daemon_disabled.sh <- rhel7/fixes/bash/service_avahi-daemon_disabled.sh
build/rhel7/fixes/bash/service_cups_disabled.sh <- rhel7/fixes/bash/service_cups_disabled.sh
shared/fixes/bash/disable_ctrlaltdel_reboot.sh <- rhel7/fixes/bash/disable_ctrlaltdel_reboot.sh
build/rhel7/fixes/bash/service_rsh_disabled.sh <- rhel7/fixes/bash/service_rsh_disabled.sh
build/rhel7/fixes/shared/bash/package_telnet_removed.sh <- build/rhel7/fixes/bash/package_telnet_removed.sh
build/rhel7/fixes/shared/bash/kernel_module_bluetooth_disabled.sh <- build/rhel7/fixes/bash/kernel_module_bluetooth_disabled.sh
build/rhel7/fixes/bash/service_rexec_disabled.sh <- rhel7/fixes/bash/service_rexec_disabled.sh
build/rhel7/fixes/shared/bash/package_vsftpd_installed.sh <- build/rhel7/fixes/bash/package_vsftpd_installed.sh
build/rhel7/fixes/bash/sysctl_kernel_randomize_va_space.sh <- rhel7/fixes/bash/sysctl_kernel_randomize_va_space.sh
build/rhel7/fixes/shared/bash/package_aide_installed.sh <- build/rhel7/fixes/bash/package_aide_installed.sh
build/rhel7/fixes/shared/bash/package_ypbind_removed.sh <- build/rhel7/fixes/bash/package_ypbind_removed.sh
build/rhel7/fixes/shared/bash/package_dovecot_removed.sh <- build/rhel7/fixes/bash/package_dovecot_removed.sh
build/rhel7/fixes/bash/service_rlogin_disabled.sh <- rhel7/fixes/bash/service_rlogin_disabled.sh
build/rhel7/fixes/shared/bash/package_talk_removed.sh <- build/rhel7/fixes/bash/package_talk_removed.sh
build/rhel7/fixes/shared/bash/package_audit_installed.sh <- build/rhel7/fixes/bash/package_audit_installed.sh
build/rhel7/fixes/shared/bash/kernel_module_usb-storage_disabled.sh <- build/rhel7/fixes/bash/kernel_module_usb-storage_disabled.sh
build/rhel7/fixes/shared/bash/package_rsh_removed.sh <- build/rhel7/fixes/bash/package_rsh_removed.sh
shared/fixes/bash/sshd_set_idle_timeout.sh <- rhel7/fixes/bash/sshd_set_idle_timeout.sh
build/rhel7/fixes/bash/service_rpcsvcgssd_disabled.sh <- rhel7/fixes/bash/service_rpcsvcgssd_disabled.sh
build/rhel7/fixes/bash/service_rpcgssd_disabled.sh <- rhel7/fixes/bash/service_rpcgssd_disabled.sh

rhel7 ansible fix shadows
build/rhel7/fixes/shared/ansible/package_httpd_removed.yml <- build/rhel7/fixes/ansible/package_httpd_removed.yml
build/rhel7/fixes/shared/ansible/package_vsftpd_installed.yml <- build/rhel7/fixes/ansible/package_vsftpd_installed.yml
build/rhel7/fixes/shared/ansible/kernel_module_bluetooth_disabled.yml <- build/rhel7/fixes/ansible/kernel_module_bluetooth_disabled.yml
build/rhel7/fixes/shared/ansible/kernel_module_usb-storage_disabled.yml <- build/rhel7/fixes/ansible/kernel_module_usb-storage_disabled.yml
build/rhel7/fixes/shared/ansible/package_talk-server_removed.yml <- build/rhel7/fixes/ansible/package_talk-server_removed.yml
shared/fixes/ansible/accounts_password_pam_maxrepeat.yml <- build/rhel7/fixes/ansible/accounts_password_pam_maxrepeat.yml
build/rhel7/fixes/shared/ansible/package_ypbind_removed.yml <- build/rhel7/fixes/ansible/package_ypbind_removed.yml
build/rhel7/fixes/shared/ansible/package_rsh_removed.yml <- build/rhel7/fixes/ansible/package_rsh_removed.yml
build/rhel7/fixes/ansible/service_avahi-daemon_disabled.yml <- rhel7/fixes/ansible/service_avahi-daemon_disabled.yml
build/rhel7/fixes/shared/ansible/package_talk_removed.yml <- build/rhel7/fixes/ansible/package_talk_removed.yml
build/rhel7/fixes/shared/ansible/package_telnet_removed.yml <- build/rhel7/fixes/ansible/package_telnet_removed.yml
build/rhel7/fixes/shared/ansible/package_net-snmp_removed.yml <- build/rhel7/fixes/ansible/package_net-snmp_removed.yml
build/rhel7/fixes/shared/ansible/package_dovecot_removed.yml <- build/rhel7/fixes/ansible/package_dovecot_removed.yml
build/rhel7/fixes/shared/ansible/package_rsh-server_removed.yml <- build/rhel7/fixes/ansible/package_rsh-server_removed.yml
build/rhel7/fixes/shared/ansible/package_audit_installed.yml <- build/rhel7/fixes/ansible/package_audit_installed.yml
shared/fixes/ansible/accounts_password_pam_maxclassrepeat.yml <- build/rhel7/fixes/ansible/accounts_password_pam_maxclassrepeat.yml
shared/fixes/ansible/accounts_password_pam_minlen.yml <- build/rhel7/fixes/ansible/accounts_password_pam_minlen.yml
build/rhel7/fixes/shared/ansible/package_aide_installed.yml <- build/rhel7/fixes/ansible/package_aide_installed.yml

rhel7 anaconda fix shadows
build/rhel7/fixes/shared/anaconda/package_aide_installed.anaconda <- build/rhel7/fixes/anaconda/package_aide_installed.anaconda
build/rhel7/fixes/shared/anaconda/package_dovecot_removed.anaconda <- build/rhel7/fixes/anaconda/package_dovecot_removed.anaconda
build/rhel7/fixes/shared/anaconda/package_talk_removed.anaconda <- build/rhel7/fixes/anaconda/package_talk_removed.anaconda
build/rhel7/fixes/shared/anaconda/package_talk-server_removed.anaconda <- build/rhel7/fixes/anaconda/package_talk-server_removed.anaconda
build/rhel7/fixes/shared/anaconda/package_telnet_removed.anaconda <- build/rhel7/fixes/anaconda/package_telnet_removed.anaconda
build/rhel7/fixes/shared/anaconda/package_rsh-server_removed.anaconda <- build/rhel7/fixes/anaconda/package_rsh-server_removed.anaconda
build/rhel7/fixes/shared/anaconda/package_audit_installed.anaconda <- build/rhel7/fixes/anaconda/package_audit_installed.anaconda
build/rhel7/fixes/shared/anaconda/package_rsh_removed.anaconda <- build/rhel7/fixes/anaconda/package_rsh_removed.anaconda
build/rhel7/fixes/shared/anaconda/package_vsftpd_installed.anaconda <- build/rhel7/fixes/anaconda/package_vsftpd_installed.anaconda
build/rhel7/fixes/shared/anaconda/package_net-snmp_removed.anaconda <- build/rhel7/fixes/anaconda/package_net-snmp_removed.anaconda
build/rhel7/fixes/shared/anaconda/package_httpd_removed.anaconda <- build/rhel7/fixes/anaconda/package_httpd_removed.anaconda
build/rhel7/fixes/shared/anaconda/package_ypbind_removed.anaconda <- build/rhel7/fixes/anaconda/package_ypbind_removed.anaconda

rhel7 puppet fix shadows
build/rhel7/fixes/shared/puppet/package_vsftpd_installed.pp <- build/rhel7/fixes/puppet/package_vsftpd_installed.pp
build/rhel7/fixes/shared/puppet/package_audit_installed.pp <- build/rhel7/fixes/puppet/package_audit_installed.pp
build/rhel7/fixes/shared/puppet/package_rsh_removed.pp <- build/rhel7/fixes/puppet/package_rsh_removed.pp
build/rhel7/fixes/shared/puppet/package_talk_removed.pp <- build/rhel7/fixes/puppet/package_talk_removed.pp
build/rhel7/fixes/shared/puppet/package_telnet_removed.pp <- build/rhel7/fixes/puppet/package_telnet_removed.pp
build/rhel7/fixes/shared/puppet/package_ypbind_removed.pp <- build/rhel7/fixes/puppet/package_ypbind_removed.pp
build/rhel7/fixes/shared/puppet/package_dovecot_removed.pp <- build/rhel7/fixes/puppet/package_dovecot_removed.pp
build/rhel7/fixes/shared/puppet/package_talk-server_removed.pp <- build/rhel7/fixes/puppet/package_talk-server_removed.pp
build/rhel7/fixes/shared/puppet/package_net-snmp_removed.pp <- build/rhel7/fixes/puppet/package_net-snmp_removed.pp
build/rhel7/fixes/shared/puppet/package_rsh-server_removed.pp <- build/rhel7/fixes/puppet/package_rsh-server_removed.pp
build/rhel7/fixes/shared/puppet/package_httpd_removed.pp <- build/rhel7/fixes/puppet/package_httpd_removed.pp
build/rhel7/fixes/shared/puppet/package_aide_installed.pp <- build/rhel7/fixes/puppet/package_aide_installed.pp
```