### PR TITLE
Changed rpm_verify_permissions rule remediation to print only errors

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions.rule
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions.rule
@@ -19,7 +19,7 @@ description: |-
     <br />
     Next, run the following command to reset its permissions to
     the correct values:
-    <pre>$ sudo rpm --setperms <i>PACKAGENAME</i></pre>
+    <pre>$ sudo rpm --quiet --setperms <i>PACKAGENAME</i></pre>
 
 rationale: |-
     Permissions on system binaries and configuration files that are too generous

--- a/rhel6/guide/system/software/integrity/rpm_verification/rpm_verify_permissions.rule
+++ b/rhel6/guide/system/software/integrity/rpm_verification/rpm_verify_permissions.rule
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Verify and Correct File Permissions with RPM'
 
-description: "The RPM package management system can check file access\npermissions of installed software packages, including many that are\nimportant to system security. After locating a file with incorrect\npermissions which can be found with <pre>$ rpm -Va | grep '^.M'</pre>,\nrun the following command to determine which package owns it:\n<pre>$ rpm -qf <i>FILENAME</i></pre>\nNext, run the following command to reset its permissions to \nthe correct values:\n<pre>$ sudo rpm --setperms <i>PACKAGENAME</i></pre>"
+description: "The RPM package management system can check file access\npermissions of installed software packages, including many that are\nimportant to system security. After locating a file with incorrect\npermissions which can be found with <pre>$ rpm -Va | grep '^.M'</pre>,\nrun the following command to determine which package owns it:\n<pre>$ rpm -qf <i>FILENAME</i></pre>\nNext, run the following command to reset its permissions to \nthe correct values:\n<pre>$ sudo rpm --quiet --setperms <i>PACKAGENAME</i></pre>"
 
 rationale: |-
     Permissions on system binaries and configuration files that are too generous

--- a/shared/fixes/ansible/rpm_verify_permissions.yml
+++ b/shared/fixes/ansible/rpm_verify_permissions.yml
@@ -13,7 +13,7 @@
     @ANSIBLE_TAGS@
 
 - name: "Correct file permissions with RPM"
-  shell: "rpm --setperms $(rpm -qf '{{item}}')"
+  shell: "rpm --quiet --setperms $(rpm -qf '{{item}}')"
   with_items: "{{ files_with_incorrect_permissions.stdout_lines }}"
   when: files_with_incorrect_permissions.stdout_lines | length > 0
   tags:

--- a/shared/fixes/bash/rpm_verify_permissions.sh
+++ b/shared/fixes/bash/rpm_verify_permissions.sh
@@ -28,5 +28,5 @@ SETPERMS_RPM_LIST=( $(echo "${SETPERMS_RPM_LIST[@]}" | tr ' ' '\n' | sort -u | t
 # correct values
 for RPM_PACKAGE in "${SETPERMS_RPM_LIST[@]}"
 do
-	rpm --setperms "${RPM_PACKAGE}"
+	rpm --quiet --setperms "${RPM_PACKAGE}"
 done


### PR DESCRIPTION
#### Rationale:
The rpm_verify_permissions rule remediation uses 'rpm --setperms' which
produces thousands of 'cannot acces' messages in case of missing files
(this mainly applies for containers which are stripped off certain files),
for example:

`chmod: cannot access '/usr/share/locale/aa': No such file or directory`

This commit adds '--quiet' option to the rpm command to only display
error messages.