### PR TITLE
exec-shield requires special handling, don't use the template for it …

### DIFF
--- a/rhel6/templates/csv/sysctl_values.csv
+++ b/rhel6/templates/csv/sysctl_values.csv
@@ -2,7 +2,7 @@
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 fs.suid_dumpable,0
 kernel.dmesg_restrict,1
-kernel.exec-shield,1
+#kernel.exec-shield,1
 kernel.randomize_va_space,2
 net.ipv4.conf.all.accept_redirects,
 net.ipv4.conf.all.accept_source_route,

--- a/shared/checks/oval/sysctl_kernel_exec_shield.xml
+++ b/shared/checks/oval/sysctl_kernel_exec_shield.xml
@@ -3,7 +3,7 @@
     <metadata>
       <title>Kernel Runtime Parameter "kernel.exec-shield" Check</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
       </affected>
       <description>The kernel runtime parameter "kernel.exec-shield" should not be disabled and set to 1 on 32-bit systems.</description>


### PR DESCRIPTION
Unshadows the check on RHEL6