### PR TITLE
No OVAL for xwindows_runlevel_setting when product uses systemd and targets OVAL 5.10

### DIFF
--- a/shared/checks/oval/xwindows_runlevel_setting.xml
+++ b/shared/checks/oval/xwindows_runlevel_setting.xml
@@ -1,3 +1,6 @@
+{{%- if init_system == "systemd" and target_oval_version == [5, 10] -%}}
+{{# this is the only scenario this definition cannot handle, there is no good alternative for symlink_test for OVAL 5.10 #}}
+{{%- else -%}}
 <def-group>
   <definition class="compliance" id="xwindows_runlevel_setting" version="1">
     <metadata>
@@ -45,4 +48,5 @@
   </ind:textfilecontent54_object>
   {{%- endif -%}}
 </def-group>
+{{%- endif -%}}
 


### PR DESCRIPTION
#### Description:

- OVAL definition for `xwindows_runlevel_setting` will be empty when product `init_system == systemd` and target OVAL is 5.10.

#### Rationale:
- This definition requires that we check which file the symbolic link is referencing, and AFAIK there is no way to it with OVAL 5.10.
- If `oval_version` is defined as [previously](https://github.com/OpenSCAP/scap-security-guide/pull/3076/files#diff-063702df45814951fc68f86d648e1113L1), the definition will not be available at all when target OVAL is 5.10.
- This way, the OVAL definition will still be available for RHEL6 when target OVAL is 5.10
- Fixes validation of OVAL 5.10 content