### PR TITLE
Parse args utils

### DIFF
--- a/build-scripts/add_stig_references.py
+++ b/build-scripts/add_stig_references.py
@@ -5,14 +5,22 @@ from __future__ import print_function
 import argparse
 import ssg
 
-parser = argparse.ArgumentParser(
-    description='Add STIG references to XCCDF files.')
-parser.add_argument(
-    "--disa-stig", help="DISA STIG Reference XCCDF file", dest="reference")
-parser.add_argument(
-    "--unlinked-xccdf", help="unlinked SSG XCCDF file", dest="destination")
-args = parser.parse_args()
 
-target_root = ssg.build_stig.add_references(args.reference, args.destination)
+def parse_args():
+    parser = argparse.ArgumentParser(description='Add STIG references to XCCDF files.')
+    parser.add_argument("--disa-stig", help="DISA STIG Reference XCCDF file",
+                        dest="reference")
+    parser.add_argument("--unlinked-xccdf", help="unlinked SSG XCCDF file",
+                        dest="destination")
+    return parser.parse_args()
 
-target_root.write(args.destination)
+
+def main():
+    args = parse_args()
+
+    target_root = ssg.build_stig.add_references(args.reference, args.destination)
+    target_root.write(args.destination)
+
+
+if __name__ == "__main__":
+    main()

--- a/build-scripts/build_all_guides.py
+++ b/build-scripts/build_all_guides.py
@@ -41,14 +41,7 @@ def parse_args():
     p.add_argument("-o", "--output", action="store", required=True,
                    help="output directory")
 
-    args, unknown = p.parse_known_args()
-    if unknown:
-        sys.stderr.write(
-            "Unknown positional arguments " + ",".join(unknown) + ".\n"
-        )
-        sys.exit(1)
-
-    return args
+    return p.parse_args()
 
 
 def main():

--- a/build-scripts/build_all_remediation_roles.py
+++ b/build-scripts/build_all_remediation_roles.py
@@ -45,14 +45,7 @@ def parse_args():
     p.add_argument("-o", "--output", action="store", required=True,
                    help="output directory")
 
-    args, unknown = p.parse_known_args()
-    if unknown:
-        sys.stderr.write(
-            "Unknown positional arguments " + ",".join(unknown) + ".\n"
-        )
-        sys.exit(1)
-
-    return args
+    return p.parse_args()
 
 
 def main():

--- a/build-scripts/combine_ovals.py
+++ b/build-scripts/combine_ovals.py
@@ -38,14 +38,7 @@ def parse_args():
                    "OVAL definitions to combine. Order matters, latter "
                    "directories override former.")
 
-    args, unknown = p.parse_known_args()
-    if unknown:
-        sys.stderr.write(
-            "Unknown positional arguments " + ",".join(unknown) + ".\n"
-        )
-        sys.exit(1)
-
-    return args
+    return p.parse_args()
 
 
 def main():

--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -44,14 +44,7 @@ def parse_args():
                    help="directory(ies) from which we will collect "
                    "remediations to combine.")
 
-    args, unknown = p.parse_known_args()
-    if unknown:
-        sys.stderr.write(
-            "Unknown positional arguments " + ",".join(unknown) + ".\n"
-        )
-        sys.exit(1)
-
-    return args
+    return p.parse_args()
 
 
 def main():

--- a/build-scripts/generate_from_templates.py
+++ b/build-scripts/generate_from_templates.py
@@ -32,14 +32,7 @@ def parse_args():
     p.add_argument("-s", "--shared", metavar="PATH", required=True,
                    help="Full absolute path to SSG shared directory")
 
-    args, unknown = p.parse_known_args()
-    if unknown:
-        sys.stderr.write(
-            "Unknown positional arguments " + ",".join(unknown) + ".\n"
-        )
-        sys.exit(1)
-
-    return args
+    return p.parse_args()
 
 
 if __name__ == "__main__":

--- a/build-scripts/profile_stats.py
+++ b/build-scripts/profile_stats.py
@@ -65,12 +65,7 @@ def parse_args():
                         choices=["plain", "json", "csv"],
                         help="Which format to use for output.")
 
-    args, unknown = parser.parse_known_args()
-    if unknown:
-        sys.stderr.write(
-            "Unknown positional arguments " + ",".join(unknown) + ".\n"
-        )
-        sys.exit(1)
+    args = parser.parse_args()
 
     if args.all:
         args.implemented = True

--- a/build-scripts/relabel_ids.py
+++ b/build-scripts/relabel_ids.py
@@ -25,16 +25,13 @@ def parse_args():
     parser.add_argument("xccdf_file")
     parser.add_argument("id_name", help="ID naming scheme")
 
-    args = parser.parse_args()
-
-    xccdf_file = args.xccdf_file
-    id_name = args.id_name
-
-    return xccdf_file, id_name
+    return parser.parse_args()
 
 
 def main():
-    xccdffile, idname = parse_args()
+    args = parse_args()
+    xccdffile = args.xccdf_file
+    idname = args.id_name
 
     # Step over xccdf file, and find referenced check files
     xccdftree = ssg.xml.parse_file(xccdffile)

--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -35,18 +35,16 @@ def parse_args():
     parser.add_argument("action",
                         choices=["build", "list-inputs", "list-outputs"],
                         help="Which action to perform.")
-    args = parser.parse_args()
-
-    # save a whole bunch of time
-    if args.action == "list-outputs":
-        print(args.output)
-        sys.exit(0)
-
-    return args
+    return parser.parse_args()
 
 
 def main():
     args = parse_args()
+
+    if args.action == "list-outputs":
+        print(args.output)
+        sys.exit(0)
+
 
     env_yaml = ssg.yaml.open_environment(
         args.build_config_yaml, args.product_yaml)

--- a/utils/count_oval_objects.py
+++ b/utils/count_oval_objects.py
@@ -16,13 +16,12 @@ import os.path
 oval_files = dict()
 xccdf_dir = None
 
-help_text = '''Shows OVAL objects used by XCCDF rules.
-Usage: ./count_oval_objects.py xccdf_file.xml'''
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Show OVAL objects used by XCCDF rules.")
     parser.add_argument("xccdf_file", help="Path to the XCCDF file to parse")
     return parser.parse_args()
+
 
 def load_xml(file_name):
     ''' Loads XML files to memory and parses it into element tree '''

--- a/utils/count_oval_objects.py
+++ b/utils/count_oval_objects.py
@@ -8,6 +8,7 @@ Shows OVAL objects used by XCCDF rules.
 Author: Jan Cerny <jcerny@redhat.com>
 '''
 
+import argparse
 import xml.etree.ElementTree as ET
 import sys
 import os.path
@@ -18,18 +19,10 @@ xccdf_dir = None
 help_text = '''Shows OVAL objects used by XCCDF rules.
 Usage: ./count_oval_objects.py xccdf_file.xml'''
 
-def get_args():
-    ''' Parses program arguments. '''
-    if len(sys.argv) == 2:
-        if sys.argv[1] == "--help" or sys.argv[1] == "-h":
-            print(help_text)
-            exit(0)
-        else:
-            return sys.argv[1]
-    else:
-        sys.stderr.write("Bad argument. For more information, try --help.\n")
-        exit(-1)
-
+def parse_args():
+    parser = argparse.ArgumentParser(description="Show OVAL objects used by XCCDF rules.")
+    parser.add_argument("xccdf_file", help="Path to the XCCDF file to parse")
+    return parser.parse_args()
 
 def load_xml(file_name):
     ''' Loads XML files to memory and parses it into element tree '''
@@ -103,7 +96,8 @@ def main():
     stats = {}
     global xccdf_dir
 
-    xccdf_file_name = get_args()
+    args = parse_args()
+    xccdf_file_name = args.xccdf_file
     xccdf_root = load_xml(xccdf_file_name)
     xccdf_dir = os.path.dirname(xccdf_file_name)
 

--- a/utils/find_duplicates.py
+++ b/utils/find_duplicates.py
@@ -42,10 +42,8 @@ class DuplicatesFinder(object):
         self._clear_normalized()
         self._shared_files_mask = shared_files_mask
 
-
     def _clear_normalized(self):
         self._normalized = {}
-
 
     def _get_normalized(self, file_path):
         """
@@ -62,7 +60,6 @@ class DuplicatesFinder(object):
             self._normalized[file_path] = normalized
             return normalized
 
-
     def _compare_files(self, shared_filename, specific_filename):
         if not os.path.isfile(specific_filename):
             return False
@@ -72,10 +69,8 @@ class DuplicatesFinder(object):
 
         return shared_normalized == specific_normalized
 
-
     def _print_match(self, first_filename, second_filename):
         print("Duplicate found! {}\t=>\t{}".format(first_filename, second_filename))
-
 
     def search(self):
         """
@@ -105,22 +100,18 @@ class DuplicatesFinder(object):
 
         return found
 
-
     def _specific_dirs(self):
         for static_path in recursive_globi(self._specific_dirs_mask):
             if not static_path.startswith(self._shared_dir):
                 yield static_path
-
 
     def _normalize_content(self, content):
         return content
 
 
 class BashDuplicatesFinder(DuplicatesFinder):
-
     def __init__(self, root_dir, specific_dirs_mask, shared_dir, shared_files_mask="*.sh"):
         DuplicatesFinder.__init__(self, root_dir, specific_dirs_mask, shared_dir, shared_files_mask)
-
 
     def _normalize_content(self, content):
         # remove comments
@@ -134,16 +125,14 @@ class BashDuplicatesFinder(DuplicatesFinder):
 
 
 class OvalDuplicatesFinder(DuplicatesFinder):
-
     def __init__(self, root_dir, specific_dirs_mask, shared_dir, shared_files_mask="*.xml"):
         DuplicatesFinder.__init__(self, root_dir, specific_dirs_mask, shared_dir, shared_files_mask)
-
 
     def _normalize_content(self, content):
         # remove comments
         # naive implementation (todo)
-        content = re.sub(r"^\s*#.*", "", content) # bash style comments - due to #platform
-        content = re.sub('<!--.*?-->', "", content, flags=re.DOTALL) # xml comments
+        content = re.sub(r"^\s*#.*", "", content)  # bash style comments - due to #platform
+        content = re.sub('<!--.*?-->', "", content, flags=re.DOTALL)  # xml comments
 
         # remove empty lines
         content = "\n".join([s for s in content.split("\n") if s])

--- a/utils/find_duplicates.py
+++ b/utils/find_duplicates.py
@@ -6,8 +6,7 @@ import sys
 import os
 import re
 import glob
-
-
+import argparse
 
 
 def recursive_globi(mask):
@@ -35,10 +34,7 @@ def recursive_globi(mask):
                 yield full_path
 
 
-
-
 class DuplicatesFinder(object):
-
     def __init__(self, root_dir, specific_dirs_mask, shared_dir, shared_files_mask):
         self._root_dir = root_dir
         self._specific_dirs_mask = os.path.join(root_dir, specific_dirs_mask)
@@ -120,8 +116,6 @@ class DuplicatesFinder(object):
         return content
 
 
-
-
 class BashDuplicatesFinder(DuplicatesFinder):
 
     def __init__(self, root_dir, specific_dirs_mask, shared_dir, shared_files_mask="*.sh"):
@@ -137,7 +131,6 @@ class BashDuplicatesFinder(DuplicatesFinder):
         content = "\n".join([s for s in content.split("\n") if s])
 
         return content
-
 
 
 class OvalDuplicatesFinder(DuplicatesFinder):
@@ -158,15 +151,18 @@ class OvalDuplicatesFinder(DuplicatesFinder):
         return content
 
 
-def main():
-    '''
-    main function
-    '''
-    if len(sys.argv) < 2:
-        print("Usage : ./find_duplicates root_ssg_directory")
-        sys.exit(1)
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root_ssg_directory", help="Path to root of ssg git repository")
+    return parser.parse_args()
 
-    root_dir = sys.argv[1]
+
+def main():
+    """
+    main function
+    """
+    args = parse_args()
+    root_dir = args.root_ssg_directory
     without_duplicates = True
 
     # Static bash scripts

--- a/utils/find_shadowed_files.py
+++ b/utils/find_shadowed_files.py
@@ -62,7 +62,7 @@ def print_shadows(resource, language, product):
             print(msg)
 
 
-def main():
+def parse_args():
     p = argparse.ArgumentParser(
         description="Looks through both source files and built files of the "
         "product and finds shadowed files. Outputs them in the format of "
@@ -73,12 +73,11 @@ def main():
                    help="Which product we should examine for shadowed checks "
                    "and fixes.")
 
-    args, unknown = p.parse_known_args()
-    if unknown:
-        sys.stderr.write(
-            "Unknown positional arguments " + ",".join(unknown) + ".\n"
-        )
-        sys.exit(1)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
 
     check_languages = ["oval"]
     fix_languages = ["bash", "ansible", "anaconda", "puppet"]

--- a/utils/fix-rules.py
+++ b/utils/fix-rules.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import jinja2
+import argparse
 
 import ssg
 
@@ -470,29 +471,43 @@ def find_int_references(directory):
         fix_file(rule_path, product_yaml, fix_int_reference)
 
 
-def __main__():
-    if sys.argv[1] == 'empty_identifiers':
-        fix_empty_identifiers(sys.argv[2])
-    elif sys.argv[1] == 'prefixed_identifiers':
-        find_prefix_cce(sys.argv[2])
-    elif sys.argv[1] == 'invalid_identifiers':
-        find_invalid_cce(sys.argv[2])
-    elif sys.argv[1] == 'int_identifiers':
-        find_int_identifiers(sys.argv[2])
-    elif sys.argv[1] == 'empty_references':
-        fix_empty_references(sys.argv[2])
-    elif sys.argv[1] == 'int_references':
-        find_int_references(sys.argv[2])
-    else:
-        print("Usage: %s mode /full/path/to/src/directory" % sys.argv[0])
-        print("Modes:")
-        print("\tempty_identifiers - check and fix rules with empty identifiers")
-        print("\tprefixed_identifiers - check and fix rules with prefixed (CCE-) identifiers")
-        print("\tinvalid_identifiers - check and fix rules with invalid identifiers")
-        print("\tint_identifiers - check and fix rules with pseudo-integer identifiers")
-        print("\tempty_references - check and fix rules with empty references")
-        print("\tint_references - check and fix rules with pseduo-integer references")
+def parse_args():
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     description="Utility for fixing mistakes in .rule files",
+                                     epilog="""
+Commands:
+\tempty_identifiers - check and fix rules with empty identifiers
+\tprefixed_identifiers - check and fix rules with prefixed (CCE-) identifiers
+\tinvalid_identifiers - check and fix rules with invalid identifiers
+\tint_identifiers - check and fix rules with pseudo-integer identifiers
+\tempty_references - check and fix rules with empty references
+\tint_references - check and fix rules with pseduo-integer references
+                                     """)
+    parser.add_argument("command", help="Which fix to perform.",
+                        choices=['empty_identifiers', 'prefixed_identifiers',
+                                 'invalid_identifiers', 'int_identifiers',
+                                 'empty_references', 'int_references'])
+    parser.add_argument("ssg_root", help="Path to root of ssg git directory")
+    return parser.parse_args()
 
+
+def __main__():
+    args = parse_args()
+
+    if args.command == 'empty_identifiers':
+        fix_empty_identifiers(args.ssg_root)
+    elif args.command == 'prefixed_identifiers':
+        find_prefix_cce(args.ssg_root)
+    elif args.command == 'invalid_identifiers':
+        find_invalid_cce(args.ssg_root)
+    elif args.command == 'int_identifiers':
+        find_int_identifiers(args.ssg_root)
+    elif args.command == 'empty_references':
+        fix_empty_references(args.ssg_root)
+    elif args.command == 'int_references':
+        find_int_references(args.ssg_root)
+    else:
+        sys.exit(1)
 
 if __name__ == "__main__":
     __main__()

--- a/utils/generate_contributors.py
+++ b/utils/generate_contributors.py
@@ -4,6 +4,7 @@ import os.path
 import codecs
 import ssg
 
+
 def main():
     contributors_md, contributors_xml = ssg.contributors.generate()
 

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -186,7 +186,7 @@ def update_repository(repository, local_file_path):
         )
 
 
-def main():
+def parse_args():
     parser = argparse.ArgumentParser(
         description='Updates SSG Galaxy Ansible Roles')
     parser.add_argument(
@@ -194,7 +194,11 @@ def main():
         help="Path to directory containing the ssg generated roles. Most "
         "likely this is going to be scap-security-guide/build/roles",
         dest="build_roles_dir")
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
 
     role_whitelist = set([
         "rhel7-role-C2S",


### PR DESCRIPTION
This is part of the #2949 series of PRs.

Before converting everything into a module and rearranging the entire source files, I felt some cleanup of `arpgarse` usage in utils was in order. Also fixes some misc. `pep8` issues.

- Updates `count_oval_objects.py`, `create-stig-overlapy.py`, `find_duplicates.py`, `fix_shadowed_files.py`, `fix-rules.py`, and `upload_ansible_roles_to_galaxy.py`.