### PR TITLE
One of the RHEL6 profiles (fisma medium) needs difok=1

### DIFF
--- a/rhel6/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/var_password_pam_difok.var
+++ b/rhel6/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/var_password_pam_difok.var
@@ -13,6 +13,7 @@ operator: equals
 interactive: false
 
 options:
+    1: 1
     2: 2
     3: 3
     4: 4


### PR DESCRIPTION
Otherwise there are selector errors like this one:
```
[211/403] [rhel6-roles] generating urn:xccdf:fix:script:ansible remediation roles for all profiles in ssg-rhel6-xccdf.xml
OpenSCAP Error: Invalid selector '1' for xccdf:value/@id='var_password_pam_difok'. Using null value instead. [xccdf_policy.c:2103]
Could not resolve xccdf:sub/@idref='var_password_pam_difok'! [xccdf_policy_substitute.c:107]
A fix for Rule/@id="accounts_password_pam_difok" was skipped: Text substitution failed. [xccdf_policy_remediate.c:552]
```