### PR TITLE
ol7 is the only OS using uuidd package installed, no need to have it …

### DIFF
--- a/shared/templates/csv/packages_installed.csv
+++ b/shared/templates/csv/packages_installed.csv
@@ -1,3 +1,2 @@
 gdm
 samba-common
-uuidd


### PR DESCRIPTION
…in shared CSV
