### PR TITLE
Improve CMake time by building all remediations at once

### DIFF
--- a/build-scripts/generate_from_templates.py
+++ b/build-scripts/generate_from_templates.py
@@ -22,29 +22,34 @@ def parse_args():
     output_sp = sp.add_parser('list-outputs', help="Generate output list")
     output_sp.set_defaults(cmd="list_outputs")
 
-    p.add_argument('--language', metavar="LANG", default=None,
-                   help="Scripts of which language should we generate? "
-                   "Default: all.")
-    p.add_argument("-i", "--input", action="store", required=True,
-                   help="input directory")
-    p.add_argument("-o", "--output", action="store", required=True,
-                   help="output directory")
-    p.add_argument("-s", "--shared", metavar="PATH", required=True,
+    p.add_argument('--languages', metavar="LANGS", required=True, type=str,
+                   nargs='+', help="List of languages to generate")
+    p.add_argument("--input", required=True, type=str, nargs='+',
+                   help="List of input directories")
+    p.add_argument("--output", required=True, type=str, nargs='+',
+                   help="List of output directories")
+    p.add_argument("--shared", metavar="PATH", required=True,
                    help="Full absolute path to SSG shared directory")
 
-    return p.parse_args()
+    args = p.parse_args()
+    if len(args.input) != len(args.output):
+        print("Error: number of inputs and number of outputs must match!",
+              file=sys.stderr)
+        sys.exit(1)
+
+    return args
 
 
 if __name__ == "__main__":
     args = parse_args()
 
-    builder = ssg.build_templates.Builder()
-    if args.language is not None:
-        builder.set_langs([args.language])
+    for index in range(0, len(args.input)):
+        builder = ssg.build_templates.Builder()
+        builder.set_langs(args.languages)
 
-    builder.set_input_dir(args.input)
-    builder.output_dir = args.output
-    builder.ssg_shared = args.shared
+        builder.set_input_dir(args.input[index])
+        builder.output_dir = args.output[index]
+        builder.ssg_shared = args.shared
 
-    func = getattr(builder, args.cmd)
-    func()
+        func = getattr(builder, args.cmd)
+        func()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -197,19 +197,6 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
           DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml"
       )
     endforeach()
-
-if (SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED AND SHELLCHECK_EXECUTABLE AND "${LANGUAGE}" STREQUAL "bash")
-        file(GLOB BASH_REMEDIATION_FUNCTIONS "${CMAKE_SOURCE_DIR}/shared/bash_remediation_functions/*.sh")
-
-        add_test(
-            NAME "shellcheck-${PRODUCT}-bash-fixes"
-            # format gcc so that people using IDEs can click on errors to get to the problematic lines
-            # SC1071: ShellCheck only supports sh/bash/ksh scripts
-            # SC1091: Not following: /usr/share/scap-security-guide/remediation_functions
-            # TODO: Stop ignoring the exit code as we fix the bash issues
-            COMMAND "${SHELLCHECK_EXECUTABLE}" --format gcc --shell bash --exclude SC1071,SC1091 ${BASH_REMEDIATION_FUNCTIONS} ${LANGUAGE_REMEDIATIONS_DEPENDS} ${EXTRA_LANGUAGE_DEPENDS} ${EXTRA_SHARED_LANGUAGE_DEPENDS}
-        )
-    endif()
 endmacro()
 
 macro(ssg_build_remediations PRODUCT)


### PR DESCRIPTION
This restructures `generate_from_templates` to accept both a list of inputs/outputs and a list of languages; for each language and each input/output pair, it performs its original behavior. This allows for fewer calls to `generate_from_templates.py`, improving build time.

Before fix:
```
cmake: 34s / 31s (real/user)
ninja: 1m35.891s / 4m37.459s (real/user)
```


After fix:
```
cmake: 17s / 13s (real/user)
ninja: 1m29.117s / 4m15.623s (real/user)
```