### PR TITLE
Fix maxrepeat=2->maxrepeat=3 for DISA/STIG guidelines

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat.rule
@@ -24,5 +24,5 @@ ocil_clause: 'maxrepeat is not found or not greater than or equal to the require
 ocil: |-
     To check the maximum value for consecutive repeating characters, run the following command:
     <pre>$ grep maxrepeat /etc/security/pwquality.conf</pre>
-    Look for the value of the <tt>maxrepeat</tt> parameter. The DoD requirement is 2, which would appear as
-    <tt>maxrepeat=2</tt>.
+    Look for the value of the <tt>maxrepeat</tt> parameter. The DoD requirement is 3, which would appear as
+    <tt>maxrepeat=3</tt>.

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -365,7 +365,6 @@ selections:
     - var_accounts_tmout=10_min
     - var_password_pam_difok=8
     - var_password_pam_maxclassrepeat=4
-    - var_password_pam_maxrepeat=2
     - var_password_pam_minclass=4
     - var_password_pam_unix_remember=5
     - account_disable_post_pw_expiration
@@ -374,7 +373,6 @@ selections:
     - accounts_minimum_age_login_defs
     - accounts_password_pam_difok
     - accounts_password_pam_maxclassrepeat
-    - accounts_password_pam_maxrepeat
     - accounts_password_pam_minclass
     - accounts_password_pam_unix_remember
     - accounts_password_warn_age_login_defs


### PR DESCRIPTION
Fixes: #2962

Sets `maxrepeat=3` per STIG guidelines. See #2962 for more information. 