### PR TITLE
Add security_patches_up_to_date rule to ol7 standard profile

### DIFF
--- a/ol7/profiles/standard.profile
+++ b/ol7/profiles/standard.profile
@@ -10,6 +10,7 @@ description: |-
 selections:
     - ensure_oracle_gpgkey_installed
     - ensure_gpgcheck_globally_activated
+    - security_patches_up_to_date
     - rpm_verify_permissions
     - rpm_verify_hashes
     - no_empty_passwords


### PR DESCRIPTION
#### Description:
Complete https://github.com/OpenSCAP/scap-security-guide/issues/2675 fix adding security_patches_up_to_date rule back to ol7 standard profile

#### Rationale:
- Fixes #2675

#### Testing:
Checked build to pass
Checked security_patches_up_to_date rule content in generated guide and to return expected validation result on OL7