### PR TITLE
Make Rule.references a dict

### DIFF
--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -469,7 +469,7 @@ class Rule(object):
         self.description = ""
         self.rationale = ""
         self.severity = "unknown"
-        self.references = []
+        self.references = {}
         self.identifiers = []
         self.ocil_clause = None
         self.ocil = None
@@ -493,7 +493,7 @@ class Rule(object):
         del yaml_contents["rationale"]
         rule.severity = required_yaml_key(yaml_contents, "severity")
         del yaml_contents["severity"]
-        rule.references = yaml_contents.pop("references", [])
+        rule.references = yaml_contents.pop("references", {})
         rule.identifiers = yaml_contents.pop("identifiers", [])
         rule.ocil_clause = yaml_contents.pop("ocil_clause", None)
         rule.ocil = yaml_contents.pop("ocil", None)


### PR DESCRIPTION
In the build system, Rules's references element is initialized to a list despite being a dictionary in the YAML. This fixes it to be a dictionary.