### PR TITLE
Install PyYAML and python-jinja2 for centos CI

### DIFF
--- a/.cico.yaml
+++ b/.cico.yaml
@@ -78,5 +78,5 @@
             git_username: openscap
             git_repo: scap-security-guide
             ci_project: '{name}'
-            ci_cmd: "yum -y install install cmake openscap-utils git PyYAML python-jinja2 && cd build && cmake ../ && make -j4 validate"
+            ci_cmd: "yum -y install install cmake openscap-utils git PyYAML python-jinja2 && cd build && cmake ../ && make -j4 && ctest -j4"
             timeout: '20m'

--- a/.cico.yaml
+++ b/.cico.yaml
@@ -78,5 +78,5 @@
             git_username: openscap
             git_repo: scap-security-guide
             ci_project: '{name}'
-            ci_cmd: "yum -y install install cmake openscap-utils git && cd build && cmake ../ && make -j4 validate"
+            ci_cmd: "yum -y install install cmake openscap-utils git PyYAML python-jinja2 && cd build && cmake ../ && make -j4 validate"
             timeout: '20m'


### PR DESCRIPTION
Otherwise centos CI fails. See https://ci.centos.org/job/openscap-scap-security-guide/262/console