### PR TITLE
Jinja renames

### DIFF
--- a/debian8/guide/system/permissions/files/permission_important_state_files/file_permissions_systemmap.rule
+++ b/debian8/guide/system/permissions/files/permission_important_state_files/file_permissions_systemmap.rule
@@ -5,8 +5,8 @@ title: 'Verify that local System.map file (if exists) is readable only by root'
 description: |-
     Files containing sensitive informations should be protected by restrictive
       permissions. Most of the time, there is no need that these files need to be read by any non-root user
-        {{{ describe_file_permissions(file="/boot/System.map-*", perms="0600") }}}
-        {{{ describe_file_owner(file="/boot/System.map-*", owner="root") }}}
+    {{{ describe_file_permissions(file="/boot/System.map-*", perms="0600") }}}
+    {{{ describe_file_owner(file="/boot/System.map-*", owner="root") }}}
 
 rationale: |-
     The <tt>System.map</tt> file contains information about kernel symbols and
@@ -18,5 +18,5 @@ references:
     anssi: NT28(R13)
 
 ocil: |-
-    {{{ check_file_permissions(file="/boot/Sysem.map-*", perms="-rw-------") }}}
-        {{{ check_file_owner(file="/boot/System.map-*", owner="root") }}}
+    {{{ ocil_file_permissions(file="/boot/Sysem.map-*", perms="-rw-------") }}}
+    {{{ ocil_file_owner(file="/boot/System.map-*", owner="root") }}}

--- a/debian8/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
+++ b/debian8/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>group</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/passwd", perms="0644") }}}
-      {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains information about the groups that are configured on
@@ -18,6 +18,6 @@ references:
     nist: AC-6
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
-      {{{ check_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
+    {{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}

--- a/debian8/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
+++ b/debian8/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>gshadow</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/gshadow", perms="0640") }}}
-      {{{ describe_file_owner(file="/etc/gshadow", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/gshadow", group="shadow") }}}
+    {{{ describe_file_owner(file="/etc/gshadow", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/gshadow", group="shadow") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains group password hashes. Protection of this file
@@ -19,6 +19,6 @@ references:
     nist: AC-6
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/gshadow", perms="-rw-r-----") }}}
-      {{{ check_file_owner(file="/etc/gshadow", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/gshadow", group="shadow") }}}
+    {{{ ocil_file_permissions(file="/etc/gshadow", perms="-rw-r-----") }}}
+    {{{ ocil_file_owner(file="/etc/gshadow", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/gshadow", group="shadow") }}}

--- a/debian8/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
+++ b/debian8/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>passwd</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/passwd", perms="0644") }}}
-      {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains information about the users that are configured on
@@ -18,6 +18,6 @@ references:
     nist: AC-6
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
-      {{{ check_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
+    {{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}

--- a/debian8/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
+++ b/debian8/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>shadow</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/shadow", perms="0640") }}}
-      {{{ describe_file_owner(file="/etc/shadow", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/shadow", group="shadow") }}}
+    {{{ describe_file_owner(file="/etc/shadow", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/shadow", group="shadow") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains the list of local
@@ -23,6 +23,6 @@ references:
     pcidss: Req-8.7.c
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/shadow", perms="-rw-r-----") }}}
-      {{{ check_file_owner(file="/etc/shadow", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/shadow", group="shadow") }}}
+    {{{ ocil_file_permissions(file="/etc/shadow", perms="-rw-r-----") }}}
+    {{{ ocil_file_owner(file="/etc/shadow", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/shadow", group="shadow") }}}

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -588,6 +588,7 @@ Available CCEs that can be assigned to new rules are listed in the `shared/refer
 
 Some of existing rule definitions contain elements that use macros.
 There are two implementations of macros:
+
 * link:http://jinja.pocoo.org/docs/2.10/[Jinja macros], that are defined in `shared/modules/macros.jinja`, and
 * legacy XSLT macros, which are defined in `shared/transforms/*.xslt`.
 

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow.rule
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow.rule
@@ -23,4 +23,4 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: "021120"
 
-ocil: '{{{ check_file_group_owner(file="/etc/cron.allow", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/cron.allow", group="root") }}}'

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow.rule
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow.rule
@@ -23,4 +23,4 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: "021110"
 
-ocil: '{{{ check_file_owner(file="/etc/cron.allow", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/cron.allow", owner="root") }}}'

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_etc_httpd_conf.rule
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_etc_httpd_conf.rule
@@ -15,4 +15,4 @@ severity: unknown
 identifiers:
     cce@rhel7: 80323-9
 
-ocil: '{{{ check_file_permissions(file="/etc/http/conf", perms="-rwxr-x---") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/http/conf", perms="-rwxr-x---") }}}'

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files.rule
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files.rule
@@ -18,4 +18,4 @@ identifiers:
 references:
     nist: CM-7
 
-ocil: '{{{ check_file_permissions(file="/etc/http/conf.d/*", perms="-rw-r-----") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/http/conf.d/*", perms="-rw-r-----") }}}'

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files.rule
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files.rule
@@ -18,4 +18,4 @@ identifiers:
 references:
     nist: CM-7
 
-ocil: '{{{ check_file_permissions(file="/etc/http/conf/*", perms="-rw-r-----") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/http/conf/*", perms="-rw-r-----") }}}'

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files.rule
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files.rule
@@ -18,4 +18,4 @@ identifiers:
 references:
     nist: CM-7
 
-ocil: '{{{ check_file_permissions(file="/etc/http/conf.modules.d/*", perms="-rw-r-----") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/http/conf.modules.d/*", perms="-rw-r-----") }}}'

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key.rule
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key.rule
@@ -20,4 +20,4 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: "040420"
 
-ocil: '{{{ check_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}'

--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key.rule
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key.rule
@@ -20,4 +20,4 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: "040410"
 
-ocil: '{{{ check_file_permissions(file="/etc/ssh/*.pub", perms="-rw-r--r--") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/ssh/*.pub", perms="-rw-r--r--") }}}'

--- a/linux_os/guide/system/accounts/accounts-physical/bootloader/file_group_owner_efi_grub2_cfg.rule
+++ b/linux_os/guide/system/accounts/accounts-physical/bootloader/file_group_owner_efi_grub2_cfg.rule
@@ -27,4 +27,4 @@ references:
     nist: AC-6(7)
     pcidss: Req-7.1
 
-ocil: '{{{ check_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}'

--- a/linux_os/guide/system/accounts/accounts-physical/bootloader/file_group_owner_grub2_cfg.rule
+++ b/linux_os/guide/system/accounts/accounts-physical/bootloader/file_group_owner_grub2_cfg.rule
@@ -28,4 +28,4 @@ references:
     nist: AC-6(7)
     pcidss: Req-7.1
 
-ocil: '{{{ check_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}'

--- a/linux_os/guide/system/accounts/accounts-physical/bootloader/file_user_owner_efi_grub2_cfg.rule
+++ b/linux_os/guide/system/accounts/accounts-physical/bootloader/file_user_owner_efi_grub2_cfg.rule
@@ -25,4 +25,4 @@ references:
     nist: AC-6(7)
     pcidss: Req-7.1
 
-ocil: '{{{ check_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}'

--- a/linux_os/guide/system/accounts/accounts-physical/bootloader/file_user_owner_grub2_cfg.rule
+++ b/linux_os/guide/system/accounts/accounts-physical/bootloader/file_user_owner_grub2_cfg.rule
@@ -26,4 +26,4 @@ references:
     nist: AC-6(7)
     pcidss: Req-7.1
 
-ocil: '{{{ check_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group.rule
@@ -22,4 +22,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_group_owner(file="/etc/group", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/group", group="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow.rule
@@ -20,4 +20,4 @@ references:
     disa: ""
     nist: AC-6
 
-ocil: '{{{ check_file_group_owner(file="/etc/gshadow", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/gshadow", group="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd.rule
@@ -22,4 +22,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_group_owner(file="/etc/passwd", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group.rule
@@ -21,4 +21,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_owner(file="/etc/group", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/group", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow.rule
@@ -20,4 +20,4 @@ references:
     disa: ""
     nist: AC-6
 
-ocil: '{{{ check_file_owner(file="/etc/gshadow", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/gshadow", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd.rule
@@ -22,4 +22,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_owner(file="/etc/passwd", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
@@ -22,4 +22,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_permissions(file="/etc/group", perms="-rw-r--r--") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/group", perms="-rw-r--r--") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
@@ -20,4 +20,4 @@ references:
     disa: ""
     nist: AC-6
 
-ocil: '{{{ check_file_permissions(file="/etc/gshadow", perms="----------") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/gshadow", perms="----------") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
@@ -24,4 +24,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
@@ -25,4 +25,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_permissions(file="/etc/shadow", perms="----------") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/shadow", perms="----------") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/groupowner_shadow_file.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/groupowner_shadow_file.rule
@@ -22,4 +22,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_group_owner(file="/etc/shadow", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/shadow", group="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/userowner_shadow_file.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/userowner_shadow_file.rule
@@ -25,4 +25,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_owner(file="/etc/shadow", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/shadow", owner="root") }}}'

--- a/rhel6/guide/services/ftp/ftp_configure_vsftpd/ftp_configure_firewall.rule
+++ b/rhel6/guide/services/ftp/ftp_configure_vsftpd/ftp_configure_firewall.rule
@@ -5,7 +5,7 @@ title: 'Configure Firewalls to Protect the FTP Server'
 description: |-
     By default, <tt>iptables</tt>
     blocks access to the ports used by the web server.
-    {{{ iptables_describe_allow(proto="tcp", port=21) }}}
+    {{{ describe_iptables_allow(proto="tcp", port=21) }}}
     Edit the file <tt>/etc/sysconfig/iptables-config</tt>. Ensure that the space-separated list of modules contains
     the FTP connection tracking module:
     <pre>IPTABLES_MODULES="ip_conntrack_ftp"</pre>

--- a/rhel6/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_configure_iptables/httpd_configure_iptables.group
+++ b/rhel6/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_configure_iptables/httpd_configure_iptables.group
@@ -5,5 +5,5 @@ title: 'Configure <tt>iptables</tt> to Allow Access to the Web Server'
 description: |-
     By default, <tt>iptables</tt>
     blocks access to the ports used by the web server.
-    {{{ iptables_describe_allow(proto="tcp", port=80) }}}
-    {{{ iptables_describe_allow(proto="tcp", port=443) }}}
+    {{{ describe_iptables_allow(proto="tcp", port=80) }}}
+    {{{ describe_iptables_allow(proto="tcp", port=443) }}}

--- a/rhel6/guide/services/imap/configure_dovecot/dovecot_allow_imap_access/dovecot_allow_imap_access.group
+++ b/rhel6/guide/services/imap/configure_dovecot/dovecot_allow_imap_access/dovecot_allow_imap_access.group
@@ -6,4 +6,4 @@ description: |-
     The default iptables configuration does not allow inbound access to any services.
     This modification will allow remote hosts to initiate connections to the IMAP daemon,
     while keeping all other ports on the server in their default protected state.
-    {{{ iptables_describe_allow(proto="tcp", port=143) }}}
+    {{{ describe_iptables_allow(proto="tcp", port=143) }}}

--- a/rhel6/guide/system/accounts/accounts-physical/bootloader/file_group_owner_grub_conf.rule
+++ b/rhel6/guide/system/accounts/accounts-physical/bootloader/file_group_owner_grub_conf.rule
@@ -20,4 +20,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000066
 
-ocil: '{{{ check_file_group_owner(file="/etc/grub.conf", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/grub.conf", group="root") }}}'

--- a/rhel6/guide/system/accounts/accounts-physical/bootloader/file_user_owner_grub_conf.rule
+++ b/rhel6/guide/system/accounts/accounts-physical/bootloader/file_user_owner_grub_conf.rule
@@ -18,4 +18,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000065
 
-ocil: '{{{ check_file_owner(file="/etc/grub.conf", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/grub.conf", owner="root") }}}'

--- a/rhel6/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit.rule
+++ b/rhel6/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit.rule
@@ -18,4 +18,4 @@ references:
     srg: SRG-OS-000057
     stigid: RHEL-06-000384
 
-ocil: '{{{ check_file_owner(file="/var/log", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/var/log", owner="root") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group.rule
@@ -20,4 +20,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000043
 
-ocil: '{{{ check_file_group_owner(file="/etc/group", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/group", group="root") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow.rule
@@ -19,4 +19,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000037
 
-ocil: '{{{ check_file_group_owner(file="/etc/gshadow", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/gshadow", group="root") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd.rule
@@ -20,4 +20,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000040
 
-ocil: '{{{ check_file_group_owner(file="/etc/passwd", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group.rule
@@ -19,4 +19,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000042
 
-ocil: '{{{ check_file_owner(file="/etc/group", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/group", owner="root") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow.rule
@@ -19,4 +19,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000036
 
-ocil: '{{{ check_file_owner(file="/etc/gshadow", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/gshadow", owner="root") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd.rule
@@ -20,4 +20,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000039
 
-ocil: '{{{ check_file_owner(file="/etc/passwd", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
@@ -20,4 +20,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000044
 
-ocil: '{{{ check_file_permissions(file="/etc/group", perms="-rw-r--r--") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/group", perms="-rw-r--r--") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
@@ -19,4 +19,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000038
 
-ocil: '{{{ check_file_permissions(file="/etc/gshadow", perms="----------") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/gshadow", perms="----------") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
@@ -22,4 +22,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000041
 
-ocil: '{{{ check_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
@@ -23,4 +23,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000035
 
-ocil: '{{{ check_file_permissions(file="/etc/shadow", perms="----------") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/shadow", perms="----------") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/groupowner_shadow_file.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/groupowner_shadow_file.rule
@@ -20,4 +20,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000034
 
-ocil: '{{{ check_file_group_owner(file="/etc/shadow", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/shadow", group="root") }}}'

--- a/rhel6/guide/system/permissions/files/permissions_important_account_files/userowner_shadow_file.rule
+++ b/rhel6/guide/system/permissions/files/permissions_important_account_files/userowner_shadow_file.rule
@@ -23,4 +23,4 @@ references:
     srg: SRG-OS-999999
     stigid: RHEL-06-000033
 
-ocil: '{{{ check_file_owner(file="/etc/shadow", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/shadow", owner="root") }}}'

--- a/shared/modules/macros.jinja
+++ b/shared/modules/macros.jinja
@@ -483,11 +483,3 @@ ocil_clause: "{{{ sebool }}} is not enabled"
     If properly configured, the output should indicate the following group-owner.
     <code>{{{ group }}}</code>
 {{%- endmacro %}}
-
-
-{{%- macro ocil_file_permissions(file, perms) %}}
-    To check the permissions of <code>{{{ file }}}</code>, run the command:
-    <pre>$ ls -l {{{ file }}}</pre>
-    If properly configured, the output should indicate the following permissions:
-    <code>{{{ perms }}}</code>
-{{%- endmacro %}}

--- a/shared/modules/macros.jinja
+++ b/shared/modules/macros.jinja
@@ -462,7 +462,7 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 {{%- endmacro %}}
 
 
-{{%- macro check_file_permissions(file, perms) %}}
+{{%- macro ocil_file_permissions(file, perms) %}}
     To check the permissions of <code>{{{ file }}}</code>, run the command:
     <pre>$ ls -l {{{ file }}}</pre>
     If properly configured, the output should indicate the following permissions:
@@ -470,7 +470,7 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 {{%- endmacro %}}
 
 
-{{%- macro check_file_owner(file, owner) %}}
+{{%- macro ocil_file_owner(file, owner) %}}
     To check the ownership of <code>{{{ file }}}</code>, run the command:
     <pre>$ ls -lL {{{ file }}}</pre>
     If properly configured, the output should indicate the following owner:
@@ -478,7 +478,7 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 {{%- endmacro %}}
 
 
-{{%- macro check_file_group_owner(file, group) %}}
+{{%- macro ocil_file_group_owner(file, group) %}}
     To check the group ownership of <code>{{{ file }}}</code>, run the command:
     <pre>$ ls -lL {{{ file }}}</pre>
     If properly configured, the output should indicate the following group-owner.
@@ -486,7 +486,7 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 {{%- endmacro %}}
 
 
-{{%- macro check_file_permissions(file, perms) %}}
+{{%- macro ocil_file_permissions(file, perms) %}}
     To check the permissions of <code>{{{ file }}}</code>, run the command:
     <pre>$ ls -l {{{ file }}}</pre>
     If properly configured, the output should indicate the following permissions:

--- a/shared/modules/macros.jinja
+++ b/shared/modules/macros.jinja
@@ -23,7 +23,7 @@ ocil: |
 {{%- endmacro %}}
 
 
-{{% macro iptables_desc(traffic_action, how_to_do, proto, port) -%}}
+{{% macro _iptables_desc(traffic_action, how_to_do, proto, port) -%}}
     To configure <tt>iptables</tt> {{{ traffic_action }}} port {{{ port }}} traffic, one must edit
     <tt>/etc/sysconfig/iptables</tt> and
     <tt>/etc/sysconfig/ip6tables</tt> (if IPv6 is in use).
@@ -32,9 +32,8 @@ ocil: |
 {{%- endmacro %}}
 
 
-{{# Example usage: iptables_describe_block(proto="tcp", port=80) #}}
-{{% macro iptables_describe_block(proto, port) -%}}
-{{{ iptables_desc(
+{{% macro describe_iptables_block(proto, port) -%}}
+{{{ _iptables_desc(
 	traffic_action="to block",
 	how_to_do="Remove the following line, ensuring that it does not appear the INPUT chain:",
 	proto=proto,
@@ -43,8 +42,8 @@ ocil: |
 {{%- endmacro %}}
 
 
-{{% macro iptables_describe_allow(proto, port) -%}}
-{{{ iptables_desc(
+{{% macro describe_iptables_allow(proto, port) -%}}
+{{{ _iptables_desc(
 	traffic_action="to allow",
 	how_to_do="Add the following line, ensuring that it appears before the final LOG and DROP lines for the INPUT chain:",
 	proto=proto,

--- a/ubuntu1404/guide/system/permissions/files/permission_important_state_files/file_permissions_systemmap.rule
+++ b/ubuntu1404/guide/system/permissions/files/permission_important_state_files/file_permissions_systemmap.rule
@@ -5,8 +5,8 @@ title: 'Verify that local System.map file (if exists) is readable only by root'
 description: |-
     Files containing sensitive informations should be protected by restrictive
       permissions. Most of the time, there is no need that these files need to be read by any non-root user
-        {{{ describe_file_permissions(file="/boot/System.map-*", perms="0600") }}}
-        {{{ describe_file_owner(file="/boot/System.map-*", owner="root") }}}
+    {{{ describe_file_permissions(file="/boot/System.map-*", perms="0600") }}}
+    {{{ describe_file_owner(file="/boot/System.map-*", owner="root") }}}
 
 rationale: |-
     The <tt>System.map</tt> file contains information about kernel symbols and
@@ -18,5 +18,5 @@ references:
     anssi: NT28(R13)
 
 ocil: |-
-    {{{ check_file_permissions(file="/boot/Sysem.map-*", perms="-rw-------") }}}
-        {{{ check_file_owner(file="/boot/System.map-*", owner="root") }}}
+    {{{ ocil_file_permissions(file="/boot/Sysem.map-*", perms="-rw-------") }}}
+    {{{ ocil_file_owner(file="/boot/System.map-*", owner="root") }}}

--- a/ubuntu1404/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
+++ b/ubuntu1404/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>group</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/passwd", perms="0644") }}}
-      {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains information about the groups that are configured on
@@ -18,6 +18,6 @@ references:
     nist: AC-6
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
-      {{{ check_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
+    {{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}

--- a/ubuntu1404/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
+++ b/ubuntu1404/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>gshadow</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/gshadow", perms="0640") }}}
-      {{{ describe_file_owner(file="/etc/gshadow", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/gshadow", group="shadow") }}}
+    {{{ describe_file_owner(file="/etc/gshadow", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/gshadow", group="shadow") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains group password hashes. Protection of this file
@@ -19,6 +19,6 @@ references:
     nist: AC-6
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/gshadow", perms="-rw-r-----") }}}
-      {{{ check_file_owner(file="/etc/gshadow", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/gshadow", group="shadow") }}}
+    {{{ ocil_file_permissions(file="/etc/gshadow", perms="-rw-r-----") }}}
+    {{{ ocil_file_owner(file="/etc/gshadow", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/gshadow", group="shadow") }}}

--- a/ubuntu1404/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
+++ b/ubuntu1404/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>passwd</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/passwd", perms="0644") }}}
-      {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains information about the users that are configured on
@@ -18,6 +18,6 @@ references:
     nist: AC-6
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
-      {{{ check_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
+    {{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}

--- a/ubuntu1404/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
+++ b/ubuntu1404/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>shadow</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/shadow", perms="0640") }}}
-      {{{ describe_file_owner(file="/etc/shadow", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/shadow", group="shadow") }}}
+    {{{ describe_file_owner(file="/etc/shadow", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/shadow", group="shadow") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains the list of local
@@ -23,6 +23,6 @@ references:
     pcidss: Req-8.7.c
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/shadow", perms="-rw-r-----") }}}
-      {{{ check_file_owner(file="/etc/shadow", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/shadow", group="shadow") }}}
+    {{{ ocil_file_permissions(file="/etc/shadow", perms="-rw-r-----") }}}
+    {{{ ocil_file_owner(file="/etc/shadow", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/shadow", group="shadow") }}}

--- a/ubuntu1604/guide/system/permissions/files/permission_important_state_files/file_permissions_boot_system_map.rule
+++ b/ubuntu1604/guide/system/permissions/files/permission_important_state_files/file_permissions_boot_system_map.rule
@@ -5,8 +5,8 @@ title: 'Verify that local System.map file (if exists) is readable only by root'
 description: |-
     Files containing sensitive informations should be protected by restrictive
       permissions. Most of the time, there is no need that these files need to be read by any non-root user
-        {{{ describe_file_permissions(file="/boot/System.map-*", perms="0600") }}}
-        {{{ describe_file_owner(file="/boot/System.map-*", owner="root") }}}
+    {{{ describe_file_permissions(file="/boot/System.map-*", perms="0600") }}}
+    {{{ describe_file_owner(file="/boot/System.map-*", owner="root") }}}
 
 rationale: |-
     The <tt>System.map</tt> file contains information about kernel symbols and
@@ -18,5 +18,5 @@ references:
     anssi: NT28(R13)
 
 ocil: |-
-    {{{ check_file_permissions(file="/boot/Sysem.map-*", perms="-rw-------") }}}
-        {{{ check_file_owner(file="/boot/System.map-*", owner="root") }}}
+    {{{ ocil_file_permissions(file="/boot/Sysem.map-*", perms="-rw-------") }}}
+    {{{ ocil_file_owner(file="/boot/System.map-*", owner="root") }}}

--- a/ubuntu1604/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
+++ b/ubuntu1604/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>group</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/passwd", perms="0644") }}}
-      {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains information about the groups that are configured on
@@ -18,6 +18,6 @@ references:
     nist: AC-6
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
-      {{{ check_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
+    {{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}

--- a/ubuntu1604/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
+++ b/ubuntu1604/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>gshadow</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/gshadow", perms="0640") }}}
-      {{{ describe_file_owner(file="/etc/gshadow", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/gshadow", group="shadow") }}}
+    {{{ describe_file_owner(file="/etc/gshadow", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/gshadow", group="shadow") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains group password hashes. Protection of this file
@@ -19,6 +19,6 @@ references:
     nist: AC-6
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/gshadow", perms="-rw-r-----") }}}
-      {{{ check_file_owner(file="/etc/gshadow", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/gshadow", group="shadow") }}}
+    {{{ ocil_file_permissions(file="/etc/gshadow", perms="-rw-r-----") }}}
+    {{{ ocil_file_owner(file="/etc/gshadow", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/gshadow", group="shadow") }}}

--- a/ubuntu1604/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
+++ b/ubuntu1604/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>passwd</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/passwd", perms="0644") }}}
-      {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ describe_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains information about the users that are configured on
@@ -18,6 +18,6 @@ references:
     nist: AC-6
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
-      {{{ check_file_owner(file="/etc/passwd", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/passwd", group="root") }}}
+    {{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
+    {{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}

--- a/ubuntu1604/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
+++ b/ubuntu1604/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
@@ -4,8 +4,8 @@ title: 'Verify Permissions and ownership on <tt>shadow</tt> File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/shadow", perms="0640") }}}
-      {{{ describe_file_owner(file="/etc/shadow", owner="root") }}}
-      {{{ describe_file_group_owner(file="/etc/shadow", group="shadow") }}}
+    {{{ describe_file_owner(file="/etc/shadow", owner="root") }}}
+    {{{ describe_file_group_owner(file="/etc/shadow", group="shadow") }}}
 
 rationale: |-
     The <tt>/etc/shadow</tt> file contains the list of local
@@ -23,6 +23,6 @@ references:
     pcidss: Req-8.7.c
 
 ocil: |-
-    {{{ check_file_permissions(file="/etc/shadow", perms="-rw-r-----") }}}
-      {{{ check_file_owner(file="/etc/shadow", owner="root") }}}
-      {{{ check_file_group_owner(file="/etc/shadow", group="shadow") }}}
+    {{{ ocil_file_permissions(file="/etc/shadow", perms="-rw-r-----") }}}
+    {{{ ocil_file_owner(file="/etc/shadow", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/shadow", group="shadow") }}}

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group.rule
@@ -15,4 +15,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_group_owner(file="/etc/group", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/group", group="root") }}}'

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow.rule
@@ -14,4 +14,4 @@ references:
     disa: ""
     nist: AC-6
 
-ocil: '{{{ check_file_group_owner(file="/etc/gshadow", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/gshadow", group="root") }}}'

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd.rule
@@ -15,4 +15,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_group_owner(file="/etc/passwd", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}'

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group.rule
@@ -14,4 +14,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_owner(file="/etc/group", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/group", owner="root") }}}'

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow.rule
@@ -14,4 +14,4 @@ references:
     disa: ""
     nist: AC-6
 
-ocil: '{{{ check_file_owner(file="/etc/gshadow", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/gshadow", owner="root") }}}'

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd.rule
@@ -15,4 +15,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_owner(file="/etc/passwd", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}'

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
@@ -15,4 +15,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_permissions(file="/etc/group", perms="-rw-r--r--") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/group", perms="-rw-r--r--") }}}'

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
@@ -14,4 +14,4 @@ references:
     disa: ""
     nist: AC-6
 
-ocil: '{{{ check_file_permissions(file="/etc/gshadow", perms="----------") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/gshadow", perms="----------") }}}'

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
@@ -15,4 +15,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}'

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
@@ -16,4 +16,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_permissions(file="/etc/shadow", perms="----------") }}}'
+ocil: '{{{ ocil_file_permissions(file="/etc/shadow", perms="----------") }}}'

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/groupowner_shadow_file.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/groupowner_shadow_file.rule
@@ -15,4 +15,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_group_owner(file="/etc/shadow", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/shadow", group="root") }}}'

--- a/wrlinux/guide/system/permissions/files/permissions_important_account_files/userowner_shadow_file.rule
+++ b/wrlinux/guide/system/permissions/files/permissions_important_account_files/userowner_shadow_file.rule
@@ -16,4 +16,4 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
-ocil: '{{{ check_file_owner(file="/etc/shadow", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/shadow", owner="root") }}}'


### PR DESCRIPTION
Renamed last user-facing jinja macros to conform to naming rules described in [the guide](https://github.com/OpenSCAP/scap-security-guide/blob/master/docs/manual/developer_guide.adoc#811-rules).