### PR TITLE
To be on the safe side, force ansible XCCDF values to be interpreted as str…

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -190,11 +190,15 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
                 "substituting directly."
             )
 
+        # we use the horrid "!!str |-" syntax to force strings without using
+        # quotes. quotes enable yaml escaping rules so we'd have to escape all
+        # the backslashes and at this point we don't know if there are any.
         fix_text = re.sub(
             r"- \(xccdf-var\s+(\S+)\)",
             r"- name: XCCDF Value \1 # promote to variable\n"
             r"  set_fact:\n"
-            r'    \1: "(ansible-populate \1)"\n'
+            r"    \1: !!str |-\n"
+            r"        (ansible-populate \1)\n"
             r"  tags:\n"
             r"    - always",
             fix_text


### PR DESCRIPTION
…ings

Avoid quotes though because that enables all sorts of escaping rules
that we would have to work around.

This fixes a regression which causes invalid Ansible syntax and breaks some of our roles - especially rhel6 and 7. Regression happened in b0eb3b7f7baa1a57dac3e373209d20bd55b3f215 and was reviewed by me (oops :-D)