### PR TITLE
Fix login.defs umask configuration.

### DIFF
--- a/shared/checks/oval/accounts_umask_etc_login_defs.xml
+++ b/shared/checks/oval/accounts_umask_etc_login_defs.xml
@@ -18,7 +18,7 @@
   <ind:textfilecontent54_object id="obj_umask_from_etc_login_defs"
   comment="Umask value from /etc/login.defs" version="1">
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)UMASK(?-i)[\s]+([^#\s]*)</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*UMASK[\s]+([^#\s]*)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -194,7 +194,7 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
             r"- \(xccdf-var\s+(\S+)\)",
             r"- name: XCCDF Value \1 # promote to variable\n"
             r"  set_fact:\n"
-            r"    \1: (ansible-populate \1)\n"
+            r'    \1: "(ansible-populate \1)"\n'
             r"  tags:\n"
             r"    - always",
             fix_text


### PR DESCRIPTION
This PR fixes two issues:
Major: The Ansible variable expansion happens inside double quotes. This ensures that octal numbers, booleans and other values that could be misinterpreted by the YML format are passed through accurately. Plus double quotes are escapable. Fixes #2989.
Minor: The OVAL check was cas-insensitive, so `UMASK` was as good as `umask`. This doesn't comply with XCCDF, nor with man pages.
The test suite now pass for the `login_defs` rule stem for both bash and ansible remediation engines.