### PR TITLE
Merge security_patches_up_to_date.rule from rhel6->linux_os

### DIFF
--- a/linux_os/guide/system/software/updating/security_patches_up_to_date.rule
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date.rule
@@ -32,9 +32,13 @@ rationale: |-
 severity: high
 
 identifiers:
+    cce@rhel6: 27635-2
     cce@rhel7: 26895-3
 
 references:
+    stigid@rhel6: RHEL-06-000011
+    srg@rhel6: SRG-OS-000191
+    disa@rhel6: 1227,1233
     cis: "1.8"
     cjis: 5.10.4.1
     disa: "366"


### PR DESCRIPTION
This file had to be manually updated due to duplicated sections (`ocil_external_content`). I believe this file to be good to go with these updates in Linux OS. I would appreciate a comprehensive comparison of this file to its RHEL 6 equivalent: 

https://github.com/OpenSCAP/scap-security-guide/blob/master/rhel6/guide/system/software/updating/security_patches_up_to

https://github.com/OpenSCAP/scap-security-guide/blob/master/linux_os/guide/system/software/updating/security_patches_up_to

Part of #3037 efforts.