### PR TITLE
Add disa stig warnings to aggregated audit rules

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events.rule
@@ -54,3 +54,14 @@ ocil: |-
     {{{ ocil_audit_syscall(syscall="renameat") }}}
 
 {{{ ocil_clause_entry_audit_syscall() }}}
+
+warnings:
+    - general: |-
+        This rule checks for multiple syscalls related to file deletion;
+        it was written with DISA STIG in mind. Other policies should use a
+        separate rule for each syscall that needs to be checked. For example:
+        <ul>
+        <li><tt>audit_rules_file_deletion_events_rmdir</tt></li>
+        <li><tt>audit_rules_file_deletion_events_unlink</tt></li>
+        <li><tt>audit_rules_file_deletion_events_unlinkat</tt></li>
+        </ul>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading.rule
@@ -53,3 +53,14 @@ ocil: |-
     {{{ ocil_audit_syscall(syscall="delete_module") }}}
 
 {{{ ocil_clause_entry_audit_syscall() }}}
+
+warnings:
+    - general: |-
+        This rule checks for multiple syscalls related to kernel module loading and unloading;
+        it was written with DISA STIG in mind. Other policies should use a
+        separate rule for each syscall that needs to be checked. For example:
+        <ul>
+        <li><tt>audit_rules_kernel_module_loading_insmod</tt></li>
+        <li><tt>audit_rules_kernel_module_loading_rmmod</tt></li>
+        <li><tt>audit_rules_kernel_module_loading_modprobe</tt></li>
+        </ul>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events.rule
@@ -42,3 +42,14 @@ references:
     disa: 172,2884
     nist: AC-17(7),AU-1(b),AU-12(a),AU-12(c),IR-5
     pcidss: Req-10.2.3
+
+warnings:
+    - general: |-
+        This rule checks for multiple syscalls related to login events;
+        it was written with DISA STIG in mind. Other policies should use a
+        separate rule for each syscall that needs to be checked. For example:
+        <ul>
+        <li><tt>audit_rules_login_events_tallylog</tt></li>
+        <li><tt>audit_rules_login_events_faillock</tt></li>
+        <li><tt>audit_rules_login_events_lastlog</tt></li>
+        </ul>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands.rule
@@ -70,3 +70,14 @@ ocil: |-
     <pre>$ sudo grep path /etc/audit/audit.rules</pre>
     It should be the case that all relevant setuid / setgid programs have a line
     in the audit rules.
+
+warnings:
+    - general: |-
+        This rule checks for multiple syscalls related to privileged commands;
+        it was written with DISA STIG in mind. Other policies should use a
+        separate rule for each syscall that needs to be checked. For example:
+        <ul>
+        <li><tt>audit_rules_privileged_commands_su</tt></li>
+        <li><tt>audit_rules_privileged_commands_umount</tt></li>
+        <li><tt>audit_rules_privileged_commands_passwd</tt></li>
+        </ul>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification.rule
@@ -57,3 +57,14 @@ ocil: |-
     <pre>auditctl -l | egrep '(/etc/passwd|/etc/shadow|/etc/group|/etc/gshadow|/etc/security/opasswd)'</pre>
     If the system is configured to watch for account changes, lines should be returned for
     each file specified (and with <tt>perm=wa</tt> for each).
+
+warnings:
+    - general: |-
+        This rule checks for multiple syscalls related to account changes;
+        it was written with DISA STIG in mind. Other policies should use a
+        separate rule for each syscall that needs to be checked. For example:
+        <ul>
+        <li><tt>audit_rules_usergroup_modification_group</tt></li>
+        <li><tt>audit_rules_usergroup_modification_gshadow</tt></li>
+        <li><tt>audit_rules_usergroup_modification_passwd</tt></li>
+        </ul>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification.rule
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification.rule
@@ -58,3 +58,14 @@ ocil: |-
     To verify that the audit system collects unauthorized file accesses, run the following commands:
     <pre>$ sudo grep EACCES /etc/audit/audit.rules</pre>
     <pre>$ sudo grep EPERM /etc/audit/audit.rules</pre>
+
+warnings:
+    - general: |-
+        This rule checks for multiple syscalls related to unsuccessful file modification;
+        it was written with DISA STIG in mind. Other policies should use a
+        separate rule for each syscall that needs to be checked. For example:
+        <ul>
+        <li><tt>audit_rules_unsuccessful_file_modification_open</tt></li>
+        <li><tt>audit_rules_unsuccessful_file_modification_ftruncate</tt></li>
+        <li><tt>audit_rules_unsuccessful_file_modification_creat</tt></li>
+        </ul>


### PR DESCRIPTION
#### Description:

- Add a warning that recommends users to select individual rules regarding auditing of file deletion events.

#### Rationale:

- Some audit rules are responsible for checking many syscalls, these rules were written with DISA use case in mind and are not recommended to be used in other profiles.
