### PR TITLE
Fixes yaml.CSafeLoader import

### DIFF
--- a/ssg/_yaml.py
+++ b/ssg/_yaml.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import codecs
 import yaml
 


### PR DESCRIPTION
So... Yeah, about that prefixing `_` fixing everything...

Internally, the `PyYAML` package uses `_yaml` for the C language implementation. On F28, the locations in question are:

> /usr/lib64/python3.6/site-packages/_yaml.cpython-36m-x86_64-linux-gnu.so
> /usr/lib64/python3.6/site-packages/yaml/

When loading CSafeLoader, `cyaml.py` imports `_yaml`; because the `_yaml.so` is up a directory, it cannot be imported using relative paths. So, either we fix PyYAML or work around it with absolute imports in `_yaml.py`; this does the latter. 

This fixes a regression introduced in #2949 from improvements in PR #2930 by @mpreisler. 