### PR TITLE
Ansible aide database more robust

### DIFF
--- a/shared/fixes/ansible/aide_build_database.yml
+++ b/shared/fixes/ansible/aide_build_database.yml
@@ -29,7 +29,7 @@
   copy:
     src: /var/lib/aide/aide.db.new.gz
     dest: /var/lib/aide/aide.db.gz
-    force: no
+    backup: yes
     remote_src: yes
   when: aide_database_stat.stat.exists is defined and aide_database_stat.stat.exists
   tags:

--- a/shared/fixes/ansible/aide_build_database.yml
+++ b/shared/fixes/ansible/aide_build_database.yml
@@ -18,7 +18,7 @@
     @ANSIBLE_TAGS@
 
 # mainly to allow ansible's check mode to work
-- name: "Check whether blank AIDE Database exists"
+- name: "Check whether the stock AIDE Database exists"
   stat:
     path: /var/lib/aide/aide.db.new.gz
   register: aide_database_stat

--- a/shared/fixes/ansible/aide_build_database.yml
+++ b/shared/fixes/ansible/aide_build_database.yml
@@ -29,7 +29,7 @@
   copy:
     src: /var/lib/aide/aide.db.new.gz
     dest: /var/lib/aide/aide.db.gz
-    backup: yes
+    force: no
     remote_src: yes
   when: aide_database_stat.stat.exists is defined and aide_database_stat.stat.exists
   tags:

--- a/shared/fixes/ansible/aide_build_database.yml
+++ b/shared/fixes/ansible/aide_build_database.yml
@@ -17,11 +17,20 @@
   tags:
     @ANSIBLE_TAGS@
 
-- name: Stage AIDE Database"
+# mainly to allow ansible's check mode to work
+- name: "Check whether blank AIDE Database exists"
+  stat:
+    path: /var/lib/aide/aide.db.new.gz
+  register: aide_database_stat
+  tags:
+    @ANSIBLE_TAGS@
+
+- name: "Stage AIDE Database"
   copy:
     src: /var/lib/aide/aide.db.new.gz
     dest: /var/lib/aide/aide.db.gz
     backup: yes
     remote_src: yes
+  when: aide_database_stat.stat.exists is defined and aide_database_stat.stat.exists
   tags:
     @ANSIBLE_TAGS@


### PR DESCRIPTION
Fixing an issue we ran into when preparing OpenSCAP labs.

This is the error:
```

PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [Ensure AIDE is installed] ************************************************
changed: [localhost] => (item=aide)

TASK [Build and Test AIDE Database] ********************************************
skipping: [localhost]

TASK [Check whether blank AIDE Database exists] ********************************
ok: [localhost]

TASK [Stage AIDE Database] *****************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Source /var/lib/aide/aide.db.new.gz not found"}
        to retry, use: --limit @/home/mpreisle/d/scap-security-guide/build/roles/ssg-rhel7-role-ospp.retry

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=1   
```

After applying this PR:
```
PLAY [all] ************************************************************************************

TASK [Gathering Facts] ************************************************************************
ok: [localhost]

TASK [Ensure AIDE is installed] ***************************************************************
changed: [localhost] => (item=aide)

TASK [Build and Test AIDE Database] ***********************************************************
skipping: [localhost]

TASK [Check whether blank AIDE Database exists] ***********************************************
ok: [localhost]

TASK [Stage AIDE Database] ********************************************************************
skipping: [localhost]

PLAY RECAP ************************************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0
```

This PR also changes behavior of the staging task. Instead of always overwriting existing AIDE database it will only copy it if destination doesn't exist. I believe this is what was originally intended. Otherwise applying this playbook repeatedly will overwrite aide database and trash data.

How to test:
```
cd build/
cmake ../
make -j 4 rhel7-roles
cd roles
sudo ansible-playbook --check -i "localhost," -c local --tags aide_build_database ./ssg-rhel7-role-ospp.yml 
```