### PR TITLE
Fixed the path to relative SSG_DIR in find_shadowed_files.py

### DIFF
--- a/utils/find_shadowed_files.py
+++ b/utils/find_shadowed_files.py
@@ -5,9 +5,7 @@ import argparse
 import sys
 
 
-SSG_DIR = os.path.dirname(os.path.dirname(os.path.dirname(
-    os.path.abspath(__file__)))
-)
+SSG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def safe_listdir(path):


### PR DESCRIPTION
So I rebased my unshadow work and suddenly nothing was shadowed. Turns out the path got messed up, I broke it in #2945, there still are shadowed files.