### PR TITLE
Add tests for rule_auditd_audispd_syslog_plugin_activated

### DIFF
--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/delete_parameter.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/delete_parameter.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+function delete_parameter {
+        if [ -z "$1" ]; then
+                echo "Specify file name"
+                exit 1
+        elif [ -z "$2" ]; then
+                echo "Specify parameters name"
+                exit 1
+        fi
+
+        local FILE=$1 PARAMETER=$2
+
+        yum install -y audit
+
+        sed -i "/^$PARAMETER[[:space:]]*=/d" "$FILE"
+}

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_activated.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_activated.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audispd-plugins
+
+. ../set_parameters_value.sh
+set_parameters_value /etc/audisp/plugins.d/syslog.conf "active" "yes"

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_activated_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_activated_not_there.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+# remediation = bash
+
+yum install -y audispd-plugins
+
+. ../delete_parameter.sh
+delete_parameter /etc/audisp/plugins.d/syslog.conf "active"

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_not_activated.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/syslog_plugin_not_activated.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_common
+
+yum install -y audispd-plugins
+
+. ../set_parameters_value.sh
+set_parameters_value /etc/audisp/plugins.d/syslog.conf "active" "no"

--- a/tests/data/group_system/group_auditing/group_auditd_data_retention/set_parameters_value.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_data_retention/set_parameters_value.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+function set_parameters_value {
+        if [ -z "$1" ]; then
+                echo "Specify file name"
+                exit 1
+        elif [ -z "$2" ]; then
+                echo "Specify paramaters name"
+                exit 1
+        elif [ -z "$3" ]; then
+                echo "Specify parameters value"
+                exit 1
+        fi
+
+        local FILE=$1 PARAMETER=$2 VALUE=$3
+
+        yum install -y audit
+
+        REGEX="^$PARAMETER[[:space:]]*=.*$"
+        if grep -q "$REGEX" "$FILE"; then
+                sed -i "s~$REGEX~$PARAMETER = $VALUE~" "$FILE"
+        else
+                echo "$PARAMETER = $VALUE" >> "$FILE"
+        fi
+}


### PR DESCRIPTION
#### Description:
Add tests for `rule_auditd_audispd_syslog_plugin_activated`, which test if the syslog plugin is (or isn't) activated and if parameter is defined.

