### PR TITLE
Add benchmark metadata element to shorthand

### DIFF
--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -227,6 +227,7 @@ class Benchmark(object):
                 add_sub_element(root, "platform", cpe)
         version = ET.SubElement(root, 'version')
         version.text = self.version
+        ET.SubElement(root, "metadata")
 
         for profile in self.profiles:
             if profile is not None:


### PR DESCRIPTION
#### Description:

- Add benchmark metadata element to shorthand.

#### Rationale:

- Script that generates shorthand from yaml was not adding metadata
element. This element is expanded to XCCDF metadata by shorthand
transformation.
- NIST SCAPVAL tool errors if there is no metadata in the Benchmark.