### PR TITLE
Use shared bash fix for RHEL7's auditd_data_retention_space_left_action

### DIFF
--- a/rhel7/fixes/bash/auditd_data_retention_space_left_action.sh
+++ b/rhel7/fixes/bash/auditd_data_retention_space_left_action.sh
@@ -1,9 +1,0 @@
-# platform = Red Hat Enterprise Linux 7
-. /usr/share/scap-security-guide/remediation_functions
-populate var_auditd_space_left_action
-
-grep -q ^space_left_action /etc/audit/auditd.conf && \
-  sed -i "s/space_left_action.*/space_left_action = $var_auditd_space_left_action/g" /etc/audit/auditd.conf
-if ! [ $? -eq 0 ]; then
-    echo "space_left_action = $var_auditd_space_left_action" >> /etc/audit/auditd.conf
-fi


### PR DESCRIPTION
The differences between shared and overriden are very small and mostly
stylistic, let's just use the shared.
