### PR TITLE
[FEEDBACK REQUESTED] Merge system in rhel6, linux_os

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gconf_gdm_enable_warning_gui_banner.rule
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gconf_gdm_enable_warning_gui_banner.rule
@@ -1,0 +1,36 @@
+documentation_complete: true
+
+title: 'Enable GUI Warning Banner'
+
+description: |-
+    To enable displaying a login warning banner in the GNOME
+    Display Manager's login screen, run the following command:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/gdm/simple-greeter/banner_message_enable true</pre>
+    To display a banner, this setting must be enabled and then
+    banner text must also be set.
+
+rationale: |-
+    An appropriate warning message reinforces policy awareness during the login
+    process and facilitates possible legal action against attackers.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 27195-7
+
+references:
+    disa@rhel6: 48,50
+    nist: AC-8(a),AC-8(b),AC-8(c)
+    srg@rhel6: SRG-OS-000024
+    stigid@rhel6: RHEL-06-000324
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    To ensure a login warning banner is enabled, run the following:
+    <pre>$ gconftool-2 -g /apps/gdm/simple-greeter/banner_message_enable</pre>
+    Search for the <tt>banner_message_enable</tt> schema.
+    If properly configured, the <tt>default</tt> value should be <tt>true</tt>.

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gconf_gdm_set_login_banner_text.rule
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gconf_gdm_set_login_banner_text.rule
@@ -1,0 +1,39 @@
+documentation_complete: true
+
+title: 'Set GUI Warning Banner Text'
+
+description: |-
+    To set the text shown by the GNOME Display Manager
+    in the login screen, run the following command:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type string \
+      --set /apps/gdm/simple-greeter/banner_message_text \
+      "Text of the warning banner here"</pre>
+    When entering a warning banner that spans several lines, remember
+    to begin and end the string with <tt>"</tt>. This command writes
+    directly either to the <tt>/etc/gconf/gconf.xml.mandatory/%gconf-tree.xml</tt>
+    if it exists or to the file <tt>/etc/gconf/gconf.xml.mandatory/apps/gdm/simple-greeter/%gconf.xml</tt>.
+    Either of these files can later be edited directly if necessary.
+
+rationale: |-
+    An appropriate warning message reinforces policy awareness during the login
+    process and facilitates possible legal action against attackers.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 27017-3
+
+references:
+    disa@rhel6: 48,1384,1385,1386,1387,1388
+    nist: AC-8(a),AC-8(b),AC-8(c)
+    srg@rhel6: SRG-OS-000228
+    stigid@rhel6: RHEL-06-000326
+
+ocil_clause: 'it does not'
+
+ocil: |-
+    To ensure the login warning banner text is properly set, run the following:
+    <pre>$ gconftool-2 -g /apps/gdm/simple-greeter/banner_message_text</pre>
+    If properly configured, the proper banner text will appear within this schema.

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/group.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/group.yml
@@ -5,7 +5,7 @@ title: 'Implement a GUI Warning Banner'
 description: |-
     In the default graphical environment, users logging
     directly into the system are greeted with a login screen provided
-    by the GNOME3 Display Manager (GDM). The warning banner should be
+    by the GNOME Display Manager (GDM). The warning banner should be
     displayed in this graphical environment for these users.
     The following sections describe how to configure the GDM login
     banner.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/group.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/group.yml
@@ -8,3 +8,11 @@ description: |-
     documentation is available in
     <tt>/usr/share/doc/pam-VERSION/txts/README.pam_faillock</tt>.
     <br /><br />
+
+warnings:
+    - general: |-
+        Locking out user accounts presents the
+        risk of a denial-of-service attack. The lockout policy
+        must weigh whether the risk of such a
+        denial-of-service attack outweighs the benefits of thwarting
+        password guessing attacks.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/group.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/group.yml
@@ -2,6 +2,18 @@ documentation_complete: true
 
 title: 'Set Password Quality Requirements'
 
+{{% if product == "rhel6" %}}
+description: |-
+    The default <tt>pam_cracklib</tt> PAM module provides strength
+    checking for passwords. It performs a number of checks, such as
+    making sure passwords are not similar to dictionary words, are of
+    at least a certain length, are not the previous password reversed,
+    and are not simply a change of case from the previous password. It
+    can also require passwords to be in certain character classes.
+    <br /><br />
+    The man page <tt>pam_cracklib(8)</tt> provides information on the
+    capabilities and configuration of each.
+{{% else %}}
 description: |-
     The default <tt>pam_pwquality</tt> PAM module provides strength
     checking for passwords. It performs a number of checks, such as
@@ -23,3 +35,4 @@ description: |-
     The man pages <tt>pam_pwquality(8)</tt> and <tt>pam_cracklib(8)</tt>
     provide information on the capabilities and configuration of
     each.
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_dcredit.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_dcredit.rule
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+title: 'Set Password Strength Minimum Digit Characters'
+
+description: "The pam_cracklib module's <tt>dcredit</tt> parameter controls requirements for\nusage of digits in a password. When set to a negative number, any password will be required to\ncontain that many digits. When set to a positive number, pam_cracklib will grant +1 additional\nlength credit for each digit.  \nAdd <tt>dcredit=-1</tt> after pam_cracklib.so to require use of a digit in passwords."
+
+rationale: |-
+    Requiring digits makes password guessing attacks more difficult by ensuring a larger
+    search space.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 26374-9
+
+references:
+    disa@rhel6: "194"
+    nist: IA-5(b),IA-5(c)
+    pcidss: Req-8.2.3
+    srg@rhel6: SRG-OS-000071
+    stigid@rhel6: RHEL-06-000056
+
+ocil_clause: 'dcredit is not found or not set to the required value'
+
+ocil: |-
+    To check how many digits are required in a password, run the following command:
+    <pre>$ grep pam_cracklib /etc/pam.d/system-auth</pre>
+    The <tt>dcredit</tt> parameter (as a negative number) will indicate how many digits are required.
+    The DoD requires at least one digit in a password.
+    This would appear as <tt>dcredit=-1</tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_difok.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_difok.rule
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+title: 'Set Password Strength Minimum Different Characters'
+
+description: |-
+    The pam_cracklib module's <tt>difok</tt> parameter controls requirements for
+    usage of different characters during a password change.
+    Add <tt>difok=<i><sub idref="var_password_pam_difok" /></i></tt> after pam_cracklib.so to require differing
+    characters when changing passwords. The DoD requirement is <tt>4</tt>.
+
+rationale: |-
+    Requiring a minimum number of different characters during password changes ensures that
+    newly changed passwords should not resemble previously compromised ones.
+    Note that passwords which are changed on compromised systems will still be compromised, however.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 26615-5
+
+references:
+    disa@rhel6: "195"
+    nist: IA-5(b),IA-5(c),IA-5(1)(b)
+    srg@rhel6: SRG-OS-000072
+    stigid@rhel6: RHEL-06-000060
+
+ocil_clause: 'difok is not found or not set to the required value'
+
+ocil: |-
+    To check how many characters must differ during a password change, run the following command:
+    <pre>$ grep pam_cracklib /etc/pam.d/system-auth</pre>
+    The <tt>difok</tt> parameter will indicate how many characters must differ.
+    The DoD requires four characters differ during a password change.
+    This would appear as <tt>difok=4</tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_lcredit.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_lcredit.rule
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+title: 'Set Password Strength Minimum Lowercase Characters'
+
+description: |-
+    The pam_cracklib module's <tt>lcredit=</tt> parameter controls requirements for
+    usage of lowercase letters in a password. When set to a negative number, any password will be required to
+    contain that many lowercase characters. When set to a positive number, pam_cracklib will grant +1 additional
+    length credit for each lowercase character.
+    Add <tt>lcredit=-1</tt> after pam_cracklib.so to require use of a lowercase character in passwords.
+
+rationale: |-
+    Requiring a minimum number of lowercase characters makes password guessing attacks
+    more difficult by ensuring a larger search space.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 26631-2
+
+references:
+    disa@rhel6: "193"
+    nist: IA-5(b),IA-5(c),IA-5(1)(a)
+    pcidss: Req-8.2.3
+    srg@rhel6: SRG-OS-000070
+    stigid@rhel6: RHEL-06-000059
+
+ocil_clause: 'lcredit is not found or not set to the required value'
+
+ocil: |-
+    To check how many lowercase characters are required in a password, run the following command:
+    <pre>$ grep pam_cracklib /etc/pam.d/system-auth</pre>
+    The <tt>lcredit</tt> parameter (as a negative number) will indicate how many special characters are required.
+    The DoD and FISMA require at least one lowercase character in a password.
+    This would appear as <tt>lcredit=-1</tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_maxrepeat.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_maxrepeat.rule
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+title: 'Set Password to Maximum of Three Consecutive Repeating Characters'
+
+description: |-
+    The pam_cracklib module's <tt>maxrepeat</tt> parameter controls requirements for
+    consecutive repeating characters. When set to a positive number, it will reject passwords
+    which contain more than that number of consecutive characters. Add <tt>maxrepeat=<sub idref="var_password_pam_maxrepeat" /></tt>
+    after pam_cracklib.so to prevent a run of (<sub idref="var_password_pam_maxrepeat" /> + 1) or more identical characters:<br />
+    <pre>password required pam_cracklib.so maxrepeat=<sub idref="var_password_pam_maxrepeat" /></pre>
+
+rationale: 'Passwords with excessive repeating characters may be more vulnerable to password-guessing attacks.'
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 27227-8
+
+references:
+    disa@rhel6: "366"
+    nist: IA-5(c)
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000299
+
+ocil_clause: 'maxrepeat is not found or not set to the required value'
+
+ocil: |-
+    To check the maximum value for consecutive repeating characters, run the following command:
+    <pre>$ grep pam_cracklib /etc/pam.d/system-auth</pre>
+    Look for the value of the <tt>maxrepeat</tt> parameter. The DoD requirement is 3.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_minclass.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_minclass.rule
@@ -1,0 +1,40 @@
+documentation_complete: true
+
+title: 'Set Password Strength Minimum Different Categories'
+
+description: |-
+    The pam_cracklib module's <tt>minclass</tt> parameter controls requirements for
+    usage of different character classes, or types, of character that must exist in a password
+    before it is considered valid. For example, setting this value to three (3) requires that
+    any password must have characters from at least three different categories in order to be
+    approved. The default value is zero (0), meaning there are no required classes. There are
+    four categories available:
+    <pre>
+    * Upper-case characters
+    * Lower-case characters
+    * Digits
+    * Special characters (for example, punctuation)
+    </pre>
+    Add <tt>minclass=<i><sub idref="var_password_pam_minclass" /></i></tt> after pam_cracklib.so entry into the
+    <tt>/etc/pam.d/system-auth</tt> file in order to require <sub idref="var_password_pam_minclass" />  differing categories of
+    characters when changing passwords.
+    For example to require at least three character classes to be used in password, use <tt>minclass=3</tt>.
+
+rationale: |-
+    Requiring a minimum number of character categories makes password guessing attacks
+    more difficult by ensuring a larger search space.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 27115-5
+
+ocil_clause: 'minclass is not found or not set to the required value'
+
+ocil: |-
+    To check how many categories of characters must be used in password during a password change,
+    run the following command:
+    <pre>$ grep pam_cracklib /etc/pam.d/system-auth</pre>
+    The <tt>minclass</tt> parameter will indicate how many character classes must be used. If
+    the requirement was for the password to contain characters from three different categories,
+    then this would appear as <tt>minclass=3</tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_minlen.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_minlen.rule
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+title: 'Set Password Minimum Length'
+
+description: |-
+    The pam_cracklib module's <tt>minlen</tt> parameter controls requirements for
+    minimum characters required in a password. Add <tt>minlen=<sub idref="var_password_pam_minlen" /></tt>
+    after pam_pwquality to set minimum password length requirements.
+
+rationale: |-
+    Password length is one factor of several that helps to determine
+    strength and how long it takes to crack a password. Use of more characters in
+    a password helps to exponentially increase the time and/or resources
+    required to compromise the password.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 26615-5
+
+references:
+    disa@rhel6: "205"
+    nist: IA-5(1)(a)
+    pcidss: Req-8.2.3
+
+ocil_clause: 'minlen is not found or not set to the required value (or higher)'
+
+ocil: |-
+    To check how many characters are required in a password, run the following command:
+    <pre>$ grep cracklib /etc/pam.d/system-auth</pre>
+    Your output should contain <tt>minlen=<sub idref="var_password_pam_minlen" /></tt>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ocredit.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ocredit.rule
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+title: 'Set Password Strength Minimum Special Characters'
+
+description: |-
+    The pam_cracklib module's <tt>ocredit=</tt> parameter controls requirements for
+    usage of special (or ``other'') characters in a password. When set to a negative number, any password will be required to
+    contain that many special characters. When set to a positive number, pam_cracklib will grant +1 additional
+    length credit for each special character.
+    Add <tt>ocredit=<sub idref="var_password_pam_ocredit" /></tt> after pam_cracklib.so to require use of a special character in passwords.
+
+rationale: |-
+    Requiring a minimum number of special characters makes password guessing attacks
+    more difficult by ensuring a larger search space.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 26409-3
+
+references:
+    disa@rhel6: "1619"
+    nist: IA-5(b),IA-5(c),IA-5(1)(a)
+    srg@rhel6: SRG-OS-000266
+    stigid@rhel6: RHEL-06-000058
+
+ocil_clause: 'ocredit is not found or not set to the required value'
+
+ocil: |-
+    To check how many special characters are required in a password, run the following command:
+    <pre>$ grep pam_cracklib /etc/pam.d/system-auth</pre>
+    The <tt>ocredit</tt> parameter (as a negative number) will indicate how many special characters are required.
+    The DoD and FISMA require at least one special character in a password.
+    This would appear as <tt>ocredit=-1</tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_retry.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_retry.rule
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Set Password Retry Prompts Permitted Per-Session'
+
+description: "To configure the number of retry prompts that are permitted per-session:\n<br /><br />\nEdit the <tt>pam_cracklib.so</tt> statement in <tt>/etc/pam.d/system-auth</tt> to \nshow <tt>retry=<sub idref=\"var_password_pam_retry\" /></tt>, or a lower value if site policy is more restrictive.\n<br /><br />\nThe DoD requirement is a maximum of 3 prompts per session."
+
+rationale: |-
+    Setting the password retry prompts that are permitted on a per-session basis to a low value
+    requires some software, such as SSH, to re-connect. This can slow down and
+    draw additional attention to some types of password-guessing attacks. Note that this
+    is different from account lockout, which is provided by the pam_faillock module.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 27123-9
+
+references:
+    disa@rhel6: "1092"
+    nist: IA-5(c)
+
+ocil_clause: 'it is not the required value'
+
+ocil: |-
+    To check how many retry attempts are permitted on a per-session basis, run the following command:
+    <pre>$ grep pam_cracklib /etc/pam.d/system-auth</pre>
+    The <tt>retry</tt> parameter will indicate how many attempts are permitted.
+    The DoD required value is less than or equal to 3.
+    This would appear as <tt>retry=3</tt>, or a lower value.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ucredit.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ucredit.rule
@@ -1,0 +1,36 @@
+documentation_complete: true
+
+title: 'Set Password Strength Minimum Uppercase Characters'
+
+description: |-
+    The pam_cracklib module's <tt>ucredit=</tt> parameter controls requirements for
+    usage of uppercase letters in a password. When set to a negative number, any password will be required to
+    contain that many uppercase characters. When set to a positive number, pam_cracklib will grant +1 additional
+    length credit for each uppercase character.
+    Add <tt>ucredit=-1</tt> after pam_cracklib.so to require use of an upper case character in passwords.
+
+rationale: |-
+    Requiring a minimum number of uppercase characters makes password guessing attacks
+    more difficult by ensuring a larger search space.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 26601-5
+
+references:
+    cui: 3.5.7
+    disa@rhel6: "192"
+    nist: IA-5(b),IA-5(c),IA-5(1)(a)
+    pcidss: Req-8.2.3
+    srg@rhel6: SRG-OS-000069
+    stigid@rhel6: RHEL-06-000057
+
+ocil_clause: 'ucredit is not found or not set to the required value'
+
+ocil: |-
+    To check how many uppercase characters are required in a password, run the following command:
+    <pre>$ grep pam_cracklib /etc/pam.d/system-auth</pre>
+    The <tt>ucredit</tt> parameter (as a negative number) will indicate how many uppercase characters are required.
+    The DoD and FISMA require at least one uppercase character in a password.
+    This would appear as <tt>ucredit=-1</tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/group.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/group.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: |-
+    Set Password Quality Requirements, if using
+    pam_cracklib
+
+description: |-
+    The <tt>pam_cracklib</tt> PAM module can be configured to meet
+    requirements for a variety of policies.
+    <br /><br />
+    For example, to configure <tt>pam_cracklib</tt> to require at least one uppercase
+    character, lowercase character, digit, and other (special)
+    character, locate the following line in <tt>/etc/pam.d/system-auth</tt>:
+    <pre>password requisite pam_cracklib.so try_first_pass retry=3</pre>
+    and then alter it to read:
+    <pre>password required pam_cracklib.so try_first_pass retry=3 maxrepeat=3 minlen=14 dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1 difok=4</pre>
+    If no such line exists, add one as the first line of the password section in <tt>/etc/pam.d/system-auth</tt>.
+    The arguments can be modified to ensure compliance with
+    your organization's security policy. Discussion of each parameter follows.
+
+warnings:
+    - general: |-
+        Note that the password quality requirements are not enforced for the
+        root account for some reason.

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot.rule
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Disable Ctrl-Alt-Del Reboot Activation'
 

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot.rule
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot.rule
@@ -4,6 +4,17 @@ prodtype: rhel7,fedora
 
 title: 'Disable Ctrl-Alt-Del Reboot Activation'
 
+{{% if product == "rhel6" %}}
+description: |-
+    By default, the system includes the following line in
+    <tt>/etc/init/control-alt-delete.conf</tt>
+    to reboot the system when the Ctrl-Alt-Del key sequence is pressed:
+    <pre>exec /sbin/shutdown -r now "Control-Alt-Delete pressed"</pre>
+    <br />
+    To configure the system to log a message instead of
+    rebooting the system, alter that line to read as follows:
+    <pre>exec /usr/bin/logger -p security.info "Control-Alt-Delete pressed"</pre>
+{{% else %}}
 description: |-
     By default, <tt>SystemD</tt> will reboot the system if the <tt>Ctrl-Alt-Del</tt>
     key sequence is pressed.
@@ -16,12 +27,23 @@ description: |-
     <br /><br />
     Do not simply delete the <tt>/usr/lib/systemd/system/ctrl-alt-del.service</tt> file,
     as this file may be restored during future system updates.
+{{% endif %}}
 
 rationale: |-
     A locally logged-in user who presses Ctrl-Alt-Del, when at the console,
     can reboot the system. If accidentally pressed, as could happen in
     the case of mixed OS environment, this can create the risk of short-term
     loss of availability of systems due to unintentional reboot.
+    {{% if product == "rhel6" %}}
+    In the GNOME graphical environment, risk of unintentional reboot from the
+    Ctrl-Alt-Del sequence is reduced because the user will be
+    prompted before any action is taken.
+
+    NOTE: When updating the <tt>initscripts</tt> package on a Red Hat Enterprise
+    Linux 6 system, custom changes to <tt>/etc/init/control-alt-delete.conf</tt>
+    may be overwritten. Refer to <b>{{{ weblink(link="https://access.redhat.com/site/solutions/70464") }}}</b>
+    for additional information.
+    {{% endif %}}
 
 severity: high
 
@@ -38,12 +60,20 @@ references:
 
 ocil_clause: 'the system is configured to reboot when Ctrl-Alt-Del is pressed'
 
+{{% if product == "rhel6" %}}
+ocil: |-
+    To ensure the system is configured to log a message instead of rebooting the
+    system when Ctrl-Alt-Del is pressed, ensure the following line is in
+    <tt>/etc/init/control-alt-delete.conf</tt>:
+    <pre>exec /usr/bin/logger -p security.info \"Control-Alt-Delete pressed\"</pre>
+{{% else %}}
 ocil: |-
     To ensure the system is configured to mask the Ctrl-Alt-Del sequence,
     enter the following command:
     <pre>$ sudo ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target</pre>
     or
     <pre>$ sudo systemctl mask ctrl-alt-del.target</pre>
+{{% endif %}}
 
 warnings:
     - functionality: |-

--- a/linux_os/guide/system/accounts/accounts-physical/grub_legacy_disable_interactive_boot.rule
+++ b/linux_os/guide/system/accounts/accounts-physical/grub_legacy_disable_interactive_boot.rule
@@ -1,0 +1,44 @@
+documentation_complete: true
+
+title: 'Disable Interactive Boot'
+
+description: |-
+    To disable the ability for users to perform interactive startups, perform both
+    of the following:
+    <ol>
+    <li>Edit the file <tt>/etc/sysconfig/init</tt>. Add or correct the line:
+    <pre>PROMPT=no</pre></li>
+    <li>Inspect the kernel boot arguments (which follow the word <tt>kernel</tt>)
+    in <tt>/etc/grub.conf</tt> and ensure the <tt>confirm</tt> argument is <b>not</b>
+    present.</li>
+    </ol>
+    Both the <tt>PROMPT</tt> option of the <tt>/etc/sysconfig/init</tt> file and
+    the <tt>confirm</tt> kernel boot argument of the <tt>/etc/grub.conf</tt> file
+    allow the console user to perform an interactive system startup, in which it is
+    possible to select the set of services which are started on boot.
+
+rationale: |-
+    Using interactive boot, the console user could disable auditing, firewalls, or
+    other services, weakening system security.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 27043-9
+
+references:
+    disa@rhel6: "213"
+    nist: SC-2,AC-3
+    srg@rhel6: SRG-OS-000080
+    stigid@rhel6: RHEL-06-000070
+
+ocil_clause: 'it does not'
+
+ocil: |-
+    To check whether interactive boot is disabled, run the following commands:
+    <ol>
+    <li><pre>$ grep PROMPT /etc/sysconfig/init</pre> If interactive boot is
+    disabled, the output will show: <pre>PROMPT=no</pre></li>
+    <li><pre>$ grep confirm /etc/grub.conf</pre> If interactive boot is disabled,
+    there should be no output.</li>
+    </ol>

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth.rule
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth.rule
@@ -4,6 +4,18 @@ prodtype: rhel6,rhel7,fedora
 
 title: 'Require Authentication for Single User Mode'
 
+{{% if product == "rhel6" %}}
+description: |-
+    Single-user mode is intended as a system recovery
+    method, providing a single user root access to the system by
+    providing a boot option at startup. By default, no authentication
+    is performed if single-user mode is selected.
+    <br /><br />
+    To require entry of the root password even if the system is
+    started in single-user mode, add or correct the following line in the
+    file <tt>/etc/sysconfig/init</tt>:
+    <pre>SINGLE=/sbin/sulogin</pre>
+{{% else %}}
 description: |-
     Single-user mode is intended as a system recovery
     method, providing a single user root access to the system by
@@ -12,6 +24,7 @@ description: |-
     <br /><br />
     By default, single-user mode is protected by requiring a password and is set
     in <tt>/usr/lib/systemd/system/rescue.service</tt>.
+{{% endif %}}
 
 rationale: |-
     This prevents attackers with physical access from trivially bypassing security
@@ -39,9 +52,17 @@ references:
 
 ocil_clause: 'the output is different'
 
+{{% if product == "rhel6" %}}
+ocil: |-
+    To check if authentication is required for single-user mode, run the following command:
+    <pre>$ grep SINGLE /etc/sysconfig/init</pre>
+    The output should be the following:
+    <pre>SINGLE=/sbin/sulogin</pre>
+{{% else %}}
 ocil: |-
     To check if authentication is required for single-user mode, run the following command:
     <pre>$ grep sulogin /usr/lib/systemd/system/rescue.service</pre>
     The output should be similar to the following, and the line must begin with
     ExecStart and /sbin/sulogin:
     <pre>ExecStart=-/sbin/sulogin</pre>
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth.rule
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth.rule
@@ -7,7 +7,11 @@ title: 'Enable Smart Card Login'
 description: |-
     To enable smart card authentication, consult the documentation at:
     <ul>
+    {{% if product == "rhel6" %}}
+    <li><b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Managing_Smart_Cards/enabling-smart-card-login.html") }}}</b></li>
+    {{% elif product == "rhel7" %}}
     <li><b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/smartcards.html#authconfig-smartcards") }}}</b></li>
+    {{% endif %}}
     </ul>
     For guidance on enabling SSH to authenticate against a Common Access Card (CAC), consult documentation at:
     <ul>

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_use_centralized_automated_auth.rule
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_use_centralized_automated_auth.rule
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+title: 'Use Centralized and Automated Authentication'
+
+description: |-
+    Implement an automated system for managing user accounts that minimizes the
+    risk of errors, either intentional or deliberate. This system
+    should integrate with an existing enterprise user management system, such as
+    one based on Identity Management tools such as Active Directory, Kerberos,
+    Directory Server, etc.
+
+rationale: |-
+    A comprehensive account management process that includes automation helps to
+    ensure the accounts designated as requiring attention are consistently and
+    promptly addressed. Enterprise environments make user account management
+    challenging and complex. A user management process requiring administrators to
+    manually address account management functions adds risk of potential
+    oversight.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 80509-3
+
+references:
+    disa@rhel6: "15"
+    srg@rhel6: SRG-OS-000001
+    stigid@rhel6: RHEL-06-000524
+
+ocil_clause: 'the system is not using a centralized authentication mechanism, or it is not automated'
+
+ocil: |-
+    Verify that the system is integrated with a centralized authentication mechanism
+    such as as Active Directory, Kerberos, Directory Server, etc. that has
+    automated account mechanisms in place.

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_password_auth_for_systemaccounts.rule
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_password_auth_for_systemaccounts.rule
@@ -1,0 +1,41 @@
+documentation_complete: true
+
+title: 'Ensure that System Accounts Are Locked'
+
+description: |-
+    Some accounts are not associated with a human user of the system, and exist to
+    perform some administrative function. An attacker should not be able to log into
+    these accounts.
+    <br /><br />
+    System accounts are those user accounts with a user ID
+    less than UID_MIN, where value of the UID_MIN directive is set in
+    <tt>/etc/login.defs</tt> configuration file. In the default configuration UID_MIN is set
+    to 500, thus system accounts are those user accounts with a user ID less than
+    500. If any system account <i>SYSACCT</i> (other than root) has an unlocked password,
+    disable it with the command:
+    <pre>$ sudo passwd -l <i>SYSACCT</i></pre>
+
+rationale: |-
+    Disabling authentication for default system accounts makes it more difficult
+    for attackers to make use of them to compromise a system.false
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 80510-1
+
+references:
+    disa@rhel6: "366"
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000029
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    To obtain a listing of all users and the contents of their shadow password
+    field, run the command:
+    <pre>$ sudo awk -F: '$1 !~ /^root$/ &amp;&amp; $2 !~ /^[!*]/ {print $1 ":" $2}' /etc/shadow</pre>
+    Identify the system accounts from this listing. These will primarily be the accounts
+    with UID numbers less than UID_MIN, other than root. Value of the UID_MIN
+    directive is set in <tt>/etc/login.defs</tt> configuration file. In the default
+    configuration, UID_MIN is set to 500.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Ensure <tt>auditd</tt> Collects File Deletion Events by User'
 
@@ -23,12 +23,21 @@ rationale: |-
     from the system. The audit trail could aid in system troubleshooting, as well as, detecting
     malicious processes that attempt to delete log files to conceal their presence.
 
+{{% if product == "rhel6" %}}
+severity: unknown
+{{% else %}}
 severity: medium
+{{% endif %}}
 
 identifiers:
+    cce@rhel6: 26651-0
     cce@rhel7: 27206-2
 
 references:
+    disa@rhel6: "126"
+    nist@rhe6: AC-3(10)
+    srg@rhel6: SRG-OS-000064
+    stigid@rhel6: RHEL-06-000200    
     cis: 5.2.14
     cjis: 5.4.1.1
     cui: 3.1.7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Ensure <tt>auditd</tt> Collects Information on Kernel Module Loading and Unloading'
 
@@ -14,7 +14,7 @@ description: |-
     -a always,exit -F arch=<i>ARCH</i> -S init_module,delete_module -F key=modules
     </pre>
 
-    Place to add the lines depends on a way <tt>auditd</tt> daemon is configured. If it is configured
+    The place to add the lines depends on a way <tt>auditd</tt> daemon is configured. If it is configured
     to use the <tt>augenrules</tt> program (the default), add the lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>.
 
@@ -26,12 +26,21 @@ rationale: |-
     the kernel and potentially introduce malicious code into kernel space. It is important
     to have an audit trail of modules that have been introduced into the kernel.
 
+{{% if product == "rhel6" %}}
+severity: unknown
+{{% else %}}
 severity: medium
+{{% endif %}}
 
 identifiers:
+    cce@rhel6: 26611-4
     cce@rhel7: 27129-6
 
 references:
+    disa@rhel6: "126"
+    nist@rhel6: AC-3(10)
+    srg@rhel6: SRG-OS-000064
+    stigid@rhel6: RHEL-06-000202
     cis: 5.2.17
     cjis: 5.4.1.1
     cui: 3.1.7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events.rule
@@ -24,12 +24,18 @@ rationale: |-
     Manual editing of these files may indicate nefarious activity, such
     as an attacker attempting to remove evidence of an intrusion.
 
+{{% if product == "rhel6" %}}
+severity: unknown
+{{% else %}}
 severity: medium
+{{% endif %}}
 
 identifiers:
+    cce@rhel6: 26691-6
     cce@rhel7: 27204-7
 
 references:
+    nist@rhel6: AC-3(10)
     cis: 5.2.8
     cjis: 5.4.1.1
     cui: 3.1.7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands.rule
@@ -34,12 +34,21 @@ rationale: |-
     limited capability. As such, motivation exists to monitor these programs for
     unusual activity.
 
+{{% if product == "rhel6" %}}
+severity: unknown
+{{% else %}}
 severity: medium
+{{% endif %}}
 
 identifiers:
+    cce@rhel6: 26457-2
     cce@rhel7: 27437-3
 
 references:
+    disa@rhel6: "40"
+    nist@rhel6: AC-3(10)
+    srg@rhel6: SRG-OS-000020
+    stigid@rhel6: RHEL-06-000198
     cis: 5.2.10
     cjis: 5.4.1.1
     cui: 3.1.7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Ensure <tt>auditd</tt> Collects Unauthorized Access Attempts to Files (unsuccessful)'
 
@@ -30,12 +30,21 @@ rationale: |-
     Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing
     these events could serve as evidence of potential system compromise.
 
+{{% if product == "rhel6" %}}
+severity: unknown
+{{% else %}}
 severity: medium
+{{% endif %}}
 
 identifiers:
+    cce@rhel6: 26712-0
     cce@rhel7: 27347-4
 
 references:
+    disa@rhel6: "126"
+    nist@rhel6: AC-3(10)
+    srg@rhel6: SRG-OS-000064
+    stigid@rhel6: RHEL-06-000197
     cis: 5.2.10
     cjis: 5.4.1.1
     cui: 3.1.7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit.rule
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+title: 'System Audit Logs Must Have Mode 0750 or Less Permissive'
+
+description: |-
+    If <tt>log_group</tt> in <tt>/etc/audit/auditd.conf</tt> is set to a group other than the <tt>root</tt>
+    group account, change the mode of the audit log files with the following command:
+    <pre>$ sudo chmod 0750 /var/log/audit</pre>
+    <br />
+    Otherwise, change the mode of the audit log files with the following command:
+    <pre>$ sudo chmod 0700 /var/log/audit</pre>
+
+rationale: 'If users can write to audit logs, audit trails can be modified or destroyed.'
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 80502-8
+
+references:
+    disa@rhel6: "164"
+    nist: AC-6,AU-1(b),AU-9,IR-5
+    srg@rhel6: SRG-OS-000059
+    stigid@rhel6: RHEL-06-000385
+
+ocil_clause: 'any are more permissive'
+
+ocil: |-
+    Run the following command to check the mode of the system audit logs:
+    <pre>$ sudo ls -ld /var/log/audit</pre>
+    Audit log directories must be mode 0700 or less permissive.

--- a/linux_os/guide/system/bootloader-grub-legacy/file_group_owner_grub_conf.rule
+++ b/linux_os/guide/system/bootloader-grub-legacy/file_group_owner_grub_conf.rule
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+title: 'Verify /etc/grub.conf Group Ownership'
+
+description: "The file <tt>/etc/grub.conf</tt> should \nbe group-owned by the <tt>root</tt> group to prevent \ndestruction or modification of the file.\n{{{ describe_file_group_owner(file="/etc/grub.conf", group="root") }}}"
+
+rationale: |-
+    The <tt>root</tt> group is a highly-privileged group. Furthermore, the group-owner of this
+    file should not have any access privileges anyway.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 27022-3
+
+references:
+    disa@rhel6: "225"
+    nist: AC-6(7)
+    pcidss: Req-7.1
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000066
+
+ocil: '{{{ ocil_file_group_owner(file="/etc/grub.conf", group="root") }}}'

--- a/linux_os/guide/system/bootloader-grub-legacy/file_permissions_grub_conf.rule
+++ b/linux_os/guide/system/bootloader-grub-legacy/file_permissions_grub_conf.rule
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Verify /boot/grub/grub.conf Permissions'
+
+description: |-
+    File permissions for <tt>/boot/grub/grub.conf</tt> should be set to 600, which
+    is the default.
+    {{{ describe_file_permissions(file="/boot/grub/grub.conf", perms="600") }}}
+
+rationale: |-
+    Proper permissions ensure that only the root user can modify important boot
+    parameters.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 26949-8
+
+references:
+    disa@rhel6: "225"
+    nist: AC-6(7)
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000067
+
+ocil_clause: 'it does not'
+
+ocil: "To check the permissions of /etc/grub.conf, run the command:\n<pre>$ sudo ls -lL /etc/grub.conf</pre>\nIf properly configured, the output should indicate the following \npermissions: <tt>-rw-------</tt>"

--- a/linux_os/guide/system/bootloader-grub-legacy/file_user_owner_grub_conf.rule
+++ b/linux_os/guide/system/bootloader-grub-legacy/file_user_owner_grub_conf.rule
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: 'Verify /etc/grub.conf User Ownership'
+
+description: "The file <tt>/etc/grub.conf</tt> should \nbe owned by the <tt>root</tt> user to prevent destruction \nor modification of the file.\n{{{ describe_file_owner(file="/etc/grub.conf", owner="root") }}}"
+
+rationale: 'Only root should be able to modify important boot parameters.'
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 26995-1
+
+references:
+    disa@rhel6: "225"
+    nist: AC-6(7)
+    pcidss: Req-7.1
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000065
+
+ocil: '{{{ ocil_file_owner(file="/etc/grub.conf", owner="root") }}}'

--- a/linux_os/guide/system/bootloader-grub-legacy/group.yml
+++ b/linux_os/guide/system/bootloader-grub-legacy/group.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Set Boot Loader Password'
+
+description: |-
+    During the boot process, the boot loader is
+    responsible for starting the execution of the kernel and passing
+    options to it. The boot loader allows for the selection of
+    different kernels - possibly on different partitions or media.
+    The default Red Hat Enterprise Linux boot loader for x86 systems is called GRUB.
+    Options it can pass to the kernel include <i>single-user mode</i>, which
+    provides root access without any authentication, and the ability to
+    disable SELinux. To prevent local users from modifying the boot
+    parameters and endangering security, protect the boot loader configuration
+    with a password and ensure its configuration file's permissions
+    are set properly.

--- a/linux_os/guide/system/bootloader-grub-legacy/grub_legacy_password.rule
+++ b/linux_os/guide/system/bootloader-grub-legacy/grub_legacy_password.rule
@@ -1,0 +1,39 @@
+documentation_complete: true
+
+title: 'Set Boot Loader Password in grub.conf'
+
+description: |-
+    The grub boot loader should have password protection
+    enabled to protect boot-time settings.
+    To do so, select a password and then generate a hash from it by running the following command:
+    <pre>$ grub-crypt --sha-512</pre>
+    When prompted to enter a password, insert the following line into <tt>/etc/grub.conf</tt>
+    immediately after the header comments. (Use the output from <tt>grub-crypt</tt> as the
+    value of <b>password-hash</b>):
+    <pre>password --encrypted <b>password-hash</b></pre>
+    NOTE: To meet FISMA Moderate, the bootloader password MUST differ from the root password.
+
+rationale: |-
+    Password protection on the boot loader configuration ensures
+    users with physical access cannot trivially alter
+    important bootloader settings. These include which kernel to use,
+    and whether to enter single-user mode.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 26911-8
+
+references:
+    disa@rhel6: "213"
+    nist: 'IA-2(1),IA-5(e) AC-3'
+    srg@rhel6: SRG-OS-000080
+    stigid@rhel6: RHEL-06-000068
+
+ocil_clause: 'it does not'
+
+ocil: |-
+    To verify the boot loader password has been set and encrypted, run the following command:
+    <pre>$ sudo grep password /etc/grub.conf</pre>
+    The output should show the following:
+    <pre>password --encrypted <b>password-hash</b></pre>

--- a/linux_os/guide/system/entropy/group.yml
+++ b/linux_os/guide/system/entropy/group.yml
@@ -1,0 +1,9 @@
+documentation_complete: true
+
+title: 'Protect Random-Number Entropy Pool'
+
+description: |-
+    The I/O operations of the Linux kernel block layer due to their inherently
+    unpredictable execution times have been traditionally considered as a reliable
+    source to contribute to random-number entropy pool of the Linux kernel. This
+    has changed with introduction of solid-state storage devices (SSDs) though.

--- a/linux_os/guide/system/entropy/kernel_disable_entropy_contribution_for_solid_state_drives.rule
+++ b/linux_os/guide/system/entropy/kernel_disable_entropy_contribution_for_solid_state_drives.rule
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'Ensure Solid State Drives Do Not Contribute To Random-Number Entropy Pool'
+
+description: |-
+    For each solid-state drive on the system, run:
+    <pre> # echo 0 &gt; /sys/block/DRIVE/queue/add_random</pre>
+
+rationale: |-
+    In contrast to traditional electromechanical magnetic disks, containing
+    spinning disks and / or movable read / write heads, the solid-state storage
+    devices (SSDs) do not contain moving / mechanical components. Therefore the
+    I/O operation completion times are much more predictable for them.
+
+severity: medium

--- a/linux_os/guide/system/logging/group.yml
+++ b/linux_os/guide/system/logging/group.yml
@@ -11,7 +11,7 @@ description: |-
     almost all Unix applications.
     <br />
     <br />
-    In Red Hat Enterprise Linux 7, rsyslog has replaced ksyslogd as the
+    In {{{ full_name }}}, rsyslog has replaced ksyslogd as the
     syslog daemon of choice, and it includes some additional security features
     such as reliable, connection-oriented (i.e. TCP) transmission of logs, the
     option to log to database formats, and the encryption of log data en route to

--- a/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_accept_remote_messages_tcp.rule
+++ b/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_accept_remote_messages_tcp.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Enable rsyslog to Accept Messages via TCP, if Acting As Log Server'
 
@@ -19,6 +19,7 @@ rationale: |-
 severity: unknown
 
 identifiers:
+    cce@rhel6: 27235-1
     cce@rhel7: 80193-6
 
 references:

--- a/linux_os/guide/system/logging/service_rsyslog_enabled.rule
+++ b/linux_os/guide/system/logging/service_rsyslog_enabled.rule
@@ -5,7 +5,7 @@ prodtype: rhel6,rhel7,fedora
 title: 'Enable rsyslog Service'
 
 description: |-
-    The <tt>rsyslog</tt> service provides syslog-style logging by default on Red Hat Enterprise Linux 7.
+    The <tt>rsyslog</tt> service provides syslog-style logging by default on {{{ full_name }}}.
     {{{ describe_service_enable(service="rsyslog") }}}
 
 rationale: |-

--- a/linux_os/guide/system/network/network-ipsec/group.yml
+++ b/linux_os/guide/system/network/network-ipsec/group.yml
@@ -4,4 +4,8 @@ title: 'IPSec Support'
 
 description: |-
     Support for Internet Protocol Security (IPsec)
+    {{% if product == "rhel7" %}}
     is provided in Red Hat Enterprise Linux 7 with Libreswan.
+    {{% elif product == "rhel6" %}}
+    is provided in Red Hat Enterprise Linux 6 with openswan and Libreswan.
+    {{% endif %}}

--- a/linux_os/guide/system/network/network-iptables/group.yml
+++ b/linux_os/guide/system/network/network-iptables/group.yml
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+title: 'iptables and ip6tables'
+
+description: |-
+    A host-based firewall called <tt>netfilter</tt> is included as
+    part of the Linux kernel distributed with the system. It is
+    activated by default. This firewall is controlled by the program
+    <tt>iptables</tt>, and the entire capability is frequently referred to by
+    this name. An analogous program called <tt>ip6tables</tt> handles filtering
+    for IPv6.
+    <br /><br />
+    Unlike TCP Wrappers, which depends on the network server
+    program to support and respect the rules written, <tt>netfilter</tt>
+    filtering occurs at the kernel level, before a program can even
+    process the data from the network packet. As such, any program on
+    the system is affected by the rules written.
+    <br /><br />
+    This section provides basic information about strengthening
+    the <tt>iptables</tt> and <tt>ip6tables</tt> configurations included with the system.
+    For more complete information that may allow the construction of a
+    sophisticated ruleset tailored to your environment, please consult
+    the references at the end of this section.

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/group.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/group.yml
@@ -1,0 +1,6 @@
+documentation_complete: true
+
+title: 'Inspect and Activate Default Rules'
+
+description: "View the currently-enforced <tt>iptables</tt> rules by running\nthe command:\n<pre>$ sudo iptables -nL --line-numbers</pre>\nThe command is analogous for <tt>ip6tables</tt>.\n<br /><br />\nIf the firewall does not appear to be active (i.e., no rules\nappear), activate it and ensure that it starts at boot by issuing\nthe following commands (and analogously for <tt>ip6tables</tt>):\n<pre>$ sudo service iptables restart</pre>\nThe default iptables rules are:\n<pre>Chain INPUT (policy ACCEPT)\nnum  target     prot opt source       destination\n1    ACCEPT     all  --  0.0.0.0/0    0.0.0.0/0    state RELATED,ESTABLISHED \n2    ACCEPT     icmp --  0.0.0.0/0    0.0.0.0/0\n3    ACCEPT     all  --  0.0.0.0/0    0.0.0.0/0\n4    ACCEPT     tcp  --  0.0.0.0/0    0.0.0.0/0    state NEW tcp dpt:22 \n5    REJECT     all  --  0.0.0.0/0    0.0.0.0/0    reject-with icmp-host-prohibited \n\nChain FORWARD (policy ACCEPT)\nnum  target     prot opt source       destination\n1    REJECT     all \
+    \ --  0.0.0.0/0    0.0.0.0/0    reject-with icmp-host-prohibited \n\nChain OUTPUT (policy ACCEPT)\nnum  target     prot opt source       destination</pre>\nThe <tt>ip6tables</tt> default rules are essentially the same."

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_ip6tables_enabled.rule
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_ip6tables_enabled.rule
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Verify ip6tables Enabled if Using IPv6'
+
+description: '{{{ describe_service_enable(service="ip6tables") }}}'
+
+rationale: |-
+    The <tt>ip6tables</tt> service provides the system's host-based firewalling
+    capability for IPv6 and ICMPv6.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 27006-6
+
+references:
+    disa@rhel6: 32,66,1115,1118,1092,1117,1098,1100,1097,1414
+    nist: AC-4,CA-3(c),CM-7
+    srg@rhel6: SRG-OS-000152,SRG-OS-000145,SRG-OS-000146
+    stigid@rhel6: RHEL-06-000103
+
+ocil: |-
+    If IPv6 is disabled, this is not applicable.
+    <br /><br />
+    {{{ ocil_service_enabled(service="ip6tables") }}}

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled.rule
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled.rule
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'Verify iptables Enabled'
+
+description: '{{{ describe_service_enable(service="iptables") }}}'
+
+rationale: |-
+    The <tt>iptables</tt> service provides the system's host-based firewalling
+    capability for IPv4 and ICMP.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 27018-1
+
+references:
+    disa@rhel6: 32,66,1115,1118,1092,1117,1098,1100,1097,1414
+    nist: AC-4,CA-3(c),CM-7
+    srg@rhel6: SRG-OS-000146,SRG-OS-000152,SRG-OS-000145
+    stigid@rhel6: RHEL-06-000117
+
+ocil: '{{{ ocil_service_enabled(service="iptables") }}}'

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule.rule
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule.rule
@@ -1,0 +1,39 @@
+documentation_complete: true
+
+title: 'Set Default ip6tables Policy for Incoming Packets'
+
+description: |-
+    To set the default policy to DROP (instead of ACCEPT) for
+    the built-in INPUT chain which processes incoming packets,
+    add or correct the following line in
+    <tt>/etc/sysconfig/ip6tables</tt>:
+    <pre>:INPUT DROP [0:0]</pre>
+    If changes were required, reload the ip6tables rules:
+    <pre>$ sudo service ip6tables reload</pre>
+
+rationale: |-
+    In <tt>ip6tables</tt>, the default policy is applied only after all
+    the applicable rules in the table are examined for a match. Setting the
+    default policy to <tt>DROP</tt> implements proper design for a firewall, i.e.
+    any packets which are not explicitly permitted should not be
+    accepted.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 27317-7
+
+references:
+    disa@rhel6: "66"
+    nist: CM-7
+    srg@rhel6: SRG-OS-000231
+    stigid@rhel6: RHEL-06-000523
+
+ocil_clause: 'the default policy for the INPUT chain is not set to DROP'
+
+ocil: |-
+    If IPv6 is disabled, this is not applicable.
+    <br /><br />
+    Inspect the file <tt>/etc/sysconfig/ip6tables</tt> to determine
+    the default policy for the INPUT chain. It should be set to DROP:
+    <pre>$ sudo grep ":INPUT" /etc/sysconfig/ip6tables</pre>

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/group.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/group.yml
@@ -1,0 +1,36 @@
+documentation_complete: true
+
+title: 'Strengthen the Default Ruleset'
+
+description: |-
+    The default rules can be strengthened. The system
+    scripts that activate the firewall rules expect them to be defined
+    in the configuration files <tt>iptables</tt> and <tt>ip6tables</tt> in the directory
+    <tt>/etc/sysconfig</tt>. Many of the lines in these files are similar
+    to the command line arguments that would be provided to the programs
+    <tt>/sbin/iptables</tt> or <tt>/sbin/ip6tables</tt> - but some are quite
+    different.
+    <br /><br />
+    The following recommendations describe how to strengthen the
+    default ruleset configuration file. An alternative to editing this
+    configuration file is to create a shell script that makes calls to
+    the iptables program to load in rules, and then invokes service
+    iptables save to write those loaded rules to
+    <tt>/etc/sysconfig/iptables.</tt>
+    <br /><br />
+    The following alterations can be made directly to
+    <tt>/etc/sysconfig/iptables</tt> and <tt>/etc/sysconfig/ip6tables</tt>.
+    Instructions apply to both unless otherwise noted. Language and address
+    conventions for regular iptables are used throughout this section;
+    configuration for ip6tables will be either analogous or explicitly
+    covered.
+
+warnings:
+    - general: |-
+        The program <tt>system-config-securitylevel</tt>
+        allows additional services to penetrate the default firewall rules
+        and automatically adjusts <tt>/etc/sysconfig/iptables</tt>. This program
+        is only useful if the default ruleset meets your security
+        requirements. Otherwise, this program should not be used to make
+        changes to the firewall configuration because it re-writes the
+        saved configuration file.

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/iptables_icmp_disabled/group.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/iptables_icmp_disabled/group.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+title: 'Restrict ICMP Message Types'
+
+description: |-
+    In <tt>/etc/sysconfig/iptables</tt>, the accepted ICMP messages
+    types can be restricted. To accept only ICMP echo reply, destination
+    unreachable, and time exceeded messages, remove the line:<br />
+    <pre>-A INPUT -p icmp --icmp-type any -j ACCEPT</pre>
+    and insert the lines:
+    <pre>-A INPUT -p icmp --icmp-type echo-reply -j ACCEPT
+    -A INPUT -p icmp --icmp-type destination-unreachable -j ACCEPT
+    -A INPUT -p icmp --icmp-type time-exceeded -j ACCEPT</pre>
+    To allow the system to respond to pings, also insert the following line:
+    <pre>-A INPUT -p icmp --icmp-type echo-request -j ACCEPT</pre>
+    Ping responses can also be limited to certain networks or hosts by using the -s
+    option in the previous rule.  Because IPv6 depends so heavily on ICMPv6, it is
+    preferable to deny the ICMPv6 packets you know you don't need (e.g. ping
+    requests) in <tt>/etc/sysconfig/ip6tables</tt>, while letting everything else
+    through:
+    <pre>-A INPUT -p icmpv6 --icmpv6-type echo-request -j DROP</pre>
+    If you are going to statically configure the system's address, it should
+    ignore Router Advertisements which could add another IPv6 address to the
+    interface or alter important network settings:
+    <pre>-A INPUT -p icmpv6 --icmpv6-type router-advertisement -j DROP</pre>
+    Restricting ICMPv6 message types in <tt>/etc/sysconfig/ip6tables</tt> is not
+    recommended because the operation of IPv6 depends heavily on ICMPv6. Thus, great
+    care must be taken if any other ICMPv6 types are blocked.

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/iptables_log_and_drop_suspicious/group.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/iptables_log_and_drop_suspicious/group.yml
@@ -1,0 +1,45 @@
+documentation_complete: true
+
+title: 'Log and Drop Packets with Suspicious Source Addresses'
+
+description: |-
+    Packets with non-routable source addresses should be rejected, as they may indicate spoofing. Because the
+    modified policy will reject non-matching packets, you only need to add these rules if you are interested in also
+    logging these spoofing or suspicious attempts before they are dropped. If you do choose to log various suspicious
+    traffic, add identical rules with a target of <tt>DROP</tt> after each <i>LOG</i>.
+    To log and then drop these IPv4 packets, insert the following rules in <tt>/etc/sysconfig/iptables</tt> (excepting
+    any that are intentionally used):
+    <pre>-A INPUT -s 10.0.0.0/8 -j LOG --log-prefix "IP DROP SPOOF A: "
+    -A INPUT -s 172.16.0.0/12 -j LOG --log-prefix "IP DROP SPOOF B: "
+    -A INPUT -s 192.168.0.0/16 -j LOG --log-prefix "IP DROP SPOOF C: "
+    -A INPUT -s 224.0.0.0/4 -j LOG --log-prefix "IP DROP MULTICAST D: "
+    -A INPUT -s 240.0.0.0/5 -j LOG --log-prefix "IP DROP SPOOF E: "
+    -A INPUT -d 127.0.0.0/8 -j LOG --log-prefix "IP DROP LOOPBACK: "</pre>
+    Similarly, you might wish to log packets containing some IPv6 reserved addresses if they are not expected
+    on your network:
+    <pre>-A INPUT -i eth0 -s ::1 -j LOG --log-prefix "IPv6 DROP LOOPBACK: "
+    -A INPUT -s 2002:E000::/20 -j LOG --log-prefix "IPv6 6to4 TRAFFIC: "
+    -A INPUT -s 2002:7F00::/24 -j LOG --log-prefix "IPv6 6to4 TRAFFIC: "
+    -A INPUT -s 2002:0000::/24 -j LOG --log-prefix "IPv6 6to4 TRAFFIC: "
+    -A INPUT -s 2002:FF00::/24 -j LOG --log-prefix "IPv6 6to4 TRAFFIC: "
+    -A INPUT -s 2002:0A00::/24 -j LOG --log-prefix "IPv6 6to4 TRAFFIC: "
+    -A INPUT -s 2002:AC10::/28 -j LOG --log-prefix "IPv6 6to4 TRAFFIC: "
+    -A INPUT -s 2002:C0A8::/32 -j LOG --log-prefix "IPv6 6to4 TRAFFIC: "</pre>
+    If you are not expecting to see site-local multicast or auto-tunneled traffic, you can log those:
+    <pre>-A INPUT -s FF05::/16 -j LOG --log-prefix "IPv6 SITE-LOCAL MULTICAST: "
+    -A INPUT -s ::0.0.0.0/96 -j LOG --log-prefix "IPv4 COMPATIBLE IPv6 ADDR: "</pre>
+    If you wish to block multicasts to all link-local nodes (e.g. if you are not using router auto-configuration and
+    do not plan to have any services that multicast to the entire local network), you can block the link-local
+    all-nodes multicast address (before accepting incoming ICMPv6):
+    <pre>-A INPUT -d FF02::1 -j LOG --log-prefix "Link-local All-Nodes Multicast: "</pre>
+    However, if you're going to allow IPv4 compatible IPv6 addresses (of the form ::0.0.0.0/96), you should
+    then consider logging the non-routable IPv4-compatible addresses:
+    <pre>-A INPUT -s ::0.0.0.0/104 -j LOG --log-prefix "IP NON-ROUTABLE ADDR: "
+    -A INPUT -s ::127.0.0.0/104 -j LOG --log-prefix "IP DROP LOOPBACK: "
+    -A INPUT -s ::224.0.0.0.0/100 -j LOG --log-prefix "IP DROP MULTICAST D: "
+    -A INPUT -s ::255.0.0.0/104 -j LOG --log-prefix "IP BROADCAST: "</pre>
+    If you are not expecting to see any IPv4 (or IPv4-compatible) traffic on your network, consider logging it before it gets dropped:
+    <pre>-A INPUT -s ::FFFF:0.0.0.0/96 -j LOG --log-prefix "IPv4 MAPPED IPv6 ADDR: "
+    -A INPUT -s 2002::/16 -j LOG --log-prefix "IPv6 6to4 ADDR: "</pre>
+    The following rule will log all traffic originating from a site-local address, which is deprecated address space:
+    <pre>-A INPUT -s FEC0::/10 -j LOG --log-prefix "SITE-LOCAL ADDRESS TRAFFIC: "</pre>

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule.rule
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule.rule
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+title: 'Set Default iptables Policy for Incoming Packets'
+
+description: |-
+    To set the default policy to DROP (instead of ACCEPT) for
+    the built-in INPUT chain which processes incoming packets,
+    add or correct the following line in
+    <tt>/etc/sysconfig/iptables</tt>:
+    <pre>:INPUT DROP [0:0]</pre>
+
+rationale: |-
+    In <tt>iptables</tt> the default policy is applied only after all
+    the applicable rules in the table are examined for a match. Setting the
+    default policy to <tt>DROP</tt> implements proper design for a firewall, i.e.
+    any packets which are not explicitly permitted should not be
+    accepted.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 26444-0
+
+references:
+    disa@rhel6: 66,1109,1154,1414
+    nist: CM-7
+    srg@rhel6: SRG-OS-000231
+    stigid@rhel6: RHEL-06-000120
+
+ocil_clause: 'the default policy for the INPUT chain is not set to DROP'
+
+ocil: |-
+    Inspect the file <tt>/etc/sysconfig/iptables</tt> to determine
+    the default policy for the INPUT chain. It should be set to DROP:
+    <pre>$ sudo grep ":INPUT" /etc/sysconfig/iptables</pre>

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule_forward.rule
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule_forward.rule
@@ -1,0 +1,38 @@
+documentation_complete: true
+
+title: 'Set Default iptables Policy for Forwarded Packets'
+
+description: |-
+    To set the default policy to DROP (instead of ACCEPT) for
+    the built-in FORWARD chain which processes packets that will be forwarded from
+    one interface to another,
+    add or correct the following line in
+    <tt>/etc/sysconfig/iptables</tt>:
+    <pre>:FORWARD DROP [0:0]</pre>
+
+rationale: |-
+    In <tt>iptables</tt>, the default policy is applied only after all
+    the applicable rules in the table are examined for a match. Setting the
+    default policy to <tt>DROP</tt> implements proper design for a firewall, i.e.
+    any packets which are not explicitly permitted should not be
+    accepted.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 27186-6
+
+references:
+    disa@rhel6: "1109"
+    nist: CM-7
+    srg@rhel6: SRG-OS-000147
+    stigid@rhel6: RHEL-06-000320
+
+ocil_clause: 'the default policy for the FORWARD chain is not set to DROP'
+
+ocil: |-
+    Run the following command to ensure the default <tt>FORWARD</tt> policy is <tt>DROP</tt>:
+    <pre>grep ":FORWARD" /etc/sysconfig/iptables</pre>
+    The output should be similar to the following:
+    <pre>$ sudo grep ":FORWARD" /etc/sysconfig/iptables
+    :FORWARD DROP [0:0</pre>

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled.rule
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled.rule
@@ -1,0 +1,44 @@
+documentation_complete: true
+
+title: 'Disable IPv6 Networking Support Automatic Loading'
+
+description: |-
+    To prevent the IPv6 kernel module (<tt>ipv6</tt>) from binding to the
+    IPv6 networking stack, add the following line to
+    <tt>/etc/modprobe.d/disabled.conf</tt> (or another file in
+    <tt>/etc/modprobe.d</tt>):
+    <pre>options ipv6 disable=1</pre>
+    This permits the IPv6 module to be loaded (and thus satisfy other modules that
+    depend on it), while disabling support for the IPv6 protocol.
+
+rationale: |-
+    Any unnecessary network stacks - including IPv6 - should be disabled, to reduce
+    the vulnerability to exploitation.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 27153-6
+
+references:
+    disa@rhel6: "1551"
+    nist: CM-7
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000098
+
+ocil_clause: 'the ipv6 kernel module is not disabled'
+
+ocil: |-
+    If the system uses IPv6, this is not applicable.
+    <br /><br />
+    If the system is configured to disable the
+    <tt>ipv6</tt> kernel module, it will contain a line
+    of the form:
+    <pre>options ipv6 disable=1</pre>
+    Such lines may be inside any file in <tt>/etc/modprobe.d</tt> or the
+    deprecated<tt>/etc/modprobe.conf</tt>.  This permits insertion of the IPv6
+    kernel module (which other parts of the system expect to be present), but
+    otherwise keeps it inactive.  Run the following command to search for such
+    lines in all files in <tt>/etc/modprobe.d</tt> and the deprecated
+    <tt>/etc/modprobe.conf</tt>:
+    <pre xml:space="preserve">$ grep -r ipv6 /etc/modprobe.conf /etc/modprobe.d</pre>

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled.rule
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled.rule
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+title: 'Disable RDS Support'
+
+description: |-
+    The Reliable Datagram Sockets (RDS) protocol is a transport
+    layer protocol designed to provide reliable high- bandwidth,
+    low-latency communications between nodes in a cluster.
+    {{{ describe_module_disable(module="rds") }}}
+
+rationale: |-
+    Disabling RDS protects
+    the system against exploitation of any flaws in its implementation.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 26239-4
+
+references:
+    disa@rhel6: "382"
+    nist: CM-7
+    srg@rhel6: SRG-OS-000096
+    stigid@rhel6: RHEL-06-000126
+
+{{{ complete_ocil_entry_module_disable(module="rds") }}}

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled.rule
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled.rule
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+title: 'Disable TIPC Support'
+
+description: |-
+    The Transparent Inter-Process Communication (TIPC) protocol
+    is designed to provide communications between nodes in a
+    cluster.
+    {{{ describe_module_disable(module="tipc") }}}
+
+rationale: |-
+    Disabling TIPC protects
+    the system against exploitation of any flaws in its implementation.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 26696-5
+
+references:
+    disa@rhel6: "382"
+    nist: CM-7
+    srg@rhel6: SRG-OS-000096
+    stigid@rhel6: RHEL-06-000127
+
+{{{ complete_ocil_entry_module_disable(module="tipc") }}}

--- a/linux_os/guide/system/network/network_ssl/group.yml
+++ b/linux_os/guide/system/network/network_ssl/group.yml
@@ -13,5 +13,7 @@ description: |-
     <b>{{{ weblink(link="http://www.openssl.org/docs/") }}}</b>.  Information on FIPS validation
     of OpenSSL is available at <b>{{{ weblink(link="http://www.openssl.org/docs/fips.html") }}}</b>
     and <b>{{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140val-all.htm") }}}</b>.
+    {{% if product == "rhel7" %}}
     For information on how to use and implement OpenSSL on Red Hat Enterprise Linux, see
     <b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Using_OpenSSL.html") }}}</b>
+    {{% endif %}}

--- a/linux_os/guide/system/permissions/mounting/grub_legacy_nousb_argument.rule
+++ b/linux_os/guide/system/permissions/mounting/grub_legacy_nousb_argument.rule
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+title: 'Disable Kernel Support for USB via Bootloader Configuration'
+
+description: |-
+    All USB support can be disabled by adding the <tt>nousb</tt>
+    argument to the kernel's boot loader configuration. To do so,
+    append \"nousb\" to the kernel line in <tt>/etc/grub.conf</tt>
+    as shown:
+    <pre>kernel /vmlinuz-<i>VERSION</i> ro vga=ext root=/dev/VolGroup00/LogVol00 rhgb quiet nousb</pre>
+
+rationale: |-
+    Disabling the USB subsystem within the Linux kernel at system boot will
+    protect against potentially malicious USB devices, although it is only practical
+    in specialized systems.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 27011-6
+
+references:
+    disa@rhel6: "1250"
+    nist: AC-19(a),AC-19(d),AC-19(e)
+
+warnings:
+    - functionality: |-
+        Disabling all kernel support for USB will cause problems for systems
+        with USB-based keyboards, mice, or printers. This configuration is
+        infeasible for systems which require USB devices, which is common.

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield.rule
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Enable ExecShield via sysctl'
 
@@ -11,9 +11,12 @@ rationale: "ExecShield uses the segmentation feature on all x86 systems\nto prev
 severity: medium
 
 identifiers:
+    cce@hrel6: 27007-4
     cce@rhel7: 27211-2
 
 references:
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000079
     cis: 1.5.2
     cui: 3.1.7
     disa: "2530"

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32.rule
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Install PAE Kernel on Supported 32-bit x86 Systems'
 
@@ -27,6 +27,7 @@ rationale: |-
 severity: unknown
 
 identifiers:
+    cce@rhel6: 27010-8
     cce@rhel7: 27116-3
 
 references:

--- a/linux_os/guide/system/selinux/group.yml
+++ b/linux_os/guide/system/selinux/group.yml
@@ -8,7 +8,7 @@ description: |-
     SELinux enforces the idea that programs should be limited in what
     files they can access and what actions they can take.
     <br /><br />
-    The default SELinux policy, as configured on Red Hat Enterprise Linux 7, has been
+    The default SELinux policy, as configured on {{{ full_name }}}, has been
     sufficiently developed and debugged that it should be usable on
     almost any Red Hat system with minimal configuration and a small
     amount of system administrator training. This policy prevents
@@ -23,5 +23,7 @@ description: |-
     default (targeted) policy on every Red Hat system, unless that
     system has unusual requirements which make a stronger policy
     appropriate.
+    {{% if product == "rhel7" %}}
     <br /><br />
     For more information on SELinux, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/SELinux_Users_and_Administrators_Guide") }}}</b>.
+    {{% endif %}}

--- a/linux_os/guide/system/selinux/grub_legacy_enable_selinux.rule
+++ b/linux_os/guide/system/selinux/grub_legacy_enable_selinux.rule
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+title: 'Ensure SELinux Not Disabled in /etc/grub.conf'
+
+description: |-
+    SELinux can be disabled at boot time by an argument in
+    <tt>/etc/grub.conf</tt>.
+    Remove any instances of <tt>selinux=0</tt> from the kernel arguments in that
+    file to prevent SELinux from being disabled at boot.
+
+rationale: |-
+    Disabling a major host protection feature, such as SELinux, at boot time prevents
+    it from confining system services at boot time.  Further, it increases
+    the chances that it will remain off during system operation.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 26956-3
+
+references:
+    disa@rhel6: 22,32
+    nist: AC-3,AC-3(3),AC-6,AU-9
+    srg@hrel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000017
+
+ocil_clause: 'SELinux is disabled at boot time'
+
+ocil: |-
+    Inspect <tt>/etc/grub.conf</tt> for any instances of <tt>selinux=0</tt>
+    in the kernel boot arguments.  Presence of <tt>selinux=0</tt> indicates
+    that SELinux is disabled at boot time.

--- a/linux_os/guide/system/selinux/service_restorecond_enabled.rule
+++ b/linux_os/guide/system/selinux/service_restorecond_enabled.rule
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6
+
 title: 'Enable the SELinux Context Restoration Service (restorecond)'
 
 description: |-

--- a/linux_os/guide/system/selinux/service_restorecond_enabled.rule
+++ b/linux_os/guide/system/selinux/service_restorecond_enabled.rule
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Enable the SELinux Context Restoration Service (restorecond)'
+
+description: |-
+    The <tt>restorecond</tt> service utilizes <tt>inotify</tt> to look
+    for the creation of new files listed in the
+    <tt>/etc/selinux/restorecond.conf</tt> configuration file. When a file is
+    created, <tt>restorecond</tt> ensures the file receives the proper SELinux
+    security context.
+    {{{ describe_service_enable(service="restorecond") }}}
+
+rationale: |-
+    The <tt>restorecond</tt> service helps ensure that the default SELinux
+    file context is applied to files. This allows automatic correction
+    of file contexts created by some programs.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 26991-0
+
+references:
+    nist: AC-3,AC-3(3),AC-4,AC-6,AU-9

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gconf_gdm_disable_user_list.rule
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gconf_gdm_disable_user_list.rule
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+title: 'Disable the User List'
+
+description: |-
+    In the default graphical environment, users logging
+    directly into the system are greeted with a login screen that displays
+    all known users. This functionality should be disabled.
+    <br /><br />
+    Run the following command to disable the user list:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/gdm/simple-greeter/disable_user_list true</pre>
+
+rationale: |-
+    Leaving the user list enabled is a security risk since it allows anyone
+    with physical access to the system to quickly enumerate known user accounts
+    without logging in.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 27230-2
+
+references:
+    disa@rhel6: "366"
+    nist: AC-23
+    srg@rhel6: SRG-OS-999999
+    stigid@rhel6: RHEL-06-000527
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    To ensure the user list is disabled, run the following command:
+    <pre>$ gconftool-2 -g /apps/gdm/simple-greeter/disable_user_list</pre>
+    The output should be <tt>true</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gconf_gnome_disable_restart_shutdown.rule
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gconf_gnome_disable_restart_shutdown.rule
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+title: 'Disable the GNOME Login Restart and Shutdown Buttons'
+
+description: |-
+    In the default graphical environment, users logging
+    directly into the system are greeted with a login screen that allows
+    any user, known or unknown, the ability shutdown or restart
+    the system. This functionality should be disabled by running the following:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/gdm/simple-greeter/disable_restart_buttons true</pre>
+
+rationale: |-
+    A user who is at the console can reboot the system at the login screen. If restart or shutdown buttons
+    are pressed at the login screen, this can create the risk of short-term loss of availability of systems
+    due to reboot.
+
+severity: high
+
+references:
+    disa@rhel6: "366"
+    nist: AC-6
+
+ocil_clause: 'disable-restart-buttons has not been configured or is not disabled'
+
+ocil: |-
+    To ensure disable and restart on the login screen are disabled, run the following command:
+    <pre>$ gconftool-2 -g /apps/gdm/simple-greeter/disable_restart_buttons</pre>
+    The output should be <tt>true</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/group.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/group.yml
@@ -3,10 +3,16 @@ documentation_complete: true
 title: 'Configure GNOME Login Screen'
 
 description: |-
-    In the default GNOME3 desktop, the login is displayed after system boot
+    In the default GNOME desktop, the login is displayed after system boot
     and can display user accounts, allow users to reboot the system, and allow users to
     login automatically and/or with a guest account. The login screen should be configured
     to prevent such behavior.
     <br /><br />
+    {{% if product == "rhel6" %}}
+    For more information about enforcing preferences in the GNOME environment using the GConf
+    configuration system, see <b>{{{ weblink(link="http://projects.gnome.org/gconf") }}}</b> and
+    the man page <tt>gconftool-2(1)</tt>.
+    {{% else %}}
     For more information about enforcing preferences in the GNOME3 environment using the DConf
     configuration system, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Desktop_Migration_and_Administration_Guide/index.html") }}}/></b> and the man page <tt>dconf(1)</tt>.
+    {{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/gconf_gnome_disable_automount.rule
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/gconf_gnome_disable_automount.rule
@@ -1,0 +1,40 @@
+documentation_complete: true
+
+title: 'Disable GNOME Automounting'
+
+description: |-
+    The system's default desktop environment, GNOME, will mount
+    devices and removable media (such as DVDs, CDs and USB flash drives) whenever
+    they are inserted into the system. Disable automount and autorun within GNOME
+    by running the following:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/nautilus/preferences/media_automount false
+    $ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/nautilus/preferences/media_autorun_never true</pre>
+
+rationale: |-
+    Disabling automatic mounting in GNOME can prevent
+    the introduction of malware via removable media.
+    It will, however, also prevent desktop users from legitimate use
+    of removable media.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 27035-5
+
+references:
+    nist: AC-19(a),AC-19(d),AC-19(e)
+
+ocil_clause: 'GNOME automounting is not disabled'
+
+ocil: |-
+    These settings can be verified by running the following:
+    <pre>$ gconftool-2 -g /apps/nautilus/preferences/media_automount</pre>
+    The output should return <tt>false</tt>.
+    <pre>$ gconftool-2 -g /apps/nautilus/preferences/media_autorun_never</pre>
+    The output should return <tt>true</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/gconf_gnome_disable_thumbnailers.rule
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/gconf_gnome_disable_thumbnailers.rule
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+title: 'Disable All GNOME Thumbnailers'
+
+description: |-
+    The system's default desktop environment, GNOME, uses
+    a number of different thumbnailer programs to generate thumbnails
+    for any new or modified content in an opened folder. The following
+    command can disable the execution of these thumbnail applications:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /desktop/gnome/thumbnailers/disable_all true</pre>
+    This effectively prevents an attacker from gaining access to a
+    system through a flaw in GNOME's Nautilus thumbnail creators.
+
+rationale: |-
+    An attacker with knowledge of a flaw in a GNOME thumbnailer application could craft a malicious
+    file to exploit this flaw. Assuming the attacker could place the malicious file on the local filesystem
+    (via a web upload for example) and assuming a user browses the same location using Nautilus, the
+    malicious file would exploit the thumbnailer with the potential for malicious code execution. It
+    is best to disable these thumbnailer applications unless they are explicitly required.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 27224-5
+
+references:
+    nist: CM-7
+
+ocil_clause: 'GNOME thumbnailers are not disabled'
+
+ocil: |-
+    These settings can be verified by running the following:
+    <pre>$ gconftool-2 -g /desktop/gnome/thumbnailers/disable_all</pre>
+    The output should return <tt>true</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/gconf_gnome_disable_wifi_create.rule
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/gconf_gnome_disable_wifi_create.rule
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Disable WIFI Network Connection Creation in GNOME'
+
+description: |-
+    <tt>GNOME</tt> allows users to create ad-hoc wireless connections through the
+    <tt>NetworkManager</tt> applet. Wireless connections should be disabled by
+    running the following:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/nm-applet/disable-wifi-create true</pre>
+
+rationale: |-
+    Wireless network connections should not be allowed to be configured by general
+    users on a given system as it could open the system to backdoor attacks.
+
+severity: medium
+
+ocil_clause: 'WIFI connections can be created through GNOME'
+
+ocil: |-
+    To ensure that WIFI connections cannot be created, run the following command:
+    <pre>$ gconftool-2 -g /apps/nm-applet/disable-wifi-create</pre>
+    The output should return <tt>true</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/gconf_gnome_disable_wifi_disconnect.rule
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/gconf_gnome_disable_wifi_disconnect.rule
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Disable WIFI Network Disconnect Notification in GNOME'
+
+description: |-
+    By default, <tt>GNOME</tt> disables WIFI notification when disconnecting from a
+    wireless network. This should be permanently set so that users do not connect to
+    a wireless network when the system finds one. While useful for mobile devices,
+    this setting should be disabled for all other systems. To configure the system
+    to disable the WIFI notication, run the following:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/nm-applet/disable-disconnected-notifications true</pre>
+
+rationale: |-
+    Wireless network connections should not be allowed to be configured by general
+    users on a given system as it could open the system to backdoor attacks.
+
+severity: medium
+
+ocil_clause: 'wireless disconnecting network notification is enabled and not disabled'
+
+ocil: |-
+    To ensure that wireless network notification is disabled, run the following command:
+    <pre>$ gconftool-2 -g /apps/nm-applet/disable-disconnected-notifications</pre>
+    The output should return <tt>true</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/gconf_gnome_disable_wifi_notification.rule
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/gconf_gnome_disable_wifi_notification.rule
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Disable WIFI Network Connection Notification in GNOME'
+
+description: |-
+    By default, <tt>GNOME</tt> disables WIFI notification when connecting to a wireless
+    network. This should be permanently set so that users do not connect to a wireless
+    network when the system finds one. While useful for mobile devices, this setting
+    should be disabled for all other systems. To configure the system to disable the
+    WIFI notication, run the following:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/nm-applet/disable-connected-notifications true</pre>
+
+rationale: |-
+    Wireless network connections should not be allowed to be configured by general
+    users on a given system as it could open the system to backdoor attacks.
+
+severity: medium
+
+ocil_clause: 'wireless connecting network notification is enabled and not disabled'
+
+ocil: |-
+    To ensure that wireless network notification is disabled, run the following command:
+    <pre>$ gconftool-2 -g /apps/nm-applet/disable-connected-notifications</pre>
+    The output should return <tt>true</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screen_locking_keybindings.rule
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screen_locking_keybindings.rule
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+title: 'Set GNOME Screen Locking Keybindings'
+
+description: "Run the following command to prevent changes to the screensaver\nlock keybindings: \n<pre>$ sudo gconftool-2 --direct \\\n  --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \\\n  --type string \\\n  --set /apps/gnome_settings_daemon/keybindings/screensaver \"&lt;Control&gt;&lt;Alt&gt;l\"</pre>"
+
+rationale: |-
+    The ability to lock graphical desktop sessions manually allows users to
+    easily secure their accounts should they need to depart from their workstations
+    temporarily.
+
+severity: low
+
+identifiers:
+    cce@: 80503-6
+
+references:
+    disa@rhel6: "58"
+    nist: AC-6
+    srg@: SRG-OS-000030
+    stigid@: RHEL-06-000508
+
+ocil_clause: 'GNOME screensaver locking keybindings are configured and cannot be changed'
+
+ocil: |-
+    To check the screensaver locking keybindings, run the following command:
+    <pre>$ gconftool-2 -g /apps/gnome_settings_daemon/keybindings/screensaver</pre>
+    If properly configured, the output should be <tt>&lt;Control&gt;&lt;Alt&gt;l</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_idle_activation_enabled.rule
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_idle_activation_enabled.rule
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+title: 'GNOME Desktop Screensaver Mandatory Use'
+
+description: |-
+    Run the following command to activate the screensaver
+    in the GNOME desktop after a period of inactivity:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/gnome-screensaver/idle_activation_enabled true</pre>
+
+rationale: |-
+    Enabling idle activation of the screensaver ensures the screensaver will
+    be activated after the idle delay.  Applications requiring continuous,
+    real-time screen display (such as network management products) require the
+    login session does not have administrator rights and the display station is located in a
+    controlled-access area.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 26600-7
+
+references:
+    disa@rhel6: "57"
+    nist: AC-11(a)
+    pcidss: Req-8.1.8
+    srg@rhel6: SRG-OS-000029
+    stigid@rhel6: RHEL-06-000258
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    To check the screensaver mandatory use status, run the following command:
+    <pre>$ gconftool-2 -g /apps/gnome-screensaver/idle_activation_enabled</pre>
+    If properly configured, the output should be <tt>true</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_idle_delay.rule
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_idle_delay.rule
@@ -1,0 +1,36 @@
+documentation_complete: true
+
+title: 'Set GNOME Login Inactivity Timeout'
+
+description: |-
+    Run the following command to set the idle time-out value for
+    inactivity in the GNOME desktop to <sub idref="inactivity_timeout_value" /> minutes:
+    <pre>$ sudo gconftool-2 \
+      --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type int \
+      --set /desktop/gnome/session/idle_delay <sub idref="inactivity_timeout_value" /></pre>
+
+rationale: |-
+    Setting the idle delay controls when the
+    screensaver will start, and can be combined with
+    screen locking to prevent access from passersby.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 26828-4
+
+references:
+    disa@rhel6: "57"
+    nist: AC-11(a)
+    pcidss: Req-8.1.8
+    srg@rhel6: SRG-OS-000029
+    stigid@rhel6: RHEL-06-000257
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    To check the current idle time-out value, run the following command:
+    <pre>$ gconftool-2 -g /desktop/gnome/session/idle_delay</pre>
+    If properly configured, the output should be <tt><sub idref="inactivity_timeout_value" /></tt>.

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_lock_enabled.rule
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_lock_enabled.rule
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+title: 'Enable Screen Lock Activation After Idle Period'
+
+description: |-
+    Run the following command to activate locking of the screensaver
+    in the GNOME desktop when it is activated:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/gnome-screensaver/lock_enabled true</pre>
+
+rationale: |-
+    Enabling the activation of the screen lock after an idle period
+    ensures password entry will be required in order to
+    access the system, preventing access by passersby.
+
+severity: medium
+
+identifiers:
+    cce@rhel6: 26235-2
+
+references:
+    disa@rhel6: "57"
+    nist: AC-11(a)
+    pcidss: Req-8.1.8
+    srg@rhel6: SRG-OS-000029
+    stigid@rhel6: RHEL-06-000259
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    To check the status of the idle screen lock activation, run the following command:
+    <pre>$ gconftool-2 -g /apps/gnome-screensaver/lock_enabled</pre>
+    If properly configured, the output should be <tt>true</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_max_idle_action.rule
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_max_idle_action.rule
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Set GNOME Login Maximum Allowed Inactivity Action'
+
+description: |-
+    Run the following command to set force logout an inactive user when the
+    maximum allowed inactivity period has expired:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type string \
+      --set /desktop/gnome/session/max_idle_action "forced-logout"</pre>
+
+rationale: |-
+    Terminating an idle session within a short time period reduces the window of
+    opportunity for unauthorized personnel to take control of a management session
+    and will also free up resources utilized by an idle session.
+
+severity: medium
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    To check the current idle time-out value, run the following command:
+    <pre>$ gconftool-2 -g /desktop/gnome/session/max_idle_action</pre>
+    If properly configured, the output should be <tt>forced-logout</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_max_idle_time.rule
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_max_idle_time.rule
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+title: 'Set GNOME Login Maximum Allowed Inactivity'
+
+description: |-
+    Run the following command to set the maximum allowed period of inactivity for an
+    inactive user in the GNOME desktop to <sub idref="inactivity_timeout_value" /> minutes:
+    <pre>$ sudo gconftool-2 \
+      --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type int \
+      --set /desktop/gnome/session/max_idle_time <sub idref="inactivity_timeout_value" /></pre>
+
+rationale: |-
+    Terminating an idle session within a short time period reduces the window of
+    opportunity for unauthorized personnel to take control of a management session
+    and will also free up resources utilized by an idle session.
+
+severity: medium
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    To check the current idle time-out value, run the following command:
+    <pre>$ gconftool-2 -g /desktop/gnome/session/max_idle_time</pre>
+    If properly configured, the output should be <tt><sub idref="idle_timeout_value" /></tt>.

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_mode_blank.rule
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screensaver_mode_blank.rule
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+title: 'Implement Blank Screensaver'
+
+description: |-
+    Run the following command to set the screensaver mode
+    in the GNOME desktop to a blank screen:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type string \
+      --set /apps/gnome-screensaver/mode blank-only</pre>
+
+rationale: |-
+    Setting the screensaver mode to blank-only conceals the
+    contents of the display from passersby.
+
+severity: unknown
+
+identifiers:
+    cce@rhel6: 26638-7
+
+references:
+    disa@rhel6: "60"
+    nist: AC-11(b)
+    pcidss: Req-8.1.8
+    srg@rhel6: SRG-OS-000031
+    stigid@rhel6: RHEL-06-000260
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    To ensure the screensaver is configured to be blank, run the following command:
+    <pre>$ gconftool-2 -g /apps/gnome-screensaver/mode</pre>
+    If properly configured, the output should be <tt>blank-only</tt>

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/group.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/group.yml
@@ -2,6 +2,36 @@ documentation_complete: true
 
 title: 'Configure GNOME Screen Locking'
 
+{{% if product == "rhel6" %}}
+description: |-
+    In the default GNOME desktop, the screen can be locked
+    by choosing <b>Lock Screen</b> from the <b>System</b> menu.
+    <br /><br />
+    The <tt>gconftool-2</tt> program can be used to enforce mandatory
+    screen locking settings for the default GNOME environment.
+    The
+    following sections detail commands to enforce idle activation of the screensaver,
+    screen locking, a blank-screen screensaver, and an idle
+    activation time.
+
+    <br /><br />
+    Because users should be trained to lock the screen when they
+    step away from the computer, the automatic locking feature is only
+    meant as a backup. The <b>Lock Screen</b> icon from the <b>System</b> menu can
+    also be dragged to the taskbar in order to facilitate even more
+    convenient screen-locking.
+    <br /><br />
+    The root account cannot be screen-locked, but this should
+    have no practical effect as the root account should <i>never</i> be used
+    to log into an X Windows environment, and should only be used to
+    for direct login via console in emergency circumstances.
+    <br /><br />
+    For more information about configuring GNOME screensaver, see
+    <b>{{{ weblink(link="http://live.gnome.org/GnomeScreensaver") }}}</b>. For more information about
+    enforcing preferences in the GNOME environment using the GConf
+    configuration system, see <b>{{{ weblink(link="http://projects.gnome.org/gconf") }}}</b> and
+    the man page <tt>gconftool-2(1)</tt>.
+{{% else %}}
 description: |-
     In the default GNOME3 desktop, the screen can be locked
     by selecting the user name in the far right corner of the main panel and
@@ -22,3 +52,4 @@ description: |-
     configuration system, see <b>{{{ weblink(link="http://wiki.gnome.org/dconf") }}}</b> and
     the man page <tt>dconf(1)</tt>. For Red Hat specific information on configuring DConf
     settings, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Desktop_Migration_and_Administration_Guide/part-Configuration_and_Administration.html") }}}</b>
+{{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/gconf_gnome_disable_clock_temperature.rule
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/gconf_gnome_disable_clock_temperature.rule
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Disable the GNOME Clock Temperature Feature'
+
+description: |-
+    Run the following command to activate locking of the screensaver
+    in the GNOME desktop when it is activated:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/panel/applets/clock/prefs/show_temperature false</pre>
+
+rationale: |-
+    Disabling the temperature feature in the GNOME clock prevents the
+    system from connecting to the internet and diclosing the system
+    location when set by a user.
+
+severity: medium
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    To check the status of the idle screen lock activation, run the following command:
+    <pre>$ gconftool-2 -g /apps/panel/applets/clock/prefs/show_temperature</pre>
+    If properly configured, the output should be <tt>false</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/gconf_gnome_disable_clock_weather.rule
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/gconf_gnome_disable_clock_weather.rule
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Disable the GNOME Clock Weather Feature'
+
+description: |-
+    Run the following command to activate locking of the screensaver
+    in the GNOME desktop when it is activated:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type bool \
+      --set /apps/panel/applets/clock/prefs/show_weather false</pre>
+
+rationale: |-
+    Disabling the weather feature in the GNOME clock prevents the
+    system from connecting to the internet and diclosing the system
+    location when set by a user.
+
+severity: medium
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    To check the status of the idle screen lock activation, run the following command:
+    <pre>$ gconftool-2 -g /apps/panel/applets/clock/prefs/show_weather</pre>
+    If properly configured, the output should be <tt>false</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/gconf_gnome_disable_ctrlaltdel_reboot.rule
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/gconf_gnome_disable_ctrlaltdel_reboot.rule
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+title: 'Disable Ctrl-Alt-Del Reboot Key Sequence in GNOME'
+
+description: |-
+    By default, <tt>GNOME</tt> will reboot the system if the <tt>Ctrl-Alt-Del</tt>
+    key sequence is pressed.
+    <br />
+    To configure the system to ignore the <tt>Ctrl-Alt-Del</tt> key sequence from the
+    Graphical User Interface (GUI) instead of rebooting the system, run the following:
+    <pre>$ sudo gconftool-2 --direct \
+      --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
+      --type string \
+      --set /apps/gnome_settings_daemon/keybindings/power ""</pre>
+
+rationale: |-
+    A locally logged-in user who presses Ctrl-Alt-Del, when at the console,
+    can reboot the system. If accidentally pressed, as could happen in
+    the case of mixed OS environment, this can create the risk of short-term
+    loss of availability of systems due to unintentional reboot.
+
+severity: high
+
+references:
+    disa@rhel6: "366"
+    nist: AC-6
+
+ocil_clause: 'GNOME is configured to reboot when Ctrl-Alt-Del is pressed'
+
+ocil: |-
+    To ensure the system is configured to ignore the Ctrl-Alt-Del sequence,
+    run the following command:
+    <pre>$ gconftool-2 -g /apps/gnome_settings_daemon/keybindings/power</pre>
+    The output should return nothing.

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_antivirus.rule
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_antivirus.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Install Virus Scanning Software'
 
@@ -19,14 +19,21 @@ rationale: |-
     Virus scanning software can be used to detect if a system has been compromised by
     computer viruses, as well as to limit their spread to other systems.
 
+{{% if product == "rhel6" %}}
+severity: unknown
+{{% else %}}
 severity: high
+{{% endif %}}
 
 identifiers:
+    cce@rhel6: 27529-7
     cce@rhel7: 27140-3
 
 references:
     disa: 1239,1668
     nist: 'SC-28, SI-3'
+    srg@rhel6: SRG-OS-00270
+    stigid@rhel6: RHEL-06-000284
 
 ocil_clause: 'virus scanning software does not run continuously, or at least daily, or has signatures that are out of date'
 

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids.rule
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Install Intrusion Detection Software'
 
@@ -14,15 +14,22 @@ rationale: |-
     Host-based intrusion detection tools provide a system-level defense when an
     intruder gains access to a system or network.
 
+{{% if product == "rhel6" %}}
+severity: medium
+{{% else %}}
 severity: high
+{{% endif %}}
 
 identifiers:
+    cce@rhel6: 27409-2
     cce@rhel7: 26818-5
 
 references:
     disa: "1263"
     nist: SC-7
     pcidss: Req-11.4
+    srg@rhel6: SRG-OS-000196
+    stigid@rhel6: RHEL-06-000285
 
 ocil_clause: 'no host-based intrusion detection tools are installed'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database.rule
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Build and Test AIDE Database'
 
@@ -23,9 +23,13 @@ rationale: |-
 severity: medium
 
 identifiers:
+    cce@rhel6: 27135-3
     cce@rhel7: 27220-3
 
 references:
+    disa@rhel6: 374,416,1069,1263,1297,1589
+    srg@rhel6: SRG-OS-000232
+    stigid@rhel6: RHEL-06-000018
     cjis: 5.10.1.3
     nist: CM-3(d),CM-3(e),CM-6(d),CM-6(3),SC-28,SI-7
     pcidss: Req-11.5

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking.rule
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Configure Periodic Execution of AIDE'
 
@@ -32,9 +32,13 @@ rationale: |-
 severity: medium
 
 identifiers:
+    cce@rhel6: 27222-9
     cce@rhel7: 26952-2
 
 references:
+    disa@rhel6: 374,416,1069,1263,1297,1589
+    srg@rhel6: SRG-OS-000202,SRG-OS-000094,SRG-OS-000098,SRG-OS-000232,SRG-OS-000196,SRG-OS-000265
+    stigid@rhel6: RHEL-06-000306
     cis: 1.3.2
     cjis: 5.10.1.3
     disa: "1744"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed.rule
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Install AIDE'
 
@@ -13,9 +13,13 @@ rationale: 'The AIDE package must be installed if it is to be available for inte
 severity: medium
 
 identifiers:
+    cce@rhel6: 27024-9
     cce@rhel7: 27096-7
 
 references:
+    disa@rhel6: "1069"
+    srg@rhel6: SRG-OS-000232
+    stigid@rhel6: RHEL-06-000016
     cis: 1.3.1
     cjis: 5.10.1.3
     nist: CM-3(d),CM-3(e),CM-6(d),CM-6(3),SC-28,SI-7

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes.rule
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora,ol7
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Verify File Hashes with RPM'
 
@@ -34,9 +34,13 @@ rationale: |-
 severity: high
 
 identifiers:
+    cce@rhel6: 7223-7
     cce@rhel7: 27157-7
 
 references:
+    disa@rhel6: "1496"
+    srg@rhel6: SRG-OS-999999,SRG-OS-000278
+    stigid@rhel6: RHEL-06-000519
     cis: 1.2.6
     cjis: 5.10.4.1
     cui: 3.3.8,3.4.1

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership.rule
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7
+prodtype: rhel6,rhel7
 
 title: 'Verify and Correct Ownership with RPM'
 
@@ -25,9 +25,13 @@ rationale: |-
 severity: high
 
 identifiers:
+    cce@rhel6: 80499-7
     cce@rhel7: 80545-7
 
 references:
+    nist@rhel6: SI-7
+    srg@rhel6: SRG-OS-000257,SRG-OS-000258
+    stigid@rhel6: RHEL-06-000279
     cis: 1.2.6,6.1.3,6.1.4,6.1.5,6.1.6,6.1.7,6.1.8,6.1.9,6.2.3
     cjis: 5.10.4.1
     cui: 3.3.8,3.4.1

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions.rule
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora,ol7
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Verify and Correct File Permissions with RPM'
 
@@ -30,9 +30,14 @@ rationale: |-
 severity: high
 
 identifiers:
+    cce@rhel6: 26731-0
     cce@rhel7: 27209-6
 
 references:
+    disa@rhel6: 1493,1495
+    nist@rhel6: SI-7
+    srg@rhel6: SRG-OS-999999,SRG-OS-000256
+    stigid@rhel6: RHEL-06-000518
     cis: 1.2.6,6.1.3,6.1.4,6.1.5,6.1.6,6.1.7,6.1.8,6.1.9,6.2.3
     cjis: 5.10.4.1
     cui: 3.3.8,3.4.1


### PR DESCRIPTION
Continuation of #3037. Independent of #3068 (should not merge conflict).

#### Description

This continues the merger of `rhel6/guide` into `linux_os/guide`. After this, everything in `rhel6/guide/system` will be in `linux_os/guide/system. `prodtype` shouldn't need to be adjusted as a previous PR (namely, #3037) added `rhel6` to all 1-1 duplicated files.

This PR:
 - Adds file that are in `rhel6` but not in `linux_os`
 - Updates descriptions and syntax changes
 - Fixes rhel6/rhel7 differences.

This was performed by walking the rhel6 tree, diffing the files it finds compared to the equivalent linux_os folder and manually comparing the output and deciding what happens. Please review this carefully as this was a lot of manual work and in some cases I might have chosen incorrectly. :)

To review, I'd probably first:
 - Look at the diff and make sure the diff seem reasonable.
 - Look at the parallels of the files changed (the equivalent file in `rhel6` that was changed in `linux_os`).
 - Perform a file-name based diff of the contents of `rhel6/guide/system` and `linux_os/guide/system` and see what differs.

But to each their own. :)

#### Plans

After this, I'll work on doing a second review of `rhel6` and `linux_os` trees, and work on converting the profiles in `rhel6` to point to the ones in `linux_os` and diff the outputted build artifacts. Then we can flip the switch to using `linux_os` in `rhel6`.