### PR TITLE
Fix dconf_gnome_disable_geolocation script and add missing dconf remedation scripts

### DIFF
--- a/shared/fixes/bash/dconf_gnome_disable_geolocation.sh
+++ b/shared/fixes/bash/dconf_gnome_disable_geolocation.sh
@@ -4,4 +4,6 @@
 include_dconf_settings
 
 dconf_settings 'org/gnome/system/location' 'enabled' 'false' 'local.d' '00-security-settings'
+dconf_settings 'org/gnome/clocks' 'geolocation' 'false' 'local.d' '00-security-settings'
 dconf_lock 'org/gnome/system/location' 'enabled' 'local.d' '00-security-settings-lock'
+dconf_lock 'org/gnome/clocks' 'geolocation' 'local.d' '00-security-settings-lock'

--- a/shared/fixes/bash/dconf_gnome_disable_wifi_create.sh
+++ b/shared/fixes/bash/dconf_gnome_disable_wifi_create.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/shared/fixes/bash/dconf_gnome_disable_wifi_create.sh
+++ b/shared/fixes/bash/dconf_gnome_disable_wifi_create.sh
@@ -1,0 +1,7 @@
+# platform = Red Hat Enterprise Linux 7
+. /usr/share/scap-security-guide/remediation_functions
+
+include_dconf_settings
+
+dconf_settings 'org/gnome/nm-applet' 'disable-wifi-create' 'true' 'local.d' '00-security-settings'
+dconf_lock 'org/gnome/nm-applet' 'disable-wifi-create' 'local.d' '00-security-settings-lock'

--- a/shared/fixes/bash/dconf_gnome_disable_wifi_notification.sh
+++ b/shared/fixes/bash/dconf_gnome_disable_wifi_notification.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/shared/fixes/bash/dconf_gnome_disable_wifi_notification.sh
+++ b/shared/fixes/bash/dconf_gnome_disable_wifi_notification.sh
@@ -1,0 +1,7 @@
+# platform = Red Hat Enterprise Linux 7
+. /usr/share/scap-security-guide/remediation_functions
+
+include_dconf_settings
+
+dconf_settings 'org/gnome/nm-applet' 'suppress-wireless-networks-available' 'true' 'local.d' '00-security-settings'
+dconf_lock 'org/gnome/nm-applet' 'suppress-wireless-networks-available' 'local.d' '00-security-settings-lock'


### PR DESCRIPTION
#### Description:

- Fix dconf_gnome_disable_geolocation script and add missing dconf remediation scripts

#### Rationale:

- Script was erroring out on remediation and a couple of remediation scripts were missing
