### PR TITLE
Dump default value without selector

### DIFF
--- a/shared/utils/yaml-to-shorthand.py
+++ b/shared/utils/yaml-to-shorthand.py
@@ -200,7 +200,9 @@ class Value(object):
             # do not confuse Value with big V with value with small v
             # value is child element of Value
             value_small = ET.SubElement(value, 'value')
-            value_small.set('selector', str(selector))
+            # by XCCDF spec, default value is value without selector
+            if selector != "default":
+                value_small.set('selector', str(selector))
             value_small.text = str(option)
 
         return value


### PR DESCRIPTION
#### Description:

- Stop dumping values with `selector="default"`
- Changes output from:

```
            <Value id="xccdf_org.ssgproject.content_value_var_auditd_space_left" type="number">
              <title xml:lang="en-US">Size remaining in disk space before prompting space_left_action</title>
              <description xml:lang="en-US">The setting for space_left (MB) in /etc/audit/auditd.conf</description>
              <value selector="750MB">750</value>
              <value selector="1000MB">1000</value>
              <value selector="100MB">100</value>
              <value selector="default">100</value>
              <value selector="500MB">500</value>
              <value selector="250MB">250</value>
            </Value>
```
to
```
<Value id="xccdf_org.ssgproject.content_value_var_auditd_space_left" type="number">
              <title xml:lang="en-US">Size remaining in disk space before prompting space_left_action</title>
              <description xml:lang="en-US">The setting for space_left (MB) in /etc/audit/auditd.conf</description>
              <value selector="750MB">750</value>
              <value selector="1000MB">1000</value>
              <value selector="100MB">100</value>
              <value>100</value>
              <value selector="500MB">500</value>
              <value selector="250MB">250</value>
            </Value>
```

#### Rationale:

- The default XCCDF value of a Value has no selector.

#### Notes
- The default value picked up can be tested by loading the content on SCAP Workbench and looking at the Value.