### PR TITLE
Remove attribute var_check from var_ref element

### DIFF
--- a/shared/checks/oval/mcafee_antivirus_definitions_updated.xml
+++ b/shared/checks/oval/mcafee_antivirus_definitions_updated.xml
@@ -32,7 +32,7 @@
 
   <ind:variable_object comment="McAfee AntiVirus definitions age"
 id="object_mcafee_definitions_modified_time" version="1">
-     <ind:var_ref var_check="all">variable_mcafee_dat_files_mtime</ind:var_ref>
+     <ind:var_ref>variable_mcafee_dat_files_mtime</ind:var_ref>
    </ind:variable_object>
 
   <ind:variable_state id="state_mcafee_definitions_max_age" version="1">


### PR DESCRIPTION
#### Description:

- Remove `var_check` attribute from `var_ref` element.

#### Rationale:

- `var_ref` elements cannot have `var_check` attribute

- Fixes SCAP Val validation check
