### PR TITLE
Unique titles in RHEL6 and Linux OS guides

### DIFF
--- a/linux_os/guide/services/dhcp/dhcp_server_configuration/group.yml
+++ b/linux_os/guide/services/dhcp/dhcp_server_configuration/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Disable DHCP Server'
+title: 'Configure DHCP Server'
 
 description: |-
     If the system must act as a DHCP server, the configuration

--- a/linux_os/guide/services/dhcp/disabling_dhcp_client/sysconfig_networking_bootproto_ifcfg.rule
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_client/sysconfig_networking_bootproto_ifcfg.rule
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Disable DHCP Client'
+title: 'Disable DHCP Client in ifcfg'
 
 description: |-
     For each interface on the system (e.g. eth0), edit

--- a/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled.rule
+++ b/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled.rule
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Disable DNS Server'
+title: 'Disable named Service'
 
 description: '{{{ describe_service_disable(service="named") }}}'
 

--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/group.yml
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Use vsftpd to Provide FTP Service if Necessary'
+title: 'Configure vsftpd to Provide FTP Service if Necessary'
 
 description: |-
     The primary vsftpd configuration file is

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_perl_securely/group.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_perl_securely/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Configure PHP Securely'
+title: 'Configure PERL Securely'
 
 description: |-
     PERL (Practical Extraction and Report Language) is an interpreted language

--- a/linux_os/guide/services/http/securing_httpd/httpd_secure_content/var_web_login_banner_text.var
+++ b/linux_os/guide/services/http/securing_httpd/httpd_secure_content/var_web_login_banner_text.var
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Login Banner Verbiage'
+title: 'Web Login Banner Verbiage'
 
 description: |-
     Enter an appropriate login banner for your organization. Please note that new lines must

--- a/linux_os/guide/system/accounts/accounts-physical/bootloader/bootloader_password.rule
+++ b/linux_os/guide/system/accounts/accounts-physical/bootloader/bootloader_password.rule
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7,fedora
 
-title: 'Set Boot Loader Password'
+title: 'Set Boot Loader Password in grub2'
 
 description: |-
     The grub2 boot loader should have a superuser account and password

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_admin_space_left_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_admin_space_left_action.var
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Action for auditd to take when disk space just starts to run low'
+title: 'Action for auditd to take when disk space is low'
 
 description: 'The setting for admin_space_left_action in /etc/audit/auditd.conf'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_ra.rule
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_ra.rule
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Configure Accepting IPv6 Router Advertisements'
+title: 'Configure Accepting IPv6 Router Advertisements on All Interfaces'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_ra", value="0") }}}'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_redirects.rule
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_redirects.rule
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Configure Accepting IPv6 Redirects By Default'
+title: 'Configure Accepting IPv6 Redirects on All Interfaces'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_redirects", value="0") }}}'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_source_route.rule
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_source_route.rule
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Configure Kernel Parameter for Accepting Source-Routed Packets for All Interfaces'
+title: 'Configure Kernel Parameter for Accepting IPv6 Source-Routed Packets for All Interfaces'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_source_route", value="0") }}}'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_default_accept_ra.rule
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_default_accept_ra.rule
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7,fedora
 
-title: 'Configure Accepting IPv6 Router Advertisements'
+title: 'Configure Accepting IPv6 Router Advertisements by Default'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv6.conf.default.accept_ra", value="0") }}}'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route.rule
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route.rule
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7,fedora
 
-title: 'Configure Kernel Parameter for Accepting Source-Routed Packets for All Interfaces'
+title: 'Configure Kernel Parameter for Accepting IPv4 Source-Routed Packets for All Interfaces'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv4.conf.all.accept_source_route", value="0") }}}'
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield.rule
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield.rule
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7,fedora
 
-title: 'Enable ExecShield'
+title: 'Enable ExecShield via sysctl'
 
 description: "By default on Red Hat Enterprise Linux 7 64-bit systems, ExecShield\nis enabled and can only be disabled if the hardware does not support ExecShield\nor is disabled in <tt>/etc/default/grub</tt>. For Red Hat Enterprise Linux 7 \n32-bit systems, <tt>sysctl</tt> can be used to enable ExecShield."
 

--- a/rhel6/guide/services/dhcp/dhcp_server_configuration/group.yml
+++ b/rhel6/guide/services/dhcp/dhcp_server_configuration/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Disable DHCP Server'
+title: 'DHCP Server Configuration'
 
 description: |-
     If the system must act as a DHCP server, the configuration

--- a/rhel6/guide/services/dhcp/disabling_dhcp_client/sysconfig_networking_bootproto_ifcfg.rule
+++ b/rhel6/guide/services/dhcp/disabling_dhcp_client/sysconfig_networking_bootproto_ifcfg.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Disable DHCP Client'
+title: 'Disable DHCP Client in ifcfg'
 
 description: |-
     For each interface on the system (e.g. eth0), edit

--- a/rhel6/guide/services/dns/disabling_dns_server/service_named_disabled.rule
+++ b/rhel6/guide/services/dns/disabling_dns_server/service_named_disabled.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Disable DNS Server'
+title: 'Disable named Service'
 
 description: '{{{ describe_service_disable(service="named") }}}'
 

--- a/rhel6/guide/services/ftp/ftp_configure_vsftpd/group.yml
+++ b/rhel6/guide/services/ftp/ftp_configure_vsftpd/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Use vsftpd to Provide FTP Service if Necessary'
+title: 'Configure vsftpd to Provide FTP Service if Necessary'
 
 description: |-
     The primary vsftpd configuration file is

--- a/rhel6/guide/system/accounts/accounts-physical/bootloader/bootloader_password.rule
+++ b/rhel6/guide/system/accounts/accounts-physical/bootloader/bootloader_password.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Set Boot Loader Password'
+title: 'Set Boot Loader Password in grub.conf'
 
 description: |-
     The grub boot loader should have password protection

--- a/rhel6/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_ra.rule
+++ b/rhel6/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_ra.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Configure Accepting IPv6 Router Advertisements'
+title: 'Configure Accepting IPv6 Router Advertisements on All Interfaces'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_ra", value="0") }}}'
 

--- a/rhel6/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_redirects.rule
+++ b/rhel6/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_redirects.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Configure Accepting IPv6 Redirects By Default'
+title: 'Configure Accepting IPv6 Redirects on All Interfaces'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_redirects", value="0") }}}'
 

--- a/rhel6/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_source_route.rule
+++ b/rhel6/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_source_route.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Configure Kernel Parameter for Accepting Source-Routed Packets for All Interfaces'
+title: 'Configure Kernel Parameter for Accepting Source-Routed Packets for All Interfaces via IPv6'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_source_route", value="0") }}}'
 

--- a/rhel6/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_default_accept_ra.rule
+++ b/rhel6/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_default_accept_ra.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Configure Accepting IPv6 Router Advertisements'
+title: 'Configure Accepting IPv6 Router Advertisements by Default'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv6.conf.default.accept_ra", value="0") }}}'
 

--- a/rhel6/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route.rule
+++ b/rhel6/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Configure Kernel Parameter for Accepting Source-Routed Packets for All Interfaces'
+title: 'Configure Kernel Parameter for Accepting IPv4 Source-Routed Packets for All Interfaces'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv4.conf.all.accept_source_route", value="0") }}}'
 

--- a/rhel6/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield.rule
+++ b/rhel6/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Enable ExecShield'
+title: 'Enable ExecShield via sysctl'
 
 description: '{{{ describe_sysctl_option_value(sysctl="kernel.exec-shield", value="1") }}}'
 


### PR DESCRIPTION
Several of the files in `rhel6` and `linux_os` guides were not unique within the guide and were duplicated. This was usually indicative of copy-paste errors and should be corrected. In a few cases, these titles were clarified to differentiate between e.g., `ipv4` and `ipv6`.

This is part of the efforts in #3037 to merge RHEL6 into Linux OS guide. By deduplicating titles, we can now use them as unique identifiers; if file-path based matching fails to find a match for a RHEL6 guide file in the Linux OS guide tree, we can also check for a match via title. 