### PR TITLE
Refactored bash service disable remediation + support for disable sockets

### DIFF
--- a/rhel7/fixes/bash/smartcard_auth.sh
+++ b/rhel7/fixes/bash/smartcard_auth.sh
@@ -6,7 +6,7 @@ package_install esc
 package_install pam_pkcs11
 
 # Enable pcscd.socket systemd activation socket
-service_command enable pcscd.socket
+systemctl enable pcscd.socket
 
 # Configure the expected /etc/pam.d/system-auth{,-ac} settings directly
 #

--- a/shared/bash_remediation_functions/service_command.sh
+++ b/shared/bash_remediation_functions/service_command.sh
@@ -3,72 +3,81 @@
 # Example Call(s):
 #
 #     service_command enable bluetooth
-#     service_command disable bluetooth.service
 #
 #     Using xinetd:
-#     service_command disable rsh.socket xinetd=rsh
+#     service_command disable rsh xinetd=rsh
 #
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+SERVICE_EXEC='/sbin/service'
+CHKCONFIG_EXEC='/sbin/chkconfig'
+
+
+function xinetd_disable {
+	sed -i "s/disable.*/disable         = no/gI" "/etc/xinetd.d/$1"
+}
+
+
+function xinetd_enable {
+	sed -i "s/disable.*/disable         = yes/gI" "/etc/xinetd.d/$1"
+}
+
+
+function systemd_disable {
+	local service_stem="$1"
+	"$SYSTEMCTL_EXEC" stop "$service_stem".service
+	"$SYSTEMCTL_EXEC" disable "$service_stem".service
+	# Disable socket activation if we have a unit file for it
+	"$SYSTEMCTL_EXEC" list-unit-files | grep -q "^$service_stem\\>".socket && "$SYSTEMCTL_EXEC" disable "$service_stem".socket
+	# The service may not be running because it has been started and failed,
+	# so let's reset the state so OVAL checks pass.
+	# Service should be 'inactive', not 'failed' after reboot though.
+	"$SYSTEMCTL_EXEC" reset-failed "$service_stem".service
+}
+
+
+function systemd_enable {
+	local service_stem="${1%%.*}"
+	"$SYSTEMCTL_EXEC" start "$service_stem".service
+	"$SYSTEMCTL_EXEC" enable "$service_stem".service
+}
+
+
+function chkconfig_disable {
+	"$SERVICE_EXEC" "$1" disable
+	"$CHKCONFIG_EXEC" --level 0123456 "$1" off
+}
+
+
+function chkconfig_enable {
+	"$SERVICE_EXEC" "$1" enable
+	"$CHKCONFIG_EXEC" --level 0123456 "$1" on
+}
+
+
 function service_command {
+	# Load function arguments into local variables
+	local service_state=$1 service=$2 xinetd
+	xinetd=$(echo "$3" | cut -d'=' -f2)
 
-# Load function arguments into local variables
-local service_state=$1
-local service=$2
-local xinetd=$(echo $3 | cut -d'=' -f2)
+	# Check sanity of the input
+	if [ $# -lt "2" ]; then
+		echo "Usage: service_command 'enable/disable' 'service_name.service'"
+		echo
+		echo "To enable or disable xinetd services add \\'xinetd=service_name\\'"
+		echo "as the last argument"
+		echo "Aborting."
+		exit 1
+	fi
 
-# Check sanity of the input
-if [ $# -lt "2" ]
-then
-  echo "Usage: service_command 'enable/disable' 'service_name.service'"
-  echo
-  echo "To enable or disable xinetd services add \'xinetd=service_name\'"
-  echo "as the last argument"  
-  echo "Aborting."
-  exit 1
-fi
+	test "$service_state" = enable || test "$service_state" = disable || { echo "The service state has to be either 'enable' or 'disable', got '$service_state'"; return 1; }
 
-# If systemctl is installed, use systemctl command; otherwise, use the service/chkconfig commands
-if [ -f "/usr/bin/systemctl" ] ; then
-  service_util="/usr/bin/systemctl"
-else
-  service_util="/sbin/service"
-  chkconfig_util="/sbin/chkconfig"
-fi
+	# If systemctl is installed, use systemctl command; otherwise, use the service/chkconfig commands
+	# foo_$service_state => foo_disabled / foo_enabled
+	if test -f "/usr/bin/systemctl"; then
+		"systemd_$service_state" "$service"
+	else
+		"chkconfig_$service_state" "$service"
+	fi
 
-# If disable is not specified in arg1, set variables to enable services.
-# Otherwise, variables are to be set to disable services.
-if [ "$service_state" != 'disable' ] ; then
-  service_state="enable"
-  service_operation="start"
-  chkconfig_state="on"
-else
-  service_state="disable"
-  service_operation="stop"
-  chkconfig_state="off"
-fi
-
-# If chkconfig_util is not empty, use chkconfig/service commands.
-if [ "x$chkconfig_util" != x ] ; then
-  $service_util $service $service_operation
-  $chkconfig_util --level 0123456 $service $chkconfig_state
-else
-  $service_util $service_operation $service
-  $service_util $service_state $service
-  # The service may not be running because it has been started and failed,
-  # so let's reset the state so OVAL checks pass.
-  # Service should be 'inactive', not 'failed' after reboot though.
-  $service_util reset-failed $service
-fi
-
-# Test if local variable xinetd is empty using non-bashism.
-# If empty, then xinetd is not being used.
-if [ "x$xinetd" != x ] ; then
-  grep -qi disable /etc/xinetd.d/$xinetd && \
-
-  if [ "$service_operation" = 'disable' ] ; then
-    sed -i "s/disable.*/disable         = no/gI" /etc/xinetd.d/$xinetd
-  else
-    sed -i "s/disable.*/disable         = yes/gI" /etc/xinetd.d/$xinetd
-  fi
-fi
-
+	test "x$xinetd" != x || "xinetd_$service_state" "$xinetd"
 }


### PR DESCRIPTION
The remediation got split into multiple functions.
The systemd service disable function now disables service and checks for availability of socket unit file. If it exists, it also disables socket.
I have checked usage of the shared remediation function and ensured that the refactoring doesn't break current use cases.