### PR TITLE
Small changes to build output

### DIFF
--- a/build-scripts/sds_move_ocil_to_checks.py
+++ b/build-scripts/sds_move_ocil_to_checks.py
@@ -191,9 +191,6 @@ def main():
             # Also update the ID replacing 'ecomp' with 'comp'
             move_ocil_content_from_ds_extended_component_to_ds_component(datastreamtree, oldocilhref)
 
-    else:
-        print("No extended-components, nothing to do...")
-
     # if the in and out files are the same and we didn't do any changes we can
     # skip the serialization
     if extendedcomps is not None or outdatastreamfile != indatastreamfile:

--- a/build-scripts/unselect_empty_xccdf_groups.py
+++ b/build-scripts/unselect_empty_xccdf_groups.py
@@ -140,8 +140,6 @@ def main():
 
         affected_profiles.append(profile_element.get("id"))
 
-    print("Unselected empty groups in %s." % (", ".join(affected_profiles)))
-
     input_tree.write(options.output)
 
 

--- a/ssg/build_stig.py
+++ b/ssg/build_stig.py
@@ -11,7 +11,7 @@ def add_references(reference, destination):
     try:
         reference_root = ET.parse(reference)
     except IOError:
-        print("INFO: DISA STIG Reference file not found for this platform")
+        print("INFO: DISA STIG Reference file not found for this platform: %s" % reference)
         sys.exit(0)
 
     reference_rules = reference_root.findall('.//{%s}Rule' % XCCDF11_NS)


### PR DESCRIPTION
I'd like to get feedback on this. Removed notifications are currently commented out because they don't appear to be errors or warnings.

Based on feedback, I'll either remove the lines completely, or consider adding a VERBOSE option to the build that extends output, but which is default disabled. 

This'll help make builds more informative by reducing the quantity of extraneous information; limiting it to Errors and warnings. 

Thoughts? 