### PR TITLE
Ignore the ropeproject folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ tarball/
 
 # Ignore QtCreator files
 CMakeLists.txt.user
+
+# Ignore VIM's ropeproject files
+.ropeproject


### PR DESCRIPTION
ROPE is a python vi plugin for code completion and stuff like that, it
generates these files for caching purposes.

This should avoid accidentally adding this cache into git.