### PR TITLE
Fix timeout parameter name in description of sshd_set_keepalive rules

### DIFF
--- a/debian8/guide/services/ssh/ssh_server/sshd_set_keepalive.rule
+++ b/debian8/guide/services/ssh/ssh_server/sshd_set_keepalive.rule
@@ -3,13 +3,13 @@ documentation_complete: true
 title: 'Set SSH Client Alive Count'
 
 description: |-
-    To ensure the SSH idle timeout occurs precisely when the <tt>ClientAliveCountMax</tt> is set,
+    To ensure the SSH idle timeout occurs precisely when the <tt>ClientAliveInterval</tt> is set,
     edit <tt>/etc/ssh/sshd_config</tt> as
     follows:
     <pre>ClientAliveCountMax 0</pre>
 
 rationale: |-
-    This ensures a user login will be terminated as soon as the <tt>ClientAliveCountMax</tt>
+    This ensures a user login will be terminated as soon as the <tt>ClientAliveInterval</tt>
     is reached.
 
 severity: unknown
@@ -20,7 +20,7 @@ references:
 ocil_clause: 'it is not'
 
 ocil: |-
-    To ensure the SSH idle timeout will occur when the <tt>ClientAliveCountMax</tt> is set, run the following command:
+    To ensure the SSH idle timeout will occur when the <tt>ClientAliveInterval</tt> is set, run the following command:
     <pre>$ sudo grep ClientAliveCountMax /etc/ssh/sshd_config</pre>
     If properly configured, output should be:
     <pre>ClientAliveCountMax 0</pre>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive.rule
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive.rule
@@ -3,12 +3,12 @@ documentation_complete: true
 title: 'Set SSH Client Alive Count'
 
 description: |-
-    To ensure the SSH idle timeout occurs precisely when the <tt>ClientAliveCountMax</tt> is set,
+    To ensure the SSH idle timeout occurs precisely when the <tt>ClientAliveInterval</tt> is set,
     edit <tt>/etc/ssh/sshd_config</tt> as follows:
     <pre>ClientAliveCountMax 0</pre>
 
 rationale: |-
-    This ensures a user login will be terminated as soon as the <tt>ClientAliveCountMax</tt>
+    This ensures a user login will be terminated as soon as the <tt>ClientAliveInterval</tt>
     is reached.
 
 severity: medium
@@ -29,7 +29,7 @@ references:
 ocil_clause: 'it is commented out or not configured properly'
 
 ocil: |-
-    To ensure the SSH idle timeout will occur when the <tt>ClientAliveCountMax</tt> is set, run the following command:
+    To ensure the SSH idle timeout will occur when the <tt>ClientAliveInterval</tt> is set, run the following command:
     <pre>$ sudo grep ClientAliveCountMax /etc/ssh/sshd_config</pre>
     If properly configured, output should be:
     <pre>ClientAliveCountMax 0</pre>

--- a/rhel6/guide/services/ssh/ssh_server/sshd_set_keepalive.rule
+++ b/rhel6/guide/services/ssh/ssh_server/sshd_set_keepalive.rule
@@ -3,13 +3,13 @@ documentation_complete: true
 title: 'Set SSH Client Alive Count'
 
 description: |-
-    To ensure the SSH idle timeout occurs precisely when the <tt>ClientAliveCountMax</tt> is set,
+    To ensure the SSH idle timeout occurs precisely when the <tt>ClientAliveInterval</tt> is set,
     edit <tt>/etc/ssh/sshd_config</tt> as
     follows:
     <pre>ClientAliveCountMax 0</pre>
 
 rationale: |-
-    This ensures a user login will be terminated as soon as the <tt>ClientAliveCountMax</tt>
+    This ensures a user login will be terminated as soon as the <tt>ClientAliveInterval</tt>
     is reached.
 
 severity: unknown
@@ -26,7 +26,7 @@ references:
 ocil_clause: 'it is not'
 
 ocil: |-
-    To ensure the SSH idle timeout will occur when the <tt>ClientAliveCountMax</tt> is set, run the following command:
+    To ensure the SSH idle timeout will occur when the <tt>ClientAliveInterval</tt> is set, run the following command:
     <pre>$ sudo grep ClientAliveCountMax /etc/ssh/sshd_config</pre>
     If properly configured, output should be:
     <pre>ClientAliveCountMax 0</pre>


### PR DESCRIPTION
#### Description:

- Descriptions in `guide/services/ssh/ssh_server/sshd_set_keepalive.rule` files for rhel6, linux_os and debian8 mistakenly named parameter for timeout `ClientAliveCountMax`. This PR updates the description to correct name `ClientAliveInterval`.

#### Rationale:

- Fixes #2937 
