### PR TITLE
Add metadata to accounts_password fixes templates

### DIFF
--- a/shared/templates/template_ANSIBLE_accounts_password
+++ b/shared/templates/template_ANSIBLE_accounts_password
@@ -1,4 +1,8 @@
 # platform = multi_platform_rhel, multi_platform_fedora
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
 - (xccdf-var var_password_pam_%VARIABLE%)
 
 - name: Ensure PAM variable %VARIABLE% is set accordingly

--- a/shared/templates/template_BASH_accounts_password
+++ b/shared/templates/template_BASH_accounts_password
@@ -1,4 +1,8 @@
 # platform = multi_platform_rhel, multi_platform_fedora
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_%VARIABLE%
 


### PR DESCRIPTION
#### Description:

- Add metadata for remediations
- Inspired on remediations dropped as part of #2993

#### Rationale:

- Metadata on fixes can help filter them, specially on Ansible fixes.
