### PR TITLE
Small style fixes

### DIFF
--- a/linux_os/guide/services/http/securing_httpd/httpd_public_resources_not_shared.rule
+++ b/linux_os/guide/services/http/securing_httpd/httpd_public_resources_not_shared.rule
@@ -25,7 +25,7 @@ severity: medium
 references:
     stigid: "WG040"
 
-ocil_clause:  |-
+ocil_clause: |-
     sharing is selected for any web folder, this is a finding.
 
     If private resources (e.g. drives, partitions, folders/directories,

--- a/shared/fixes/ansible/disable_interactive_boot.yml
+++ b/shared/fixes/ansible/disable_interactive_boot.yml
@@ -3,7 +3,7 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name:  Verify that Interactive Boot is Disabled
+- name: Verify that Interactive Boot is Disabled
   lineinfile:
     create: yes
     dest: /etc/default/grub


### PR DESCRIPTION
To make parsing easier when merging `rhel6` into `linux_os` guides, remove extraneous double space. The change in the shared Ansible folder is unnecessary but as it is the only one, might as well keep it for consistency. 