### PR TITLE
Add Ubuntu to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,15 @@ services:
 
 language: python
 
-before_install:
-    - docker build --no-cache --tag ssg:latest .
-
-script:
-    - docker run ssg:latest
+matrix:
+    include:
+        - env: BASE_IMAGE="Fedora"
+          before_install:
+            - docker build --no-cache --tag ssg:latest -f Dockerfile .
+          script:
+            - docker run ssg:latest
+        - env: BASE_IMAGE="Ubuntu"
+          before_install:
+            - docker build --no-cache --tag ssg_ubuntu:latest -f Dockerfile_ubuntu .
+          script:
+            - docker run ssg_ubuntu:latest

--- a/Dockerfile_ubuntu
+++ b/Dockerfile_ubuntu
@@ -1,0 +1,22 @@
+FROM ubuntu:18.04
+
+ENV OSCAP_USERNAME oscap
+ENV OSCAP_DIR scap-security-guide
+ENV BUILD_JOBS 4
+
+RUN apt-get -qq update && \
+    apt-get -qq install cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml && \
+    mkdir -p /home/$OSCAP_USERNAME && \
+    rm -rf /usr/share/doc /usr/share/doc-base \
+        /usr/share/man /usr/share/locale /usr/share/zoneinfo
+
+WORKDIR /home/$OSCAP_USERNAME
+
+COPY . $OSCAP_DIR/
+
+# clean the build dir in case the user is also building SSG locally
+RUN rm -rf $OSCAP_DIR/build/*
+
+WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
+
+CMD cmake -G Ninja .. && ninja -j $BUILD_JOBS && ctest -j $BUILD_JOBS


### PR DESCRIPTION


#### Description:

Adds a simple Dockerfile to build SSG in a container based
on Ubuntu 18.04. Then it adds a Travis CI job that builds
SSG and runs tests in that container. The Travis configuration
had to be changed to define a build matrix.

#### Rationale:
Adds another OS - Ubuntu - that we don't test the build on yet.

