### PR TITLE
We import the openscap python bindings just to guess the default OVAL…

### DIFF
--- a/ssg/_constants.py
+++ b/ssg/_constants.py
@@ -1,15 +1,6 @@
 import datetime
 import os.path
 
-try:
-    from openscap import oscap_get_version
-    if oscap_get_version() < 1.2:
-        OSCAP_OVAL_VERSION = "5.10"
-    else:
-        OSCAP_OVAL_VERSION = "5.11"
-except ImportError:
-    OSCAP_OVAL_VERSION = "5.10"
-
 
 JINJA_MACROS_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros.jinja")

--- a/ssg/_oval.py
+++ b/ssg/_oval.py
@@ -132,14 +132,30 @@ def read_ovaldefgroup_file(testfile):
     return body
 
 
+def get_openscap_supported_oval_version():
+    try:
+        from openscap import oscap_get_version
+        if [int(x) for x in str(oscap_get_version()).split(".")] >= [1, 2, 0]:
+            return "5.11"
+    except ImportError:
+        pass
+
+    return "5.10"
+
+
 def parse_options():
     usage = "usage: %(prog)s [options] definition_file.xml"
     parser = argparse.ArgumentParser(usage=usage)
     # only some options are on by default
 
-    parser.add_argument("--oval_version", required=True,
+    oscap_oval_version = get_openscap_supported_oval_version()
+
+    parser.add_argument("--oval_version",
+                        default=oscap_oval_version,
                         dest="oval_version", action="store",
-                        help="OVAL version to use. Example: 5.11, 5.10, ...")
+                        help="OVAL version to use. Example: 5.11, 5.10, ... "
+                             "If not supplied the highest version supported by "
+                             "openscap will be used: %s" % (oscap_oval_version))
     parser.add_argument("-q", "--quiet", "--silent", default=False,
                         action="store_true", dest="silent_mode",
                         help="Don't show any output when testing OVAL files")

--- a/ssg/_oval.py
+++ b/ssg/_oval.py
@@ -9,7 +9,6 @@ import subprocess
 
 from ssg._constants import oval_footer as footer
 from ssg._constants import oval_namespace as ovalns
-from ssg._constants import OSCAP_OVAL_VERSION
 from ssg._xml import ElementTree as ET
 from ssg._xml import oval_generated_header
 from ssg._id_translate import IDTranslator
@@ -138,10 +137,9 @@ def parse_options():
     parser = argparse.ArgumentParser(usage=usage)
     # only some options are on by default
 
-    parser.add_argument("--oval_version", default=OSCAP_OVAL_VERSION,
+    parser.add_argument("--oval_version", required=True,
                         dest="oval_version", action="store",
-                        help="OVAL version to use. Example: 5.11, 5.10, ... \
-                        [Default: %(default)s]")
+                        help="OVAL version to use. Example: 5.11, 5.10, ...")
     parser.add_argument("-q", "--quiet", "--silent", default=False,
                         action="store_true", dest="silent_mode",
                         help="Don't show any output when testing OVAL files")


### PR DESCRIPTION
… version?!?

~~The build system always knows the version so let's just make it required.~~