### PR TITLE
Add new rule accounts_authorized_local_users_sidadm_orasid to profile sap on ol7

### DIFF
--- a/linux_os/guide/system/software/sap/accounts_authorized_local_users.rule
+++ b/linux_os/guide/system/software/sap/accounts_authorized_local_users.rule
@@ -10,8 +10,7 @@ description: |-
     users required by the installed softoware groups and applications that exist on 
     the operating system. The authorized user list can be customized in the refine
     value variable <tt>var_accounts_authorized_local_users_regex</tt>. 
-    OVAL reqular expression is used for the user list
-    {{{ weblink(link="http://oval.mitre.org/language/about/re_support_5.6.html") }}}.
+    OVAL regular expression is used for the user list.
     Configure the system so all accounts on the system are assigned to an active system,
     application, or user account. Remove accounts that do not support approved system
     activities or that allow for a normal user to perform administrative-level actions.

--- a/linux_os/guide/system/software/sap/accounts_authorized_local_users_sidadm_orasid.rule
+++ b/linux_os/guide/system/software/sap/accounts_authorized_local_users_sidadm_orasid.rule
@@ -1,0 +1,49 @@
+documentation_complete: true
+
+prodtype: ol7
+
+title: 'Only sidadm and orasid/oracle User Accounts Exist on Operating System'
+
+description: |-
+    SAP tends to use the server or virtual machine exclusively. There should be only
+    SAP system users <tt>sidadm</tt> and <tt>orasid</tt> that exist on the operating
+    system (or virtual machine). If SAP Host Agent is installed, the user <tt>sapadm</tt>
+    must exist too. With Oracle Database using <tt>oracle</tt> user, the user <tt>oracle</tt>
+    should exist as well. 
+    While <tt>SID</tt> is the SAP System ID, which is always three alphanumeric characters
+    in upper case, beginning with an alphabetic character, the user names <tt>sidadm</tt> 
+    and <tt>orasid</tt> are in lower case.
+    Besides the above SAP users that are automatically detected, other operating system
+    users can be customized in the refine value variable
+    <tt>var_accounts_authorized_local_users_regex</tt>.
+    OVAL regular expression is used for the user list.
+    <tt>Limitation: Currently this OVAL test only works when there is exactly one SAP
+    system on each operating system (or virtual machine). </tt> The SAP system users
+    <tt>sidadm</tt>, <tt>orasid</tt>, <tt>sapadm</tt> and <tt>oracle</tt> can be automatically
+    detected. If there is no or multiple SAP systems installed on the operating system
+    (or virtual machine), the test will fail. In this case, please use the general purpose
+    test <tt>accounts_authorized_local_users</tt> and customize the refine value variable
+    <tt>var_accounts_authorized_local_users_regex</tt> by adding all the authorized
+    user names to the list.
+    Test result of both <tt>false</tt> or <tt>error</tt> means mismatch of user names and
+    SAP system. Nevertheless, the bash remediation commands can always be used to delete
+    unexpected users on the operating system. It works in all cases zero, one and multiple
+    SAP systems on the operating system (or virtual machine).
+
+rationale: |-
+    Accounts providing no operational purpose provide additional opportunities for
+    system compromise. Unnecessary accounts include user accounts for individuals not
+    requiring access to the system and application accounts for applications not installed
+    on the system.
+
+severity: medium
+
+ocil_clause: 'there are unauthorized local user accounts on the system'
+
+ocil: |-
+    To verify that there are no unauthorized local user accounts, run the following command:
+    <pre>$ less /etc/passwd </pre>
+    Inspect the results, and if unauthorized local user accounts exist, remove them by
+    running the following command:
+    <pre>$ sudo userdel <i>unauthorized_user</i></pre>
+

--- a/linux_os/guide/system/software/sap/accounts_authorized_local_users_sidadm_orasid.rule
+++ b/linux_os/guide/system/software/sap/accounts_authorized_local_users_sidadm_orasid.rule
@@ -9,23 +9,16 @@ description: |-
     SAP system users <tt>sidadm</tt> and <tt>orasid</tt> that exist on the operating
     system (or virtual machine). If SAP Host Agent is installed, the user <tt>sapadm</tt>
     must exist too. With Oracle Database using <tt>oracle</tt> user, the user <tt>oracle</tt>
-    should exist as well. 
-    While <tt>SID</tt> is the SAP System ID, which is always three alphanumeric characters
-    in upper case, beginning with an alphabetic character, the user names <tt>sidadm</tt> 
-    and <tt>orasid</tt> are in lower case.
+    should exist as well. While <tt>SID</tt> is the SAP System ID, which is always
+    three alphanumeric characters in upper case, beginning with an alphabetic character,
+    the user names <tt>sidadm</tt> and <tt>orasid</tt> are in lower case.
+    <br /> <br />
     Besides the above SAP users that are automatically detected, other operating system
     users can be customized in the refine value variable
     <tt>var_accounts_authorized_local_users_regex</tt>.
     OVAL regular expression is used for the user list.
-    <tt>Limitation: Currently this OVAL test only works when there is exactly one SAP
-    system on each operating system (or virtual machine). </tt> The SAP system users
-    <tt>sidadm</tt>, <tt>orasid</tt>, <tt>sapadm</tt> and <tt>oracle</tt> can be automatically
-    detected. If there is no or multiple SAP systems installed on the operating system
-    (or virtual machine), the test will fail. In this case, please use the general purpose
-    test <tt>accounts_authorized_local_users</tt> and customize the refine value variable
-    <tt>var_accounts_authorized_local_users_regex</tt> by adding all the authorized
-    user names to the list.
-    Test result of both <tt>false</tt> or <tt>error</tt> means mismatch of user names and
+    <br /> <br />
+    Test result of both <tt>fail</tt> or <tt>error</tt> means mismatch of user names and
     SAP system. Nevertheless, the bash remediation commands can always be used to delete
     unexpected users on the operating system. It works in all cases zero, one and multiple
     SAP systems on the operating system (or virtual machine).
@@ -47,3 +40,15 @@ ocil: |-
     running the following command:
     <pre>$ sudo userdel <i>unauthorized_user</i></pre>
 
+warnings:
+    - general: |-
+        Currently this rule only works when there is no or only one SAP System ID exist on
+        on each operating system or virtual machine. The SAP system users <tt>sidadm</tt>,
+        <tt>orasid</tt>, <tt>sapadm</tt> and <tt>oracle</tt> can be automatically
+        detected. If there are multiple SAP systems installed on the operating system
+        or virtual machine, the OVAL test will fail even when every SAP system users is
+        authorized to the system. 
+        <br /> <br />
+        In this case, please use the general purpose test <tt>accounts_authorized_local_users</tt>
+        and customize the refine value variable <tt>var_accounts_authorized_local_users_regex</tt>
+        by adding all the authorized user names to the list.

--- a/linux_os/guide/system/software/sap/var_accounts_authorized_local_users_regex.var
+++ b/linux_os/guide/system/software/sap/var_accounts_authorized_local_users_regex.var
@@ -8,8 +8,7 @@ description: |-
     includes both users requried by the operating system and by the installed applications.
     Depending on the Operating System distribution, version, software groups and applications,
     the user list is different and can be customized with scap-workbench.
-    OVAL reqular expression is used for the user list.
-    {{{ weblink(link="http://oval.mitre.org/language/about/re_support_5.6.html") }}}
+    OVAL regular expression is used for the user list.
     The list starts with '^' and ends with '$' so that it matches exactly the
     username, not any string that includes the username. Users are separated with '|'.
     For example, three users: bin, oracle and sapadm are allowd, then the list is
@@ -18,10 +17,10 @@ description: |-
 
 type: string
 
-operator: equals
+operator: pattern match
 
 interactive: true
 
 options:
     ol7forsap: "^(root|bin|daemon|adm|lp|sync|shutdown|halt|mail|operator|games|ftp|nobody|pegasus|systemd-bus-proxy|systemd-network|dbus|polkitd|abrt|unbound|tss|libstoragemgmt|rpc|colord|usbmuxd$|pcp|saslauth|geoclue|setroubleshoot|rtkit|chrony|qemu|radvd|rpcuser|nfsnobody|pulse|gdm|gnome-initial-setup|postfix|avahi|ntp|sshd|tcpdump|oprofile|uuidd)$"
-    saponol7 : "^(root|bin|daemon|adm|lp|sync|shutdown|halt|mail|operator|games|ftp|nobody|pegasus|systemd-bus-proxy|systemd-network|dbus|polkitd|abrt|unbound|tss|libstoragemgmt|rpc|colord|usbmuxd$|pcp|saslauth|geoclue|setroubleshoot|rtkit|chrony|qemu|radvd|rpcuser|nfsnobody|pulse|gdm|gnome-initial-setup|postfix|avahi|ntp|sshd|tcpdump|oprofile|uuidd|[a-z][a-z0-9][a-z0-9]adm|ora[a-z][a-z0-9][a-z0-9]|oracle)$"
+    saponol7 : "^(root|bin|daemon|adm|lp|sync|shutdown|halt|mail|operator|games|ftp|nobody|pegasus|systemd-bus-proxy|systemd-network|dbus|polkitd|abrt|unbound|tss|libstoragemgmt|rpc|colord|usbmuxd$|pcp|saslauth|geoclue|setroubleshoot|rtkit|chrony|qemu|radvd|rpcuser|nfsnobody|pulse|gdm|gnome-initial-setup|postfix|avahi|ntp|sshd|tcpdump|oprofile|uuidd|[a-z][a-z0-9][a-z0-9]adm|ora[a-z][a-z0-9][a-z0-9]|sapadm|oracle)$"

--- a/ol7/profiles/sap.profile
+++ b/ol7/profiles/sap.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Security Profile of Oracle Linux 7 for SAP'
 
 description: |-
-    This profile contains rules for Oracle Linux 7 Operating System in compliance with SAP note 2069760 {{{ weblink(link="https://support.sap.com/content/dam/support/en_us/library/ssp/offerings-and-programs/support-services/sap-security-optimization-services-portfolio/Security_Baseline_Template.zip") }}}
+    This profile contains rules for Oracle Linux 7 Operating System in compliance with SAP note 2069760 and SAP Security Baseline Template version 1.9 Item I-8 and section 4.1.2.2.
     Regardless of your system's workload all of these checks should pass.
     
 selections:
@@ -16,4 +16,4 @@ selections:
     - package_ypbind_removed
     - package_ypserv_removed
     - var_accounts_authorized_local_users_regex=ol7forsap
-    - accounts_authorized_local_users
+    - accounts_authorized_local_users_sidadm_orasid

--- a/shared/checks/oval/accounts_authorized_local_users_sidadm_orasid.xml
+++ b/shared/checks/oval/accounts_authorized_local_users_sidadm_orasid.xml
@@ -241,11 +241,4 @@
 
   <external_variable id="var_accounts_authorized_local_users_regex" version="1"
   datatype="string" comment="accounts authorized local users on operating system"/>
-
-<!-- for test purpose only 
-  <constant_variable id="var_accounts_authorized_local_users_regex" version="1" datatype="string" 
-  comment="explicitly allowed os users on operating system">
-    <value>^(root|bin|daemon|adm|lp|sync|shutdown|halt|mail|operator|games|ftp|nobody|pegasus|systemd-bus-proxy|systemd-network|dbus|polkitd|abrt|unbound|tss|libstoragemgmt|rpc|colord|usbmuxd$|pcp|saslauth|geoclue|setroubleshoot|rtkit|chrony|qemu|radvd|rpcuser|nfsnobody|pulse|gdm|gnome-initial-setup|postfix|avahi|ntp|sshd|tcpdump|oprofile|uuidd|sun|xirui)$</value>
-  </constant_variable>
--->
 </def-group>

--- a/shared/checks/oval/accounts_authorized_local_users_sidadm_orasid.xml
+++ b/shared/checks/oval/accounts_authorized_local_users_sidadm_orasid.xml
@@ -1,0 +1,251 @@
+<def-group oval_version="5.11">
+  <definition class="compliance" id="accounts_authorized_local_users_sidadm_orasid" version="1">
+    <metadata>
+      <title>Only sidadm and orasid/oracle Exist as Local Users on Operating System</title>
+      <affected family="unix">
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description> SAP system users sidadm/sapadm and orasid/oracle should be the only
+      users besides the authorized usrs listed in var_accounts_authorized_local_users_regex
+      that exist locally on the operating system.
+      Limitation: only works with zero to one SAP system on each OS/VM. 
+      </description>
+    </metadata>
+    <criteria operator="AND">
+      <!-- users in the external list -->
+      <criterion test_ref="test_accounts_authorized_local_users_sidadm_orasid"
+      comment="authorized os user accounts except sidadm/sapadm and orasid/oracle" />
+      <!-- sidadm -->
+      <criterion test_ref="test_accounts_authorized_local_users_sidadm"
+      comment="sidadm in /etc/passwd has corresponding /sapmnt/SID directory" />
+      <!-- orasid -->
+      <criterion test_ref="test_accounts_authorized_local_users_orasid"
+      comment="orasid in /etc/passwd has corresponding /sapmnt/SID/exe/brspace 
+      or /sapmnt/SID/exe/type/platform/brspace files" />
+      <!-- sapadm -->
+      <criteria operator="OR"
+      comment="either sapadm does not exist or both sapadm and /usr/sap/hostctrl exist">
+        <criterion test_ref="test_accounts_authorized_local_users_sapadm"
+        comment="sapadm exists in /etc/passwd" negate="true"/>
+        <criteria operator="AND" comment="both sapadm and /usr/sap/hostctrl exist">
+          <criterion test_ref="test_accounts_authorized_local_users_sapadm"
+          comment="sapadm exists in /etc/passwd" />
+          <criterion test_ref="test_usr_sap_hostctrl_exits"
+          comment="/usr/sap/hostctrl exists as folder" />
+        </criteria>
+      </criteria>
+      <!-- oracle -->
+      <criteria operator="OR">
+        <criterion test_ref="test_accounts_authorized_local_users_oracle_for_db"
+        comment="oracle user account in /etc/passwd is used for oracle database"/>
+        <criterion test_ref="test_accounts_authorized_local_users_oracle_for_brspace"
+        comment="oracle user account in /etc/passwd is used for brsapce file"/>
+      </criteria>
+    </criteria>
+  </definition>
+
+  <!-- authorized users in var_accounts_authorized_local_users_regex -->
+  <ind:textfilecontent54_test id="test_accounts_authorized_local_users_sidadm_orasid"
+  version="1" check_existence="any_exist" check="all"
+  comment="authorized os user accounts except sidadm and orasid/oracle">
+    <ind:object object_ref="object_accounts_authorized_local_users_sidadm_orasid" />
+    <ind:state state_ref="state_accounts_authorized_local_users_sidadm_orasid" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_authorized_local_users_sidadm_orasid"
+  version="1" comment="user accounts in /etc/passwd except sidadm and orasid/oracle">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^([a-zA-Z0-9_.-]+?):</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">filter_default_os_user</filter>
+    <filter action="exclude">filter_sidadm_sapadm_orasid_oracle_users</filter>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="filter_default_os_user" version="1"
+  comment="The user root is always allowed as default opering system user" >
+    <ind:subexpression operation="equals">root</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="filter_sidadm_sapadm_orasid_oracle_users" version="1"
+  comment="sidadm, orasid and oracle users" >
+    <ind:subexpression operation="pattern match">^([a-z][a-z0-9][a-z0-9]adm|ora[a-z][a-z0-9][a-z0-9]|oracle)$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_accounts_authorized_local_users_sidadm_orasid"
+  version="1" comment="query if user accounts from /etc/passwd are authrorized" >
+    <ind:subexpression operation="pattern match"
+    var_ref="var_accounts_authorized_local_users_regex"/>
+  </ind:textfilecontent54_state>
+
+  <!-- sidadm user -->
+  <ind:textfilecontent54_test id="test_accounts_authorized_local_users_sidadm" version="1"
+  check_existence="any_exist" check="all" comment="query /etc/passwd">
+    <ind:object object_ref="object_accounts_authorized_local_users_sidadm" />
+    <ind:state state_ref="state_accounts_authorized_local_users_sidadm" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_authorized_local_users_sidadm"
+  version="1" comment="get sid from sidadm user accounts in /etc/passwd">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^([a-z][a-z0-9][a-z0-9])adm:</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">filter_sapadm_user</filter>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="filter_sapadm_user"
+  version="1" comment="filter sapadm user" >
+    <ind:subexpression operation="equals">sap</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_accounts_authorized_local_users_sidadm"
+  version="1" comment="verify sid from sidadm user accounts with SID from /sapmnt/SID" >
+    <ind:subexpression operation="case insensitive equals"
+    var_ref="var_get_SID_from_sapmnt"></ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <unix:file_object id="object_get_SID_from_sapmnt" version="1"
+  comment="Query if /sapmnt/SID exist and is a folder, SID must be in three alphanumeric
+  characters in upper case and starting with an alphabetic character. If /sapmnt/SID exists,
+  then SID is a valid SAP System ID.">
+    <unix:path operation="pattern match">^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]$</unix:path>
+    <unix:filename xsi:nil="true" />
+  </unix:file_object>
+
+  <local_variable id="var_get_SID_from_sapmnt" version="1" datatype="string" 
+  comment="variable of SAP System ID (SID) from /sapmnt/SID">
+    <regex_capture pattern="/sapmnt/([A-Z][A-Z0-9][A-Z0-9])">
+      <object_component item_field="path" object_ref="object_get_SID_from_sapmnt" />
+    </regex_capture>
+  </local_variable>
+
+  <!-- sapadm user -->
+  <ind:textfilecontent54_test id="test_accounts_authorized_local_users_sapadm" version="1"
+  check_existence="only_one_exists" check="all" comment="query sapadm from /etc/passwd">
+    <ind:object object_ref="object_accounts_authorized_local_users_sapadm" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_authorized_local_users_sapadm"
+  version="1" comment="get sapadm user account in /etc/passwd">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^(sapadm):</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <unix:file_test id="test_usr_sap_hostctrl_exits" version="1"
+  check_existence="only_one_exists" check="all" comment="query if /usr/sap/hostctrl exists">
+    <unix:object object_ref="object_usr_sap_hostctrl" />
+  </unix:file_test>
+
+  <unix:file_object id="object_usr_sap_hostctrl"
+  version="1" comment="query if /usr/sap/hostctrl exists" >
+    <unix:path>/usr/sap/hostctrl</unix:path>
+    <unix:filename xsi:nil="true"/>
+  </unix:file_object>
+
+  <!-- orasid user -->
+  <ind:textfilecontent54_test id="test_accounts_authorized_local_users_orasid" version="1"
+  check_existence="any_exist" check="all" comment="query /etc/passwd">
+    <ind:object object_ref="object_accounts_authorized_local_users_orasid" />
+    <ind:state state_ref="state_accounts_authorized_local_users_orasid" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_authorized_local_users_orasid"
+  version="1" comment="get sid from orasid user accounts in /etc/passwd">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^ora([a-z][a-z0-9][a-z0-9]):</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">filter_oracle_user</filter>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="filter_oracle_user"
+  version="1" comment="filter oracle user" >
+    <ind:subexpression operation="equals">cle</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_accounts_authorized_local_users_orasid"
+  version="1" comment="verify sid from orasid user accounts with SID from 
+  /sapmnt/SID/exe/brspace or /sapmnt/SID/exe/type/platform/brspace files" >
+    <ind:subexpression operation="case insensitive equals"
+    var_ref="var_get_SID_from_sapmnt_brspace"></ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <unix:file_object id="object_get_SID_from_sapmnt_brspace" version="1"
+  comment="If /sapmnt/SID/exe/brspace or /sapmnt/SID/exe/type/platform/brspace file exist, then
+  SID is a valid SAP System ID that connects with oracle database. The user orasid is required.">
+    <unix:filepath operation="pattern match">^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/(|(|n)uc/[A-Za-z0-9_]+/)brspace$</unix:filepath>
+  </unix:file_object>
+
+  <local_variable id="var_get_SID_from_sapmnt_brspace" version="1" datatype="string" 
+  comment="Get SID from /sapmnt/SID/.../brspace">
+    <regex_capture pattern="^/sapmnt/([A-Z][A-Z0-9][A-Z0-9])">
+      <object_component item_field="path" object_ref="object_get_SID_from_sapmnt_brspace" />
+    </regex_capture>
+  </local_variable>
+
+  <!-- oracle user -->
+  <!-- Verify if oracle user account is owner of /oracle/SID or brspace file -->
+  <ind:textfilecontent54_test id="test_accounts_authorized_local_users_oracle_for_db"
+  version="1" check_existence="any_exist" check="all" comment="query /etc/passwd">
+    <ind:object object_ref="object_accounts_authorized_local_users_oracle" />
+    <ind:state state_ref="state_accounts_authorized_local_users_oracle_for_db" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_accounts_authorized_local_users_oracle_for_brspace"
+  version="1" check_existence="any_exist" check="all" comment="query /etc/passwd">
+    <ind:object object_ref="object_accounts_authorized_local_users_oracle" />
+    <ind:state state_ref="state_accounts_authorized_local_users_oracle_for_brspace" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_authorized_local_users_oracle"
+  version="1" comment="get oracle user id in /etc/passwd">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^oracle:x:([\d]+)</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_accounts_authorized_local_users_oracle_for_db"
+  version="1" comment="verify if oracle uid is used by /oracle/SID directory"> 
+    <ind:subexpression operation="equals"
+    var_ref="var_get_uid_oracle_SID"></ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_accounts_authorized_local_users_oracle_for_brspace"
+  version="1" comment="verify if oracle user id is used by 
+  /sapmnt/SID/exe/brspace or /sapmnt/SID/exe/type/platform/brspace files" >
+    <ind:subexpression operation="equals"
+    var_ref="var_get_uid_brspace"></ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <!-- object to get user id of /oracle/SID on the operating system. -->
+  <unix:file_object id="object_get_uid_oracle_SID" version="1"
+  comment="Query /oracle/SID directories">
+    <unix:path operation="pattern match">^/oracle/[A-Z][A-Z0-9][A-Z0-9]$</unix:path>
+    <unix:filename xsi:nil="true"/>
+  </unix:file_object>
+
+  <!-- object to get user id of brspace -->
+  <unix:file_object id="object_get_uid_brspace" version="1"
+  comment="Query brspace file">
+    <unix:filepath operation="pattern match">^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/(|(|n)uc/[A-Za-z0-9_]+/)brspace$</unix:filepath>
+  </unix:file_object>
+
+  <local_variable id="var_get_uid_oracle_SID" version="1" datatype="string"
+  comment="uid of /oracle/SID">
+    <object_component object_ref="object_get_uid_oracle_SID" item_field="user_id"/>
+  </local_variable>
+
+  <local_variable id="var_get_uid_brspace" version="1" datatype="string"
+  comment="uid of brspace file">
+    <object_component object_ref="object_get_uid_brspace" item_field="user_id"/>
+  </local_variable>
+
+  <external_variable id="var_accounts_authorized_local_users_regex" version="1"
+  datatype="string" comment="accounts authorized local users on operating system"/>
+
+<!-- for test purpose only 
+  <constant_variable id="var_accounts_authorized_local_users_regex" version="1" datatype="string" 
+  comment="explicitly allowed os users on operating system">
+    <value>^(root|bin|daemon|adm|lp|sync|shutdown|halt|mail|operator|games|ftp|nobody|pegasus|systemd-bus-proxy|systemd-network|dbus|polkitd|abrt|unbound|tss|libstoragemgmt|rpc|colord|usbmuxd$|pcp|saslauth|geoclue|setroubleshoot|rtkit|chrony|qemu|radvd|rpcuser|nfsnobody|pulse|gdm|gnome-initial-setup|postfix|avahi|ntp|sshd|tcpdump|oprofile|uuidd|sun|xirui)$</value>
+  </constant_variable>
+-->
+</def-group>

--- a/shared/fixes/bash/accounts_authorized_local_users_sidadm_orasid.sh
+++ b/shared/fixes/bash/accounts_authorized_local_users_sidadm_orasid.sh
@@ -5,45 +5,42 @@ populate var_accounts_authorized_local_users_regex
 # never delete the root user
 default_os_user="root"
 
-# add users sidamd and orasid
+# add users sidamd, orasid, sapadm and oracle if needed
 userlist="root"
 
-# if /sapmnt/SID exists, add sidadm to the list
-SIDlist=$(find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]$')
-for i in $SIDlist ; do
+# if /sapmnt/SID exists, add sidadm to the userlist
+sapmntSIDlist=$(find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]$')
+for i in $sapmntSIDlist ; do
 	SID=${i:8:3}
 	userlist="$userlist|$(echo "$SID" | sed -e 's/\(.*\)/\L\1/')adm"
 done
 
-# if /sapmnt/SID/exe/brspace or /sapmnt/SID/exe/<type>/<platform>/brspace exists,
+# if /sapmnt/SID/exe/brspace or /sapmnt/SID/exe/<codepage>/<platform>/brspace exists,
 # add orasid to the list
-SIDlist=$(find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/brspace$' \
+brspacelist=$(find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/brspace$' \
 	-o -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/uc/[a-z0-9_]+/brspace$' \
 	-o -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/nuc/[a-z0-9_]+/brspace$')
-for i in $SIDlist ; do
+for i in $brspacelist ; do
         SID=${i:8:3}
         userlist="$userlist|ora$(echo "$SID" | sed -e 's/\(.*\)/\L\1/')"
 done
+
+# if owner of any /sapmnt/SID/exe/brspace or /sapmnt/SID/exe/<type>/<platform>/brspace 
+# file is oracle, add oracle to the list
+oracle=false
+for i in $brspacelist ; do
+        if [ $(ls -ld $i | awk '{print $3}') = "oracle" ]; then
+                oracle=true
+        fi
+done
+if test "$oracle" = true ; then
+        userlist="$userlist|oracle"
+fi
 
 # if /usr/sap/hostctrl exists, add sapadm to the list
 if [ -d /usr/sap/hostctrl ] ; then
 	userlist="$userlist|sapadm"
 fi
-
-# if owner of any /sapmnt/SID/exe/brspace or /sapmnt/SID/exe/<type>/<platform>/brspace 
-# file is oracle, add oracle to the list
-oracle=false
-SIDlist=$(find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/brspace$' \
-	-o -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/uc/[a-z0-9_]+/brspace$' \
-	-o -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/nuc/[a-z0-9_]+/brspace$')
-for i in $SIDlist ; do
-	if [ $(ls -ld $i | awk '{print $3}') == "oracle" ]; then
-		oracle=true
-	fi 	
-done
-if $oracle == true ; then
-	userlist="$userlist|oracle"
-fi 
 
 # delete users that is in /etc/passwd but neither in the userlist
 # nor in default_os_user nor in the var_accounts_authorized_local_users_regex

--- a/shared/fixes/bash/accounts_authorized_local_users_sidadm_orasid.sh
+++ b/shared/fixes/bash/accounts_authorized_local_users_sidadm_orasid.sh
@@ -1,0 +1,56 @@
+# platform = multi_platform_ol
+. /usr/share/scap-security-guide/remediation_functions
+populate var_accounts_authorized_local_users_regex
+
+# never delete the root user
+default_os_user="root"
+
+# add users sidamd and orasid
+userlist="root"
+
+# if /sapmnt/SID exists, add sidadm to the list
+SIDlist=$(find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]$')
+for i in $SIDlist ; do
+	SID=${i:8:3}
+	userlist="$userlist|$(echo "$SID" | sed -e 's/\(.*\)/\L\1/')adm"
+done
+
+# if /sapmnt/SID/exe/brspace or /sapmnt/SID/exe/<type>/<platform>/brspace exists,
+# add orasid to the list
+SIDlist=$(find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/brspace$' \
+	-o -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/uc/[a-z0-9_]+/brspace$' \
+	-o -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/nuc/[a-z0-9_]+/brspace$')
+for i in $SIDlist ; do
+        SID=${i:8:3}
+        userlist="$userlist|ora$(echo "$SID" | sed -e 's/\(.*\)/\L\1/')"
+done
+
+# if /usr/sap/hostctrl exists, add sapadm to the list
+if [ -d /usr/sap/hostctrl ] ; then
+	userlist="$userlist|sapadm"
+fi
+
+# if owner of any /sapmnt/SID/exe/brspace or /sapmnt/SID/exe/<type>/<platform>/brspace 
+# file is oracle, add oracle to the list
+oracle=false
+SIDlist=$(find /sapmnt -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/brspace$' \
+	-o -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/uc/[a-z0-9_]+/brspace$' \
+	-o -regex '^/sapmnt/[A-Z][A-Z0-9][A-Z0-9]/exe/nuc/[a-z0-9_]+/brspace$')
+for i in $SIDlist ; do
+	if [ $(ls -ld $i | awk '{print $3}') == "oracle" ]; then
+		oracle=true
+	fi 	
+done
+if $oracle == true ; then
+	userlist="$userlist|oracle"
+fi 
+
+# delete users that is in /etc/passwd but neither in the userlist
+# nor in default_os_user nor in the var_accounts_authorized_local_users_regex
+default_os_user=^$default_os_user$
+userlist=^$userlist$
+for username in $( sed 's/:.*//' /etc/passwd ) ; do
+	if [[ ! "$username" =~ ($default_os_user|$userlist|$var_accounts_authorized_local_users_regex) ]]; then
+		userdel $username ; 
+	fi
+done


### PR DESCRIPTION
#### Description:

- Only user accounts _sidadm_, _orasid_, _sapadm_, _oracle_ and authorized users in an external list are allowed on the OS/VM
- Individual test of existence of SAP users _sidadm_, _orasid_, _sapadm_ and Oracle user _oracle_ according to SAP system ID and installed SAP/Oracle software components
- Works when there is exactly one SAP system on each OS/VM

