### PR TITLE
add missing python-jinja2 PyYAML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV OSCAP_DIR scap-security-guide
 ENV BUILD_JOBS 4
 
 RUN yum -y upgrade && \
-    yum -y install make cmake openscap-utils && \
+    yum -y install cmake make openscap-utils python-jinja2 PyYAML && \
     mkdir -p /home/$OSCAP_USERNAME && \
     yum clean all && \
     rm -rf /usr/share/doc /usr/share/doc-base \


### PR DESCRIPTION
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>

#### Description:

Docker build fails due to missing dependencies.

```---> Running in 54d58c5f1c1c
-- SCAP Security Guide 0.1.40
-- (see /home/oscap/scap-security-guide/BUILD.md for build instructions)
--
-- Found PythonInterp: /usr/bin/python2 (found suitable version "2.7.5", minimum required is "2")
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:108 (message):
  Could NOT find PY_yaml (missing: PY_YAML)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:315 (_FPHSA_FAILURE_MESSAGE)
  cmake/FindPythonModule.cmake:23 (find_package_handle_standard_args)
  CMakeLists.txt:74 (find_python_module)


-- Configuring incomplete, errors occurred!
See also "/home/oscap/scap-security-guide/build/CMakeFiles/CMakeOutput.log".
The command '/bin/sh -c cmake ..' returned a non-zero code: 1
```
