### PR TITLE
Fix broken Python 3 build

### DIFF
--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -50,8 +50,8 @@ def add_warning_elements(element, warnings):
     #
     # Each of the {dict} should have only one key/value pair.
     for warning_dict in warnings:
-        warning = add_sub_element(element, "warning", warning_dict.values()[0])
-        warning.set("category", warning_dict.keys()[0])
+        warning = add_sub_element(element, "warning", list(warning_dict.values())[0])
+        warning.set("category", list(warning_dict.keys())[0])
 
 
 class Profile(object):


### PR DESCRIPTION
In Python 2, dict methods items(), keys() and values() return
a list. But in Python 3, they return view objects. The returned
value needs to be converted to a list explicitely if we want to
access the members using an index.
Addressing:
```
  File "/home/jcerny/scap-security-guide/shared/utils/yaml-to-shorthand.py", line 53, in add_warning_elements
    warning = add_sub_element(element, "warning", warning_dict.values()[0])
TypeError: 'dict_values' object does not support indexing
```
