### PR TITLE
Add new rule file_owner_sapmnt_SID_exe to profile sap on ol7 

### DIFF
--- a/linux_os/guide/system/software/sap/file_owner_sapmnt_SID_exe.rule
+++ b/linux_os/guide/system/software/sap/file_owner_sapmnt_SID_exe.rule
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+prodtype: ol7
+
+title: 'Owner of Directory /sapmnt/SID/exe is sidadm'
+
+description: |-
+    The directory <tt>/sapmnt/SID/exe</tt> should be owned by <tt>sidadm</tt>.
+    <tt>SID</tt> is SAP System ID which is always three alphanumeric characters
+    beginning with an alphabetic character. <tt>SID</tt> is in uppercase while the
+    user <tt>sidadm</tt> in lowercase.
+    <tt>Limitation:</tt> with the current version, this OVAL test can only verify
+    the ownership of <tt>/sapmnt/SID/exe</tt> when one SID exists on each OS/VM.
+    If there are multiple <tt>sidadm</tt> users on one OS/VM, the test will fail
+    regardless the directories <tt>/sapmnt/SID/exe</tt> belongs to whom.
+    Nevertheless, you may always use the following bash commands to set correct ownership,
+    the commands can deal with multiple SIDs on each OS/VM: 
+    <pre>$sudo for i in $(find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe$');do SID=${i:8:3};sidadm=$(echo "$SID" | sed -e 's/\(.*\)/\L\1/')adm;uid=$(id -u $sidadm);chown $sidadm $i;done </pre>
+
+rationale: |-
+
+severity: medium
+
+references:
+
+ocil_clause: 'unexpected access privileges of directory /sapmnt/SID/exe' 
+
+ocil: |-
+    Use the following commands to set correct ownership:
+    <pre>$sudo for i in $(find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe$');do SID=${i:8:3};sidadm=$(echo "$SID" | sed -e 's/\(.*\)/\L\1/')adm;uid=$(id -u $sidadm);chown $sidadm $i;done </pre>

--- a/ol7/profiles/sap.profile
+++ b/ol7/profiles/sap.profile
@@ -17,3 +17,4 @@ selections:
     - package_ypserv_removed
     - var_accounts_authorized_local_users_regex=ol7forsap
     - accounts_authorized_local_users
+    - file_owner_sapmnt_SID_exe

--- a/ol7/templates/csv/file_owner.csv
+++ b/ol7/templates/csv/file_owner.csv
@@ -1,0 +1,16 @@
+# Directory or file ownership
+# The format is: 
+#
+# PATH,USER[,[ALT_NAME],[directory|file],[PATHREGEX]]
+# 
+# The first column is the full path (include file name if the type is file).
+# The second column is the user the directory or file should belong to.
+# The third column is optional alternative name, it overwrites the convention. 
+# The fourth column is optional, it indicates if the type is directory or file.
+# Default is file.
+# The fifth column is optional, it's the regular expression of the path as defined
+# for OVAL in http://oval.mitre.org/language/about/re_support_5.6.html.
+# Remediation files will only be generated from template if the fifth column does not
+# exist or is empty. Please write individual remediations when using regex.
+#
+/sapmnt/SID/exe,sidadm,,directory,^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe$

--- a/shared/fixes/bash/file_owner_sapmnt_SID_exe.sh
+++ b/shared/fixes/bash/file_owner_sapmnt_SID_exe.sh
@@ -1,0 +1,14 @@
+# platform = multi_platform_ol
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+# Get /sapmnt/SID/exe from /sapmnt. Works for multiple SIDs.
+SIDexelist=$(find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe$')
+
+for i in $SIDexelist ; do
+        SID=${i:8:3}
+        sidadm=$(echo "$SID" | sed -e 's/\(.*\)/\L\1/')adm
+        uid=$(id -u $sidadm)
+        chown $sidadm $i
+done

--- a/shared/templates/create_file_owner.py
+++ b/shared/templates/create_file_owner.py
@@ -14,7 +14,7 @@ class FileOwnerGenerator(FilesGenerator):
         user = args[1]
 
         # Third column is the alternative name, it overwrites the convention
-        if len(args) > 2:
+        if len(args) > 2 and args[2]:
             name = '_' + args[2]
 
         if not path:
@@ -24,17 +24,39 @@ class FileOwnerGenerator(FilesGenerator):
             raise RuntimeError(
                 "ERROR: input violation: the user must be defined")
 
-#        if target == "oval":
-#            self.file_from_template(
-#                "./template_OVAL_file_owner",
-#                {
-#                    "%PATH%": path,
-#                    "%NAME%": name
-#                },
-#                "./oval/file_owner{0}.xml", name
-#            )
+        # The fourth column is optional. It is used to indicate if the given path is a
+        # directory or a file. The default value is file.
+        if len(args) > 3 and args[3] == "directory":
+            dftype = "directory"
+        else:
+            dftype = "file"
 
-        if target == "bash":
+        # The fifth column is optional. It is used to describe the path name in regular
+        # expression as defined in http://oval.mitre.org/language/about/re_support_5.6.html.
+        # If it does not exist, use the exact full string of path as regex.
+        # Remediation files will only be generated from template if this column does not exist
+        # or is empty.
+        if len(args) > 4 and args[4]:
+            pathregex = args[4]
+            rem_from_template = False
+        else:
+            pathregex = '^' + path + '$'
+            rem_from_template = True
+
+        if target == "oval":
+            self.file_from_template(
+                "./template_OVAL_file_owner",
+                {
+                    "%PATH%": path,
+                    "%USER%": user,
+                    "%PATHID%": name,
+                    "%PATHREGEX%": pathregex,
+                    "%DFTYPE%": dftype
+                },
+                "./oval/file_owner{0}.xml", name
+            )
+
+        elif target == "bash" and rem_from_template:
             self.file_from_template(
                 "./template_BASH_file_owner",
                 {
@@ -44,7 +66,7 @@ class FileOwnerGenerator(FilesGenerator):
                 "./bash/file_owner{0}.sh", name
             )
 
-        elif target == "ansible":
+        elif target == "ansible" and rem_from_template:
             self.file_from_template(
                 "./template_ANSIBLE_file_owner",
                 {
@@ -59,4 +81,4 @@ class FileOwnerGenerator(FilesGenerator):
 
     def csv_format(self):
         return("CSV should contains lines of the format: " +
-               "PATH, USER [,ALT_NAME]")
+               "PATH,USER[,[ALT_NAME],[directory|file],[PATHREGEX]]")

--- a/shared/templates/csv/file_owner.csv
+++ b/shared/templates/csv/file_owner.csv
@@ -1,0 +1,15 @@
+# Directory or file ownership
+# The format is: 
+#
+# PATH,USER[,[ALT_NAME],[directory|file],[PATHREGEX]]
+# 
+# The first column is the full path (include file name if the type is file).
+# The second column is the user the directory or file should belong to.
+# The third column is optional alternative name, it overwrites the convention. 
+# The fourth column is optional, it indicates if the type is directory or file.
+# Default is file.
+# The fifth column is optional, it's the regular expression of the path as defined
+# for OVAL in http://oval.mitre.org/language/about/re_support_5.6.html.
+# Remediation files will only be generated from template if the fifth column does not
+# exist or is empty. Please write individual remediations when using regex.
+#

--- a/shared/templates/template_OVAL_file_owner
+++ b/shared/templates/template_OVAL_file_owner
@@ -1,0 +1,59 @@
+<def-group>
+  <definition class="compliance" id="file_owner%PATHID%" version="1">
+    <metadata>
+      <title>Owner of %DFTYPE% %PATH%</title>
+      <affected family="unix">
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>%DFTYPE% %PATH% should be owned by user %USER%. This means
+      the user_id of %DFTYPE% %PATH% should be the same as uid of %USER% 
+      from /etc/passwd.</description>
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_file_owner%PATHID%_is_%USER%" />
+    </criteria>
+  </definition>
+
+  <unix:file_test id="test_file_owner%PATHID%_is_%USER%" version="1"
+  check_existence="any_exist" check="all"
+  comment="user_id of %DFTYPE% %PATH% equals uid of %USER% from /etc/passwd">
+    <unix:object object_ref="object_file_owner%PATHID%_is_%USER%" />
+    <unix:state state_ref="state_file_owner%PATHID%_is_%USER%" />
+  </unix:file_test>
+
+  <unix:file_object id="object_file_owner%PATHID%_is_%USER%" version="1"
+  comment="%DFTYPE% %PATH%">
+    {{% if "%DFTYPE%" == "directory" %}}
+      <unix:path operation="pattern match">%PATHREGEX%</unix:path>
+      <unix:filename xsi:nil="true"/>
+    {{% else %}}
+      <unix:filepath operation="pattern match">%PATHREGEX%</unix:filepath>
+    {{% endif %}}
+  </unix:file_object>
+
+  <!-- limitation: the test works fine when there is one user matches the pattern 
+       on the os/vm, but cannot deal with multiple pattern users on one os/vm. -->
+  <!-- for example, if there are two sidadm users: linadm and qo1adm, the test will
+       fail regardless whom the directoires /sapmnt/SID/exe belongs to. -->
+  <unix:file_state id="state_file_owner%PATHID%_is_%USER%" version="1"
+  comment="user_id of %PATH% is %USER%">
+    <unix:user_id datatype="int" var_ref="var_user_id_%USER%"/>
+  </unix:file_state>
+
+  <ind:textfilecontent54_object id="object_uid_of_%USER%" version="1"
+  comment="get uid of %USER% from /etc/passwd, take sidadm differently as other users. 
+  filter out the sapadm user which is owner of SAP HostAgent.">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    {{% if "%USER%" == "sidadm" %}}
+      <ind:pattern operation="pattern match">^(?!sap)[a-z][a-z0-9][a-z0-9]adm:x:([\d]+):</ind:pattern>
+    {{% else %}}
+      <ind:pattern operation="pattern match">^%USER%:x([\d]+):</ind:pattern>
+    {{% endif %}}
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_user_id_%USER%" version="1" datatype="int"
+  comment="uid of %USER% in /etc/passwd">
+    <object_component object_ref="object_uid_of_%USER%" item_field="subexpression" />
+  </local_variable>
+</def-group>


### PR DESCRIPTION
#### Description:
- Add new rule file_owner_sapmnt_SID_exe to profile sap on ol7 
- Add new OVAL template for verifying directory/file ownership
- Add function to generate OVAL from template for verifying directory/file ownership
- The existing csv format "PATH, USER, [ALT_ANME]" is extended with "[directory|file], [PATHREGEX]"
- Limitation: it only works when each OS/VM only has one SAP System ID (SID) and hence one sidadm. I may take uid of sidadm users from /etc/passwd into a variable, but it looks the file_test will compare user_id with each item in the variable and hope it equals to each of them. The result if false if there are two uids from /etc/passwd that get into the variable.  Any advise on how to deal with this situation?

#### Rationale:

- I was planning to merge permissions, owner and groupowner to one rule access_privileges but am hesitated because  the limitation on file_owner. 

The file_permissions and file_groupowner does not have the above issue. Both are ready to create pull request if they do not need to get into one rule access_privileges. If you want to have a look:
https://github.com/xiruiyang/scap-security-guide/tree/permissions
https://github.com/xiruiyang/scap-security-guide/tree/groupowner
or I may create separate pull request for them?
