### PR TITLE
Untemplatize package_dracut-fips_installed as passing check can denote FIPS certification

### DIFF
--- a/shared/checks/oval/package_dracut-fips_installed.xml
+++ b/shared/checks/oval/package_dracut-fips_installed.xml
@@ -1,0 +1,29 @@
+<!-- DO NOT TEMPLATE this check. dracut-fips should only be installed on 
+ certified systems, and changes to this file should be scrutinized through the
+ review process.
+-->
+<def-group>
+  <definition class="compliance" id="package_dracut-fips_installed"
+  version="1">
+    <metadata>
+      <title>Package dracut-fips Installed</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+      </affected>
+      <description>The RPM package dracut-fips should be installed.</description>
+    </metadata>
+    <criteria>
+      <extend_definition comment="Installed OS is certified" definition_ref="installed_OS_is_certified" />
+      <criterion comment="package dracut-fips is installed"
+      test_ref="test_package_dracut-fips_installed" />
+    </criteria>
+  </definition>
+  <linux:rpminfo_test check="all" check_existence="all_exist"
+  id="test_package_dracut-fips_installed" version="1"
+  comment="package dracut-fips is installed">
+    <linux:object object_ref="obj_package_dracut-fips_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_package_dracut-fips_installed" version="1">
+    <linux:name>dracut-fips</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/shared/templates/csv/packages_installed.csv
+++ b/shared/templates/csv/packages_installed.csv
@@ -1,7 +1,6 @@
 aide
 audit
 dconf
-dracut-fips
 gdm
 ntp
 rsyslog


### PR DESCRIPTION
#### Description:

- Untemplatize package_dracut-fips-installed as passing check can denote FIPS certification

#### Rationale:

- This file should not be templated and should be scrutinized through the GitHub review process to keep track of changes made to it as pass this check can be used to justify FIPS validation/certification.
