### PR TITLE
Update check for auditctl/augenrules for RHEL6

### DIFF
--- a/shared/checks/oval/audit_rules_auditctl.xml
+++ b/shared/checks/oval/audit_rules_auditctl.xml
@@ -28,12 +28,16 @@
   {{# Older versions of audit didn't have option to use augenrules, hence check_existence="any_exist" #}}
   <ind:textfilecontent54_test check="all" check_existence="any_exist" comment="audit auditctl" id="test_audit_rules_auditctl" version="1">
     <ind:object object_ref="object_audit_rules_auditctl" />
+    <ind:state state_ref="state_audit_rules_auditctl" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_audit_rules_auditctl" version="1">
     <ind:filepath>/etc/sysconfig/auditd</ind:filepath>
-    <ind:pattern operation="pattern match">^USE_AUGENRULES="no"$</ind:pattern>
+    <ind:pattern operation="pattern match">^USE_AUGENRULES="(.*)"$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_audit_rules_auditctl" version="1">
+    <ind:subexpression datatype="string" operation="equals">no</ind:subexpression>
+  </ind:textfilecontent54_state>
 {{% endif %}}
 
 </def-group>

--- a/shared/checks/oval/audit_rules_auditctl.xml
+++ b/shared/checks/oval/audit_rules_auditctl.xml
@@ -3,7 +3,7 @@
     <metadata>
       <title>Record Any Attempts to Run semanage</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
       </affected>
       <description>Test if auditctl is in use for audit rules.</description>
@@ -15,6 +15,7 @@
   </definition>
 
   <!-- Test the auditctl case -->
+{{% if init_system == "systemd" %}}
   <ind:textfilecontent54_test check="all" comment="audit auditctl" id="test_audit_rules_auditctl" version="1">
     <ind:object object_ref="object_audit_rules_auditctl" />
   </ind:textfilecontent54_test>
@@ -23,5 +24,16 @@
     <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/auditctl.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+{{% else %}}
+  {{# Older versions of audit didn't have option to use augenrules, hence check_existence="any_exist" #}}
+  <ind:textfilecontent54_test check="all" check_existence="any_exist" comment="audit auditctl" id="test_audit_rules_auditctl" version="1">
+    <ind:object object_ref="object_audit_rules_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_auditctl" version="1">
+    <ind:filepath>/etc/sysconfig/auditd</ind:filepath>
+    <ind:pattern operation="pattern match">^USE_AUGENRULES="no"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+{{% endif %}}
 
 </def-group>

--- a/shared/checks/oval/audit_rules_augenrules.xml
+++ b/shared/checks/oval/audit_rules_augenrules.xml
@@ -19,10 +19,18 @@
   <ind:textfilecontent54_test check="all" comment="audit augenrules" id="test_audit_rules_augenrules" version="1">
     <ind:object object_ref="object_audit_rules_augenrules" />
   </ind:textfilecontent54_test>
+{{% if init_system == "systemd" %}}
   <ind:textfilecontent54_object id="object_audit_rules_augenrules" version="1">
     <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
     <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/augenrules.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+{{% else %}}
+  <ind:textfilecontent54_object id="object_audit_rules_augenrules" version="1">
+    <ind:filepath>/etc/sysconfig/auditd</ind:filepath>
+    <ind:pattern operation="pattern match">^USE_AUGENRULES="yes"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+{{% endif %}}
 
 </def-group>


### PR DESCRIPTION
#### Description:
- Update `audit_rules_auditctl` and `audit_rules_augenrules` to check correct config files in RHEL6

#### Rationale:

- Augenrules is available for RHEL6 and we should be able to check whether
auditd is using augenrules or not.
