### PR TITLE
Add new rule file_groupowner_sapmnt_SID_exe to profile sap on ol7

### DIFF
--- a/ol7/profiles/sap.profile
+++ b/ol7/profiles/sap.profile
@@ -17,3 +17,4 @@ selections:
     - package_ypserv_removed
     - var_accounts_authorized_local_users_regex=ol7forsap
     - accounts_authorized_local_users
+    - file_groupowner_sapmnt_SID_exe

--- a/ol7/templates/csv/file_groupowner.csv
+++ b/ol7/templates/csv/file_groupowner.csv
@@ -1,0 +1,12 @@
+# Directory or file groupownership
+# The format is: 
+#
+# path,group[,[pathregex],[directory|file]]
+# 
+# The first column is the full path (include file name if the type is file).
+# The second column is the group name the directory or file should belong to.
+# The third column is optional, it's the regular expression of the path as defined in
+# http://oval.mitre.org/language/about/re_support_5.6.html.
+# The fourth column indicates if the type is directory or file. Default is file.
+#
+/sapmnt/SID/exe,sapsys,^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe$,directory

--- a/shared/fixes/bash/file_groupowner_sapmnt_SID_exe.sh
+++ b/shared/fixes/bash/file_groupowner_sapmnt_SID_exe.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_ol
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe$' -exec chgrp sapsys {} \;
+

--- a/shared/guide/system/software/sap/file_groupowner_sapmnt_SID_exe.rule
+++ b/shared/guide/system/software/sap/file_groupowner_sapmnt_SID_exe.rule
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: ol7
+
+title: 'Groupowner of Directory /sapmnt/SID/exe'
+
+description: |-
+    It is recommended the directory <tt>/sapmnt/SID/exe</tt> should be owned by
+    group <tt>sapsys</tt>.
+    <tt>SID</tt> is SAP System ID which is always three alphanumeric characters in
+    uppercase beginning with an alphabetic character.
+    To set correct group ownership, use the following command: 
+    <pre>$sudo chgrp sapsys /sapmnt/SID/exe </pre>
+    Replace the <tt>SID</tt> with the real value.
+
+rationale: |-
+
+severity: medium
+
+references:
+
+ocil_clause: 'unexpected group ownership of directory /sapmnt/SID/exe' 
+
+ocil: |-
+    Use the following commands to set correct group ownership:
+    <pre>$sudo chgrp sapsys /sapmnt/SID/exe </pre>
+    Replace the SID with the real value.

--- a/shared/templates/create_file_groupowner.py
+++ b/shared/templates/create_file_groupowner.py
@@ -26,13 +26,13 @@ class FileGroupOwnerGenerator(FilesGenerator):
         if len(args) > 2 and args[2]:
             pathregex = args[2]
         else:
-            pathregex = '^' + path + '$' 
+            pathregex = '^' + path + '$'
 
         # The fourth column is optional. It is used to indicate if the given path is a
         # directory or a file. The default value is file.
-        if len(args) > 3 and args[3]=="directory":
+        if len(args) > 3 and args[3] == "directory":
             dftype = "directory"
-        else :
+        else:
             dftype = "file"
 
         if target == "oval":

--- a/shared/templates/csv/file_groupowner.csv
+++ b/shared/templates/csv/file_groupowner.csv
@@ -1,0 +1,11 @@
+# Directory or file groupownership
+# The format is: 
+#
+# path,group[,[pathregex],[directory|file]]
+# 
+# The first column is the full path (include file name if the type is file).
+# The second column is the group name the directory or file should belong to.
+# The third column is optional, it's the regular expression of the path as defined in
+# http://oval.mitre.org/language/about/re_support_5.6.html.
+# The fourth column indicates if the type is directory or file. Default is file.
+#

--- a/shared/templates/template_OVAL_file_groupowner
+++ b/shared/templates/template_OVAL_file_groupowner
@@ -1,0 +1,48 @@
+<def-group>
+  <definition class="compliance" id="file_groupowner%PATHID%" version="1">
+    <metadata>
+      <title>Group Owner of %DFTYPE% %PATH%</title>
+      <affected family="unix">
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>%DFTYPE% %PATH% should be owned by group %GROUP%</description>
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_file_groupowner%PATHID%_is_%GROUP%" />
+    </criteria>
+  </definition>
+
+  <unix:file_test id="test_file_groupowner%PATHID%_is_%GROUP%" version="1"
+  check_existence="any_exist" check="all"
+  comment="%DFTYPE% %PATH% is owned by group %GROUP%">
+    <unix:object object_ref="object_file_groupowner%PATHID%" />
+    <unix:state state_ref="state_file_groupowner%PATHID%" />
+  </unix:file_test>
+
+  <unix:file_object id="object_file_groupowner%PATHID%" version="1"
+  comment="%DFTYPE% %PATH%">
+    {{% if "%DFTYPE%" == "directory" %}}
+      <unix:path operation="pattern match">%PATHREGEX%</unix:path>
+      <unix:filename xsi:nil="true"/>
+    {{% else %}}
+      <unix:filepath operation="pattern match">%PATHREGEX%</unix:filepath>
+    {{% endif %}}
+  </unix:file_object>
+
+  <unix:file_state id="state_file_groupowner%PATHID%" version="1"
+  comment="group owner is %GROUP%">
+    <unix:group_id datatype="int" var_ref="var_group_id_%GROUP%"/>
+  </unix:file_state>
+
+  <ind:textfilecontent54_object id="object_group_id_%GROUP%" version="1"
+  comment="get group id of %GROUP% from file /etc/group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^%GROUP%:x:([\d]+):</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_group_id_%GROUP%" version="1" datatype="int" 
+  comment="put group id of %GROUP% into a variable">
+    <object_component object_ref="object_group_id_%GROUP%" item_field="subexpression"/>
+  </local_variable>
+</def-group>


### PR DESCRIPTION
#### Description:

- Add new rule _file_groupowner_sapmnt_SID_exe_ to profile sap on ol7
- Add new OVAL template file _template_OVAL_file_groupowner_ in shared folder
- there is a difference in the .csv file format.  The third column was _alt_name_, but it was not really used, so I think it's safe to redefine it to _pathregex_ at this moment.
- The _file_groupowner.csv_ file uses regex, should it be renamed to _file_groupowner_regex.csv_?
- The individual bash remediation  _file_groupowner_sapmnt_SID_exe.sh_ does not occur in build. There is only the bash file generated from template. Could there be an Enhancement Request that if individual bash file exists, it should be used instead of the one generated from template?


