### PR TITLE
Missing references in Linux OS guides

### DIFF
--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_log_transactions.rule
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_log_transactions.rule
@@ -21,6 +21,10 @@ severity: unknown
 identifiers:
     cce@rhel7: 80247-0
 
+references:
+    srg@rhel6: SRG-OS-000037
+    stigid@rhel6: RHEL-06-000339
+
 ocil_clause: 'xferlog_enable is missing, or is not set to yes'
 
 ocil: |-

--- a/linux_os/guide/services/mail/service_postfix_enabled.rule
+++ b/linux_os/guide/services/mail/service_postfix_enabled.rule
@@ -20,6 +20,10 @@ severity: unknown
 identifiers:
     cce@rhel7: 80287-6
 
+references:
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000287
+
 ocil_clause: 'the system is not a cross domain solution and the service is not enabled'
 
 ocil: '{{{ ocil_service_enabled(service="postfix") }}}'

--- a/linux_os/guide/services/smb/configuring_samba/mount_option_smb_client_signing.rule
+++ b/linux_os/guide/services/smb/configuring_samba/mount_option_smb_client_signing.rule
@@ -23,6 +23,10 @@ severity: unknown
 identifiers:
     cce@rhel7: 80281-9
 
+references:
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000273
+
 ocil_clause: 'it does not'
 
 ocil: |-

--- a/linux_os/guide/services/smb/configuring_samba/require_smb_client_signing.rule
+++ b/linux_os/guide/services/smb/configuring_samba/require_smb_client_signing.rule
@@ -23,6 +23,10 @@ severity: unknown
 identifiers:
     cce@rhel7: 80280-1
 
+references:
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000272
+
 ocil_clause: 'it is not'
 
 ocil: |-

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol.rule
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol.rule
@@ -16,6 +16,10 @@ severity: medium
 identifiers:
     cce@rhel7: 80276-9
 
+references:
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000340
+
 ocil_clause: 'there is output'
 
 ocil: |-


### PR DESCRIPTION
Several rules in the `linux_os` guide tree were missing a references section completely, so the work in #3037 does not update them. This adds the missing references from the RHEL 6 guides into the Linux OS shared guide.

Part of #3037 efforts.