### PR TITLE
Unshadow rhel6 packages installed

### DIFF
--- a/fedora/templates/csv/packages_installed.csv
+++ b/fedora/templates/csv/packages_installed.csv
@@ -4,6 +4,7 @@ chrony
 cronie
 dconf
 firewalld
+gdm
 libreswan
 openssh-server
 vsftpd

--- a/rhel6/checks/oval/package_openswan_installed.xml
+++ b/rhel6/checks/oval/package_openswan_installed.xml
@@ -1,6 +1,4 @@
 <def-group>
-  <!-- THIS FILE SHOULD NOT BE MANAGED BY create_package_installed.py template !!!
-       (since it's slightly different from common create_package_installed.py's output)  -->
   <definition class="compliance" id="package_openswan_installed" version="2">
     <metadata>
       <title>Package openswan / libreswan Installed</title>

--- a/rhel6/templates/csv/packages_installed.csv
+++ b/rhel6/templates/csv/packages_installed.csv
@@ -9,7 +9,6 @@ iptables
 iptables-ipv6
 irqbalance
 ntp
-openswan
 openssh-server
 pam_pkcs11
 pcsc-lite

--- a/rhel7/templates/csv/packages_installed.csv
+++ b/rhel7/templates/csv/packages_installed.csv
@@ -7,6 +7,7 @@ dconf
 docker
 esc
 firewalld
+gdm
 irqbalance
 #kernel-PAE
 libreswan

--- a/shared/templates/csv/packages_installed.csv
+++ b/shared/templates/csv/packages_installed.csv
@@ -1,2 +1,1 @@
-gdm
 samba-common


### PR DESCRIPTION
#### Description:

- Drop `gdm` from shared packages_installed CSV and adds to the products that need it.
- Drop `openswan` from rhel6 packages_installed CSV, the template for packages_installed does not apply for this check.

#### Rationale:

- Unshadows packages_installed rules for RHEL6.
