### PR TITLE
Fix link to reference documentation for PAM configuration file

### DIFF
--- a/rhel6/guide/system/accounts/accounts-pam/accounts-pam.group
+++ b/rhel6/guide/system/accounts/accounts-pam/accounts-pam.group
@@ -44,4 +44,4 @@ warnings:
         will re-write the PAM configuration files, destroying any manually
         made changes and replacing them with a series of system defaults.
         One reference to the configuration file syntax can be found at
-        <weblink-macro link="http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html"/>.
+        <weblink-macro link="http://www.linux-pam.org/Linux-PAM-html/sag-configuration-file.html"/>.

--- a/shared/guide/system/accounts/accounts-pam/accounts-pam.group
+++ b/shared/guide/system/accounts/accounts-pam/accounts-pam.group
@@ -44,4 +44,4 @@ warnings:
         will re-write the PAM configuration files, destroying any manually
         made changes and replacing them with a series of system defaults.
         One reference to the configuration file syntax can be found at
-        <weblink-macro link="http://www.kernel.org/pub/linux/libs/pam/Linux-PAM-html/sag-configuration-file.html"/>.
+        <weblink-macro link="http://www.linux-pam.org/Linux-PAM-html/sag-configuration-file.html"/>.


### PR DESCRIPTION
#### Description:
- Fix link to reference documentation for PAM configuration file.

#### Rationale:

- Current link is resulting in 404 error.
- Fixes linkchecker results.
