### PR TITLE
Do not depend on Python 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     )
 endif()
 
-find_package(PythonInterp 2 REQUIRED)
+find_package(PythonInterp REQUIRED)
 find_python_module(yaml REQUIRED)
 find_python_module(jinja2 REQUIRED)
 


### PR DESCRIPTION
We can build SSG using both Python 2 and Python 3. However, on systems
where Python 2 is not installed, CMake will fail, because it tries to
find Python 2 interpreter. We do not have to require any version.