### PR TITLE
Update RHEL 6 and Linux OS severity fields

### DIFF
--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode.rule
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode.rule
@@ -16,7 +16,11 @@ rationale: |-
     given directory. Serving files from an intentionally-specified directory
     reduces the risk of sharing files which should remain private.
 
+{{% if product == "rhel7" %}}
 severity: medium
+{{% else %}}
+severity: high
+{{% endif %}}
 
 identifiers:
     cce@rhel7: 80214-0

--- a/linux_os/guide/services/ssh/ssh_server/sshd_print_last_log.rule
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_print_last_log.rule
@@ -12,7 +12,7 @@ rationale: |-
     Providing users feedback on when account accesses last occurred facilitates user
     recognition and reporting of unauthorized account use.
 
-severity: low
+severity: medium
 
 identifiers:
     cce@rhel7: 80225-6

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces.rule
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces.rule
@@ -21,7 +21,7 @@ rationale: |-
     serve to create a man-in-the-middle attack or be used to create a denial of
     service to valid network resources.
 
-severity: unknown
+severity: medium
 
 identifiers:
     cce@rhel7: 27358-1

--- a/rhel6/guide/services/nfs_and_rpc/nfs_configuring_servers/no_insecure_locks_exports.rule
+++ b/rhel6/guide/services/nfs_and_rpc/nfs_configuring_servers/no_insecure_locks_exports.rule
@@ -8,7 +8,7 @@ rationale: |-
     Allowing insecure file locking could allow for sensitive data to be
     viewed or edited by an unauthorized user.
 
-severity: high
+severity: medium
 
 identifiers:
     cce: 27167-6


### PR DESCRIPTION
In several places, the Linux OS and RHEL 6 guides have mismatched severity fields. To the extent possible by the author, these have been validated and corrected, e.g., via the STIG viewer. Review would be appreciated.

Part of: #3037 efforts.