### PR TITLE
Set SLE12 init system to systemd

### DIFF
--- a/sle12/product.yml
+++ b/sle12/product.yml
@@ -5,3 +5,5 @@ benchmark_root: "../shared/guide"
 profiles_root: "./profiles"
 
 pkg_system: "rpm"
+
+init_system: "systemd"


### PR DESCRIPTION
SLE 12 comes with systemd [1]

[1] https://www.suse.com/media/white-paper/systemd_in_suse_linux_enterprise_12_white_paper.pdf

init_systemd not being set was causing all sorts of problems with descriptions in the content.