### PR TITLE
Make cmake to favorize Python3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,10 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     )
 endif()
 
+
+set(Python_ADDITIONAL_VERSIONS 3 2)
 find_package(PythonInterp REQUIRED)
+
 find_python_module(yaml REQUIRED)
 find_python_module(jinja2 REQUIRED)
 find_python_module(pytest)


### PR DESCRIPTION
This PR changes the cmake setting, so it will pick up Python3 interpreter if available, and will fall back to Python2.
The Python3 build is ordered differently (maybe because there was an implementation change to the 3.6 dicts), but datastreams that I have checked contain the same lines.