### PR TITLE
Add ansible to Fedora Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV OSCAP_DIR scap-security-guide
 ENV BUILD_JOBS 4
 
 RUN dnf -y upgrade && \
-    dnf -y install cmake ninja-build openscap-utils python3-jinja2 python3-PyYAML && \
+    dnf -y install cmake ninja-build openscap-utils python3-jinja2 python3-PyYAML ansible && \
     mkdir -p /home/$OSCAP_USERNAME && \
     dnf clean all && \
     rm -rf /usr/share/doc /usr/share/doc-base \


### PR DESCRIPTION
This will then cause Travis to run our `ansible` playbook syntax checks for us. The Travis build will take slightly longer, but if we remove it from Jenkins, we can reduce load on that. 

This was not added to Ubuntu as `ansible` should have consistent syntax across host architecture. 