### PR TITLE
Travis - CentOS 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,8 @@ matrix:
             - docker build --no-cache --tag ssg_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
           script:
             - docker run ssg_$BASE_IMAGE:latest
+        - env: BASE_IMAGE="centos6"
+          before_install:
+            - docker build --no-cache --tag ssg_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
+          script:
+            - docker run ssg_$BASE_IMAGE:latest

--- a/Dockerfiles/centos6
+++ b/Dockerfiles/centos6
@@ -1,0 +1,23 @@
+FROM centos:6
+
+ENV OSCAP_USERNAME oscap
+ENV OSCAP_DIR scap-security-guide
+ENV BUILD_JOBS 4
+
+RUN yum -y upgrade && \
+    yum -y install cmake openscap-utils python-jinja2 python-argparse PyYAML && \
+    mkdir -p /home/$OSCAP_USERNAME && \
+    yum clean all && \
+    rm -rf /usr/share/doc /usr/share/doc-base \
+        /usr/share/man /usr/share/locale /usr/share/zoneinfo
+
+WORKDIR /home/$OSCAP_USERNAME
+
+COPY . $OSCAP_DIR/
+
+# clean the build dir in case the user is also building SSG locally
+RUN rm -rf $OSCAP_DIR/build/*
+
+WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
+
+CMD cmake -DPYTHON_EXECUTABLE=/usr/bin/python2 .. && make -j $BUILD_JOBS && ctest -j $BUILD_JOBS


### PR DESCRIPTION
Dependencies:
 - ~#3101~ -- merged, thanks @mpreisler!
 - ~#3116~ -- merged, thanks @jan-cerny 

Adds CentOS 6 docker build to Travis CI. This helps prevent make-only build failures, allows us to test older Python versions (2.6). 

~I'll rebase this PR after #3116 merges.~ Rebased.