### PR TITLE
removed unnecessary "string" prefix

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text.rule
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text.rule
@@ -13,7 +13,7 @@ description: |-
     To enable, add or edit <tt>banner-message-text</tt> to
     <tt>/etc/dconf/db/gdm.d/00-security-settings</tt>. For example:
     <pre>[org/gnome/login-screen]
-    banner-message-text=string '<i>APPROVED_BANNER</i>'</pre>
+    banner-message-text='<i>APPROVED_BANNER</i>'</pre>
     Once the setting has been added, add a lock to
     <tt>/etc/dconf/db/gdm.d/locks/00-security-settings-lock</tt> to prevent user modification.
     For example:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank.rule
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank.rule
@@ -9,7 +9,7 @@ description: |-
     add or set <tt>picture-uri</tt> to <tt>string ''</tt> in
     <tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:
     <pre>[org/gnome/desktop/screensaver]
-    picture-uri=string ''
+    picture-uri=''
     </pre>
     Once the settings have been added, add a lock to
     <tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent user modification.

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot.rule
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot.rule
@@ -4,7 +4,7 @@ prodtype: rhel7,fedora
 
 title: 'Disable Ctrl-Alt-Del Reboot Key Sequence in GNOME3'
 
-description: "By default, <tt>GNOME</tt> will reboot the system if the <tt>Ctrl-Alt-Del</tt>\nkey sequence is pressed.\n<br /><br />\nTo configure the system to ignore the <tt>Ctrl-Alt-Del</tt> key sequence from the\nGraphical User Interface (GUI) instead of rebooting the system, add or set \n<tt>logout</tt> to <tt>string ''</tt> in\n<tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:\n<pre>[org/gnome/settings-daemon/plugins/media-keys]\nlogout=string ''\n</pre>\nOnce the settings have been added, add a lock to\n<tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent user modification.\nFor example:\n<pre>/org/gnome/settings-daemon/plugins/media-keys/logout</pre>\nAfter the settings have been set, run <tt>dconf update</tt>."
+description: "By default, <tt>GNOME</tt> will reboot the system if the <tt>Ctrl-Alt-Del</tt>\nkey sequence is pressed.\n<br /><br />\nTo configure the system to ignore the <tt>Ctrl-Alt-Del</tt> key sequence from the\nGraphical User Interface (GUI) instead of rebooting the system, add or set \n<tt>logout</tt> to <tt>string ''</tt> in\n<tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:\n<pre>[org/gnome/settings-daemon/plugins/media-keys]\nlogout=''\n</pre>\nOnce the settings have been added, add a lock to\n<tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent user modification.\nFor example:\n<pre>/org/gnome/settings-daemon/plugins/media-keys/logout</pre>\nAfter the settings have been set, run <tt>dconf update</tt>."
 
 rationale: |-
     A locally logged-in user who presses Ctrl-Alt-Del, when at the console,

--- a/shared/checks/oval/dconf_gnome_disable_ctrlaltdel_reboot.xml
+++ b/shared/checks/oval/dconf_gnome_disable_ctrlaltdel_reboot.xml
@@ -27,7 +27,7 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^\[org/gnome/settings-daemon/plugins/media-keys]([^\n]*\n+)+?logout=string[\s]''$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[org/gnome/settings-daemon/plugins/media-keys]([^\n]*\n+)+?logout=[\s]''$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/checks/oval/dconf_gnome_login_banner_text.xml
+++ b/shared/checks/oval/dconf_gnome_login_banner_text.xml
@@ -41,7 +41,7 @@
   version="1">
     <ind:path>/etc/dconf/db/gdm.d/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^banner-message-text=string[\s]*'*(.*?)'$</ind:pattern>
+    <ind:pattern operation="pattern match">^banner-message-text=[\s]*'*(.*?)'$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/checks/oval/dconf_gnome_screensaver_mode_blank.xml
+++ b/shared/checks/oval/dconf_gnome_screensaver_mode_blank.xml
@@ -30,7 +30,7 @@
     <!-- GSettings expects proper datatype specifier when setting 'picture-uri' per:
          https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
          Thus require 'string' datatype to be specified in 'picture-uri' configuration too -->
-    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver]([^\n]*\n+)+?picture-uri=string[\s]\'\'$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver]([^\n]*\n+)+?picture-uri=[\s]\'\'$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

- GNOME dconf settings incorrectly have 'string' prepended some value settings.

- Fixes #1691
