### PR TITLE
Unshadow packages removed WRT RHEL6

### DIFF
--- a/fedora/templates/csv/packages_removed.csv
+++ b/fedora/templates/csv/packages_removed.csv
@@ -1,3 +1,6 @@
+mcstrans
 net-snmp
 openssh-server
 prelink
+setroubleshoot
+xorg-x11-server-common

--- a/firefox/templates/csv/packages_removed.csv
+++ b/firefox/templates/csv/packages_removed.csv
@@ -1,0 +1,2 @@
+setroubleshoot
+xorg-x11-server-common

--- a/rhel7/templates/csv/packages_removed.csv
+++ b/rhel7/templates/csv/packages_removed.csv
@@ -9,6 +9,7 @@ mcstrans
 net-snmp
 ntpdate
 openldap-servers
+openssh-server
 prelink
 rsh
 rsh-server

--- a/rhel7/templates/csv/packages_removed.csv
+++ b/rhel7/templates/csv/packages_removed.csv
@@ -5,13 +5,18 @@ dhcp
 dovecot
 httpd
 iputils
+mcstrans
 net-snmp
 ntpdate
+openldap-servers
 prelink
 rsh
 rsh-server
 quagga
 samba
+samba-common
+sendmail
+setroubleshoot
 squid
 talk
 talk-server
@@ -21,4 +26,5 @@ tftp
 tftp-server
 vsftpd
 xinetd
+xorg-x11-server-common
 ypserv

--- a/shared/templates/csv/packages_removed.csv
+++ b/shared/templates/csv/packages_removed.csv
@@ -1,7 +1,1 @@
-mcstrans
 nss-pam-ldapd
-openldap-servers
-samba-common
-sendmail
-setroubleshoot
-xorg-x11-server-common


### PR DESCRIPTION
#### Description:

- Removed packages from shared packages_removed csv that already were in RHEL6 csv
- Re-added the packages in products that were relying on shared csv.

#### Rationale:

- This will un-shadow some OVAL and fixes for RHEL6 regarding package_removed rules.
