### PR TITLE
Fix Scientific Linux version

### DIFF
--- a/shared/checks/oval/installed_OS_is_sl7.xml
+++ b/shared/checks/oval/installed_OS_is_sl7.xml
@@ -6,7 +6,7 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <reference ref_id="cpe:/o:scientificlinux:scientificlinux:6"
+      <reference ref_id="cpe:/o:scientificlinux:scientificlinux:7"
       source="CPE" />
       <description>The operating system installed on the system is
       Scientific Linux 7</description>


### PR DESCRIPTION
#### Description:
Fix Scientific Linux CPE.

#### Rationale:
It's for 99.9% typo.