### PR TITLE
Fix python3 regression from #3000

### DIFF
--- a/ssg/_build_ovals.py
+++ b/ssg/_build_ovals.py
@@ -245,7 +245,7 @@ def _check_oval_version_from_oval(xml_content, oval_version):
     try:
         argument = oval_header + xml_content + oval_footer
         oval_file_tree = ElementTree.fromstring(argument)
-    except ElementTree.ParseError, p:
+    except ElementTree.ParseError as p:
         line, column = p.position
         lines = argument.splitlines()
         before = '\n'.join(lines[:line])


### PR DESCRIPTION
This is a regression introduced in #3000. Comma for naming the resulting exception is valid syntax in python2, but does not work in python3. 