### PR TITLE
Ansible service result deprecation warning

### DIFF
--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -9,7 +9,7 @@
     enabled="no"
     state="stopped"
   register: service_result
-  failed_when: "service_result|failed and ('Could not find the requested service' not in service_result.msg)"
+  failed_when: "service_result is failed and ('Could not find the requested service' not in service_result.msg)"
   with_items:
     - %DAEMONNAME%
   tags:

--- a/shared/utils/build-all-remediation-roles.py
+++ b/shared/utils/build-all-remediation-roles.py
@@ -62,7 +62,7 @@ def add_minimum_ansible_version(ansible_src):
    pre_tasks:
      - name: %s
        assert:
-         that: "ansible_version.full | version_compare('%s', '>=')"
+         that: "ansible_version.full is version_compare('%s', '>=')"
          msg: >
            "You must update Ansible to at least version %s to use this role."
           """ % (ssgcommon.ansible_version_requirement_pre_task_name,


### PR DESCRIPTION
Avoid deprecation warnings such as:
```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|version_compare` instead use `result is version_compare`. This feature will be removed in version 2.9. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```