### PR TITLE
remove kernel IPv6 from RHEL6 STIG

### DIFF
--- a/rhel6/profiles/standard.profile
+++ b/rhel6/profiles/standard.profile
@@ -93,7 +93,6 @@ selections:
     - sysctl_net_ipv4_tcp_syncookies
     - sysctl_net_ipv4_conf_all_rp_filter
     - sysctl_net_ipv4_conf_default_rp_filter
-    - kernel_module_ipv6_option_disabled
     - sysctl_net_ipv6_conf_default_accept_redirects
     - service_ip6tables_enabled
     - service_iptables_enabled

--- a/rhel6/profiles/usgcb-rhel6-server.profile
+++ b/rhel6/profiles/usgcb-rhel6-server.profile
@@ -149,7 +149,6 @@ selections:
     - sysctl_net_ipv4_conf_default_rp_filter
     - wireless_disable_in_bios
     - service_bluetooth_disabled
-    - kernel_module_ipv6_option_disabled
     - network_ipv6_disable_rpc
     - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
     - sysctl_net_ipv6_conf_default_accept_ra


### PR DESCRIPTION
Removes rhel6 IPv6 kernel module check to align with DISA content.

Resolves https://github.com/OpenSCAP/scap-security-guide/issues/2758