### PR TITLE
Fix test suite

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -27,6 +27,14 @@ Ansible installed on the host machine.
 
 1. Install domain, using `kickstarts/rhel_centos_7.cfg`
    Typically, you supply a boot option `inst.ks=https://raw.githubusercontent.com/OpenSCAP/scap-security-guide/master/tests/kickstarts/rhel_centos_7.cfg`.
+   To create a CentOS 7 machine named like our examples, run:
+    ```bash
+    virt-install -n ssg-test-suite-centos -r 4096 --vcpus=4 \
+    --os-variant=rhel7 --accelerate \
+    --disk path=/var/lib/libvirt/images/ssg-test-suite-centos.qcow,size=50 \
+    -x "inst.ks=https://raw.githubusercontent.com/OpenSCAP/scap-security-guide/master/tests/kickstarts/rhel_centos_7.cfg" \
+    --location http://mirror.centos.org/centos/7/os/x86_64
+    ```
 1. Import ssh key to the machine and make sure that you can use them to log in
    as the `root` superuser.
 1. Setup repo, so machine can install and uninstall packages.
@@ -84,7 +92,7 @@ Rule-based testing enables to perform two kinds of tests:
 If you would like to evaluate the rule `rule_sysctl_net_ipv4_conf_default_secure_redirects`:
 
 ```
-./test_suite.py rule --hypervisor qemu:///system --domain ssg-test-suite-centos --datastream ./ssg-centos7-ds.xml ipv4_conf_default_secure_redirects
+./test_suite.py rule --hypervisor qemu:///system --domain ssg-test-suite-centos --datastream ./ssg-centos7-ds.xml --xccdf-id xccdf-id ipv4_conf_default_secure_redirects
 ```
 
 Notice there is not full rule name used on the command line.

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -69,6 +69,7 @@ def parse_args():
 
     subparsers = parser.add_subparsers(dest='subparser_name',
                                        help='Subcommands: profile, rule')
+    subparsers.required = True
 
     parser_profile = subparsers.add_parser('profile',
                                            help=('Testing profile-based '

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -17,46 +17,48 @@ from ssg_test_suite import xml_operations
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--hypervisor",
-                        dest="hypervisor",
-                        metavar="HYPERVISOR",
-                        default="qemu:///session",
-                        help="libvirt hypervisor")
-    parser.add_argument("--domain",
-                        dest="domain_name",
-                        metavar="DOMAIN",
-                        required=True,
-                        help=("Specify libvirt domain to be used as a test "
-                              "bed. This domain will get remediations "
-                              "applied in it, possibly making system "
-                              "unusable for a moment. Snapshot will be "
-                              "reverted immediately afterwards. "
-                              "Domain will be returned without changes"))
-    parser.add_argument("--datastream",
-                        dest="datastream",
-                        metavar="DATASTREAM",
-                        required=True,
-                        help=("Path to the Source DataStream on this "
-                              "machine which is going to be tested"))
-    parser.add_argument("--xccdf-id",
-                        dest="xccdf_id",
-                        metavar="REF-ID",
-                        required=True,
-                        help="Reference ID related to benchmark to be used."
-                             " Get one using 'oscap info <datastream>'.")
-    parser.add_argument("--loglevel",
-                        dest="loglevel",
-                        metavar="LOGLEVEL",
-                        default="INFO",
-                        help="Default level of console output")
-    parser.add_argument("--logdir",
-                        dest="logdir",
-                        metavar="LOGDIR",
-                        default=None,
-                        help="Directory to which all output is saved")
+    parser = argparse.ArgumentParser()
 
-    parser.add_argument(
+    common_parser = argparse.ArgumentParser(add_help=False)
+    common_parser.add_argument("--hypervisor",
+                               dest="hypervisor",
+                               metavar="HYPERVISOR",
+                               default="qemu:///session",
+                               help="libvirt hypervisor")
+    common_parser.add_argument("--domain",
+                               dest="domain_name",
+                               metavar="DOMAIN",
+                               required=True,
+                               help=("Specify libvirt domain to be used as a test "
+                                     "bed. This domain will get remediations "
+                                     "applied in it, possibly making system "
+                                     "unusable for a moment. Snapshot will be "
+                                     "reverted immediately afterwards. "
+                                     "Domain will be returned without changes"))
+    common_parser.add_argument("--datastream",
+                               dest="datastream",
+                               metavar="DATASTREAM",
+                               required=True,
+                               help=("Path to the Source DataStream on this "
+                                     "machine which is going to be tested"))
+    common_parser.add_argument("--xccdf-id",
+                               dest="xccdf_id",
+                               metavar="REF-ID",
+                               required=True,
+                               help="Reference ID related to benchmark to be used."
+                                    " Get one using 'oscap info <datastream>'.")
+    common_parser.add_argument("--loglevel",
+                               dest="loglevel",
+                               metavar="LOGLEVEL",
+                               default="INFO",
+                               help="Default level of console output")
+    common_parser.add_argument("--logdir",
+                               dest="logdir",
+                               metavar="LOGDIR",
+                               default=None,
+                               help="Directory to which all output is saved")
+
+    common_parser.add_argument(
         "--remediate-using",
         dest="remediate_using",
         default="oscap",
@@ -72,14 +74,14 @@ def parse_args():
                                            help=('Testing profile-based '
                                                  'remediation applied on already '
                                                  'installed machine'),
-                                           parents=[parser])
+                                           parents=[common_parser])
     parser_profile.set_defaults(func=ssg_test_suite.profile.perform_profile_check)
     parser_rule = subparsers.add_parser('rule',
                                         help=('Testing remediations of particular '
                                               'rule for various situations - '
                                               'currently not supported '
                                               'by openscap!'),
-                                        parents=[parser])
+                                        parents=[common_parser])
     parser_rule.set_defaults(func=ssg_test_suite.rule.perform_rule_check)
 
     parser_profile.add_argument("target",
@@ -122,6 +124,7 @@ def main():
         msg = "Error inferring benchmark ID: {}".format(str(exc))
         logging.error(msg)
         sys.exit(1)
+
 
     LogHelper.add_console_logger(log, options.loglevel)
     # logging dir needs to be created based on other options


### PR DESCRIPTION
For real this time :)

```
$ python3 ./test_suite.py rule --hypervisor 'qemu+ssh://root@remote.cipherboy.com/system' --domain ographics --datastream ../build/ssg-centos7-ds.xml --xccdf-id scap_org.open-scap_cref_ssg-rhel7-xccdf-1.2.xml ipv4_conf_default_secure_redirects
Setting console output to log level INFO
INFO - Logging into /home/cipherboy/GitHub/c2/scap-security-guide/tests/logs/rule-custom-2018-07-03-0730/test_suite.log
<snip>
```

```
$ python2 ./test_suite.py rule --hypervisor 'qemu+ssh://root@remote.cipherboy.com/system' --domain ographics --datastream ../build/ssg-centos7-ds.xml --xccdf-id scap_org.open-scap_cref_ssg-rhel7-xccdf-1.2.xml ipv4_conf_default_secure_redirects
Setting console output to log level INFO
INFO - Logging into /home/cipherboy/GitHub/c2/scap-security-guide/tests/logs/rule-custom-2018-07-03-0730-1/test_suite.log
<snip>
```

```
$ git log --oneline | head -n 1
feaf89693 Updates to testing README
```

Fixes regression in #3071.