### PR TITLE
Output on ctest failure when running on CentOS CI

### DIFF
--- a/.cico.yaml
+++ b/.cico.yaml
@@ -78,5 +78,5 @@
             git_username: openscap
             git_repo: scap-security-guide
             ci_project: '{name}'
-            ci_cmd: "yum -y install install cmake openscap-utils git PyYAML python-jinja2 && cd build && cmake ../ && make -j4 && ctest -j4"
+            ci_cmd: "yum -y install install cmake openscap-utils git PyYAML python-jinja2 && cd build && cmake ../ && make -j4 && CTEST_OUTPUT_ON_FAILURE=1 ctest -j4"
             timeout: '20m'


### PR DESCRIPTION
Makes it easier to debug the issue because the errors will be there in
the output.

Should make debugging https://ci.centos.org/job/openscap-scap-security-guide/266/console easier