### PR TITLE
Fix utilities for compraison, testoval

### DIFF
--- a/utils/compare_remediations.sh
+++ b/utils/compare_remediations.sh
@@ -22,7 +22,7 @@ meld="$3"
 
 # Get list of remediations in pretty & sorted xml
 function extractRemediations() {
-	xsltproc $(dirname "$0")/../transforms/xccdf-get-only-remediations-sorted.xslt "$1"  | tee /tmp/res.xml | \
+	xsltproc $(dirname "$0")/../shared/transforms/xccdf-get-only-remediations-sorted.xslt "$1"  | tee /tmp/res.xml | \
 		xmllint --c14n11 /dev/stdin | \
 		xmllint -format /dev/stdin | \
 		sed 's;^\s*#.*$;;g' | \
@@ -35,7 +35,7 @@ function compareFile() {
 	local originalFile="$1"
 	toCompare=$(sed "s;^$originalRepo;$updatedRepo;" <<< "$originalFile")
 	echo "-----------------------------------------------------------------"
-	echo "$originalFile <=> $toCompare" 
+	echo "$originalFile <=> $toCompare"
 	echo "-----------------------------------------------------------------"
 
 	extractRemediations "$originalFile" > /tmp/original

--- a/utils/testoval.py
+++ b/utils/testoval.py
@@ -2,7 +2,7 @@
 
 import sys
 import os
-import ssg
+import ssg.oval
 
 # always use shared/testoval_module.py version
 if __name__ == "__main__":


### PR DESCRIPTION
These are broken since the refactor of the `ssg` module and since the rearrangement of utilities. Some of these changes are likely duplicated in #3014 / unnecessary with #3014, but that is fine as that is stalled for the time being. 