### PR TITLE
Add dbus to suid whitelist

### DIFF
--- a/rhel7/checks/oval/file_permissions_unauthorized_suid.xml
+++ b/rhel7/checks/oval/file_permissions_unauthorized_suid.xml
@@ -73,6 +73,7 @@
     <value>/usr/lib/amanda/runtar</value>
     <value>/usr/lib/dbus-1/dbus-daemon-launch-helper</value>
     <value>/usr/libexec/abrt-action-install-debuginfo-to-abrt-cache</value>
+    <value>/usr/libexec/dbus-1/dbus-daemon-launch-helper</value>
     <value>/usr/libexec/kde4/kpac_dhcp_helper</value>
     <value>/usr/libexec/qemu-bridge-helper</value>
     <value>/usr/libexec/spice-gtk-x86_64/spice-client-glib-usb-acl-helper</value>


### PR DESCRIPTION
#### Description:

- Add dbus to suid whitelist

#### Rationale:

- dbus can also put `dbus-daemon-launch-helper` in `/usr/libexec`. Since `dbus-daemon-launch-helper` is already in the suid whitelist, this just adds another path to the whitelist.
- Fixes #2883
