### PR TITLE
Remove duplicated openSUSE CPE UNIX family test

### DIFF
--- a/shared/checks/oval/installed_OS_is_opensuse.xml
+++ b/shared/checks/oval/installed_OS_is_opensuse.xml
@@ -9,26 +9,15 @@
       <reference ref_id="cpe:/o:opensuse:leap:42.1" source="CPE" />
       <reference ref_id="cpe:/o:opensuse:leap:42.2" source="CPE" />
       <reference ref_id="cpe:/o:opensuse:leap:42.3" source="CPE" />
-      <description>The operating system installed on the system is
-      openSUSE.</description>
+      <description>The operating system installed on the system is openSUSE.</description>
     </metadata>
-    <criteria>
-      <criterion comment="Installed operating system is part of the unix family"
-      test_ref="test_opensuse_unix_family" />
-      <criterion comment="opensuse is installed" test_ref="test_opensuse_installed" />
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is part of the Unix family" definition_ref="installed_OS_is_part_of_Unix_family" />
+      <criterion comment="openSUSE is installed" test_ref="test_opensuse_installed" />
     </criteria>
   </definition>
 
-  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_opensuse_unix_family" version="1">
-    <ind:object object_ref="obj_opensuse_unix_family" />
-    <ind:state state_ref="state_opensuse_unix_family" />
-  </ind:family_test>
-  <ind:family_state id="state_opensuse_unix_family" version="1">
-    <ind:family>unix</ind:family>
-  </ind:family_state>
-  <ind:family_object id="obj_opensuse_unix_family" version="1" />
-
-  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="opensuse is installed" id="test_opensuse_installed" version="1">
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="openSUSE is installed" id="test_opensuse_installed" version="1">
     <linux:object object_ref="obj_opensuse_installed" />
     <linux:state state_ref="state_opensuse_installed" />
   </linux:rpminfo_test>


### PR DESCRIPTION
Remove duplicated UNIX family test `test_opensuse_unix_family` and link
against the more generic UNIX family test via `extend_definition`.