### PR TITLE
Remove all references for dropped OVALs

### DIFF
--- a/shared/utils/relabel-ids.py
+++ b/shared/utils/relabel-ids.py
@@ -148,7 +148,7 @@ class OVALFileLinker(FileLinker):
             self.tree, ".//{0}".format(self._get_checkid_string()))
 
         drop_oval_checks_extending_non_existing_checks(
-            self.tree, indexed_oval_defs)
+            self.tree, self.oval_groups, indexed_oval_defs)
 
         self._add_cce_id_refs_to_oval_checks(xccdf_to_cce_id_mapping)
 
@@ -327,7 +327,7 @@ def get_nonexisting_check_definition_extends(definition, indexed_oval_defs):
     return None
 
 
-def drop_oval_checks_extending_non_existing_checks(ovaltree, indexed_oval_defs):
+def drop_oval_checks_extending_non_existing_checks(ovaltree, oval_groups, indexed_oval_defs):
     # Incomplete OVAL checks are as useful as non existing checks
     # Here we check if all extend_definition refs from a definition exists in local OVAL file
     definitions = ovaltree.find(".//{%s}definitions" % oval_ns)
@@ -342,6 +342,8 @@ def drop_oval_checks_extending_non_existing_checks(ovaltree, indexed_oval_defs):
             defstoremove.add(definition)
 
     for definition in defstoremove:
+        del oval_groups["definitions"][definition.get("id")]
+        del indexed_oval_defs[definition.get("id")]
         definitions.remove(definition)
 
 


### PR DESCRIPTION
#### Description:

- Remove all references to OVAL definitions dropped due to incompleteness. 

#### Rationale:

- OVAL 5.10 doesn't have `systemdunitproperty` test, and some definitions can be incomplete.
- When building content with only OVAL 5.10, incomplete OVAL definitions are dropped. But references to these definitions still existed in auxiliary data structures. Not dropping them was causing a traceback when later we tried to add ``check-exports``.
```
Traceback (most recent call last):
  File "/home/jenkins/workspace/scap-security-guide-nightly-oval510-zip/shared/utils/relabel-ids.py", line 514, in <module>
    main()
  File "/home/jenkins/workspace/scap-security-guide-nightly-oval510-zip/shared/utils/relabel-ids.py", line 500, in main
    oval_linker.link_xccdf()
  File "/home/jenkins/workspace/scap-security-guide-nightly-oval510-zip/shared/utils/relabel-ids.py", line 99, in link_xccdf
    self.add_missing_check_exports(check, checkcontentref)
  File "/home/jenkins/workspace/scap-security-guide-nightly-oval510-zip/shared/utils/relabel-ids.py", line 225, in add_missing_check_exports
    for def_id in self.get_nested_definitions(check_name):
  File "/home/jenkins/workspace/scap-security-guide-nightly-oval510-zip/shared/utils/relabel-ids.py", line 211, in get_nested_definitions
    extensions = parse_oval.find_extending_defs(self.oval_groups, definition_tree)
  File "/home/jenkins/workspace/scap-security-guide-nightly-oval510-zip/shared/modules/parse_oval.py", line 94, in find_extending_defs
    finder.find_element(defn, "extend_definition", "definition_ref")
  File "/home/jenkins/workspace/scap-security-guide-nightly-oval510-zip/shared/modules/parse_oval.py", line 35, in find_element
    self._recurse(start_element)
  File "/home/jenkins/workspace/scap-security-guide-nightly-oval510-zip/shared/modules/parse_oval.py", line 38, in _recurse
    if element.tag.endswith(self.target):
AttributeError: 'NoneType' object has no attribute 'tag'
```
