### PR TITLE
Add rules for profile sap on ol7:  remove NIS packages 

### DIFF
--- a/ol7/profiles/sap.profile
+++ b/ol7/profiles/sap.profile
@@ -3,10 +3,8 @@ documentation_complete: true
 title: 'Security Profile of Oracle Linux 7 for SAP'
 
 description: |-
-    This profile contains rules for Oracle Linux 7 Operating System
-    in compliance with SAP note 2069760 and SAP Security Baseline v1.9
-    Item I-8 and section 4.1.2.2. Regardless of your system's workload
-    all of these checks should pass.
+    This profile contains rules for Oracle Linux 7 Operating System in compliance with SAP note 2069760 <weblink-macro link="https://launchpad.support.sap.com/#/notes/2069760" /> and SAP Security Baseline Template version 1.9 Item I-8 and section 4.1.2.2. <weblink-macro link="https://support.sap.com/content/dam/support/en_us/library/ssp/offerings-and-programs/support-services/sap-security-optimization-services-portfolio/Security_Baseline_Template.zip" />
+    Regardless of your system's workload all of these checks should pass.
     
 selections:
     - package_glibc_installed

--- a/ol7/profiles/sap.profile
+++ b/ol7/profiles/sap.profile
@@ -15,3 +15,5 @@ selections:
     - service_rlogin_disabled
     - service_rsh_disabled
     - no_rsh_trust_files
+    - package_ypbind_removed
+    - package_ypserv_removed

--- a/shared/guide/services/obsolete/nis/package_ypbind_removed.rule
+++ b/shared/guide/services/obsolete/nis/package_ypbind_removed.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7
+prodtype: rhel7,ol7
 
 title: 'Remove NIS Client'
 

--- a/shared/guide/services/obsolete/nis/package_ypserv_removed.rule
+++ b/shared/guide/services/obsolete/nis/package_ypserv_removed.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7
+prodtype: rhel7,ol7
 
 title: 'Uninstall ypserv Package'
 


### PR DESCRIPTION

#### Description:
- Add two existing rules into the profile sap on ol7
        modified:   ol7/profiles/sap.profile
	modified:   shared/guide/services/obsolete/nis/package_ypbind_removed.rule
	modified:   shared/guide/services/obsolete/nis/package_ypserv_removed.rule