### PR TITLE
[WIP] Restructure Dockerfiles to improve caching

### DIFF
--- a/Dockerfiles/fedora_python2
+++ b/Dockerfiles/fedora_python2
@@ -4,10 +4,9 @@ ENV OSCAP_USERNAME oscap
 ENV OSCAP_DIR scap-security-guide
 ENV BUILD_JOBS 4
 
-RUN dnf -y upgrade && \
-    dnf -y install cmake ninja-build openscap-utils python2-jinja2 python2-pyyaml && \
-    mkdir -p /home/$OSCAP_USERNAME && \
-    dnf clean all && \
+RUN mkdir -p /home/$OSCAP_USERNAME
+RUN dnf -y install cmake ninja-build openscap-utils python2-jinja2 python2-pyyaml
+RUN dnf -y update && dnf clean all && \
     rm -rf /usr/share/doc /usr/share/doc-base \
         /usr/share/man /usr/share/locale /usr/share/zoneinfo
 

--- a/Dockerfiles/fedora_python3
+++ b/Dockerfiles/fedora_python3
@@ -4,10 +4,9 @@ ENV OSCAP_USERNAME oscap
 ENV OSCAP_DIR scap-security-guide
 ENV BUILD_JOBS 4
 
-RUN dnf -y upgrade && \
-    dnf -y install cmake ninja-build openscap-utils python3-jinja2 python3-PyYAML ansible && \
-    mkdir -p /home/$OSCAP_USERNAME && \
-    dnf clean all && \
+RUN mkdir -p /home/$OSCAP_USERNAME
+RUN dnf -y install cmake ninja-build openscap-utils python3-jinja2 python3-PyYAML ansible
+RUN dnf -y update && dnf clean all && \
     rm -rf /usr/share/doc /usr/share/doc-base \
         /usr/share/man /usr/share/locale /usr/share/zoneinfo
 

--- a/Dockerfiles/ubuntu
+++ b/Dockerfiles/ubuntu
@@ -4,9 +4,9 @@ ENV OSCAP_USERNAME oscap
 ENV OSCAP_DIR scap-security-guide
 ENV BUILD_JOBS 4
 
-RUN apt-get -qq update && \
-    apt-get -qq install cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml && \
-    mkdir -p /home/$OSCAP_USERNAME && \
+RUN mkdir -p /home/$OSCAP_USERNAME
+RUN apt-get -qq update && apt-get -qq install cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml
+RUN apt-get -qq upgrade && apt-get -qq clean all && \
     rm -rf /usr/share/doc /usr/share/doc-base \
         /usr/share/man /usr/share/locale /usr/share/zoneinfo
 


### PR DESCRIPTION
Our Dockerfiles don't support caching well; we install updates (which change frequently) before installing our base dependencies; these dependencies thus cannot be cached. 

Since updating, installing dependencies, removing unnecessary files, and creating the home directory was all one step, we could not cache any of these steps independently of the others. This switches the order so that the most-static steps are executed first, followed by the most-dynamic steps.

Note that I kept the `rm -rf`s and added an `apt-get -qq clean all` to Ubuntu; these reduce the size of the generated images, but likely not by a significant amount since they exist in the base image, which must also be cached.