### PR TITLE
Fix worker join

### DIFF
--- a/build-scripts/build_all_guides.py
+++ b/build-scripts/build_all_guides.py
@@ -90,7 +90,8 @@ def main():
         worker.daemon = True
         worker.start()
 
-    queue.join()
+    for worker in workers:
+        worker.join()
 
     index_source = ssg.build_guides.build_index(benchmarks, input_basename,
                                                 index_links, index_options,

--- a/build-scripts/build_all_guides.py
+++ b/build-scripts/build_all_guides.py
@@ -69,7 +69,8 @@ def main():
 
     if args.cmd == "list_outputs":
         guide_paths = ssg.build_guides.get_output_guide_paths(benchmarks,
-            benchmark_profile_pairs, path_base, output_dir)
+                                                              benchmark_profile_pairs,
+                                                              path_base, output_dir)
 
         for guide_path in guide_paths:
             print(guide_path)

--- a/build-scripts/build_all_remediation_roles.py
+++ b/build-scripts/build_all_remediation_roles.py
@@ -94,7 +94,8 @@ def main():
         worker.daemon = True
         worker.start()
 
-    queue.join()
+    for worker in workers:
+        worker.join()
 
 
 if __name__ == "__main__":

--- a/build-scripts/build_all_remediation_roles.py
+++ b/build-scripts/build_all_remediation_roles.py
@@ -18,6 +18,7 @@ import sys
 import ssg
 ElementTree = ssg.xml.ElementTree
 
+
 def parse_args():
     p = argparse.ArgumentParser()
 

--- a/ssg/_build_guides.py
+++ b/ssg/_build_guides.py
@@ -71,6 +71,9 @@ def builder(queue):
                 "Error details:\n%s\n\n" % (guide_path, e)
             )
             queue.task_done()
+            with queue.mutex:
+                queue.queue.clear()
+            raise e
 
 
 def _benchmark_profile_pair_sort_key(benchmark_id, profile_id, profile_title):

--- a/ssg/_build_guides.py
+++ b/ssg/_build_guides.py
@@ -56,15 +56,8 @@ def builder(queue):
                 f.write(guide_html.encode("utf-8"))
 
             queue.task_done()
-
-            print(
-                "Generated '%s' for profile ID '%s' in benchmark '%s'." %
-                (guide_path, profile_id, benchmark_id)
-            )
-
         except Queue.Empty:
             break
-
         except Exception as e:
             sys.stderr.write(
                 "Fatal error encountered when generating guide '%s'. "

--- a/ssg/_build_roles.py
+++ b/ssg/_build_roles.py
@@ -102,15 +102,8 @@ def builder(queue):
                 f.write(role_src.encode("utf-8"))
 
             queue.task_done()
-
-            print(
-                "Generated '%s' for profile ID '%s' in benchmark '%s', template=%s." %
-                (role_path, profile_id, benchmark_id, template)
-            )
-
         except Queue.Empty:
             break
-
         except Exception as e:
             sys.stderr.write(
                 "Fatal error encountered when generating role '%s'. "

--- a/ssg/_build_roles.py
+++ b/ssg/_build_roles.py
@@ -117,4 +117,6 @@ def builder(queue):
                 "Error details:\n%s\n\n" % (role_path, e)
             )
             queue.task_done()
-            sys.exit(1)
+            with queue.mutex:
+                queue.queue.clear()
+            raise e


### PR DESCRIPTION
When using `queue.join()`, often the python interpreter will start exiting before the workers themselves exit. This fixes that by waiting for all workers to join. This prevents the warning about `NoneType` not having the exception type that we're catching in the workers.

This PR also removes the informational messages during the building of roles and guides so real warnings can be seen. 