### PR TITLE
Removed obsoleted check macro xsl tests.

### DIFF
--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -390,14 +390,7 @@
           <xsl:attribute name="system">ocil-transitional</xsl:attribute>
           <check-export>
 
-            <xsl:attribute name="export-name">
-              <!-- add clauses if specific macros are found within -->
-              <xsl:if test="fileperms-check-macro or fileowner-check-macro or filegroupowner-check-macro">it does not</xsl:if>
-              <xsl:if test="service-disable-check-macro">the service is running</xsl:if>
-              <xsl:if test="socket-disable-check-macro">the socket is running</xsl:if>
-              <xsl:if test="service-enable-check-macro">the service is not running</xsl:if>
-              <xsl:if test="module-disable-check-macro">no line is returned</xsl:if>
-            </xsl:attribute>
+            <xsl:attribute name="export-name"/>
 
             <!-- add clause if explicitly specified (and also override any above) -->
             <xsl:if test="@clause">

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -389,14 +389,7 @@
         <check>
           <xsl:attribute name="system">ocil-transitional</xsl:attribute>
           <check-export>
-
-            <xsl:attribute name="export-name"/>
-
-            <!-- add clause if explicitly specified (and also override any above) -->
-            <xsl:if test="@clause">
-              <xsl:attribute name="export-name"><xsl:value-of select="@clause" /></xsl:attribute>
-            </xsl:if>
-
+            <xsl:attribute name="export-name"><xsl:value-of select="@clause" /></xsl:attribute>
             <xsl:attribute name="value-id">conditional_clause</xsl:attribute>
           </check-export>
           <!-- add the actual manual checking text -->


### PR DESCRIPTION
#### Description:

- Removal of tests within xslt that bears no value anymore. 

#### Rationale:

- With replacement of macros with jinja (see #2835 )this test no longer serves it's purpose and can be removed.
