### PR TITLE
There is no need to set the sshd_listening_port to "default"

### DIFF
--- a/eap6/profiles/stig-eap6-disa.profile
+++ b/eap6/profiles/stig-eap6-disa.profile
@@ -6,7 +6,6 @@ description: 'This is a *draft* profile for STIG. This profile is being develope
     a STIG in coordination with DISA FSO.'
 
 selections:
-    - var_jboss_profile=default
     - jboss_eap_configure_secure_management_access
     - jboss_eap_configure_https
     - jboss_eap_configure_host_access_restrictions

--- a/firefox/profiles/stig-firefox-upstream.profile
+++ b/firefox/profiles/stig-firefox-upstream.profile
@@ -18,7 +18,6 @@ description: |-
 
 selections:
     - var_default_home_page=about_blank
-    - var_required_file_types=default
     - firefox_preferences-dod_root_certificate_installed
     - firefox_preferences-enable_ca_trust
     - firefox_preferences-addons_plugin_updates

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -72,7 +72,6 @@ selections:
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_interval
     - accounts_passwords_pam_faillock_unlock_time
-    - sshd_listening_port=default
     - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
     - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
     - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled


### PR DESCRIPTION
Because it will be "default" when not set to anything...

This avoids errors such as:
```
OpenSCAP Error: Invalid selector 'default' for xccdf:value/@id='sshd_listening_port'. Using null value instead. [xccdf_policy.c:2103]
Could not resolve xccdf:sub/@idref='sshd_listening_port'! [xccdf_policy_substitute.c:107]
A fix for Rule/@id="firewalld_sshd_port_enabled" was skipped: Text substitution failed. [xccdf_policy_remediate.c:552]
```

This is a regression caused by #2933