### PR TITLE
Create the lock file if it doesn't exist

### DIFF
--- a/shared/fixes/ansible/dconf_gnome_login_banner_text.yml
+++ b/shared/fixes/ansible/dconf_gnome_login_banner_text.yml
@@ -46,6 +46,7 @@
     path: '/etc/dconf/db/gdm.d/locks/00-security-settings-lock'
     regexp: '^org/gnome/login-screen/banner-message-text$'
     line: 'org/gnome/login-screen/banner-message-text'
+    create: yes
     state: present
   tags:
     @ANSIBLE_TAGS@


### PR DESCRIPTION
Prevents issues in ansible-playbook check mode:
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Destination /etc/dconf/db/gdm.d/locks/00-security-settings-lock does not exist !", "rc": 257}
```