### PR TITLE
Make all jinja macros defined in jinja files.

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -596,17 +596,19 @@ Available CCEs that can be assigned to new rules are listed in the `shared/refer
 Some of existing rule definitions contain elements that use macros.
 There are two implementations of macros:
 
-* link:http://jinja.pocoo.org/docs/2.10/[Jinja macros], that are defined in `shared/modules/macros.jinja`, and
-* legacy XSLT macros, which are defined in `shared/transforms/*.xslt`.
+* link:http://jinja.pocoo.org/docs/2.10/[Jinja macros], that are defined in `shared/macros.jinja`, and `shared/macros-highlevel.jinja`.
+* Legacy XSLT macros, which are defined in `shared/transforms/*.xslt`.
 
 For example, the `ocil` element of `service_ntpd_enabled` uses the `ocil_service_enabled` jinja macro.
 Due to the need of supporting Ansible output, which also uses jinja, we had to modify control sequences, so macro operations require one more curly brace.
 For example, invocation of the partition macro looks like `{{{ complete_ocil_entry_separate_partition(part="/tmp") }}}` - there are three opening and closing curly braces instead of the two that are documented in the Jinja guide.
 
+`shared/macros.jinja` contains specific low-level macros s.a. `systemd_ocil_service_enabled`, whereas `shared/macros-highlevel.jinja` contains general macros s.a. `ocil_service_enabled`, that decide which one of the specialized macros to call based on the actual product being used.
+
 The macros that are likely to be used in descriptions begin by `describe_`, whereas macros likely to be used in OCIL entries begin with `ocil_`.
 Sometimes, a rule requires `ocil` and `ocil_clause` to be specified, and they depend on each other.
 Macros that begin with `complete_ocil_entry_` were designed for exactly this purpose, as they make sure that OCIL and OCIL clauses are defined and consistent.
-
+Macros that begin with underscores are not meant to be used in descriptions.
 
 Rules are unselected by default - even if the scanner reads rule definitions, they are effectively ignored during the scan or remediation.
 A rule may be selected by any number of profiles, so when the scanner is scanning using a profile the rule is included in, the rule is taken into account.

--- a/shared/macros-highlevel.jinja
+++ b/shared/macros-highlevel.jinja
@@ -1,0 +1,127 @@
+{{% macro ocil_package(package) -%}}
+    {{%- if pkg_system == "rpm" -%}}
+        {{{ rpm_ocil_package(package) }}}
+    {{%- elif pkg_system == "dpkg" -%}}
+        {{{ dpkg_ocil_package(package) }}}
+    {{%- else %}}
+        JINJA MACRO ERROR: Unknown package system '{{{ pkg_system }}}'.
+    {{%- endif -%}}
+{{%- endmacro %}}
+
+
+{{% macro complete_ocil_entry_package(package) -%}}
+    {{%- if pkg_system == "rpm" %}}
+        {{{ rpm_complete_ocil_entry_package(package) }}}
+    {{%- elif pkg_system == "dpkg" %}}
+        {{{ dpkg_complete_ocil_entry_package(package) }}}
+    {{%- else %}}
+        JINJA MACRO ERROR: Unknown package system '{{{ pkg_system }}}'.
+    {{%- endif -%}}
+{{%- endmacro %}}
+
+
+{{%- macro describe_package_install(package) -%}}
+    {{%- if pkg_manager == "apt_get" -%}}
+        {{{ apt_get_describe_package_install(package) }}}
+    {{%- elif pkg_manager == "zypper" -%}}
+        {{{ zypper_describe_package_install(package) }}}
+    {{%- elif pkg_manager == "yum" -%}}
+        {{{ yum_describe_package_install(package) }}}
+    {{%- elif pkg_manager == "dnf" -%}}
+        {{{ dnf_describe_package_install(package) }}}
+    {{%- else %}}
+        JINJA MACRO ERROR: Unknown package manager '{{{ pkg_manager }}}'.
+    {{%- endif -%}}
+{{%- endmacro %}}
+
+
+{{%- macro describe_package_remove(package) -%}}
+    {{%- if pkg_manager == "apt_get" -%}}
+        {{{ apt_get_describe_package_remove(package) }}}
+    {{%- elif pkg_manager == "zypper" -%}}
+        {{{ zypper_describe_package_remove(package) }}}
+    {{%- elif pkg_manager == "yum" -%}}
+        {{{ yum_describe_package_remove(package) }}}
+    {{%- elif pkg_manager == "dnf" -%}}
+        {{{ dnf_describe_package_remove(package) }}}
+    {{%- else %}}
+        JINJA MACRO ERROR: Unknown package manager '{{{ pkg_manager }}}'.
+    {{%- endif -%}}
+{{%- endmacro %}}
+
+
+{{% macro describe_service_enable(service) -%}}
+    {{%- if init_system == "systemd" -%}}
+        {{{ systemd_describe_service_enable(service) }}}
+    {{%- elif init_system == "upstart" -%}}
+        {{{ upstart_describe_service_enable(service) }}}
+    {{%- else %}}
+        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+    {{%- endif -%}}
+{{%- endmacro %}}
+
+
+{{% macro describe_service_disable(service) -%}}
+    {{%- if init_system == "systemd" -%}}
+        {{{ systemd_describe_service_disable(service) }}}
+    {{%- elif init_system == "upstart" -%}}
+        {{{ upstart_describe_service_disable(service) }}}
+    {{%- else %}}
+        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+    {{%- endif -%}}
+{{%- endmacro %}}
+
+
+{{% macro ocil_service_enabled(service) -%}}
+    {{%- if init_system == "systemd" -%}}
+        {{{ systemd_ocil_service_enabled(service) }}}
+    {{%- elif init_system == "upstart" -%}}
+        {{{ upstart_ocil_service_enabled(service) }}}
+    {{%- else %}}
+        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+    {{%- endif -%}}
+{{%- endmacro %}}
+
+
+{{% macro ocil_service_disabled(service) -%}}
+    {{%- if init_system == "systemd" -%}}
+        {{{ systemd_ocil_service_disabled(service) }}}
+    {{%- elif init_system == "upstart" -%}}
+        {{{ upstart_ocil_service_disabled(service) }}}
+    {{%- else %}}
+        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+    {{%- endif -%}}
+{{%- endmacro %}}
+
+
+{{% macro describe_socket_enable(socket) -%}}
+    {{%- if init_system == "systemd" -%}}
+        {{{ systemd_describe_socket_enable(socket) }}}
+    {{%- elif init_system == "upstart" -%}}
+        {{{ upstart_describe_socket_enable(socket) }}}
+    {{%- else %}}
+        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+    {{%- endif -%}}
+{{%- endmacro %}}
+
+
+{{% macro describe_socket_disable(socket) -%}}
+    {{%- if init_system == "systemd" -%}}
+        {{{ systemd_describe_socket_disable(socket) }}}
+    {{%- elif init_system == "upstart" -%}}
+        {{{ upstart_describe_socket_disable(socket) }}}
+    {{%- else %}}
+        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+    {{%- endif -%}}
+{{%- endmacro %}}
+
+
+{{% macro complete_ocil_entry_socket_and_service_disabled(service) -%}}
+    {{%- if init_system == "systemd" -%}}
+        {{{ systemd_complete_ocil_entry_socket_and_service_disabled(service) }}}
+    {{%- elif init_system == "upstart" -%}}
+        {{{ upstart_complete_ocil_entry_socket_and_service_disabled(service) }}}
+    {{%- else %}}
+        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+    {{%- endif -%}}
+{{%- endmacro %}}

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -223,10 +223,10 @@ ocil_clause: "service and/or socket are running"
 {{%- endmacro %}}
 
 
-{{%- macro rpm_ocil_package(package) %}}
+{{%- macro rpm_ocil_package(package) -%}}
     Run the following command to determine if the <code>{{{ package }}}</code> package is installed:
     <pre>$ rpm -q {{{ package }}}</pre>
-{{%- endmacro %}}
+{{%- endmacro -%}}
 
 
 {{%- macro dpkg_ocil_package(package) %}}
@@ -237,7 +237,7 @@ ocil_clause: "service and/or socket are running"
 
 {{%- macro rpm_complete_ocil_entry_package(package) %}}
 ocil: |-
-    rpm_ocil_package(package)
+    {{{ rpm_ocil_package(package) }}}
 
 ocil_clause: "the package is installed"
 {{%- endmacro %}}
@@ -245,7 +245,7 @@ ocil_clause: "the package is installed"
 
 {{%- macro dpkg_complete_ocil_entry_package(package) %}}
 ocil: |-
-    dpkg_ocil_package(package)
+    {{{ dpkg_ocil_package(package) }}}
 
 ocil_clause: "the package is installed"
 {{%- endmacro %}}

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -4,8 +4,10 @@ import datetime
 import os.path
 
 
-JINJA_MACROS_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
+JINJA_MACROS_BASE_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros.jinja")
+JINJA_MACROS_HIGHLEVEL_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
+    __file__)), "shared", "macros-highlevel.jinja")
 
 xml_version = """<?xml version="1.0" encoding="UTF-8"?>"""
 

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -69,7 +69,7 @@ _get_jinja_environment.env = None
 
 def _extract_substitutions_dict_from_template(filename, substitutions_dict):
     template = _get_jinja_environment(substitutions_dict).get_template(filename)
-    all_symbols = template.make_module().__dict__
+    all_symbols = template.make_module(substitutions_dict).__dict__
     symbols_to_export = dict()
     for name, symbol in all_symbols.items():
         if name.startswith("_"):


### PR DESCRIPTION
Previously, some macros were added to the list of available jinja macros by Pyhon code.
This could confuse people looking for those definitions, and it also required editing jinja and Python files in case of macro renames.
This PR makes sure that every jinja macro is defined in a jinja file, rather than automagically generated by the Python build system.
Remark: The dashes in jinja control sequences are arranged in such way that the built datastreams before and after are almost the same.
There was a somehow unrelated jinja bug discovered during the process, and fix for it is part of this PR.