### PR TITLE
Mention testing in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -168,6 +168,19 @@ tables/table-rhel7-stig.html
 ...
 ```
 
+### Testing
+
+To ensure validity of built artifacts prior to installation, we recommend
+running our test suite against the build output. This is done with ctest:
+
+```bash
+cd scap-security-guide/
+cd build/
+cmake ../
+make -j4
+ctest -j4
+```
+
 ### Installation
 
 System-wide installation:


### PR DESCRIPTION
#### Description:

- This mentions running `ctest` in the build instructions in `/BUILD.md`. 

#### Rationale:

- Outside of the [developer documentation](https://github.com/OpenSCAP/scap-security-guide/blob/master/docs/manual/developer_guide.adoc#tests-ctest), running `ctest` isn't described. It would be good to verify the tests pass before before installation.