### PR TITLE
Make sure we parse all yaml

### DIFF
--- a/chromium/guide/chromium/var_auth_schema.var
+++ b/chromium/guide/chromium/var_auth_schema.var
@@ -6,8 +6,6 @@ description: 'Chromium HTTP Authentication Types'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/chromium/guide/chromium/var_default_search_provider_name.var
+++ b/chromium/guide/chromium/var_default_search_provider_name.var
@@ -6,8 +6,6 @@ description: 'The URL for the Default Search provider in Chromium'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/chromium/guide/chromium/var_enable_encrypted_searching.var
+++ b/chromium/guide/chromium/var_enable_encrypted_searching.var
@@ -6,8 +6,6 @@ description: 'Encrypted search URL for the Default Search Provider'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/chromium/guide/chromium/var_extension_whitelist.var
+++ b/chromium/guide/chromium/var_extension_whitelist.var
@@ -6,8 +6,6 @@ description: 'Chromium extensions approved for use'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/chromium/guide/chromium/var_trusted_home_page.var
+++ b/chromium/guide/chromium/var_trusted_home_page.var
@@ -6,8 +6,6 @@ description: 'Default homepage for Chromium users'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/chromium/guide/chromium/var_url_blacklist.var
+++ b/chromium/guide/chromium/var_url_blacklist.var
@@ -6,8 +6,6 @@ description: 'Blacklisted Protocol Schemas in Chromium'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/firefox/guide/firefox/var_default_home_page.var
+++ b/firefox/guide/firefox/var_default_home_page.var
@@ -6,8 +6,6 @@ description: 'The default home page for Firefox users.'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/firefox/guide/firefox/var_required_file_types.var
+++ b/firefox/guide/firefox/var_required_file_types.var
@@ -8,8 +8,6 @@ description: |-
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/services/http/securing_httpd/var_httpd_loglevel.var
+++ b/linux_os/guide/services/http/securing_httpd/var_httpd_loglevel.var
@@ -6,8 +6,6 @@ description: 'The setting for LogLevel in /etc/httpd/conf/httpd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/services/http/securing_httpd/var_max_keepalive_requests.var
+++ b/linux_os/guide/services/http/securing_httpd/var_max_keepalive_requests.var
@@ -6,8 +6,6 @@ description: 'The setting for MaxKeepAliveRequests in httpd.conf'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/services/ntp/var_multiple_time_servers.var
+++ b/linux_os/guide/services/ntp/var_multiple_time_servers.var
@@ -6,8 +6,6 @@ description: 'The list of vendor-approved time servers'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/services/ntp/var_time_service_set_maxpoll.var
+++ b/linux_os/guide/services/ntp/var_time_service_set_maxpoll.var
@@ -6,8 +6,6 @@ description: 'The maximum NTP or Chrony poll interval number in seconds specifie
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/var_account_disable_post_pw_expiration.var
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/var_account_disable_post_pw_expiration.var
@@ -6,8 +6,6 @@ description: 'The number of days to wait after a password expires, until the acc
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_maximum_age_login_defs.var
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_maximum_age_login_defs.var
@@ -6,8 +6,6 @@ description: 'Maximum age of password in days'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_minimum_age_login_defs.var
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_minimum_age_login_defs.var
@@ -6,8 +6,6 @@ description: 'Minimum age of password in days'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_password_minlen_login_defs.var
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_password_minlen_login_defs.var
@@ -6,8 +6,6 @@ description: 'Minimum number of characters in password'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_password_warn_age_login_defs.var
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_password_warn_age_login_defs.var
@@ -6,8 +6,6 @@ description: 'The number of days'' warning given before a password expires.'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_disk_full_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_disk_full_action.var
@@ -6,8 +6,6 @@ description: 'The setting for disk_full_action in /etc/audisp/audisp-remote.conf
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_network_failure_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_network_failure_action.var
@@ -6,8 +6,6 @@ description: 'The setting for network_failure_action in /etc/audisp/audisp-remot
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_remote_server.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_remote_server.var
@@ -6,8 +6,6 @@ description: 'The setting for remote_server in /etc/audisp/audisp-remote.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_action_mail_acct.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_action_mail_acct.var
@@ -6,8 +6,6 @@ description: 'The setting for action_mail_acct in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_admin_space_left_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_admin_space_left_action.var
@@ -6,8 +6,6 @@ description: 'The setting for admin_space_left_action in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_flush.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_flush.var
@@ -6,8 +6,6 @@ description: 'The setting for flush in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_max_log_file.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_max_log_file.var
@@ -6,8 +6,6 @@ description: 'The setting for max_log_size in /etc/audit/auditd.conf'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_max_log_file_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_max_log_file_action.var
@@ -6,8 +6,6 @@ description: 'The setting for max_log_file_action in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_num_logs.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_num_logs.var
@@ -6,8 +6,6 @@ description: 'The setting for num_logs in /etc/audit/auditd.conf'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left.var
@@ -6,8 +6,6 @@ description: 'The setting for space_left (MB) in /etc/audit/auditd.conf'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left_action.var
@@ -6,8 +6,6 @@ description: 'The setting for space_left_action in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/accounts/accounts-restrictions/account_expiration/var_account_disable_post_pw_expiration.var
+++ b/rhel6/guide/system/accounts/accounts-restrictions/account_expiration/var_account_disable_post_pw_expiration.var
@@ -6,8 +6,6 @@ description: 'The number of days to wait after a password expires, until the acc
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_maximum_age_login_defs.var
+++ b/rhel6/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_maximum_age_login_defs.var
@@ -6,8 +6,6 @@ description: 'Maximum age of password in days'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_minimum_age_login_defs.var
+++ b/rhel6/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_minimum_age_login_defs.var
@@ -6,8 +6,6 @@ description: 'Minimum age of password in days'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_password_minlen_login_defs.var
+++ b/rhel6/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_password_minlen_login_defs.var
@@ -6,8 +6,6 @@ description: 'Minimum number of characters in password'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_password_warn_age_login_defs.var
+++ b/rhel6/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_password_warn_age_login_defs.var
@@ -6,8 +6,6 @@ description: 'The number of days'' warning given before a password expires.'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_action_mail_acct.var
+++ b/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_action_mail_acct.var
@@ -6,8 +6,6 @@ description: 'The setting for action_mail_acct in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_admin_space_left_action.var
+++ b/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_admin_space_left_action.var
@@ -6,8 +6,6 @@ description: 'The setting for space_left_action in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
+++ b/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
@@ -6,8 +6,6 @@ description: 'The setting for disk_error_action in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
+++ b/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
@@ -6,8 +6,6 @@ description: 'The setting for disk_full_action in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_flush.var
+++ b/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_flush.var
@@ -6,8 +6,6 @@ description: 'The setting for flush in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_max_log_file.var
+++ b/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_max_log_file.var
@@ -6,8 +6,6 @@ description: 'The setting for max_log_size in /etc/audit/auditd.conf'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_max_log_file_action.var
+++ b/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_max_log_file_action.var
@@ -6,8 +6,6 @@ description: 'The setting for max_log_file_action in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_num_logs.var
+++ b/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_num_logs.var
@@ -6,8 +6,6 @@ description: 'The setting for num_logs in /etc/audit/auditd.conf'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left.var
+++ b/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left.var
@@ -6,8 +6,6 @@ description: 'The setting for space_left (MB) in /etc/audit/auditd.conf'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left_action.var
+++ b/rhel6/guide/system/auditing/configure_auditd_data_retention/var_auditd_space_left_action.var
@@ -6,8 +6,6 @@ description: 'The setting for space_left_action in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/shared/modules/ssgcommon.py
+++ b/shared/modules/ssgcommon.py
@@ -255,7 +255,7 @@ def _open_yaml(stream):
     """
     yaml_contents = yaml.safe_load(stream)
 
-    if yaml_contents.get("documentation_complete") == "false":
+    if yaml_contents.pop("documentation_complete", "true") == "false":
         return None
 
     return yaml_contents

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -128,6 +128,7 @@ class Value(object):
 
     def __init__(self, id_):
         self.id_ = id_
+        self.operator = "equals"
 
     @staticmethod
     def from_yaml(yaml_file, product_yaml=None):
@@ -174,6 +175,8 @@ class Value(object):
         value = ET.Element('Value')
         value.set('id', self.id_)
         value.set('type', self.type)
+        if self.operator != "equals":  # equals is the default
+            value.set('operator', self.operator)
         title = ET.SubElement(value, 'title')
         title.text = self.title
         add_sub_element(value, 'description', self.description)

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -138,14 +138,23 @@ class Value(object):
         value_id, _ = os.path.splitext(os.path.basename(yaml_file))
         value = Value(value_id)
         value.title = required_yaml_key(yaml_contents, "title")
+        del yaml_contents["title"]
         value.description = required_yaml_key(yaml_contents, "description")
+        del yaml_contents["description"]
         value.type = required_yaml_key(yaml_contents, "type")
+        del yaml_contents["type"]
         value.options = required_yaml_key(yaml_contents, "options")
-        value.warnings = yaml_contents.get("warnings", [])
+        del yaml_contents["options"]
+        value.warnings = yaml_contents.pop("warnings", [])
 
         for warning_list in value.warnings:
             if len(warning_list) != 1:
                 raise ValueError("Only one key/value pair should exist for each dictionary")
+
+        # FIXME: uncomment once unparsed data in Values are cleared up
+        #if yaml_contents:
+        #    raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
+        #                       % (yaml_file, yaml_contents))
 
         return value
 

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -143,6 +143,18 @@ class Value(object):
         del yaml_contents["description"]
         value.type = required_yaml_key(yaml_contents, "type")
         del yaml_contents["type"]
+        value.operator = yaml_contents.pop("operator", "equals")
+        possible_operators = ["equals", "not equal", "greater than",
+                              "less than", "greater than or equal",
+                              "less than or equal", "pattern match"]
+
+        if value.operator not in possible_operators:
+            raise ValueError(
+                "Found an invalid operator value '%s' in '%s'. "
+                "Expected one of: %s"
+                % (value.operator, yaml_file, ", ".join(possible_operators))
+            )
+
         value.options = required_yaml_key(yaml_contents, "options")
         del yaml_contents["options"]
         value.warnings = yaml_contents.pop("warnings", [])

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -78,9 +78,17 @@ class Profile(object):
 
         profile = Profile(basename)
         profile.title = required_yaml_key(yaml_contents, "title")
+        del yaml_contents["title"]
         profile.description = required_yaml_key(yaml_contents, "description")
-        profile.extends = yaml_contents.get("extends", None)
+        del yaml_contents["description"]
+        profile.extends = yaml_contents.pop("extends", None)
         profile.selections = required_yaml_key(yaml_contents, "selections")
+        del yaml_contents["selections"]
+
+        if yaml_contents:
+            raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
+                               % (yaml_file, yaml_contents))
+
         return profile
 
     def to_xml_element(self):

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -358,14 +358,20 @@ class Group(object):
 
         group_id, _ = os.path.splitext(os.path.basename(yaml_file))
         group = Group(group_id)
-        group.prodtype = yaml_contents.get("prodtype", "all")
+        group.prodtype = yaml_contents.pop("prodtype", "all")
         group.title = required_yaml_key(yaml_contents, "title")
+        del yaml_contents["title"]
         group.description = required_yaml_key(yaml_contents, "description")
-        group.warnings = yaml_contents.get("warnings", [])
+        del yaml_contents["description"]
+        group.warnings = yaml_contents.pop("warnings", [])
 
         for warning_list in group.warnings:
             if len(warning_list) != 1:
                 raise ValueError("Only one key/value pair should exist for each dictionary")
+
+        if yaml_contents:
+            raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
+                               % (yaml_file, yaml_contents))
 
         return group
 

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -432,21 +432,29 @@ class Rule(object):
 
         rule_id, _ = os.path.splitext(os.path.basename(yaml_file))
         rule = Rule(rule_id)
-        rule.prodtype = yaml_contents.get("prodtype", "all")
+        rule.prodtype = yaml_contents.pop("prodtype", "all")
         rule.title = required_yaml_key(yaml_contents, "title")
+        del yaml_contents["title"]
         rule.description = required_yaml_key(yaml_contents, "description")
+        del yaml_contents["description"]
         rule.rationale = required_yaml_key(yaml_contents, "rationale")
+        del yaml_contents["rationale"]
         rule.severity = required_yaml_key(yaml_contents, "severity")
-        rule.references = yaml_contents.get("references", [])
-        rule.identifiers = yaml_contents.get("identifiers", [])
-        rule.ocil_clause = yaml_contents.get("ocil_clause")
-        rule.ocil = yaml_contents.get("ocil")
-        rule.external_oval = yaml_contents.get("oval_external_content")
-        rule.warnings = yaml_contents.get("warnings", [])
+        del yaml_contents["severity"]
+        rule.references = yaml_contents.pop("references", [])
+        rule.identifiers = yaml_contents.pop("identifiers", [])
+        rule.ocil_clause = yaml_contents.pop("ocil_clause", None)
+        rule.ocil = yaml_contents.pop("ocil", None)
+        rule.external_oval = yaml_contents.pop("oval_external_content", None)
+        rule.warnings = yaml_contents.pop("warnings", [])
 
         for warning_list in rule.warnings:
             if len(warning_list) != 1:
                 raise ValueError("Only one key/value pair should exist for each dictionary")
+
+        if yaml_contents:
+            raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
+                               % (yaml_file, yaml_contents))
 
         return rule
 

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -129,6 +129,7 @@ class Value(object):
     def __init__(self, id_):
         self.id_ = id_
         self.operator = "equals"
+        self.interactive = False
 
     @staticmethod
     def from_yaml(yaml_file, product_yaml=None):
@@ -156,6 +157,9 @@ class Value(object):
                 % (value.operator, yaml_file, ", ".join(possible_operators))
             )
 
+        value.interactive = \
+            yaml_contents.pop("interactive", "false").lower() == "true"
+
         value.options = required_yaml_key(yaml_contents, "options")
         del yaml_contents["options"]
         value.warnings = yaml_contents.pop("warnings", [])
@@ -177,6 +181,8 @@ class Value(object):
         value.set('type', self.type)
         if self.operator != "equals":  # equals is the default
             value.set('operator', self.operator)
+        if self.interactive:  # False is the default
+            value.set('interactive', 'true')
         title = ET.SubElement(value, 'title')
         title.text = self.title
         add_sub_element(value, 'description', self.description)

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -211,18 +211,34 @@ class Benchmark(object):
 
         benchmark = Benchmark(id_)
         benchmark.title = required_yaml_key(yaml_contents, "title")
+        del yaml_contents["title"]
         benchmark.status = required_yaml_key(yaml_contents, "status")
+        del yaml_contents["status"]
         benchmark.description = required_yaml_key(yaml_contents, "description")
+        del yaml_contents["description"]
         notice_contents = required_yaml_key(yaml_contents, "notice")
         benchmark.notice_id = required_yaml_key(notice_contents, "id")
+        del notice_contents["id"]
         benchmark.notice_description = required_yaml_key(notice_contents,
                                                          "description")
+        del notice_contents["description"]
+        if not notice_contents:
+            del yaml_contents["notice"]
+
         benchmark.front_matter = required_yaml_key(yaml_contents,
                                                    "front-matter")
+        del yaml_contents["front-matter"]
         benchmark.rear_matter = required_yaml_key(yaml_contents,
                                                   "rear-matter")
-        benchmark.cpes = yaml_contents.get("cpes", [])
+        del yaml_contents["rear-matter"]
+        benchmark.cpes = yaml_contents.pop("cpes", [])
         benchmark.version = str(required_yaml_key(yaml_contents, "version"))
+        del yaml_contents["version"]
+
+        if yaml_contents:
+            raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
+                               % (yaml_file, yaml_contents))
+
         return benchmark
 
     def add_profiles_from_dir(self, action, dir_, product_yaml):

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -168,10 +168,9 @@ class Value(object):
             if len(warning_list) != 1:
                 raise ValueError("Only one key/value pair should exist for each dictionary")
 
-        # FIXME: uncomment once unparsed data in Values are cleared up
-        #if yaml_contents:
-        #    raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
-        #                       % (yaml_file, yaml_contents))
+        if yaml_contents:
+            raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
+                               % (yaml_file, yaml_contents))
 
         return value
 

--- a/wrlinux/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_password_warn_age_login_defs.var
+++ b/wrlinux/guide/system/accounts/accounts-restrictions/password_expiration/var_accounts_password_warn_age_login_defs.var
@@ -6,8 +6,6 @@ description: 'The number of days'' warning given before a password expires.'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/wrlinux/guide/system/auditing/var_auditd_action_mail_acct.var
+++ b/wrlinux/guide/system/auditing/var_auditd_action_mail_acct.var
@@ -6,8 +6,6 @@ description: 'The setting for action_mail_acct in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/wrlinux/guide/system/auditing/var_auditd_flush.var
+++ b/wrlinux/guide/system/auditing/var_auditd_flush.var
@@ -6,8 +6,6 @@ description: 'The setting for flush in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/wrlinux/guide/system/auditing/var_auditd_max_log_file_action.var
+++ b/wrlinux/guide/system/auditing/var_auditd_max_log_file_action.var
@@ -6,8 +6,6 @@ description: 'The setting for max_log_file_action in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:

--- a/wrlinux/guide/system/auditing/var_auditd_num_logs.var
+++ b/wrlinux/guide/system/auditing/var_auditd_num_logs.var
@@ -6,8 +6,6 @@ description: 'The setting for num_logs in /etc/audit/auditd.conf'
 
 type: number
 
-operator:
-
 interactive: false
 
 options:

--- a/wrlinux/guide/system/auditing/var_auditd_space_left_action.var
+++ b/wrlinux/guide/system/auditing/var_auditd_space_left_action.var
@@ -6,8 +6,6 @@ description: 'The setting for space_left_action in /etc/audit/auditd.conf'
 
 type: string
 
-operator:
-
 interactive: false
 
 options:


### PR DESCRIPTION
#### Description:

- Tightens up the YAML parser, when there is any unparsed/unconsumed data it will fail the build
- Adds support for the interactive key in Values
- Adds support for the operator key in Values

#### Rationale:

- Makes it possible to notice typos, errors in yaml, unused stuff that people assume is used (operator, interactive, ..)
- Fix regression regarding interactive and operator attributes for XCCDF Values