### PR TITLE
Update cpe-generate.py help text

### DIFF
--- a/build-scripts/cpe-generate.py
+++ b/build-scripts/cpe-generate.py
@@ -212,5 +212,6 @@ def main():
 
     sys.exit(0)
 
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The help text for `cpe-generate.py` was out of date and did not reflect the current set of nor count of arguments necessary to run the script. This should update that. 

If desired, I could convert this to using `argparse`. Preferences from anyone? 