### PR TITLE
Add uid_min and implied auid product.yml

### DIFF
--- a/rhel6/product.yml
+++ b/rhel6/product.yml
@@ -14,3 +14,5 @@ cpes:
   - "cpe:/o:redhat:enterprise_linux:6"
   - "cpe:/o:redhat:enterprise_linux:6::client"
   - "cpe:/o:redhat:enterprise_linux:6::computenode"
+
+uid_min: 500 # sets the starting value for user ids, also used to set auid

--- a/shared/checks/oval/dir_perms_world_writable_system_owned.xml
+++ b/shared/checks/oval/dir_perms_world_writable_system_owned.xml
@@ -1,9 +1,4 @@
 <def-group>
-{{% if product == "rhel6" %}}
-  {{% set AUID = 500 %}}
-{{% else %}}
-  {{% set AUID = 1000 %}}
-{{% endif %}}
   <definition class="compliance" id="dir_perms_world_writable_system_owned" version="1">
     <metadata>
       <title>Find world writable directories not owned by a system account</title>
@@ -13,11 +8,11 @@
       </affected>
       <description>All world writable directories should be owned by a system user.</description>
     </metadata>
-    <criteria comment="check for local directories that are world writable and have uid greater than or equal to {{{ AUID }}}" negate="true">
-      <criterion comment="check for local directories that are world writable and have uid greater than or equal to {{{ AUID }}}" test_ref="test_dir_world_writable_uid_gt_value" />
+    <criteria comment="check for local directories that are world writable and have uid greater than or equal to {{{ auid }}}" negate="true">
+      <criterion comment="check for local directories that are world writable and have uid greater than or equal to {{{ auid }}}" test_ref="test_dir_world_writable_uid_gt_value" />
     </criteria>
   </definition>
-  <unix:file_test check="all" comment="check for local directories that are world writable and have uid greater than or equal to {{{ AUID }}}" id="test_dir_world_writable_uid_gt_value" version="1">
+  <unix:file_test check="all" comment="check for local directories that are world writable and have uid greater than or equal to {{{ auid }}}" id="test_dir_world_writable_uid_gt_value" version="1">
     <unix:object object_ref="all_local_directories" />
     <unix:state state_ref="state_gid_is_user_and_world_writable" />
   </unix:file_test>
@@ -27,8 +22,8 @@
     <unix:filename xsi:nil="true" />
     <filter action="include">state_gid_is_user_and_world_writable</filter>
   </unix:file_object>
-  <unix:file_state comment="uid greater than or equal to {{{ AUID }}} and world writable" id="state_gid_is_user_and_world_writable" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ AUID }}}</unix:user_id>
+  <unix:file_state comment="uid greater than or equal to {{{ auid }}} and world writable" id="state_gid_is_user_and_world_writable" version="1">
+    <unix:user_id datatype="int" operation="greater than or equal">{{{ auid }}}</unix:user_id>
     <unix:owrite datatype="boolean">true</unix:owrite>
   </unix:file_state>
 </def-group>

--- a/shared/templates/template_BASH_audit_rules_dac_modification
+++ b/shared/templates/template_BASH_audit_rules_dac_modification
@@ -3,12 +3,6 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-{{% if product == "rhel6" %}}
-  {{% set AUID = 500 %}}
-{{% else %}}
-  {{% set AUID = 1000 %}}
-{{% endif %}}
-
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system
 [ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
@@ -17,7 +11,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 	PATTERN="-a always,exit -F arch=$ARCH -S %ATTR%.*"
 	GROUP="perm_mod"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S %ATTR% -F auid>={{{ AUID }}} -F auid!=4294967295 -F key=perm_mod"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S %ATTR% -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
 
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_OVAL_audit_rules_dac_modification
+++ b/shared/templates/template_OVAL_audit_rules_dac_modification
@@ -36,18 +36,12 @@
     </criteria>
   </definition>
 
-{{% if product == "rhel6" %}}
-  {{% set AUID = 500 %}}
-{{% else %}}
-  {{% set AUID = 1000 %}}
-{{% endif %}}
-
   <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit %ATTR%" id="test_32bit_ardm_%ATTR%_augenrules" version="1">
     <ind:object object_ref="object_32bit_ardm_%ATTR%_augenrules" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_%ATTR%_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -56,7 +50,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_%ATTR%_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -65,7 +59,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_%ATTR%_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -74,7 +68,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_%ATTR%_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
@@ -46,18 +46,12 @@
     </criteria>
   </definition>
 
-{{% if product == "rhel6" %}}
-  {{% set AUID = 500 %}}
-{{% else %}}
-  {{% set AUID = 1000 %}}
-{{% endif %}}
-
   <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit file eacces" id="test_32bit_arufm_eacces_%NAME%_augenrules" version="1">
     <ind:object object_ref="object_32bit_arufm_eacces_%NAME%_augenrules" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_arufm_eacces_%NAME%_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -66,7 +60,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_arufm_eperm_%NAME%_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -75,7 +69,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_arufm_eacces_%NAME%_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -84,7 +78,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_arufm_eperm_%NAME%_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -93,7 +87,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_arufm_eacces_%NAME%_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -102,7 +96,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_arufm_eperm_%NAME%_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -111,7 +105,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_arufm_eacces_%NAME%_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -120,7 +114,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_arufm_eperm_%NAME%_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ AUID }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -195,4 +195,4 @@ OCILREFATTR_TO_TAG = {
 }
 
 # Application constants
-default_uid_min = 1000
+DEFAULT_UID_MIN = 1000

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -193,3 +193,6 @@ OVALREFATTR_TO_TAG = {
 OCILREFATTR_TO_TAG = {
     "question_ref": "question",
 }
+
+# Application constants
+default_uid_min = 1000

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -8,7 +8,7 @@ from .jinja import _rename_items
 from .jinja import process_file
 from .constants import (PKG_MANAGER_TO_SYSTEM,
                         JINJA_MACROS_BASE_DEFINITIONS, JINJA_MACROS_HIGHLEVEL_DEFINITIONS)
-from .constants import default_uid_min
+from .constants import DEFAULT_UID_MIN
 
 try:
     from yaml import CSafeLoader as yaml_SafeLoader
@@ -48,8 +48,8 @@ def _get_implied_properties(existing_properties):
         pkg_manager = existing_properties["pkg_manager"]
         result["pkg_system"] = PKG_MANAGER_TO_SYSTEM[pkg_manager]
 
-    if ("uid_min" not in existing_properties):
-        result["uid_min"] = result["auid"] = default_uid_min
+    if "uid_min" not in existing_properties:
+        result["uid_min"] = result["auid"] = DEFAULT_UID_MIN
     else:
         result["auid"] = existing_properties["uid_min"]
 

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -49,9 +49,13 @@ def _get_implied_properties(existing_properties):
         result["pkg_system"] = PKG_MANAGER_TO_SYSTEM[pkg_manager]
 
     if "uid_min" not in existing_properties:
-        result["uid_min"] = result["auid"] = DEFAULT_UID_MIN
-    else:
-        result["auid"] = existing_properties["uid_min"]
+        result["uid_min"] = DEFAULT_UID_MIN
+
+    if "auid" not in existing_properties:
+        if "uid_min" in existing_properties:
+            result["auid"] = existing_properties["uid_min"]
+        else:
+            result["auid"] = DEFAULT_UID_MIN
 
     return result
 

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -8,6 +8,7 @@ from .jinja import _rename_items
 from .jinja import process_file
 from .constants import (PKG_MANAGER_TO_SYSTEM,
                         JINJA_MACROS_BASE_DEFINITIONS, JINJA_MACROS_HIGHLEVEL_DEFINITIONS)
+from .constants import default_uid_min
 
 try:
     from yaml import CSafeLoader as yaml_SafeLoader
@@ -46,6 +47,12 @@ def _get_implied_properties(existing_properties):
             "pkg_system" not in existing_properties):
         pkg_manager = existing_properties["pkg_manager"]
         result["pkg_system"] = PKG_MANAGER_TO_SYSTEM[pkg_manager]
+
+    if ("uid_min" not in existing_properties):
+        result["uid_min"] = result["auid"] = default_uid_min
+    else:
+        result["auid"] = existing_properties["uid_min"]
+
     return result
 
 


### PR DESCRIPTION
Avoid setting value of `auid` in every definition or fix. Lets set them product wise.

#### Description:

- Adds `uid_min` to product.yml.
  - If not defined, its default value is 1000
- `auid` is implied and set to `uid_min`.
- I have made them two separate values, because there are rules based on value of `uid_min` and there are the auditd rules that use `auid`, and it may be confusing to use them interchangeably.

#### Rationale:

- The `auid` parameter used in `auditd` rules should be set according to `uid_min` of the platform.
