### PR TITLE
Prepare ocp3 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,8 @@ if (SSG_PRODUCT_JRE)
     add_subdirectory("jre")
 endif()
 if (SSG_PRODUCT_OCP3)
+    # FIXME: disabled because it has no rules in it,
+    #        please uncomment when any rule is added
     #add_subdirectory("ocp3")
 endif()
 if (SSG_PRODUCT_OPENSUSE)

--- a/ocp3/CMakeLists.txt
+++ b/ocp3/CMakeLists.txt
@@ -4,23 +4,6 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 set(PRODUCT "ocp3")
-#set(DISA_SRG_TYPE "os")
+set(DISA_SRG_TYPE "os")
 
-#ssg_build_product(${PRODUCT})
-
-#ssg_build_html_table_by_ref(${PRODUCT} "nist")
-#ssg_build_html_table_by_ref(${PRODUCT} "cis")
-#ssg_build_html_table_by_ref(${PRODUCT} "cui")
-#ssg_build_html_table_by_ref(${PRODUCT} "pcidss")
-
-#ssg_build_html_nistrefs_table(${PRODUCT} "common")
-#ssg_build_html_nistrefs_table(${PRODUCT} "ospp-${PRODUCT}")
-#ssg_build_html_nistrefs_table(${PRODUCT} "C2S")
-#ssg_build_html_nistrefs_table(${PRODUCT} "stig-${PRODUCT}-disa")
-
-#ssg_build_html_cce_table(${PRODUCT})
-
-#ssg_build_html_srgmap_tables(${PRODUCT} ${DISA_SRG_TYPE})
-
-#ssg_build_html_stig_tables(${PRODUCT} "stig-${PRODUCT}-disa")
-
+ssg_build_product(${PRODUCT})

--- a/ocp3/product.yml
+++ b/ocp3/product.yml
@@ -1,0 +1,9 @@
+product: ocp3
+
+benchmark_root: "../shared/guide"
+
+profiles_root: "./profiles"
+
+pkg_system: "rpm"
+
+init_system: "systemd"

--- a/ocp3/profiles/C2S-master.profile
+++ b/ocp3/profiles/C2S-master.profile
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'C2S for Red Hat Enterprise OpenShift Container Platform 3 Master Node'
+title: 'C2S for Master Node'
 
 description: |-
     This profile demonstrates compliance against the
@@ -15,6 +15,6 @@ description: |-
     ensure a system is in compliance or consistency with the CIS
     baseline.
 
-extends: C2S-ocp-node
+extends: C2S-node
 
 selections: []

--- a/ocp3/profiles/C2S-node.profile
+++ b/ocp3/profiles/C2S-node.profile
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'C2S for Red Hat Enterprise OpenShift Container Platform 3 Node'
+title: 'C2S for Node'
 
 description: |-
     This profile demonstrates compliance against the

--- a/shared/modules/map_product_module.py
+++ b/shared/modules/map_product_module.py
@@ -14,9 +14,10 @@ OPENSUSE = 'openSUSE'
 SUSE = 'SUSE Linux Enterprise'
 WRLINUX = 'Wind River Linux'
 OL = 'Oracle Linux'
+OCP = 'Red Hat OpenShift Container Platform'
 
 multi_product_list = ["rhel", "fedora", "rhel-osp", "debian", "ubuntu",
-                      "wrlinux", "opensuse", "sle", "ol"]
+                      "wrlinux", "opensuse", "sle", "ol", "ocp"]
 
 PRODUCT_NAME_PARSER = re.compile("([a-zA-Z\-]+)([0-9]+)")
 
@@ -74,7 +75,8 @@ def map_product(version):
         return WRLINUX
     if version.startswith("ol"):
         return OL
-
+    if version.startswith("ocp"):
+        return OCP
 
     raise RuntimeError("Can't map version '%s' to any known product!"
                        % (version))


### PR DESCRIPTION
We are not building the ocp3 product because it's empty. This doesn't change that fact but it moves the ocp3 source code closer to current state of SSG master. Because it was not being built we didn't do some of the refactoring and we never created a `product.yml` for it.