### PR TITLE
Made grep usage faster where it can make a difference.

### DIFF
--- a/shared/bash_remediation_functions/replace_or_append.sh
+++ b/shared/bash_remediation_functions/replace_or_append.sh
@@ -67,7 +67,7 @@ function replace_or_append {
   # If the key exists, change it. Otherwise, add it to the config_file.
   # We search for the key string followed by a word boundary (matched by \>),
   # so if we search for 'setting', 'setting2' won't match.
-  if grep -q $grep_case_insensitive_option "${key}\\>" "$config_file"; then
+  if LC_ALL=C grep -q -m 1 $grep_case_insensitive_option -e "${key}\\>" "$config_file"; then
     "${sed_command[@]}" "s/${key}\\>.*/$formatted_output/g$sed_case_insensitive_option" "$config_file"
   else
     # \n is precaution for case where file ends without trailing newline

--- a/shared/templates/template_BASH_accounts_password
+++ b/shared/templates/template_BASH_accounts_password
@@ -9,7 +9,7 @@ populate var_password_pam_%VARIABLE%
 {{% if product == "rhel6" %}}
 {{# There is no package libpwquality for RHEL6 #}}
 
-if grep -q "%VARIABLE%=" /etc/pam.d/system-auth; then
+if LC_ALL=C grep -m 1 -q -e "%VARIABLE%=" /etc/pam.d/system-auth; then
 	sed -i --follow-symlinks "s/\(%VARIABLE% *= *\).*/\1$var_password_pam_%VARIABLE%/" /etc/pam.d/system-auth
 else
 	sed -i --follow-symlinks "/pam_cracklib.so/ s/$/ %VARIABLE%=$var_password_pam_%VARIABLE%/" /etc/pam.d/system-auth

--- a/shared/templates/template_BASH_kernel_module_disabled
+++ b/shared/templates/template_BASH_kernel_module_disabled
@@ -3,7 +3,7 @@
 # strategy = disable
 # complexity = low
 # disruption = medium
-if grep --silent "^install %KERNMODULE%" /etc/modprobe.d/%KERNMODULE%.conf ; then
+if LC_ALL=C grep -q -m 1 "^install %KERNMODULE%" /etc/modprobe.d/%KERNMODULE%.conf ; then
 	sed -i 's/^install %KERNMODULE%.*/install %KERNMODULE% /bin/true/g' /etc/modprobe.d/%KERNMODULE%.conf
 else
 	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/%KERNMODULE%.conf


### PR DESCRIPTION
Targeted templates and functions used often, fixes #3031

- Added -m 1 option, which stops reading the file when one occurence
  of the pattern is found.
- Added `-e` before patterns, which helps if the pattern happens to begin by dash.
- Made grep to use LC_ALL=C, as we are working with ASCII config files.
- This should result in considerable faster grep:
  https://www.inmotionhosting.com/support/website/ssh/speed-up-grep-searches-with-lc-all