### PR TITLE
Make rsyslog_remote_loghost_address to match linux_os

### DIFF
--- a/rhel6/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost_address.var
+++ b/rhel6/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost_address.var
@@ -8,7 +8,7 @@ type: string
 
 operator: equals
 
-interactive: false
+interactive: true
 
 options:
     default: NULL


### PR DESCRIPTION
This allows it to match the `linux_os` guide equivalent.