### PR TITLE
inactivity_timeout_value OVAL operation should be "less than or equal"

### DIFF
--- a/shared/checks/oval/dconf_gnome_screensaver_idle_delay.xml
+++ b/shared/checks/oval/dconf_gnome_screensaver_idle_delay.xml
@@ -66,7 +66,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_screensaver_idle_delay_setting" version="1">
-    <ind:subexpression datatype="int" operation="equals" var_check="all" var_ref="inactivity_timeout_value" />
+    <ind:subexpression datatype="int" operation="less than or equal" var_check="all" var_ref="inactivity_timeout_value" />
   </ind:textfilecontent54_state>
 
   <external_variable comment="inactivity timeout variable" datatype="int"


### PR DESCRIPTION
#### Description:

- Change `equals` to `less than or equal`

#### Rationale:

- inactivity_timeout_value OVAL operation should be "less than or equal"
- Fixes #2870
