### PR TITLE
Change DRAFT marker in Profile titles

### DIFF
--- a/rhel7/profiles/C2S-docker.profile
+++ b/rhel7/profiles/C2S-docker.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] C2S for Docker'
+title: 'DRAFT - C2S for Docker'
 
 description: |-
     This profile demonstrates compliance against the

--- a/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] ANSSI DAT-NT28 (enhanced)'
+title: 'DRAFT - ANSSI DAT-NT28 (enhanced)'
 
 description: 'Draft profile for ANSSI compliance at the enhanced level. ANSSI stands for Agence nationale de la sécurité des
     systèmes d''information. Based on https://www.ssi.gouv.fr/.'

--- a/rhel7/profiles/anssi_nt28_high.profile
+++ b/rhel7/profiles/anssi_nt28_high.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] ANSSI DAT-NT28 (high)'
+title: 'DRAFT - ANSSI DAT-NT28 (high)'
 
 description: 'Draft profile for ANSSI compliance at the high level. ANSSI stands for Agence nationale de la sécurité des systèmes
     d''information. Based on https://www.ssi.gouv.fr/.'

--- a/rhel7/profiles/anssi_nt28_intermediary.profile
+++ b/rhel7/profiles/anssi_nt28_intermediary.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] ANSSI DAT-NT28 (intermediary)'
+title: 'DRAFT - ANSSI DAT-NT28 (intermediary)'
 
 description: 'Draft profile for ANSSI compliance at the intermediary level. ANSSI stands for Agence nationale de la sécurité
     des systèmes d''information. Based on https://www.ssi.gouv.fr/.'

--- a/rhel7/profiles/anssi_nt28_minimal.profile
+++ b/rhel7/profiles/anssi_nt28_minimal.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] ANSSI DAT-NT28 (minimal)'
+title: 'DRAFT - ANSSI DAT-NT28 (minimal)'
 
 description: 'Draft profile for ANSSI compliance at the minimal level. ANSSI stands for Agence nationale de la sécurité des
     systèmes d''information. Based on https://www.ssi.gouv.fr/.'

--- a/rhel7/profiles/docker-host.profile
+++ b/rhel7/profiles/docker-host.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] Standard Docker Host Security Profile'
+title: 'DRAFT - Standard Docker Host Security Profile'
 
 description: "This profile contains rules to ensure standard security \n
     \ baseline of Red Hat Enterprise Linux 7 system running the docker \n

--- a/rhel7/profiles/ospp42-draft.profile
+++ b/rhel7/profiles/ospp42-draft.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] Protection Profile for General Purpose Operating Systems'
+title: 'DRAFT - Protection Profile for General Purpose Operating Systems'
 
 description: "This profile reflects mandatory configuration controls identified\nin the NIAP Configuration Annex to the Protection\
     \ Profile for General Purpose Operating\nSystems (Protection Profile Version 4.2 draft). \n\nThis Annex is consistent\

--- a/rhel7/profiles/pci-dss.profile
+++ b/rhel7/profiles/pci-dss.profile
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'DRAFT - PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7'
+title: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7'
 
 description: 'Ensures PCI-DSS v3 related security configuration settings \n
     \ are applied.'

--- a/rhel7/profiles/pci-dss.profile
+++ b/rhel7/profiles/pci-dss.profile
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: '[DRAFT] PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7'
+title: 'DRAFT - PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7'
 
 description: 'Ensures PCI-DSS v3 related security configuration settings \n
     \ are applied.'

--- a/rhel7/profiles/stig-ansible-tower-upstream.profile
+++ b/rhel7/profiles/stig-ansible-tower-upstream.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] DISA STIG for Red Hat Ansible Tower'
+title: 'DRAFT - DISA STIG for Red Hat Ansible Tower'
 
 description: |-
     This is a *draft* profile for STIG. This profile is being

--- a/rhel7/profiles/stig-http-disa.profile
+++ b/rhel7/profiles/stig-http-disa.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] DISA STIG for Apache HTTP on Red Hat Enterprise Linux 7'
+title: 'DRAFT - DISA STIG for Apache HTTP on Red Hat Enterprise Linux 7'
 
 description: |-
     This profile contains configuration checks that align to the

--- a/rhel7/profiles/stig-ipa-server-upstream.profile
+++ b/rhel7/profiles/stig-ipa-server-upstream.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] DISA STIG for Red Hat IdM'
+title: 'DRAFT - DISA STIG for Red Hat IdM'
 
 description: |-
     This is a *draft* profile for STIG. This profile is being

--- a/rhel7/profiles/stig-rhvh-upstream.profile
+++ b/rhel7/profiles/stig-rhvh-upstream.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] STIG for Red Hat Virtualization Hypervisor'
+title: 'DRAFT - STIG for Red Hat Virtualization Hypervisor'
 
 description: "This is a *draft* profile for STIG. This profile is being \n
     \ developed under the DISA Vendor STIG model in coordination with \n

--- a/rhel7/profiles/stig-satellite-upstream.profile
+++ b/rhel7/profiles/stig-satellite-upstream.profile
@@ -1,6 +1,6 @@
 documentation_complete: false
 
-title: '[DRAFT] DISA STIG for Red Hat Satellite'
+title: 'DRAFT - DISA STIG for Red Hat Satellite'
 
 description: |-
     This is a *draft* profile for STIG. This profile is being


### PR DESCRIPTION
#### Description:

- Change DRAFT marker in Profile titles
- UnDraft PCI-DSS Profile. 

#### Rationale:

- These changes fix import error of roles in Ansible Galaxy
- Tried quoting the title, but it get shown in [README ](https://galaxy.ansible.com/Ansible-Security-Compliance/rhel7-role-pci-dss/) page.
- Why is PCDI-DSS the only profile marked draft with `documentation_complete: true`?
