### PR TITLE
Add openSUSE Leap 15.0 CPE with seperate OVAL test

### DIFF
--- a/opensuse/cpe/opensuse-cpe-dictionary.xml
+++ b/opensuse/cpe/opensuse-cpe-dictionary.xml
@@ -5,16 +5,16 @@
       <cpe-item name="cpe:/o:opensuse:leap:42.1">
             <title xml:lang="en-us">openSUSE Leap 42.1</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
-            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_opensuse</check>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_opensuse_leap42</check>
       </cpe-item>
       <cpe-item name="cpe:/o:opensuse:leap:42.2">
             <title xml:lang="en-us">openSUSE Leap 42.2</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
-            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_opensuse</check>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_opensuse_leap42</check>
       </cpe-item>
       <cpe-item name="cpe:/o:opensuse:leap:42.3">
             <title xml:lang="en-us">openSUSE Leap 42.3</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
-            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_opensuse</check>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_opensuse_leap42</check>
       </cpe-item>
 </cpe-list>

--- a/opensuse/cpe/opensuse-cpe-dictionary.xml
+++ b/opensuse/cpe/opensuse-cpe-dictionary.xml
@@ -17,4 +17,9 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_opensuse_leap42</check>
       </cpe-item>
+      <cpe-item name="cpe:/o:opensuse:leap:15.0">
+            <title xml:lang="en-us">openSUSE Leap 15.0</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_opensuse_leap15</check>
+      </cpe-item>
 </cpe-list>

--- a/opensuse/transforms/constants.xslt
+++ b/opensuse/transforms/constants.xslt
@@ -6,7 +6,7 @@
 <xsl:variable name="product_short_name">openSUSE</xsl:variable>
 <xsl:variable name="product_stig_id_name">empty</xsl:variable>
 <xsl:variable name="product_guide_id_name">OPENSUSE</xsl:variable>
-<xsl:variable name="platform_cpes">cpe:/o:opensuse:leap:42.1,cpe:/o:opensuse:leap:42.2,cpe:/o:opensuse:leap:42.3</xsl:variable>
+<xsl:variable name="platform_cpes">cpe:/o:opensuse:leap:42.1,cpe:/o:opensuse:leap:42.2,cpe:/o:opensuse:leap:42.3,cpe:/o:opensuse:leap:15.0</xsl:variable>
 <xsl:variable name="prod_type">opensuse</xsl:variable>
 
 <xsl:variable name="cisuri">empty</xsl:variable>

--- a/oval.config.in
+++ b/oval.config.in
@@ -28,6 +28,6 @@ multi_platform_ubuntu = 1604,1404
 multi_platform_wrlinux = 8
 multi_platform_rhel = 6,7
 multi_platform_openstack = 
-multi_platform_opensuse = 42.1,42.2,42.3
+multi_platform_opensuse = 42.1,42.2,42.3,15.0
 multi_platform_sle = 11,12
 multi_platform_ol = 7

--- a/shared/checks/oval/installed_OS_is_opensuse.xml
+++ b/shared/checks/oval/installed_OS_is_opensuse.xml
@@ -1,14 +1,10 @@
 <def-group>
-  <definition class="inventory"
-  id="installed_OS_is_opensuse" version="1">
+  <definition class="inventory" id="installed_OS_is_opensuse" version="1">
     <metadata>
       <title>openSUSE</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <reference ref_id="cpe:/o:opensuse:leap:42.1" source="CPE" />
-      <reference ref_id="cpe:/o:opensuse:leap:42.2" source="CPE" />
-      <reference ref_id="cpe:/o:opensuse:leap:42.3" source="CPE" />
       <description>The operating system installed on the system is openSUSE.</description>
     </metadata>
     <criteria operator="AND">
@@ -22,7 +18,7 @@
     <linux:state state_ref="state_opensuse_installed" />
   </linux:rpminfo_test>
   <linux:rpminfo_state id="state_opensuse_installed" version="1">
-    <linux:version operation="pattern match">^42.*$</linux:version>
+    <linux:name operation="pattern match">openSUSE-release</linux:name>
   </linux:rpminfo_state>
   <linux:rpminfo_object id="obj_opensuse_installed" version="1">
     <linux:name>openSUSE-release</linux:name>

--- a/shared/checks/oval/installed_OS_is_opensuse_leap15.xml
+++ b/shared/checks/oval/installed_OS_is_opensuse_leap15.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="inventory" id="installed_OS_is_opensuse_leap15" version="1">
+    <metadata>
+      <title>openSUSE Leap 15</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:opensuse:leap:15.0" source="CPE" />
+      <description>The operating system installed on the system is openSUSE Leap 15.</description>
+    </metadata>
+    <criteria operator="AND">
+      <extend_definition comment="openSUSE is installed" definition_ref="installed_OS_is_opensuse" />
+      <criterion comment="openSUSE Leap 15 is installed" test_ref="test_opensuse_leap15_installed" />
+    </criteria>
+  </definition>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="openSUSE Leap 15 is installed" id="test_opensuse_leap15_installed" version="1">
+    <linux:object object_ref="obj_opensuse_leap15_installed" />
+    <linux:state state_ref="state_opensuse_leap15_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_opensuse_leap15_installed" version="1">
+    <linux:version operation="pattern match">^15.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_opensuse_leap15_installed" version="1">
+    <linux:name>openSUSE-release</linux:name>
+  </linux:rpminfo_object>
+
+</def-group>

--- a/shared/checks/oval/installed_OS_is_opensuse_leap42.xml
+++ b/shared/checks/oval/installed_OS_is_opensuse_leap42.xml
@@ -1,0 +1,30 @@
+<def-group>
+  <definition class="inventory" id="installed_OS_is_opensuse_leap42" version="1">
+    <metadata>
+      <title>openSUSE Leap 42</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:opensuse:leap:42.1" source="CPE" />
+      <reference ref_id="cpe:/o:opensuse:leap:42.2" source="CPE" />
+      <reference ref_id="cpe:/o:opensuse:leap:42.3" source="CPE" />
+      <description>The operating system installed on the system is openSUSE Leap 42.</description>
+    </metadata>
+    <criteria operator="AND">
+      <extend_definition comment="openSUSE is installed" definition_ref="installed_OS_is_opensuse" />
+      <criterion comment="openSUSE Leap 42 is installed" test_ref="test_opensuse_leap42_installed" />
+    </criteria>
+  </definition>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="openSUSE Leap 42 is installed" id="test_opensuse_leap42_installed" version="1">
+    <linux:object object_ref="obj_opensuse_leap42_installed" />
+    <linux:state state_ref="state_opensuse_leap42_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_opensuse_leap42_installed" version="1">
+    <linux:version operation="pattern match">^42.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_opensuse_leap42_installed" version="1">
+    <linux:name>openSUSE-release</linux:name>
+  </linux:rpminfo_object>
+
+</def-group>


### PR DESCRIPTION
Add the CPE for the upcoming major release openSUSE Leap 15.0 and therefore separate the Leap 42 OVAL test. The release of openSUSE Leap 15.0 is scheduled for the 25th of May 2018.