### PR TITLE
Remove subprocess check output

### DIFF
--- a/shared/modules/ssgcommon.py
+++ b/shared/modules/ssgcommon.py
@@ -1,6 +1,5 @@
 import datetime
 import platform
-import subprocess
 import re
 import codecs
 import jinja2
@@ -100,32 +99,6 @@ def oval_generated_header(product_name, schema_version, ssg_version):
         <oval:timestamp>%s</oval:timestamp>
     </generator>""" % (product_name, ssg_version, platform.python_version(),
                        schema_version, timestamp)
-
-
-def subprocess_check_output(*popenargs, **kwargs):
-    # Backport of subprocess.check_output taken from
-    # https://gist.github.com/edufelipe/1027906
-    #
-    # Originally from Python 2.7 stdlib under PSF, compatible with BSD-3
-    # Copyright (c) 2003-2005 by Peter Astrand <astrand@lysator.liu.se>
-    # Changes by Eduardo Felipe
-
-    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
-    output, unused_err = process.communicate()
-    retcode = process.poll()
-    if retcode:
-        cmd = kwargs.get("args")
-        if cmd is None:
-            cmd = popenargs[0]
-        error = subprocess.CalledProcessError(retcode, cmd)
-        error.output = output
-        raise error
-    return output
-
-
-if hasattr(subprocess, "check_output"):
-    # if available we just use the real function
-    subprocess_check_output = subprocess.check_output
 
 
 def get_check_content_ref_if_exists_and_not_remote(check):

--- a/shared/utils/build-all-guides.py
+++ b/shared/utils/build-all-guides.py
@@ -18,6 +18,7 @@ except ImportError:
 import os.path
 import argparse
 import threading
+import subprocess
 try:
     import queue as Queue
 except ImportError:
@@ -49,7 +50,7 @@ def generate_guide_for_input_content(input_content, benchmark_id, profile_id):
         args.extend(["--profile", profile_id])
     args.append(input_content)
 
-    return ssgcommon.subprocess_check_output(args).decode("utf-8")
+    return subprocess.check_output(args).decode("utf-8")
 
 
 def get_cpu_count():

--- a/shared/utils/build-all-remediation-roles.py
+++ b/shared/utils/build-all-remediation-roles.py
@@ -23,6 +23,7 @@ try:
 except ImportError:
     import Queue
 import sys
+import subprocess
 import multiprocessing
 
 
@@ -54,7 +55,7 @@ def generate_role_for_input_content(input_content, benchmark_id, profile_id,
     args.extend(["--template", template])
     args.append(input_content)
 
-    return ssgcommon.subprocess_check_output(args).decode("utf-8")
+    return subprocess.check_output(args).decode("utf-8")
 
 
 def add_minimum_ansible_version(ansible_src):

--- a/shared/utils/oscap-svg-support.py
+++ b/shared/utils/oscap-svg-support.py
@@ -2,14 +2,7 @@
 
 import tempfile
 import sys
-import os.path
-
-
-# Put shared python modules in path
-sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-        "modules"))
-import ssgcommon
+import subprocess
 
 
 svg_benchmark = """<?xml version="1.0"?>
@@ -43,7 +36,7 @@ def main():
     xccdf.write(svg_benchmark.encode("utf-8"))
     xccdf.flush()
 
-    out = ssgcommon.subprocess_check_output(
+    out = subprocess.check_output(
         [oscap_executable, "xccdf", "generate", "guide", xccdf.name]
     ).decode("utf-8")
 


### PR DESCRIPTION
While looking at refactoring `ssgcommon.py`, I noticed that this shim for Python 2.6 was still in our build tree; however, [some](https://github.com/OpenSCAP/scap-security-guide/blob/master/tests/ssg_test_suite/oscap.py#L61) [other](https://github.com/OpenSCAP/scap-security-guide/blob/master/shared/transforms/pcidss/generate_pcidss_json.py#L163) [instances](https://github.com/OpenSCAP/scap-security-guide/blob/master/shared/misc/generate_contributors.py#L107) don't use the shim.

These commits remove the shim's usages and the shim itself.