### PR TITLE
Yaml constructors

### DIFF
--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -128,8 +128,13 @@ class Value(object):
 
     def __init__(self, id_):
         self.id_ = id_
+        self.title = ""
+        self.description = ""
+        self.type_ = "string"
         self.operator = "equals"
         self.interactive = False
+        self.options = {}
+        self.warnings = []
 
     @staticmethod
     def from_yaml(yaml_file, product_yaml=None):
@@ -219,7 +224,6 @@ class Benchmark(object):
         conditional_clause.description = conditional_clause.title
         conditional_clause.type_ = "string"
         conditional_clause.options = {"": "This is a placeholder"}
-        conditional_clause.warnings = []
 
         self.add_value(conditional_clause)
 

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -67,6 +67,10 @@ class Profile(object):
 
     def __init__(self, id_):
         self.id_ = id_
+        self.title = ""
+        self.description = ""
+        self.extends = None
+        self.selections = []
 
     @staticmethod
     def from_yaml(yaml_file, product_yaml=None):

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -464,6 +464,17 @@ class Rule(object):
     """
     def __init__(self, id_):
         self.id_ = id_
+        self.prodtype = "all"
+        self.title = ""
+        self.description = ""
+        self.rationale = ""
+        self.severity = "unknown"
+        self.references = []
+        self.identifiers = []
+        self.ocil_clause = None
+        self.ocil = None
+        self.external_oval = None
+        self.warnings = []
 
     @staticmethod
     def from_yaml(yaml_file, product_yaml=None):

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -216,6 +216,15 @@ class Benchmark(object):
     """
     def __init__(self, id_):
         self.id_ = id_
+        self.title = ""
+        self.status = ""
+        self.description = ""
+        self.notice_id = ""
+        self.notice_description = ""
+        self.front_matter = ""
+        self.rear_matter = ""
+        self.cpes = []
+        self.version = "0.1"
         self.profiles = []
         self.values = {}
         self.bash_remediation_fns_group = None

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -383,6 +383,10 @@ class Group(object):
     """
     def __init__(self, id_):
         self.id_ = id_
+        self.prodtype = "all"
+        self.title = ""
+        self.description = ""
+        self.warnings = []
         self.values = {}
         self.groups = {}
         self.rules = {}

--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -143,7 +143,7 @@ class Value(object):
         del yaml_contents["title"]
         value.description = required_yaml_key(yaml_contents, "description")
         del yaml_contents["description"]
-        value.type = required_yaml_key(yaml_contents, "type")
+        value.type_ = required_yaml_key(yaml_contents, "type")
         del yaml_contents["type"]
         value.operator = yaml_contents.pop("operator", "equals")
         possible_operators = ["equals", "not equal", "greater than",
@@ -177,7 +177,7 @@ class Value(object):
     def to_xml_element(self):
         value = ET.Element('Value')
         value.set('id', self.id_)
-        value.set('type', self.type)
+        value.set('type', self.type_)
         if self.operator != "equals":  # equals is the default
             value.set('operator', self.operator)
         if self.interactive:  # False is the default
@@ -217,7 +217,7 @@ class Benchmark(object):
         conditional_clause = Value("conditional_clause")
         conditional_clause.title = "A conditional clause for check statements."
         conditional_clause.description = conditional_clause.title
-        conditional_clause.type = "string"
+        conditional_clause.type_ = "string"
         conditional_clause.options = {"": "This is a placeholder"}
         conditional_clause.warnings = []
 


### PR DESCRIPTION
This doesn't change behavior, it just makes things a bit more predictable and documented. It's good practice to "announce" all member vars in the constructor.

I also avoided the `type` python keyword shadowing.