### PR TITLE
Purge multi platform oval

### DIFF
--- a/oval.config.in
+++ b/oval.config.in
@@ -21,7 +21,7 @@
 # Note: this file uses .ini style formatting
 #
 [Platform]
-multi_platform_all = multi_platform_fedora, multi_platform_rhel, multi_platform_debian, multi_platform_ubuntu, multi_platform_wrlinux, multi_platform_ol
+multi_platform_all = multi_platform_fedora,multi_platform_rhel,multi_platform_debian,multi_platform_ubuntu,multi_platform_wrlinux,multi_platform_ol
 multi_platform_fedora = 28,27,26
 multi_platform_debian = 8
 multi_platform_ubuntu = 1604,1404

--- a/oval.config.in
+++ b/oval.config.in
@@ -21,7 +21,7 @@
 # Note: this file uses .ini style formatting
 #
 [Platform]
-multi_platform_oval = multi_platform_fedora, multi_platform_rhel, multi_platform_debian, multi_platform_buntu, multi_platform_wrlinux, multi_platform_ol
+multi_platform_all = multi_platform_fedora, multi_platform_rhel, multi_platform_debian, multi_platform_buntu, multi_platform_wrlinux, multi_platform_ol
 multi_platform_fedora = 24,23
 multi_platform_debian = 8
 multi_platform_ubuntu = 1604,1404

--- a/oval.config.in
+++ b/oval.config.in
@@ -21,7 +21,7 @@
 # Note: this file uses .ini style formatting
 #
 [Platform]
-multi_platform_all = multi_platform_fedora, multi_platform_rhel, multi_platform_debian, multi_platform_buntu, multi_platform_wrlinux, multi_platform_ol
+multi_platform_all = multi_platform_fedora, multi_platform_rhel, multi_platform_debian, multi_platform_ubuntu, multi_platform_wrlinux, multi_platform_ol
 multi_platform_fedora = 28,27,26
 multi_platform_debian = 8
 multi_platform_ubuntu = 1604,1404

--- a/oval.config.in
+++ b/oval.config.in
@@ -22,7 +22,7 @@
 #
 [Platform]
 multi_platform_all = multi_platform_fedora, multi_platform_rhel, multi_platform_debian, multi_platform_buntu, multi_platform_wrlinux, multi_platform_ol
-multi_platform_fedora = 24,23
+multi_platform_fedora = 28,27,26
 multi_platform_debian = 8
 multi_platform_ubuntu = 1604,1404
 multi_platform_wrlinux = 8

--- a/shared/utils/combine-ovals.py
+++ b/shared/utils/combine-ovals.py
@@ -92,7 +92,7 @@ def add_platforms(xml_tree, multi_platform):
 
         for plat_elem in affected:
             try:
-                if plat_elem.text == 'multi_platform_oval':
+                if plat_elem.text == 'multi_platform_all':
                     for platforms in multi_platform[plat_elem.text]:
                         for plat in multi_platform[platforms]:
                             platform = ElementTree.Element(


### PR DESCRIPTION
For OVAL checks with `multi_platform_all`:

We broke the multi platform oval support so now for all defs it shows just this:
```
        <ns0:affected family="unix">
        </ns0:affected>
```

With this change it will show this:
```
        <ns0:affected family="unix">
          <ns0:platform>Oracle Linux 7</ns0:platform>
          <ns0:platform>Wind River Linux 8</ns0:platform>
          <ns0:platform>Ubuntu 1404</ns0:platform>
          <ns0:platform>Ubuntu 1604</ns0:platform>
          <ns0:platform>Debian 8</ns0:platform>
          <ns0:platform>Red Hat Enterprise Linux 7</ns0:platform>
          <ns0:platform>Red Hat Enterprise Linux 6</ns0:platform>
          <ns0:platform>Fedora 26</ns0:platform>
          <ns0:platform>Fedora 27</ns0:platform>
          <ns0:platform>Fedora 28</ns0:platform>
        </ns0:affected>
```