### PR TITLE
Update check for service disabled to account for sockets when systemd and OVAL 5.10

### DIFF
--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -206,23 +206,36 @@
       </affected>
       <description>The %SERVICENAME% service should be disabled if possible.</description>
     </metadata>
-    <criteria comment="package %PACKAGENAME% removed or service %SERVICENAME% is not configured to start" operator="OR">
+    <criteria comment="package %PACKAGENAME% removed or service and socket %SERVICENAME% are not configured to start" operator="OR">
       <extend_definition comment="%PACKAGENAME% removed" definition_ref="package_%PACKAGENAME%_removed" />
-      <criterion comment="%SERVICENAME% disabled in multi-user.target" test_ref="test_%SERVICENAME%_disabled_multi_user_target" />
+      <criteria operator="AND" comment="service and socket %SERVICENAME% are disabled">
+        <criterion comment="%SERVICENAME% disabled in multi-user.target" test_ref="test_%SERVICENAME%_disabled_multi_user_target" />
+        <criterion comment="%SERVICENAME% socket disabled in sockets.target" test_ref="test_%SERVICENAME%_socket_disabled_sockets_target" />
+      </criteria>
     </criteria>
   </definition>
 
   <unix:file_test check="all" check_existence="none_exist"
    comment="look for %SERVICENAME%.service in /etc/systemd/system/multi-user.target.wants"
    id="test_%SERVICENAME%_disabled_multi_user_target" version="1">
-
     <unix:object object_ref="object_%SERVICENAME%_disabled_multi_user_target" />
   </unix:file_test>
 
   <unix:file_object comment="look for %SERVICENAME%.service in /etc/systemd/system/multi-user.target.wants"
    id="object_%SERVICENAME%_disabled_multi_user_target" version="1">
-
     <unix:filepath>/etc/systemd/system/multi-user.target.wants/%SERVICENAME%.service</unix:filepath>
+    <filter action="include">service_%SERVICENAME%_state_symlink</filter>
+  </unix:file_object>
+
+  <unix:file_test check="all" check_existence="none_exist"
+   comment="look for %SERVICENAME%.socket in /etc/systemd/system/sockets.target.wants"
+   id="test_%SERVICENAME%_socket_disabled_sockets_target" version="1">
+    <unix:object object_ref="object_%SERVICENAME%_socket_disabled_sockets_target" />
+  </unix:file_test>
+
+  <unix:file_object comment="look for %SERVICENAME%.socket in /etc/systemd/system/sockets.target.wants"
+   id="object_%SERVICENAME%_socket_disabled_sockets_target" version="1">
+    <unix:filepath>/etc/systemd/system/sockets.target.wants/%SERVICENAME%.socket</unix:filepath>
     <filter action="include">service_%SERVICENAME%_state_symlink</filter>
   </unix:file_object>
 

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -224,7 +224,7 @@
   <unix:file_object comment="look for %SERVICENAME%.service in /etc/systemd/system/multi-user.target.wants"
    id="object_%SERVICENAME%_disabled_multi_user_target" version="1">
     <unix:filepath>/etc/systemd/system/multi-user.target.wants/%SERVICENAME%.service</unix:filepath>
-    <filter action="include">service_%SERVICENAME%_state_symlink</filter>
+    <filter action="include">unit_%SERVICENAME%_state_symlink</filter>
   </unix:file_object>
 
   <unix:file_test check="all" check_existence="none_exist"
@@ -236,10 +236,10 @@
   <unix:file_object comment="look for %SERVICENAME%.socket in /etc/systemd/system/sockets.target.wants"
    id="object_%SERVICENAME%_socket_disabled_sockets_target" version="1">
     <unix:filepath>/etc/systemd/system/sockets.target.wants/%SERVICENAME%.socket</unix:filepath>
-    <filter action="include">service_%SERVICENAME%_state_symlink</filter>
+    <filter action="include">unit_%SERVICENAME%_state_symlink</filter>
   </unix:file_object>
 
-  <unix:file_state id="service_%SERVICENAME%_state_symlink" version="1">
+  <unix:file_state id="unit_%SERVICENAME%_state_symlink" version="1">
     <unix:type operation="equals">symbolic link</unix:type>
   </unix:file_state>
 

--- a/tests/data/group_services/group_avahi/group_disable_avahi_group/rule_service_avahi-daemon_disabled/service_disabled.pass.sh
+++ b/tests/data/group_services/group_avahi/group_disable_avahi_group/rule_service_avahi-daemon_disabled/service_disabled.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+
+yum -y install avahi
+
+systemctl disable avahi-daemon.service
+systemctl disable avahi-daemon.socket

--- a/tests/data/group_services/group_avahi/group_disable_avahi_group/rule_service_avahi-daemon_disabled/socket_enabled.fail.sh
+++ b/tests/data/group_services/group_avahi/group_disable_avahi_group/rule_service_avahi-daemon_disabled/socket_enabled.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+
+yum -y install avahi
+
+systemctl disable avahi-daemon.service
+systemctl enable avahi-daemon.socket


### PR DESCRIPTION
#### Description:

- Extend template to check for socket disabled when system is systemd based
but OVAL 5.11 cannot be used.

#### Rationale:

- Allows checks for services_disabled to be streamlined. It will always check that sockets for a disabled service are also disabled.


