### PR TITLE
Fixed unintended behavior of remediations.

### DIFF
--- a/shared/bash_remediation_functions/include_mount_options_functions.sh
+++ b/shared/bash_remediation_functions/include_mount_options_functions.sh
@@ -31,7 +31,7 @@ function assert_mount_point_in_fstab {
 function remove_defaults_from_fstab_if_overriden {
 	local _mount_point_match_regexp
 	_mount_point_match_regexp="$(get_mount_point_regexp "$1")"
-	if [ $(grep "$_mount_point_match_regexp" /etc/fstab | grep -q "defaults,") -gt 0 ]
+	if $(grep "$_mount_point_match_regexp" /etc/fstab | grep -q "defaults,")
 	then
 		sed -i "s|\(${_mount_point_match_regexp}.*\)defaults,|\1|" /etc/fstab
 	fi

--- a/shared/templates/template_BASH_mount_option
+++ b/shared/templates/template_BASH_mount_option
@@ -5,10 +5,15 @@
 
 include_mount_options_functions
 
-# test "$mount_has_to_exist" = 'yes'
-test "%MOUNT_HAS_TO_EXIST%" = 'yes' && assert_mount_point_in_fstab %MOUNTPOINT% \
-	|| { echo "Not remediating, because there is no record of %MOUNTPOINT% in /etc/fstab" >&2; exit 1; }
+function perform_remediation {
+	# test "$mount_has_to_exist" = 'yes'
+	if test "%MOUNT_HAS_TO_EXIST%" = 'yes'; then
+		assert_mount_point_in_fstab %MOUNTPOINT% || { echo "Not remediating, because there is no record of %MOUNTPOINT% in /etc/fstab" >&2; return 1; }
+	fi
 
-ensure_mount_option_in_fstab "%MOUNTPOINT%" "%MOUNTOPTION%"
+	ensure_mount_option_in_fstab "%MOUNTPOINT%" "%MOUNTOPTION%"
 
-ensure_partition_is_mounted "%MOUNTPOINT%"
+	ensure_partition_is_mounted "%MOUNTPOINT%"
+}
+
+perform_remediation

--- a/shared/templates/template_BASH_mount_option_var
+++ b/shared/templates/template_BASH_mount_option_var
@@ -8,10 +8,15 @@ populate %MOUNTPOINT%
 
 include_mount_options_functions
 
-# test "$mount_has_to_exist" = 'yes'
-test "%MOUNT_HAS_TO_EXIST%" = 'yes' && assert_mount_point_in_fstab "$%MOUNTPOINT%" \
-	|| { echo "Not remediating, because there is no record of $%MOUNTPOINT% in /etc/fstab" >&2; exit 1; }
+function perform_remediation {
+	# test "$mount_has_to_exist" = 'yes'
+	if test "%MOUNT_HAS_TO_EXIST%" = 'yes'; then
+		assert_mount_point_in_fstab "$%MOUNTPOINT%" || { echo "Not remediating, because there is no record of $%MOUNTPOINT% in /etc/fstab" >&2; return 1; }
+	fi
 
-ensure_mount_option_in_fstab "$%MOUNTPOINT%" "%MOUNTOPTION%"
+	ensure_mount_option_in_fstab "$%MOUNTPOINT%" "%MOUNTOPTION%"
 
-ensure_partition_is_mounted "$%MOUNTPOINT%"
+	ensure_partition_is_mounted "$%MOUNTPOINT%"
+}
+
+perform_remediation


### PR DESCRIPTION
Fixes: #2836

- Actual remediations were moved into functions.
- The 'exit' statement has been substituted by return, so series of
  remediations doesn't end abruptly.
- Minor bug has been fixed in shared functionality.