### PR TITLE
Convert custom string-replacement to jinja macros

### DIFF
--- a/build-scripts/generate_from_templates.py
+++ b/build-scripts/generate_from_templates.py
@@ -7,6 +7,7 @@ import sys
 import argparse
 
 import ssg.build_templates
+import ssg.yaml
 
 
 def parse_args():
@@ -31,6 +32,16 @@ def parse_args():
                    help="List of output directories")
     p.add_argument("--shared", metavar="PATH", required=True,
                    help="Full absolute path to SSG shared directory")
+    p.add_argument(
+        "--build-config-yaml", required=True, dest="build_config_yaml",
+        help="YAML file with information about the build configuration. "
+        "e.g.: ~/scap-security-guide/build/build_config.yml"
+    )
+    p.add_argument(
+        "--product-yaml", required=True, dest="product_yaml",
+        help="YAML file with information about the product we are building. "
+        "e.g.: ~/scap-security-guide/rhel7/product.yml"
+    )
 
     args = p.parse_args()
     if len(args.input) != len(args.output):
@@ -44,8 +55,11 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
 
+    env_yaml = ssg.yaml.open_environment(
+        args.build_config_yaml, args.product_yaml)
+
     for index in range(0, len(args.input)):
-        builder = ssg.build_templates.Builder()
+        builder = ssg.build_templates.Builder(env_yaml)
         builder.set_langs(args.languages)
 
         builder.set_input_dir(args.input[index])

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -184,13 +184,13 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
     set(BUILD_REMEDIATIONS_DIR "${CMAKE_CURRENT_BINARY_DIR}/fixes")
 
     execute_process(
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages ${LANGUAGES} --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_REMEDIATIONS_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared" --shared "${SSG_SHARED}" list-inputs
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages ${LANGUAGES} --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_REMEDIATIONS_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared" --shared "${SSG_SHARED}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" list-inputs
         OUTPUT_VARIABLE LANGUAGE_REMEDIATIONS_DEPENDS_STR
     )
     string(REPLACE "\n" ";" LANGUAGE_REMEDIATIONS_DEPENDS "${LANGUAGE_REMEDIATIONS_DEPENDS_STR}")
 
     execute_process(
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages ${LANGUAGES} --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_REMEDIATIONS_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared" --shared "${SSG_SHARED}" list-outputs
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages ${LANGUAGES} --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_REMEDIATIONS_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared" --shared "${SSG_SHARED}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" list-outputs
         OUTPUT_VARIABLE LANGUAGE_REMEDIATIONS_OUTPUTS_STR
     )
     string(REPLACE "\n" ";" LANGUAGE_REMEDIATIONS_OUTPUTS "${LANGUAGE_REMEDIATIONS_OUTPUTS_STR}")
@@ -209,7 +209,7 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
         OUTPUT ${LANGUAGE_REMEDIATIONS_OUTPUTS}
         # We have to remove the entire dir to avoid keeping remediations when user removes something from the CSV
         COMMAND "${CMAKE_COMMAND}" -E remove_directory "${BUILD_REMEDIATIONS_DIR}"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages ${LANGUAGES} --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_REMEDIATIONS_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared" --shared "${SSG_SHARED}" build
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages ${LANGUAGES} --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_REMEDIATIONS_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared" --shared "${SSG_SHARED}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" build
         DEPENDS generate-internal-bash-remediation-functions.xml
         DEPENDS "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml"
         DEPENDS ${LANGUAGE_REMEDIATIONS_DEPENDS}
@@ -292,12 +292,12 @@ macro(ssg_build_oval_unlinked PRODUCT)
 
     message(STATUS "Scanning for dependencies of ${PRODUCT} checks (OVAL)...")
     execute_process(
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages oval --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_CHECKS_DIR}" "${BUILD_CHECKS_DIR}/shared" --shared "${SSG_SHARED}" list-inputs
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages oval --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_CHECKS_DIR}" "${BUILD_CHECKS_DIR}/shared" --shared "${SSG_SHARED}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" list-inputs
         OUTPUT_VARIABLE OVAL_CHECKS_DEPENDS_STR
     )
     string(REPLACE "\n" ";" OVAL_CHECKS_DEPENDS "${OVAL_CHECKS_DEPENDS_STR}")
     execute_process(
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages oval --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_CHECKS_DIR}" "${BUILD_CHECKS_DIR}/shared" --shared "${SSG_SHARED}" list-outputs
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages oval --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_CHECKS_DIR}" "${BUILD_CHECKS_DIR}/shared" --shared "${SSG_SHARED}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" list-outputs
         OUTPUT_VARIABLE OVAL_CHECKS_OUTPUTS_STR
     )
     string(REPLACE "\n" ";" OVAL_CHECKS_OUTPUTS "${OVAL_CHECKS_OUTPUTS_STR}")
@@ -310,7 +310,7 @@ macro(ssg_build_oval_unlinked PRODUCT)
         # We have to remove all old checks in case the user removed something from the CSV files
         COMMAND "${CMAKE_COMMAND}" -E remove_directory "${BUILD_CHECKS_DIR}/oval"
         COMMAND "${CMAKE_COMMAND}" -E remove_directory "${BUILD_CHECKS_DIR}/shared/oval"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages oval --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_CHECKS_DIR}" "${BUILD_CHECKS_DIR}/shared" --shared "${SSG_SHARED}" build
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages oval --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_CHECKS_DIR}" "${BUILD_CHECKS_DIR}/shared" --shared "${SSG_SHARED}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" build
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" ${OVAL_COMBINE_PATHS}
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         DEPENDS ${OVAL_CHECKS_DEPENDS}

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1,5 +1,7 @@
 = SCAP Security Guide Developer Guide
 :imagesdir: ./images
+:templatesdir: ../../shared/templates
+:rhel7dir: ../../rhel7/templates/csv
 :toc:
 :toc-placement: preamble
 :numbered:
@@ -771,73 +773,30 @@ When writing new bash remediations content, please follow the following guidelin
 Often, a set of very related checks and/or remediations needs to be created. Instead of creating them individually, you can use the templating mechanism provided by the SSG. It supports OVAL checks and Ansible, Bash, Anaconda and Puppet remediations.
 In order to use this mechanism, you have to:
 
-1) Create the template files, one for each type of file. Each one should be named `template_<TYPE>_<NAME>`. Where `<TYPE>` should be OVAL, ANSIBLE, BASH, ANACONDA or PUPPET and `<NAME>` is the what we will call hereafter the template name.
-Use variables where appropriate. Variables must be surrounded by the symbol % and be uppercase, like `%NAME%` or `%PATH_TO_FILE%`.
+1) Create the template files, one for each type of file. Each one should be named `template_<TYPE>_<NAME>.jinja`. Where `<TYPE>` should be OVAL, ANSIBLE, BASH, ANACONDA or PUPPET and `<NAME>` is the what we will call hereafter the template name.
+Use the jinja syntax we use elsewhere in the project; refer to the earlier section on jinja macros for more information.
 
 This is an example of an OVAL template file called _template_OVAL_package_installed_
 
 [source,xml]
 ----
-<def-group>
-  <definition class="compliance" id="package_%PKGNAME%_installed"
-  version="1">
-    <metadata>
-      <title>Package %PKGNAME% Installed</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-      </affected>
-      <description>The RPM package %PKGNAME% should be installed.</description>
-    </metadata>
-    <criteria>
-      <criterion comment="package %PKGNAME% is installed"
-      test_ref="test_package_%PKGNAME%_installed" />
-    </criteria>
-  </definition>
-  <linux:rpminfo_test check="all" check_existence="all_exist"
-  id="test_package_%PKGNAME%_installed" version="1"
-  comment="package %PKGNAME% is installed">
-    <linux:object object_ref="obj_package_%PKGNAME%_installed" />
-  </linux:rpminfo_test>
-  <linux:rpminfo_object id="obj_package_%PKGNAME%_installed" version="1">
-    <linux:name>%PKGNAME%</linux:name>
-  </linux:rpminfo_object>
-</def-group>
+include::{templatesdir}/template_OVAL_package_installed
 ----
 
 And here is the Ansible template file called _template_ANSIBLE_package_installed_:
 
 [source,yml]
 ----
-# platform = multi_platform_all
-# reboot = false
-# strategy = enable
-# complexity = low
-# disruption = low
-- name: Ensure %PKGNAME% is installed
-  package:
-    name="{{item}}"
-    state=present
-  with_items:
-    - %PKGNAME%
-  tags:
-    @ANSIBLE_TAGS@
+include::{templatesdir}/template_ANSIBLE_package_installed
 ----
 
-2) Create a csv (comma-separated-values) file in the _/template/csv_ directory with the same name of the template followed by the extension _.csv_. It should contain all the instances you want to generate from the template, one per line. Use the line to supply values to the variables.
+2) Create a csv (comma-separated-values) file in the _PRODUCT/template/csv_ directory with the same name of the template followed by the extension _.csv_. It should contain all the instances you want to generate from the template, one per line. Use the line to supply values to the variables. You can use `#` to make a comment until the end of the line.
 
-This is the file packages_installed.csv
+This is the file _rhel7/template/csv/packages_installed.csv_:
 
 [source,csv]
 ----
-aide
-audit
-chrony
-cronie
-dconf
-firewalld
-esc
-irqbalance
-#kernel-PAE
+include::{rhel7dir}/template/csv/packages_installed.csv
 ----
 
 3) Create a python file containing the generator class. The name of the file should start with _create__ and then be followed by the template name and the extension _.py_. The generator class name should also be the template name, in Camel case, followed by _Generator_.
@@ -850,59 +809,10 @@ This is the file with the generator class for the installed package template, it
 
 [source,python]
 ----
-#
-# create_package_installed.py
-#   automatically generate checks for installed packages
-#
-
-from template_common import FilesGenerator, UnknownTargetError
-
-
-class PackageInstalledGenerator(FilesGenerator):
-    def generate(self, target, package_info):
-        pkgname = package_info[0]
-        if not pkgname:
-            raise RuntimeError(
-                "ERROR: input violation: the package name must be defined")
-
-        if target == "oval":
-            self.file_from_template(
-                "./template_OVAL_package_installed",
-                {"%PKGNAME%": pkgname},
-                "./oval/package_{0}_installed.xml", pkgname
-            )
-
-        elif target == "bash":
-            self.file_from_template(
-                "./template_BASH_package_installed",
-                {"%PKGNAME%": pkgname},
-                "./bash/package_{0}_installed.sh", pkgname
-            )
-
-        elif target == "ansible":
-            self.file_from_template(
-                "./template_ANSIBLE_package_installed",
-                {"%PKGNAME%": pkgname},
-                "./ansible/package_{0}_installed.yml", pkgname
-            )
-
-        elif target == "anaconda":
-            self.file_from_template(
-                "./template_ANACONDA_package_installed",
-                {"%PKGNAME%": pkgname},
-                "./anaconda/package_{0}_installed.anaconda", pkgname
-            )
-
-        elif target == "puppet":
-            self.file_from_template(
-                "./template_PUPPET_package_installed",
-                {"%PKGNAME%": pkgname},
-                "./puppet/package_{0}_installed.pp", pkgname
-            )
-
+include::{templatesdir}/create_package_installed.py
 ----
 
-4) Finally, you have to ensure the SSG knows your template. To do that, you have to edit the file _build-scripts/generate-from-template.py_ and include the generator class you've just created and declare which csv file to use along with it.
+4) Finally, you have to ensure the SSG knows your template. To do that, you have to edit the file _ssg/build_templates.py_ and include the generator class you've just created and declare which csv file to use along with it.
 
 This is an example of a patch to add a new template into the templating system:
 

--- a/shared/templates/create_accounts_password.py
+++ b/shared/templates/create_accounts_password.py
@@ -14,7 +14,7 @@ class AccountsPasswordGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_accounts_password",
                 {
-                    "%VARIABLE%": VARIABLE
+                    "VARIABLE": VARIABLE
                 },
                 "./bash/accounts_password_pam_{0}.sh", VARIABLE
             )
@@ -23,7 +23,7 @@ class AccountsPasswordGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_accounts_password",
                 {
-                    "%VARIABLE%": VARIABLE
+                    "VARIABLE": VARIABLE
                 },
                 "./ansible/accounts_password_pam_{0}.yml", VARIABLE
             )
@@ -31,8 +31,8 @@ class AccountsPasswordGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_accounts_password",
                 {
-                    "%VARIABLE%": VARIABLE,
-                    "%OPERATION%": OPERATION
+                    "VARIABLE": VARIABLE,
+                    "OPERATION": OPERATION
                 },
                 "./oval/accounts_password_pam_{0}.xml", VARIABLE
             )

--- a/shared/templates/create_audit_rules_dac_modification.py
+++ b/shared/templates/create_audit_rules_dac_modification.py
@@ -19,7 +19,7 @@ class AuditRulesDacModificationGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_audit_rules_dac_modification",
                 {
-                    "%ATTR%":           attr,
+                    "ATTR":           attr,
                 },
                 "./oval/audit_rules_dac_modification_{0}.xml", attr
             )
@@ -28,7 +28,7 @@ class AuditRulesDacModificationGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_audit_rules_dac_modification",
                 {
-                    "%ATTR%":	attr,
+                    "ATTR":	attr,
                 },
                 "./bash/audit_rules_dac_modification_{0}.sh", attr
             )
@@ -37,7 +37,7 @@ class AuditRulesDacModificationGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_audit_rules_dac_modification",
                 {
-                    "%ATTR%":	attr,
+                    "ATTR":	attr,
                 },
                 "./ansible/audit_rules_dac_modification_{0}.yml", attr
             )

--- a/shared/templates/create_audit_rules_execution.py
+++ b/shared/templates/create_audit_rules_execution.py
@@ -20,10 +20,10 @@ class AuditRulesExecutionGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_audit_rules_privileged_commands",
                 {
-                    "%ID%": "audit_rules_execution_" + name,
-                    "%TITLE%": "Record Any Attempts to Run " + name,
-                    "%NAME%":	name,
-                    "%PATH%":	path.replace("/", "\\/")
+                    "ID": "audit_rules_execution_" + name,
+                    "TITLE": "Record Any Attempts to Run " + name,
+                    "NAME":	name,
+                    "PATH":	path.replace("/", "\\/")
                 },
                 "./oval/audit_rules_execution_{0}.xml", name
             )
@@ -32,7 +32,7 @@ class AuditRulesExecutionGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_audit_rules_privileged_commands",
                 {
-                    "%PATH%":	path
+                    "PATH":	path
                 },
                 "./bash/audit_rules_execution_{0}.sh", name
             )
@@ -41,8 +41,8 @@ class AuditRulesExecutionGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_audit_rules_privileged_commands",
                 {
-                    "%NAME%":	name,
-                    "%PATH%":	path
+                    "NAME":	name,
+                    "PATH":	path
                 },
                 "./ansible/audit_rules_execution_{0}.yml", name
             )

--- a/shared/templates/create_audit_rules_file_deletion_events.py
+++ b/shared/templates/create_audit_rules_file_deletion_events.py
@@ -16,7 +16,7 @@ class AuditRulesFileDeletionEventsGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_audit_rules_file_deletion_events",
                 {
-                    "%NAME%":	name
+                    "NAME":	name
                 },
                 "./oval/audit_rules_file_deletion_events_{0}.xml", name
             )
@@ -25,7 +25,7 @@ class AuditRulesFileDeletionEventsGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_audit_rules_file_deletion_events",
                 {
-                    "%NAME%":	name
+                    "NAME":	name
                 },
                 "./bash/audit_rules_file_deletion_events_{0}.sh", name
             )
@@ -34,7 +34,7 @@ class AuditRulesFileDeletionEventsGenerator(FilesGenerator):
 #            self.file_from_template(
 #                "./template_ANSIBLE_audit_rules_file_deletion_events",
 #                {
-#                    "%NAME%":	name
+#                    "NAME":	name
 #                },
 #                "./ansible/audit_rules_file_deletion_events_{0}.yml", name
 #            )

--- a/shared/templates/create_audit_rules_login_events.py
+++ b/shared/templates/create_audit_rules_login_events.py
@@ -19,8 +19,8 @@ class AuditRulesLoginEventsGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_audit_rules_login_events",
                 {
-                    "%NAME%":	name,
-                    "%PATH%":	path.replace("/", "\\/")
+                    "NAME":	name,
+                    "PATH":	path.replace("/", "\\/")
                 },
                 "./oval/audit_rules_login_events_{0}.xml", name
             )
@@ -29,7 +29,7 @@ class AuditRulesLoginEventsGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_audit_rules_login_events",
                 {
-                    "%PATH%":	path
+                    "PATH":	path
                 },
                 "./bash/audit_rules_login_events_{0}.sh", name
             )
@@ -38,8 +38,8 @@ class AuditRulesLoginEventsGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_audit_rules_login_events",
                 {
-                    "%NAME%":	name,
-                    "%PATH%":	path
+                    "NAME":	name,
+                    "PATH":	path
                 },
                 "./ansible/audit_rules_login_events_{0}.yml", name
             )

--- a/shared/templates/create_audit_rules_privileged_commands.py
+++ b/shared/templates/create_audit_rules_privileged_commands.py
@@ -19,10 +19,10 @@ class AuditRulesPrivilegedCommandsGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_audit_rules_privileged_commands",
                 {
-                    "%ID%": "audit_rules_privileged_commands_" + name,
-                    "%TITLE%": "Ensure auditd Collects Information on the Use of Privileged Commands - " + name,
-                    "%NAME%":	name,
-                    "%PATH%":	path.replace("/", "\\/")
+                    "ID": "audit_rules_privileged_commands_" + name,
+                    "TITLE": "Ensure auditd Collects Information on the Use of Privileged Commands - " + name,
+                    "NAME":	name,
+                    "PATH":	path.replace("/", "\\/")
                 },
                 "./oval/audit_rules_privileged_commands_{0}.xml", name
             )
@@ -31,7 +31,7 @@ class AuditRulesPrivilegedCommandsGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_audit_rules_privileged_commands",
                 {
-                    "%PATH%":	path
+                    "PATH":	path
                 },
                 "./bash/audit_rules_privileged_commands_{0}.sh", name
             )
@@ -40,8 +40,8 @@ class AuditRulesPrivilegedCommandsGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_audit_rules_privileged_commands",
                 {
-                    "%NAME%":	name,
-                    "%PATH%":	path
+                    "NAME":	name,
+                    "PATH":	path
                 },
                 "./ansible/audit_rules_privileged_commands_{0}.yml", name
             )

--- a/shared/templates/create_audit_rules_unsuccessful_file_modification.py
+++ b/shared/templates/create_audit_rules_unsuccessful_file_modification.py
@@ -16,7 +16,7 @@ class AuditRulesUnsuccessfulFileModificationGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_audit_rules_unsuccessful_file_modification",
                 {
-                    "%NAME%":	name
+                    "NAME":	name
                 },
                 "./oval/audit_rules_unsuccessful_file_modification_{0}.xml", name
             )
@@ -25,7 +25,7 @@ class AuditRulesUnsuccessfulFileModificationGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_audit_rules_unsuccessful_file_modification",
                 {
-                    "%NAME%":	name
+                    "NAME":	name
                 },
                 "./bash/audit_rules_unsuccessful_file_modification_{0}.sh", name
             )
@@ -34,7 +34,7 @@ class AuditRulesUnsuccessfulFileModificationGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_audit_rules_unsuccessful_file_modification",
                 {
-                    "%NAME%":	name
+                    "NAME":	name
                 },
                 "./ansible/audit_rules_unsuccessful_file_modification_{0}.yml", name
             )

--- a/shared/templates/create_audit_rules_usergroup_modification.py
+++ b/shared/templates/create_audit_rules_usergroup_modification.py
@@ -19,8 +19,8 @@ class AuditRulesUserGroupModificationGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_audit_rules_usergroup_modification",
                 {
-                    "%NAME%":	name,
-                    "%PATH%":	path.replace("/", "\\/")
+                    "NAME":	name,
+                    "PATH":	path.replace("/", "\\/")
                 },
                 "./oval/audit_rules_usergroup_modification_{0}.xml", name
             )
@@ -29,7 +29,7 @@ class AuditRulesUserGroupModificationGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_audit_rules_usergroup_modification",
                 {
-                    "%PATH%":	path
+                    "PATH":	path
                 },
                 "./bash/audit_rules_usergroup_modification_{0}.sh", name
             )
@@ -38,8 +38,8 @@ class AuditRulesUserGroupModificationGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_audit_rules_usergroup_modification",
                 {
-                    "%NAME%":	name,
-                    "%PATH%":	path
+                    "NAME":	name,
+                    "PATH":	path
                 },
                 "./ansible/audit_rules_usergroup_modification_{0}.yml", name
             )

--- a/shared/templates/create_file_groupowner.py
+++ b/shared/templates/create_file_groupowner.py
@@ -28,8 +28,8 @@ class FileGroupOwnerGenerator(FilesGenerator):
 #            self.file_from_template(
 #                "./template_OVAL_file_groupowner",
 #                {
-#                    "%PATH%": path,
-#                    "%NAME%": name
+#                    "PATH": path,
+#                    "NAME": name
 #                },
 #                "./oval/file_groupowner{0}.xml", name
 #            )
@@ -38,8 +38,8 @@ class FileGroupOwnerGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_file_groupowner",
                 {
-                    "%PATH%": path,
-                    "%GROUP%": group,
+                    "PATH": path,
+                    "GROUP": group,
                 },
                 "./bash/file_groupowner{0}.sh", name
             )
@@ -48,8 +48,8 @@ class FileGroupOwnerGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_file_groupowner",
                 {
-                    "%PATH%": path,
-                    "%GROUP%": group,
+                    "PATH": path,
+                    "GROUP": group,
                 },
                 "./ansible/file_groupowner{0}.yml", name
             )

--- a/shared/templates/create_file_owner.py
+++ b/shared/templates/create_file_owner.py
@@ -28,8 +28,8 @@ class FileOwnerGenerator(FilesGenerator):
 #            self.file_from_template(
 #                "./template_OVAL_file_owner",
 #                {
-#                    "%PATH%": path,
-#                    "%NAME%": name
+#                    "PATH": path,
+#                    "NAME": name
 #                },
 #                "./oval/file_owner{0}.xml", name
 #            )
@@ -38,8 +38,8 @@ class FileOwnerGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_file_owner",
                 {
-                    "%PATH%": path,
-                    "%USER%": user,
+                    "PATH": path,
+                    "USER": user,
                 },
                 "./bash/file_owner{0}.sh", name
             )
@@ -48,8 +48,8 @@ class FileOwnerGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_file_owner",
                 {
-                    "%PATH%": path,
-                    "%USER%": user,
+                    "PATH": path,
+                    "USER": user,
                 },
                 "./ansible/file_owner{0}.yml", name
             )

--- a/shared/templates/create_file_permissions.py
+++ b/shared/templates/create_file_permissions.py
@@ -28,10 +28,10 @@ class FilePermissionsGenerator(FilesGenerator):
 #            self.file_from_template(
 #                "./template_OVAL_file_permissions",
 #                {
-#                    "%PATH%": path,
-#                    "%MODE%": mode,
-#                    "%PLATFORMS%": platforms,
-#                    "%NAME%": name
+#                    "PATH": path,
+#                    "MODE": mode,
+#                    "PLATFORMS": platforms,
+#                    "NAME": name
 #                },
 #                "./oval/file_permissions{0}.xml", name
 #            )
@@ -40,8 +40,8 @@ class FilePermissionsGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_file_permissions",
                 {
-                    "%PATH%": path,
-                    "%MODE%": mode,
+                    "PATH": path,
+                    "MODE": mode,
                 },
                 "./bash/file_permissions{0}.sh", name
             )
@@ -50,8 +50,8 @@ class FilePermissionsGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_file_permissions",
                 {
-                    "%PATH%": path,
-                    "%MODE%": mode,
+                    "PATH": path,
+                    "MODE": mode,
                 },
                 "./ansible/file_permissions{0}.yml", name
             )

--- a/shared/templates/create_kernel_modules_disabled.py
+++ b/shared/templates/create_kernel_modules_disabled.py
@@ -14,7 +14,7 @@ class KernelModulesDisabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_kernel_module_disabled",
                 {
-                   "%KERNMODULE%": kernmod
+                   "KERNMODULE": kernmod
                 },
                 "./bash/kernel_module_{0}_disabled.sh", kernmod
             )
@@ -23,7 +23,7 @@ class KernelModulesDisabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_kernel_module_disabled",
                 {
-                    "%KERNMODULE%": kernmod
+                    "KERNMODULE": kernmod
                 },
                 "./oval/kernel_module_{0}_disabled.xml", kernmod
             )
@@ -32,7 +32,7 @@ class KernelModulesDisabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_kernel_module_disabled",
                 {
-                   "%KERNMODULE%": kernmod
+                   "KERNMODULE": kernmod
                 },
                 "./ansible/kernel_module_{0}_disabled.yml", kernmod
             )

--- a/shared/templates/create_mount_options.py
+++ b/shared/templates/create_mount_options.py
@@ -74,9 +74,9 @@ class RemediationTarget(MountOptionTarget):
         self.generator.file_from_template(
             self.template_file,
             {
-                "%MOUNT_HAS_TO_EXIST%": mount_has_to_exist,
-                "%MOUNTPOINT%": self._mount_point,
-                "%MOUNTOPTION%": re.sub(' ', ',', self._mount_option),
+                "MOUNT_HAS_TO_EXIST": mount_has_to_exist,
+                "MOUNTPOINT": self._mount_point,
+                "MOUNTOPTION": re.sub(' ', ',', self._mount_option),
             },
             self._output_fname,
             ""
@@ -116,9 +116,9 @@ class OvalTarget(MountOptionTarget):
         self.generator.file_from_template(
             self.template_file,
             {
-                "%MOUNTPOINT%":  self._mount_point,
-                "%MOUNTOPTION%": self._mount_option,
-                "%POINTID%":     self._point_id,
+                "MOUNTPOINT":  self._mount_point,
+                "MOUNTOPTION": self._mount_option,
+                "POINTID":     self._point_id,
             },
             self._output_fname,
             ""

--- a/shared/templates/create_mounts.py
+++ b/shared/templates/create_mounts.py
@@ -18,7 +18,7 @@ class MountsGenerator(FilesGenerator):
                 self.file_from_template(
                     "./template_ANACONDA_mount",
                     {
-                        "%MOUNTPOINT%":  mount_point,
+                        "MOUNTPOINT":  mount_point,
                     },
                     "./anaconda/partition_for{0}.anaconda", point_id
                 )
@@ -27,8 +27,8 @@ class MountsGenerator(FilesGenerator):
                 self.file_from_template(
                     "./template_OVAL_mount",
                     {
-                        "%MOUNTPOINT%":  mount_point,
-                        "%POINTID%":     point_id,
+                        "MOUNTPOINT":  mount_point,
+                        "POINTID":     point_id,
                     },
                     "./oval/partition_for{0}.xml", point_id
                 )

--- a/shared/templates/create_package_installed.py
+++ b/shared/templates/create_package_installed.py
@@ -27,8 +27,8 @@ class PackageInstalledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_package_installed",
                 {
-                    "%PKGNAME%": pkgname,
-                    "%EVR%": evr
+                    "PKGNAME": pkgname,
+                    "EVR": evr
                 },
                 "./oval/package_{0}_installed.xml", pkgname
             )
@@ -36,28 +36,28 @@ class PackageInstalledGenerator(FilesGenerator):
         elif target == "bash":
             self.file_from_template(
                 "./template_BASH_package_installed",
-                {"%PKGNAME%": pkgname},
+                {"PKGNAME": pkgname},
                 "./bash/package_{0}_installed.sh", pkgname
             )
 
         elif target == "ansible":
             self.file_from_template(
                 "./template_ANSIBLE_package_installed",
-                {"%PKGNAME%": pkgname},
+                {"PKGNAME": pkgname},
                 "./ansible/package_{0}_installed.yml", pkgname
             )
 
         elif target == "anaconda":
             self.file_from_template(
                 "./template_ANACONDA_package_installed",
-                {"%PKGNAME%": pkgname},
+                {"PKGNAME": pkgname},
                 "./anaconda/package_{0}_installed.anaconda", pkgname
             )
 
         elif target == "puppet":
             self.file_from_template(
                 "./template_PUPPET_package_installed",
-                {"%PKGNAME%": pkgname},
+                {"PKGNAME": pkgname},
                 "./puppet/package_{0}_installed.pp", pkgname
             )
 

--- a/shared/templates/create_package_removed.py
+++ b/shared/templates/create_package_removed.py
@@ -15,35 +15,35 @@ class PackageRemovedGenerator(FilesGenerator):
         if target == "oval":
             self.file_from_template(
                 "./template_OVAL_package_removed",
-                {"%PKGNAME%": pkgname},
+                {"PKGNAME": pkgname},
                 "./oval/package_{0}_removed.xml", pkgname
             )
 
         elif target == "bash":
             self.file_from_template(
                 "./template_BASH_package_removed",
-                {"%PKGNAME%": pkgname},
+                {"PKGNAME": pkgname},
                 "./bash/package_{0}_removed.sh", pkgname
             )
 
         elif target == "ansible":
             self.file_from_template(
                 "./template_ANSIBLE_package_removed",
-                {"%PKGNAME%": pkgname},
+                {"PKGNAME": pkgname},
                 "./ansible/package_{0}_removed.yml", pkgname
             )
 
         elif target == "anaconda":
             self.file_from_template(
                 "./template_ANACONDA_package_removed",
-                {"%PKGNAME%": pkgname},
+                {"PKGNAME": pkgname},
                 "./anaconda/package_{0}_removed.anaconda", pkgname
             )
 
         elif target == "puppet":
             self.file_from_template(
                 "./template_PUPPET_package_removed",
-                {"%PKGNAME%": pkgname},
+                {"PKGNAME": pkgname},
                 "./puppet/package_{0}_removed.pp", pkgname
             )
 

--- a/shared/templates/create_permission.py
+++ b/shared/templates/create_permission.py
@@ -42,8 +42,8 @@ class PermissionGenerator(FilesGenerator):
                 self.file_from_template(
                     "./template_BASH_permissions",
                     {
-                        "%FILEPATH%":      full_path,
-                        "%FILEMODE%":      mode,
+                        "FILEPATH":      full_path,
+                        "FILEMODE":      mode,
                     },
                     "./bash/file_permissions{0}.sh", path_id
                 )
@@ -52,9 +52,9 @@ class PermissionGenerator(FilesGenerator):
                 self.file_from_template(
                     "./template_BASH_regex_permissions",
                     {
-                        "%FILEPATH%":      dir_path,
-                        "%FILENAME%":      file_name,
-                        "%FILEMODE%":      mode,
+                        "FILEPATH":      dir_path,
+                        "FILENAME":      file_name,
+                        "FILEMODE":      mode,
                     },
                     "./bash/file_permissions{0}.sh", path_id
                 )
@@ -63,8 +63,8 @@ class PermissionGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_permissions",
                 {
-                    "%FILEPATH%":      full_path,
-                    "%FILEMODE%":      mode,
+                    "FILEPATH":      full_path,
+                    "FILEMODE":      mode,
                 },
                 "./ansible/file_permissions{0}.yml", path_id
             )
@@ -97,14 +97,14 @@ class PermissionGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_permissions",
                 {
-                    "%FILEID%":        path_id,
-                    "%FILEPATH%":      full_path,
-                    "%FILEDIR%":       dir_path,
-                    "%FILEUID%":       uid,
-                    "%FILEGID%":       gid,
-                    "%FILEMODE%":      mode,
-                    "%STATEMODE%":     mode_str,
-                    "%UNIX_FILENAME%": unix_filename
+                    "FILEID":        path_id,
+                    "FILEPATH":      full_path,
+                    "FILEDIR":       dir_path,
+                    "FILEUID":       uid,
+                    "FILEGID":       gid,
+                    "FILEMODE":      mode,
+                    "STATEMODE":     mode_str,
+                    "UNIX_FILENAME": unix_filename
                 },
                 "./oval/file_permissions{0}.xml", path_id
             )

--- a/shared/templates/create_selinux_booleans.py
+++ b/shared/templates/create_selinux_booleans.py
@@ -22,15 +22,15 @@ class SEBoolGenerator(FilesGenerator):
                     self.file_from_template(
                         "./template_OVAL_sebool",
                         {
-                            "%SEBOOLID%": sebool_id,
-                            "%SEBOOL_BOOL%": sebool_bool
+                            "SEBOOLID": sebool_id,
+                            "SEBOOL_BOOL": sebool_bool
                         },
                         "./oval/sebool_{0}.xml", sebool_id)
                 else:
                     self.file_from_template(
                         "./template_OVAL_sebool_var",
                         {
-                            "%SEBOOLID%": sebool_id
+                            "SEBOOLID": sebool_id
                         },
                         "./oval/sebool_{0}.xml", sebool_id
                     )
@@ -40,15 +40,15 @@ class SEBoolGenerator(FilesGenerator):
                     self.file_from_template(
                         "./template_BASH_sebool",
                         {
-                            "%SEBOOLID%": sebool_id,
-                            "%SEBOOL_BOOL%": sebool_bool
+                            "SEBOOLID": sebool_id,
+                            "SEBOOL_BOOL": sebool_bool
                         },
                         "./bash/sebool_{0}.sh", sebool_id)
                 else:
                     self.file_from_template(
                         "./template_BASH_sebool_var",
                         {
-                            "%SEBOOLID%": sebool_id
+                            "SEBOOLID": sebool_id
                         },
                         "./bash/sebool_{0}.sh", sebool_id
                     )
@@ -58,15 +58,15 @@ class SEBoolGenerator(FilesGenerator):
                     self.file_from_template(
                         "./template_ANSIBLE_sebool",
                         {
-                            "%SEBOOLID%": sebool_id,
-                            "%SEBOOL_BOOL%": sebool_bool
+                            "SEBOOLID": sebool_id,
+                            "SEBOOL_BOOL": sebool_bool
                         },
                         "./ansible/sebool_{0}.yml", sebool_id)
                 else:
                     self.file_from_template(
                         "./template_ANSIBLE_sebool_var",
                         {
-                            "%SEBOOLID%": sebool_id
+                            "SEBOOLID": sebool_id
                         },
                         "./ansible/sebool_{0}.yml", sebool_id
                     )

--- a/shared/templates/create_services_disabled.py
+++ b/shared/templates/create_services_disabled.py
@@ -26,8 +26,8 @@ class ServiceDisabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_service_disabled",
                 {
-                    "%SERVICENAME%": servicename,
-                    "%DAEMONNAME%": daemonname
+                    "SERVICENAME": servicename,
+                    "DAEMONNAME": daemonname
                 },
                 "./bash/service_{0}_disabled.sh", servicename
             )
@@ -36,8 +36,8 @@ class ServiceDisabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_service_disabled",
                 {
-                    "%SERVICENAME%": servicename,
-                    "%DAEMONNAME%": daemonname
+                    "SERVICENAME": servicename,
+                    "DAEMONNAME": daemonname
                 },
                 "./ansible/service_{0}_disabled.yml", servicename
             )
@@ -46,8 +46,8 @@ class ServiceDisabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_PUPPET_service_disabled",
                 {
-                    "%SERVICENAME%": servicename,
-                    "%DAEMONNAME%": daemonname
+                    "SERVICENAME": servicename,
+                    "DAEMONNAME": daemonname
                 },
                 "./puppet/service_{0}_disabled.yml", servicename
             )
@@ -56,9 +56,9 @@ class ServiceDisabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_service_disabled",
                 {
-                    "%SERVICENAME%": servicename,
-                    "%DAEMONNAME%":  daemonname,
-                    "%PACKAGENAME%": packagename
+                    "SERVICENAME": servicename,
+                    "DAEMONNAME":  daemonname,
+                    "PACKAGENAME": packagename
                 },
                 "./oval/service_{0}_disabled.xml", servicename
             )

--- a/shared/templates/create_services_enabled.py
+++ b/shared/templates/create_services_enabled.py
@@ -28,9 +28,9 @@ class ServiceEnabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_OVAL_service_enabled",
                 {
-                    "%SERVICENAME%": servicename,
-                    "%PACKAGENAME%": packagename,
-                    "%DAEMONNAME%": daemonname
+                    "SERVICENAME": servicename,
+                    "PACKAGENAME": packagename,
+                    "DAEMONNAME": daemonname
                 },
                 "./oval/service_{0}_enabled.xml", servicename
             )
@@ -38,8 +38,8 @@ class ServiceEnabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_BASH_service_enabled",
                 {
-                    "%SERVICENAME%": servicename,
-                    "%DAEMONNAME%": daemonname
+                    "SERVICENAME": servicename,
+                    "DAEMONNAME": daemonname
                 },
                 "./bash/service_{0}_enabled.sh", servicename
             )
@@ -48,8 +48,8 @@ class ServiceEnabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_service_enabled",
                 {
-                    "%SERVICENAME%": servicename,
-                    "%DAEMONNAME%": daemonname
+                    "SERVICENAME": servicename,
+                    "DAEMONNAME": daemonname
                 },
                 "./ansible/service_{0}_enabled.yml", servicename
             )
@@ -58,8 +58,8 @@ class ServiceEnabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_PUPPET_service_enabled",
                 {
-                    "%SERVICENAME%": servicename,
-                    "%DAEMONNAME%": daemonname
+                    "SERVICENAME": servicename,
+                    "DAEMONNAME": daemonname
                 },
                 "./puppet/service_{0}_enabled.yml", servicename
             )

--- a/shared/templates/create_sysctl.py
+++ b/shared/templates/create_sysctl.py
@@ -45,8 +45,8 @@ class SysctlGenerator(FilesGenerator):
                 self.file_from_template(
                     "template_BASH_sysctl_var",
                     {
-                        "%SYSCTLID%":  sysctl_var_id,
-                        "%SYSCTLVAR%": sysctl_var
+                        "SYSCTLID":  sysctl_var_id,
+                        "SYSCTLVAR": sysctl_var
                     },
                     "./bash/sysctl_{0}.sh", sysctl_var_id
                 )
@@ -54,9 +54,9 @@ class SysctlGenerator(FilesGenerator):
                 self.file_from_template(
                     "./template_BASH_sysctl",
                     {
-                        "%SYSCTLID%":  sysctl_var_id,
-                        "%SYSCTLVAR%": sysctl_var,
-                        "%SYSCTLVAL%": sysctl_val
+                        "SYSCTLID":  sysctl_var_id,
+                        "SYSCTLVAR": sysctl_var,
+                        "SYSCTLVAL": sysctl_val
                     },
                     "./bash/sysctl_{0}.sh", sysctl_var_id
                 )
@@ -68,8 +68,8 @@ class SysctlGenerator(FilesGenerator):
                 self.file_from_template(
                     "template_ANSIBLE_sysctl_var",
                     {
-                        "%SYSCTLID%":  sysctl_var_id,
-                        "%SYSCTLVAR%": sysctl_var
+                        "SYSCTLID":  sysctl_var_id,
+                        "SYSCTLVAR": sysctl_var
                     },
                     "./ansible/sysctl_{0}.yml", sysctl_var_id
                 )
@@ -77,9 +77,9 @@ class SysctlGenerator(FilesGenerator):
                 self.file_from_template(
                     "./template_ANSIBLE_sysctl",
                     {
-                        "%SYSCTLID%":  sysctl_var_id,
-                        "%SYSCTLVAR%": sysctl_var,
-                        "%SYSCTLVAL%": sysctl_val
+                        "SYSCTLID":  sysctl_var_id,
+                        "SYSCTLVAR": sysctl_var,
+                        "SYSCTLVAL": sysctl_val
                     },
                     "./ansible/sysctl_{0}.yml", sysctl_var_id
                 )
@@ -93,8 +93,8 @@ class SysctlGenerator(FilesGenerator):
                     self.file_from_template(
                         sysctlfile,
                         {
-                            "%SYSCTLID%":  sysctl_var_id,
-                            "%SYSCTLVAR%": sysctl_var,
+                            "SYSCTLID":  sysctl_var_id,
+                            "SYSCTLVAR": sysctl_var,
                         },
                         "./oval/{0}.xml", prefix + sysctl_var_id
                     )
@@ -105,9 +105,9 @@ class SysctlGenerator(FilesGenerator):
                     self.file_from_template(
                         sysctlfile,
                         {
-                            "%SYSCTLID%":  sysctl_var_id,
-                            "%SYSCTLVAR%": sysctl_var,
-                            "%SYSCTLVAL%": sysctl_val
+                            "SYSCTLID":  sysctl_var_id,
+                            "SYSCTLVAR": sysctl_var,
+                            "SYSCTLVAL": sysctl_val
                         },
                         "./oval/{0}.xml", prefix + sysctl_var_id
                     )

--- a/shared/templates/template_ANACONDA_mount
+++ b/shared/templates/template_ANACONDA_mount
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = high
 
-part %MOUNTPOINT%
+part {{{ MOUNTPOINT }}}

--- a/shared/templates/template_ANACONDA_mount_option
+++ b/shared/templates/template_ANACONDA_mount_option
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = high
 
-part %MOUNTPOINT% --mountoptions="%MOUNTOPTION%"
+part {{{ MOUNTPOINT }}} --mountoptions="{{{ MOUNTOPTION }}}"

--- a/shared/templates/template_ANACONDA_mount_option_var
+++ b/shared/templates/template_ANACONDA_mount_option_var
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = high
 
-part (anaconda-populate %MOUNTPOINT%) --mountoptions="%MOUNTOPTION%"
+part (anaconda-populate {{{ MOUNTPOINT }}}) --mountoptions="{{{ MOUNTOPTION }}}"

--- a/shared/templates/template_ANACONDA_package_installed
+++ b/shared/templates/template_ANACONDA_package_installed
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-package --add=%PKGNAME%
+package --add={{{ PKGNAME }}}

--- a/shared/templates/template_ANACONDA_package_removed
+++ b/shared/templates/template_ANACONDA_package_removed
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-package --remove=%PKGNAME%
+package --remove={{{ PKGNAME }}}

--- a/shared/templates/template_ANSIBLE_accounts_password
+++ b/shared/templates/template_ANSIBLE_accounts_password
@@ -3,9 +3,9 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- (xccdf-var var_password_pam_%VARIABLE%)
+- (xccdf-var var_password_pam_{{{ VARIABLE }}})
 
-- name: Ensure PAM variable %VARIABLE% is set accordingly
+- name: Ensure PAM variable {{{ VARIABLE }}} is set accordingly
 {{% if product == "rhel6" %}}
   pamd:
     name: system-auth
@@ -13,13 +13,13 @@
     control: requisite
     module_path: pam_cracklib.so
     state: args_present
-    module_args: '%VARIABLE% = {{ var_password_pam_%VARIABLE% }}'
+    module_args: '{{{ VARIABLE }}} = {{ var_password_pam_{{{ VARIABLE }}} }}'
 {{% else %}}
   lineinfile:
     create=yes
     dest="/etc/security/pwquality.conf"
-    regexp="^#?\s*%VARIABLE%"
-    line="%VARIABLE% = {{ var_password_pam_%VARIABLE% }}"
+    regexp="^#?\s*{{{ VARIABLE }}}"
+    line="{{{ VARIABLE }}} = {{ var_password_pam_{{{ VARIABLE }}} }}"
 {{% endif %}}
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_audit_rules_dac_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_dac_modification
@@ -7,7 +7,7 @@
 #
 # What architecture are we on?
 #
-- name: Set architecture for audit %ATTR% tasks
+- name: Set architecture for audit {{{ ATTR }}} tasks
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
@@ -20,57 +20,57 @@
     recurse: no
     contains: "-F key=perm_mod$"
     patterns: "*.rules"
-  register: find_%ATTR%
+  register: find_{{{ ATTR }}}
 
 - name: If existing DAC ruleset not found, use /etc/audit/rules.d/privileged.rules as the recipient for the rule
   set_fact:
-    all_files: 
+    all_files:
       - /etc/audit/rules.d/privileged.rules
-  when: find_%ATTR%.matched == 0
+  when: find_{{{ ATTR }}}.matched == 0
 
 - name: Use matched file as the recipient for the rule
   set_fact:
     all_files:
-      - "{{ find_%ATTR%.files | map(attribute='path') | list | first }}"
-  when: find_%ATTR%.matched > 0
+      - "{{ find_{{{ ATTR }}}.files | map(attribute='path') | list | first }}"
+  when: find_{{{ ATTR }}}.matched > 0
 
-- name: Inserts/replaces the %ATTR% rule in rules.d when on x86
+- name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on x86
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b32 -S %ATTR% -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
+    line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
     create: yes
   tags:
     @ANSIBLE_TAGS@
 
-- name: Inserts/replaces the %ATTR% rule in rules.d when on x86_64
+- name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on x86_64
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b64 -S %ATTR% -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
+    line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
     create: yes
   when: audit_arch == 'b64'
   tags:
     @ANSIBLE_TAGS@
-#    
+#   
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
-- name: Inserts/replaces the %ATTR% rule in /etc/audit/audit.rules when on x86
+- name: Inserts/replaces the {{{ ATTR }}} rule in /etc/audit/audit.rules when on x86
   lineinfile:
     line: "{{ item }}"
     state: present
     dest: /etc/audit/audit.rules
   with_items:
-    - "-a always,exit -F arch=b32 -S %ATTR% -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
+    - "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
   tags:
     @ANSIBLE_TAGS@
 
-- name: Inserts/replaces the %ATTR% rule in audit.rules when on x86_64
+- name: Inserts/replaces the {{{ ATTR }}} rule in audit.rules when on x86_64
   lineinfile:
     line: "{{ item }}"
     state: present
     dest: /etc/audit/audit.rules
     create: yes
   with_items:
-    - "-a always,exit -F arch=b64 -S %ATTR% -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
+    - "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
   when: audit_arch == 'b64'
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_audit_rules_file_deletion_events
+++ b/shared/templates/template_ANSIBLE_audit_rules_file_deletion_events
@@ -7,7 +7,7 @@
 #
 # What architecture are we on?
 #
-- name: Set architecture for audit %NAME% tasks
+- name: Set architecture for audit {{{ NAME }}} tasks
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
@@ -20,67 +20,67 @@
     recurse: no
     contains: "-F key=delete$"
     patterns: "*.rules"
-  register: find_%NAME%
+  register: find_{{{ NAME }}}
 
 - name: If existing DAC ruleset not found, use /etc/audit/rules.d/delete.rules as the recipient for the rule
   set_fact:
-    all_files: 
+    all_files:
       - /etc/audit/rules.d/delete.rules
-  when: find_%NAME%.matched == 0
+  when: find_{{{ NAME }}}.matched == 0
 
 - name: Use matched file as the recipient for the rule
   set_fact:
     all_files:
-      - "{{ find_%NAME%.files | map(attribute='path') | list | first }}"
-  when: find_%NAME%.matched > 0
+      - "{{ find_{{{ NAME }}}.files | map(attribute='path') | list | first }}"
+  when: find_{{{ NAME }}}.matched > 0
 
-- name: Inserts/replaces the %NAME% rule in rules.d when on x86
+- name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b32 -S %NAME% -F auid>=1000 -F auid!=4294967295 -F key=delete"
+    line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>=1000 -F auid!=4294967295 -F key=delete"
     create: yes
   tags:
     @ANSIBLE_TAGS@
 
-- name: Inserts/replaces the %NAME% rule in rules.d when on x86_64
+- name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86_64
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b64 -S %NAME% -F auid>=1000 -F auid!=4294967295 -F key=delete"
+    line: "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>=1000 -F auid!=4294967295 -F key=delete"
     create: yes
   when: audit_arch == 'b64'
   tags:
     @ANSIBLE_TAGS@
 
-- name: Inserts/replaces the %NAME% rule in rules.d when on x86
+- name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b32 -S %NAME% -F auid>=1000 -F auid!=4294967295 -F key=delete"
+    line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>=1000 -F auid!=4294967295 -F key=delete"
     create: yes
   when: audit_arch == 'b32'
   tags:
     @ANSIBLE_TAGS@
-#    
+#   
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
-- name: Inserts/replaces the %NAME% rule in /etc/audit/audit.rules when on x86
+- name: Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules when on x86
   lineinfile:
     line: "{{ item }}"
     state: present
     dest: /etc/audit/audit.rules
   with_items:
-    - "-a always,exit -F arch=b32 -S %NAME% -F auid>=1000 -F auid!=4294967295 -F key=delete"
+    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>=1000 -F auid!=4294967295 -F key=delete"
   when: audit_arch == 'b32'
   tags:
     @ANSIBLE_TAGS@
 
-- name: Inserts/replaces the %NAME% rule in audit.rules when on x86_64
+- name: Inserts/replaces the {{{ NAME }}} rule in audit.rules when on x86_64
   lineinfile:
     line: "{{ item }}"
     state: present
     dest: /etc/audit/audit.rules
     create: yes
   with_items:
-    - "-a always,exit -F arch=b64 -S %NAME% -F auid>=1000 -F auid!=4294967295 -F key=delete"
+    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>=1000 -F auid!=4294967295 -F key=delete"
   when: audit_arch == 'b64'
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_audit_rules_login_events
+++ b/shared/templates/template_ANSIBLE_audit_rules_login_events
@@ -7,7 +7,7 @@
 #
 # What architecture are we on?
 #
-- name: Set architecture for audit %NAME% tasks
+- name: Set architecture for audit {{{ NAME }}} tasks
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
@@ -20,37 +20,37 @@
     recurse: no
     contains: "-k logins$"
     patterns: "*.rules"
-  register: find_%NAME%
+  register: find_{{{ NAME }}}
 
 - name: If existing user/group modification ruleset not found, use /etc/audit/rules.d/logins.rules as the recipient for the rule
   set_fact:
-    all_files: 
+    all_files:
       - /etc/audit/rules.d/logins.rules
-  when: find_%NAME%.matched == 0
+  when: find_{{{ NAME }}}.matched == 0
 
 - name: Use matched file as the recipient for the rule
   set_fact:
     all_files:
-      - "{{ find_%NAME%.files | map(attribute='path') | list | first }}"
-  when: find_%NAME%.matched > 0
+      - "{{ find_{{{ NAME }}}.files | map(attribute='path') | list | first }}"
+  when: find_{{{ NAME }}}.matched > 0
 
-- name: Inserts/replaces the %NAME% rule in rules.d when on x86
+- name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-w %PATH% -p wa -k logins"
+    line: "-w {{{ PATH }}} -p wa -k logins"
     create: yes
   tags:
     @ANSIBLE_TAGS@
 
-#    
+#   
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
-- name: Inserts/replaces the %NAME% rule in /etc/audit/audit.rules 
+- name: Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules
   lineinfile:
     line: "{{ item }}"
     state: present
     dest: /etc/audit/audit.rules
   with_items:
-    - "-w %PATH% -p wa -k logins"
+    - "-w {{{ PATH }}} -p wa -k logins"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_audit_rules_privileged_commands
+++ b/shared/templates/template_ANSIBLE_audit_rules_privileged_commands
@@ -10,36 +10,36 @@
   find:
     paths: "/etc/audit/rules.d"
     recurse: no
-    contains: "^.*path=%PATH%.*$"
+    contains: "^.*path={{{ PATH }}}.*$"
     patterns: "*.rules"
-  register: find_%NAME%
+  register: find_{{{ NAME }}}
 
 - name: Use /etc/audit/rules.d/privileged.rules as the recipient for the rule
   set_fact:
-    all_files: 
+    all_files:
       - /etc/audit/rules.d/privileged.rules
-  when: find_%NAME%.matched == 0
+  when: find_{{{ NAME }}}.matched == 0
 
 - name: Use matched file as the recipient for the rule
   set_fact:
     all_files:
-      - "{{ find_%NAME%.files | map(attribute='path') | list | first }}"
-  when: find_%NAME%.matched > 0
+      - "{{ find_{{{ NAME }}}.files | map(attribute='path') | list | first }}"
+  when: find_{{{ NAME }}}.matched > 0
 
-- name: Inserts/replaces the %NAME% rule in rules.d
+- name: Inserts/replaces the {{{ NAME }}} rule in rules.d
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: '-a always,exit -F path=%PATH% -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged'
+    line: '-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged'
     create: yes
   tags:
     @ANSIBLE_TAGS@
-    
-# Inserts/replaces the %NAME% rule in /etc/audit/audit.rules
+   
+# Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules
 
-- name: Inserts/replaces the %NAME% rule in audit.rules
+- name: Inserts/replaces the {{{ NAME }}} rule in audit.rules
   lineinfile:
     path: /etc/audit/audit.rules
-    line: '-a always,exit -F path=%PATH% -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged'
+    line: '-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged'
     create: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_unsuccessful_file_modification
@@ -7,7 +7,7 @@
 #
 # What architecture are we on?
 #
-- name: Set architecture for audit %NAME% tasks
+- name: Set architecture for audit {{{ NAME }}} tasks
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
@@ -20,65 +20,65 @@
     recurse: no
     contains: "-F key=perm_mod$"
     patterns: "*.rules"
-  register: find_%NAME%
+  register: find_{{{ NAME }}}
 
 - name: If existing DAC ruleset not found, use /etc/audit/rules.d/access.rules as the recipient for the rule
   set_fact:
-    all_files: 
+    all_files:
       - /etc/audit/rules.d/access.rules
-  when: find_%NAME%.matched == 0
+  when: find_{{{ NAME }}}.matched == 0
 
 - name: Use matched file as the recipient for the rule
   set_fact:
     all_files:
-      - "{{ find_%NAME%.files | map(attribute='path') | list | first }}"
-  when: find_%NAME%.matched > 0
+      - "{{ find_{{{ NAME }}}.files | map(attribute='path') | list | first }}"
+  when: find_{{{ NAME }}}.matched > 0
 
-- name: Inserts/replaces the %NAME% rule in rules.d when on x86
+- name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86
   lineinfile:
     path: "{{ all_files[0] }}"
     line: "{{ item }}"
     create: yes
   with_items:
-    - "-a always,exit -F arch=b32 -S %NAME% -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
-    - "-a always,exit -F arch=b32 -S %NAME% -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
   tags:
     @ANSIBLE_TAGS@
 
-- name: Inserts/replaces the %NAME% rule in rules.d when on x86_64
+- name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86_64
   lineinfile:
     path: "{{ all_files[0] }}"
     line: "{{ item }}"
     create: yes
   with_items:
-    - "-a always,exit -F arch=b64 -S %NAME% -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
-    - "-a always,exit -F arch=b64 -S %NAME% -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
   when: audit_arch == 'b64'
   tags:
     @ANSIBLE_TAGS@
-#    
+#   
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
-- name: Inserts/replaces the %NAME% rule in /etc/audit/audit.rules when on x86
+- name: Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules when on x86
   lineinfile:
     line: "{{ item }}"
     state: present
     dest: /etc/audit/audit.rules
   with_items:
-    - "-a always,exit -F arch=b32 -S %NAME% -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
-    - "-a always,exit -F arch=b32 -S %NAME% -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
   tags:
     @ANSIBLE_TAGS@
 
-- name: Inserts/replaces the %NAME% rule in audit.rules when on x86_64
+- name: Inserts/replaces the {{{ NAME }}} rule in audit.rules when on x86_64
   lineinfile:
     line: "{{ item }}"
     state: present
     dest: /etc/audit/audit.rules
     create: yes
   with_items:
-    - "-a always,exit -F arch=b64 -S %NAME% -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
-    - "-a always,exit -F arch=b64 -S %NAME% -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
   when: audit_arch == 'b64'
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_audit_rules_usergroup_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_usergroup_modification
@@ -7,7 +7,7 @@
 #
 # What architecture are we on?
 #
-- name: Set architecture for audit %NAME% tasks
+- name: Set architecture for audit {{{ NAME }}} tasks
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
@@ -20,37 +20,37 @@
     recurse: no
     contains: "-k audit_rules_usergroup_modification$"
     patterns: "*.rules"
-  register: find_%NAME%
+  register: find_{{{ NAME }}}
 
 - name: If existing user/group modification ruleset not found, use /etc/audit/rules.d/privileged.rules as the recipient for the rule
   set_fact:
-    all_files: 
+    all_files:
       - /etc/audit/rules.d/privileged.rules
-  when: find_%NAME%.matched == 0
+  when: find_{{{ NAME }}}.matched == 0
 
 - name: Use matched file as the recipient for the rule
   set_fact:
     all_files:
-      - "{{ find_%NAME%.files | map(attribute='path') | list | first }}"
-  when: find_%NAME%.matched > 0
+      - "{{ find_{{{ NAME }}}.files | map(attribute='path') | list | first }}"
+  when: find_{{{ NAME }}}.matched > 0
 
-- name: Inserts/replaces the %NAME% rule in rules.d when on x86
+- name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-w %PATH% -p wa -k audit_rules_usergroup_modification"
+    line: "-w {{{ PATH }}} -p wa -k audit_rules_usergroup_modification"
     create: yes
   tags:
     @ANSIBLE_TAGS@
 
-#    
+#   
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
-- name: Inserts/replaces the %NAME% rule in /etc/audit/audit.rules 
+- name: Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules
   lineinfile:
     line: "{{ item }}"
     state: present
     dest: /etc/audit/audit.rules
   with_items:
-    - "-w %PATH% -p wa -k audit_rules_usergroup_modification"
+    - "-w {{{ PATH }}} -p wa -k audit_rules_usergroup_modification"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_file_groupowner
+++ b/shared/templates/template_ANSIBLE_file_groupowner
@@ -4,18 +4,18 @@
 # complexity = low
 # disruption = low
 
-- name: Find %PATH% file(s)
+- name: Find {{{ PATH }}} file(s)
   find:
-    paths: "{{ '%PATH%' | dirname }}"
-    patterns: "{{ '%PATH%' | basename }}"
+    paths: "{{ '{{{ PATH }}}' | dirname }}"
+    patterns: "{{ '{{{ PATH }}}' | basename }}"
   register: files_found
   tags:
     @ANSIBLE_TAGS@
 
-- name: Set group ownership to %GROUP%
+- name: Set group ownership to {{{ GROUP }}}
   file:
     path: "{{ item.path }}"
-    group: %GROUP%
+    group: {{{ GROUP }}}
   with_items:
     - "{{ files_found.files }}"
   tags:

--- a/shared/templates/template_ANSIBLE_file_owner
+++ b/shared/templates/template_ANSIBLE_file_owner
@@ -4,18 +4,18 @@
 # complexity = low
 # disruption = low
 
-- name: Find %PATH% file(s)
+- name: Find {{{ PATH }}} file(s)
   find:
-    paths: "{{ '%PATH%' | dirname }}"
-    patterns: "{{ '%PATH%' | basename }}"
+    paths: "{{ '{{{ PATH }}}' | dirname }}"
+    patterns: "{{ '{{{ PATH }}}' | basename }}"
   register: files_found
   tags:
     @ANSIBLE_TAGS@
 
-- name: Set user ownership to %USER%
+- name: Set user ownership to {{{ USER }}}
   file:
     path: "{{ item.path }}"
-    owner: %USER%
+    owner: {{{ USER }}}
   with_items:
     - "{{ files_found.files }}"
   tags:

--- a/shared/templates/template_ANSIBLE_file_permissions
+++ b/shared/templates/template_ANSIBLE_file_permissions
@@ -4,10 +4,10 @@
 # complexity = low
 # disruption = low
 
-- name: Find %PATH% file(s)
+- name: Find {{{ PATH }}} file(s)
   find:
-    paths: "{{ '%PATH%' | dirname }}"
-    patterns: "{{ '%PATH%' | basename }}"
+    paths: "{{ '{{{ PATH }}}' | dirname }}"
+    patterns: "{{ '{{{ PATH }}}' | basename }}"
   register: files_found
   tags:
     @ANSIBLE_TAGS@
@@ -15,7 +15,7 @@
 - name: Set permissions
   file:
     path: "{{ item.path }}"
-    mode: %MODE%
+    mode: {{{ MODE }}}
   with_items:
     - "{{ files_found.files }}"
   tags:

--- a/shared/templates/template_ANSIBLE_kernel_module_disabled
+++ b/shared/templates/template_ANSIBLE_kernel_module_disabled
@@ -3,14 +3,14 @@
 # strategy = disable
 # complexity = low
 # disruption = medium
-- name: Ensure kernel module '%KERNMODULE%' is disabled
+- name: Ensure kernel module '{{{ KERNMODULE }}}' is disabled
   lineinfile:
     create=yes
     dest="/etc/modprobe.d/{{item}}.conf"
     regexp="{{item}}"
     line="install {{item}} /bin/true"
   with_items:
-    - %KERNMODULE%
+    - {{{ KERNMODULE }}}
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -4,31 +4,31 @@
 # complexity = low
 # disruption = high
 - name: get back device associated to mountpoint
-  shell: mount | grep ' %MOUNTPOINT% ' |cut -d ' ' -f 1
+  shell: mount | grep ' {{{ MOUNTPOINT }}} ' |cut -d ' ' -f 1
   register: device_name
   check_mode: no
   tags:
     @ANSIBLE_TAGS@
 
 - name: get back device previous mount option
-  shell: mount | grep ' %MOUNTPOINT% ' | sed -re 's:.*\((.*)\):\1:'
+  shell: mount | grep ' {{{ MOUNTPOINT }}} ' | sed -re 's:.*\((.*)\):\1:'
   register: device_cur_mountoption
   check_mode: no
   tags:
     @ANSIBLE_TAGS@
 
 - name: get back device fstype
-  shell: mount | grep ' %MOUNTPOINT% ' | cut -d ' ' -f 5
+  shell: mount | grep ' {{{ MOUNTPOINT }}} ' | cut -d ' ' -f 5
   register: device_fstype
   check_mode: no
   tags:
     @ANSIBLE_TAGS@
 
-- name: Ensure permission %MOUNTOPTION% are set on %MOUNTPOINT%
+- name: Ensure permission {{{ MOUNTOPTION }}} are set on {{{ MOUNTPOINT }}}
   mount:
-    path: "%MOUNTPOINT%"
+    path: "{{{ MOUNTPOINT }}}"
     src: "{{device_name.stdout}}"
-    opts: "{{device_cur_mountoption.stdout}},%MOUNTOPTION%"
+    opts: "{{device_cur_mountoption.stdout}},{{{ MOUNTOPTION }}}"
     state: "mounted"
     fstype: "{{device_fstype.stdout}}"
   tags:

--- a/shared/templates/template_ANSIBLE_mount_option_var
+++ b/shared/templates/template_ANSIBLE_mount_option_var
@@ -3,34 +3,34 @@
 # strategy = configure
 # complexity = low
 # disruption = high
-- (xccdf-var %MOUNTPOINT%)
+- (xccdf-var {{{ MOUNTPOINT }}})
 
 - name: get back device associated to mountpoint
-  shell: mount | grep ' {{ %MOUNTPOINT% }} ' |cut -d ' ' -f 1
+  shell: mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' |cut -d ' ' -f 1
   register: device_name
   check_mode: no
   tags:
     @ANSIBLE_TAGS@
 
 - name: get back device previous mount option
-  shell: mount | grep ' {{ %MOUNTPOINT% }} ' | sed -re 's:.*\((.*)\):\1:'
+  shell: mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' | sed -re 's:.*\((.*)\):\1:'
   register: device_cur_mountoption
   check_mode: no
   tags:
     @ANSIBLE_TAGS@
 
 - name: get back device fstype
-  shell: mount | grep ' {{ %MOUNTPOINT% }} ' | cut -d ' ' -f 5
+  shell: mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' | cut -d ' ' -f 5
   register: device_fstype
   check_mode: no
   tags:
     @ANSIBLE_TAGS@
 
-- name: Ensure permission %MOUNTOPTION% are set on %MOUNTPOINT%
+- name: Ensure permission {{{ MOUNTOPTION }}} are set on {{{ MOUNTPOINT }}}
   mount:
-    path: "{{ %MOUNTPOINT% }}"
+    path: "{{ {{{ MOUNTPOINT }}} }}"
     src: "{{device_name.stdout}}"
-    opts: "{{ device_cur_mountoption.stdout }},%MOUNTOPTION%"
+    opts: "{{ device_cur_mountoption.stdout }},{{{ MOUNTOPTION }}}"
     state: "mounted"
     fstype: "{{device_fstype.stdout}}"
   tags:

--- a/shared/templates/template_ANSIBLE_package_installed
+++ b/shared/templates/template_ANSIBLE_package_installed
@@ -3,12 +3,12 @@
 # strategy = enable
 # complexity = low
 # disruption = low
-- name: Ensure %PKGNAME% is installed
+- name: Ensure {{{ PKGNAME }}} is installed
   package:
     name="{{item}}"
     state=present
   with_items:
-    - %PKGNAME%
+    - {{{ PKGNAME }}}
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/template_ANSIBLE_package_removed
+++ b/shared/templates/template_ANSIBLE_package_removed
@@ -3,12 +3,12 @@
 # strategy = disable
 # complexity = low
 # disruption = low
-- name: Ensure %PKGNAME% is removed
+- name: Ensure {{{ PKGNAME }}} is removed
   package:
     name="{{item}}"
     state=absent
   with_items:
-    - %PKGNAME%
+    - {{{ PKGNAME }}}
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/template_ANSIBLE_permissions
+++ b/shared/templates/template_ANSIBLE_permissions
@@ -3,12 +3,12 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-- name: Ensure permission %FILEMODE% on %FILEPATH%
+- name: Ensure permission {{{ FILEMODE }}} on {{{ FILEPATH }}}
   file:
     path="{{item}}"
-    mode=%FILEMODE%
+    mode={{{ FILEMODE }}}
   with_items:
-    - %FILEPATH%
+    - {{{ FILEPATH }}}
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/template_ANSIBLE_sebool
+++ b/shared/templates/template_ANSIBLE_sebool
@@ -3,10 +3,10 @@
 # strategy = enable
 # complexity = low
 # disruption = low
-- name: Set SELinux boolean %SEBOOLID% to %SEBOOL_BOOL%
+- name: Set SELinux boolean {{{ SEBOOLID }}} to {{{ SEBOOL_BOOL }}}
   seboolean:
-    name: %SEBOOLID%
-    state: %SEBOOL_BOOL%
+    name: {{{ SEBOOLID }}}
+    state: {{{ SEBOOL_BOOL }}}
     persistent: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_sebool_var
+++ b/shared/templates/template_ANSIBLE_sebool_var
@@ -3,17 +3,17 @@
 # strategy = enable
 # complexity = low
 # disruption = low
-- (xccdf-var var_%SEBOOLID%)
+- (xccdf-var var_{{{ SEBOOLID }}})
 
 - name: Ensure libsemanage-python installed
   package:
     name: libsemanage-python
     state: latest
 
-- name: Set SELinux boolean %SEBOOLID% accordingly
+- name: Set SELinux boolean {{{ SEBOOLID }}} accordingly
   seboolean:
-    name: %SEBOOLID%
-    state: "{{ var_%SEBOOLID% }}"
+    name: {{{ SEBOOLID }}}
+    state: "{{ var_{{{ SEBOOLID }}} }}"
     persistent: yes
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -3,7 +3,7 @@
 # strategy = disable
 # complexity = low
 # disruption = low
-- name: Disable service %SERVICENAME%
+- name: Disable service {{{ SERVICENAME }}}
   service:
     name="{{item}}"
     enabled="no"
@@ -11,12 +11,12 @@
   register: service_result
   failed_when: "service_result is failed and ('Could not find the requested service' not in service_result.msg)"
   with_items:
-    - %DAEMONNAME%
+    - {{{ DAEMONNAME }}}
   tags:
     @ANSIBLE_TAGS@
 
 {{% if init_system == "systemd" %}}
-- name: Disable socket of service %SERVICENAME% if applicable
+- name: Disable socket of service {{{ SERVICENAME }}} if applicable
   service:
     name="{{item}}"
     enabled="no"
@@ -24,7 +24,7 @@
   register: socket_result
   failed_when: "socket_result is failed and ('Could not find the requested service' not in socket_result.msg)"
   with_items:
-    - %DAEMONNAME%.socket
+    - {{{ DAEMONNAME }}}.socket
   tags:
     @ANSIBLE_TAGS@
 {{% endif %}}

--- a/shared/templates/template_ANSIBLE_service_enabled
+++ b/shared/templates/template_ANSIBLE_service_enabled
@@ -3,13 +3,13 @@
 # strategy = enable
 # complexity = low
 # disruption = low
-- name: Enable service %SERVICENAME%
+- name: Enable service {{{ SERVICENAME }}}
   service:
     name="{{item}}"
     enabled="yes"
     state="started"
   with_items:
-    - %DAEMONNAME%
+    - {{{ DAEMONNAME }}}
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/template_ANSIBLE_sysctl
+++ b/shared/templates/template_ANSIBLE_sysctl
@@ -3,10 +3,10 @@
 # strategy = disable
 # complexity = low
 # disruption = medium
-- name: Ensure sysctl %SYSCTLVAR% is set to %SYSCTLVAL%
+- name: Ensure sysctl {{{ SYSCTLVAR }}} is set to {{{ SYSCTLVAL }}}
   sysctl:
-    name: %SYSCTLVAR%
-    value: %SYSCTLVAL%
+    name: {{{ SYSCTLVAR }}}
+    value: {{{ SYSCTLVAL }}}
     state: present
     reload: yes
   tags:

--- a/shared/templates/template_ANSIBLE_sysctl_var
+++ b/shared/templates/template_ANSIBLE_sysctl_var
@@ -3,12 +3,12 @@
 # strategy = disable
 # complexity = low
 # disruption = medium
-- (xccdf-var sysctl_%SYSCTLID%_value)
+- (xccdf-var sysctl_{{{ SYSCTLID }}}_value)
 
-- name: Ensure sysctl %SYSCTLVAR% is set
+- name: Ensure sysctl {{{ SYSCTLVAR }}} is set
   sysctl:
-    name: %SYSCTLVAR%
-    value: "{{ sysctl_%SYSCTLID%_value }}"
+    name: {{{ SYSCTLVAR }}}
+    value: "{{ sysctl_{{{ SYSCTLID }}}_value }}"
     state: present
     reload: yes
   tags:

--- a/shared/templates/template_BASH_accounts_password
+++ b/shared/templates/template_BASH_accounts_password
@@ -4,19 +4,19 @@
 # complexity = low
 # disruption = low
 . /usr/share/scap-security-guide/remediation_functions
-populate var_password_pam_%VARIABLE%
+populate var_password_pam_{{{ VARIABLE }}}
 
 {{% if product == "rhel6" %}}
 {{# There is no package libpwquality for RHEL6 #}}
 
-if LC_ALL=C grep -m 1 -q -e "%VARIABLE%=" /etc/pam.d/system-auth; then
-	sed -i --follow-symlinks "s/\(%VARIABLE% *= *\).*/\1$var_password_pam_%VARIABLE%/" /etc/pam.d/system-auth
+if LC_ALL=C grep -m 1 -q -e "{{{ VARIABLE }}}=" /etc/pam.d/system-auth; then
+	sed -i --follow-symlinks "s/\({{{ VARIABLE }}} *= *\).*/\1$var_password_pam_{{{ VARIABLE }}}/" /etc/pam.d/system-auth
 else
-	sed -i --follow-symlinks "/pam_cracklib.so/ s/$/ %VARIABLE%=$var_password_pam_%VARIABLE%/" /etc/pam.d/system-auth
+	sed -i --follow-symlinks "/pam_cracklib.so/ s/$/ {{{ VARIABLE }}}=$var_password_pam_{{{ VARIABLE }}}/" /etc/pam.d/system-auth
 fi
 
 {{% else %}}
 
-replace_or_append '/etc/security/pwquality.conf' '^%VARIABLE%' $var_password_pam_%VARIABLE% '@CCENUM@' '%s = %s'
+replace_or_append '/etc/security/pwquality.conf' '^{{{ VARIABLE }}}' $var_password_pam_{{{ VARIABLE }}} '@CCENUM@' '%s = %s'
 
 {{% endif %}}

--- a/shared/templates/template_BASH_audit_rules_dac_modification
+++ b/shared/templates/template_BASH_audit_rules_dac_modification
@@ -9,9 +9,9 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S %ATTR%.*"
+	PATTERN="-a always,exit -F arch=$ARCH -S {{{ ATTR }}}.*"
 	GROUP="perm_mod"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S %ATTR% -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
 
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_BASH_audit_rules_file_deletion_events
+++ b/shared/templates/template_BASH_audit_rules_file_deletion_events
@@ -9,9 +9,9 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S %NAME%.*"
+	PATTERN="-a always,exit -F arch=$ARCH -S {{{ NAME }}}.*"
 	GROUP="delete"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S %NAME% -F auid>=1000 -F auid!=4294967295 -F key=delete"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F auid>=1000 -F auid!=4294967295 -F key=delete"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_BASH_audit_rules_login_events
+++ b/shared/templates/template_BASH_audit_rules_login_events
@@ -5,5 +5,5 @@
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 
-fix_audit_watch_rule "auditctl" "%PATH%" "wa" "logins"
-fix_audit_watch_rule "augenrules" "%PATH%" "wa" "logins"
+fix_audit_watch_rule "auditctl" "{{{ PATH }}}" "wa" "logins"
+fix_audit_watch_rule "augenrules" "{{{ PATH }}}" "wa" "logins"

--- a/shared/templates/template_BASH_audit_rules_privileged_commands
+++ b/shared/templates/template_BASH_audit_rules_privileged_commands
@@ -3,9 +3,9 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-PATTERN="-a always,exit -F path=%PATH%\\s*.*"
+PATTERN="-a always,exit -F path={{{ PATH }}}\\s*.*"
 GROUP="privileged"
-FULL_RULE="-a always,exit -F path=%PATH% -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged"
+FULL_RULE="-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged"
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_BASH_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_BASH_audit_rules_unsuccessful_file_modification
@@ -9,9 +9,9 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S %NAME% -F exit=-EACCES.*"
+	PATTERN="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EACCES.*"
 	GROUP="access"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S %NAME% -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
@@ -19,9 +19,9 @@ done
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-        PATTERN="-a always,exit -F arch=$ARCH -S %NAME% -F exit=-EPERM.*" 
+        PATTERN="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EPERM.*"
         GROUP="access"
-        FULL_RULE="-a always,exit -F arch=$ARCH -S %NAME% -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
+        FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access"
         # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
         fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
         fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_BASH_audit_rules_usergroup_modification
+++ b/shared/templates/template_BASH_audit_rules_usergroup_modification
@@ -5,5 +5,5 @@
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 
-fix_audit_watch_rule "auditctl" "%PATH%" "wa" "audit_rules_usergroup_modification"
-fix_audit_watch_rule "augenrules" "%PATH%" "wa" "audit_rules_usergroup_modification"
+fix_audit_watch_rule "auditctl" "{{{ PATH }}}" "wa" "audit_rules_usergroup_modification"
+fix_audit_watch_rule "augenrules" "{{{ PATH }}}" "wa" "audit_rules_usergroup_modification"

--- a/shared/templates/template_BASH_file_groupowner
+++ b/shared/templates/template_BASH_file_groupowner
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-chgrp %GROUP% %PATH%
+chgrp {{{ GROUP }}} {{{ PATH }}}

--- a/shared/templates/template_BASH_file_owner
+++ b/shared/templates/template_BASH_file_owner
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-chown %USER% %PATH%
+chown {{{ USER }}} {{{ PATH }}}

--- a/shared/templates/template_BASH_file_permissions
+++ b/shared/templates/template_BASH_file_permissions
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-chmod %MODE% %PATH%
+chmod {{{ MODE }}} {{{ PATH }}}

--- a/shared/templates/template_BASH_kernel_module_disabled
+++ b/shared/templates/template_BASH_kernel_module_disabled
@@ -3,9 +3,9 @@
 # strategy = disable
 # complexity = low
 # disruption = medium
-if LC_ALL=C grep -q -m 1 "^install %KERNMODULE%" /etc/modprobe.d/%KERNMODULE%.conf ; then
-	sed -i 's/^install %KERNMODULE%.*/install %KERNMODULE% /bin/true/g' /etc/modprobe.d/%KERNMODULE%.conf
+if LC_ALL=C grep -q -m 1 "^install {{{ KERNMODULE }}}" /etc/modprobe.d/{{{ KERNMODULE }}}.conf ; then
+	sed -i 's/^install {{{ KERNMODULE }}}.*/install {{{ KERNMODULE }}} /bin/true/g' /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 else
-	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/%KERNMODULE%.conf
-	echo "install %KERNMODULE% /bin/true" >> /etc/modprobe.d/%KERNMODULE%.conf
+	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+	echo "install {{{ KERNMODULE }}} /bin/true" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 fi

--- a/shared/templates/template_BASH_mount_option
+++ b/shared/templates/template_BASH_mount_option
@@ -7,13 +7,13 @@ include_mount_options_functions
 
 function perform_remediation {
 	# test "$mount_has_to_exist" = 'yes'
-	if test "%MOUNT_HAS_TO_EXIST%" = 'yes'; then
-		assert_mount_point_in_fstab %MOUNTPOINT% || { echo "Not remediating, because there is no record of %MOUNTPOINT% in /etc/fstab" >&2; return 1; }
+	if test "{{{ MOUNT_HAS_TO_EXIST }}}" = 'yes'; then
+		assert_mount_point_in_fstab {{{ MOUNTPOINT }}} || { echo "Not remediating, because there is no record of {{{ MOUNTPOINT }}} in /etc/fstab" >&2; return 1; }
 	fi
 
-	ensure_mount_option_in_fstab "%MOUNTPOINT%" "%MOUNTOPTION%"
+	ensure_mount_option_in_fstab "{{{ MOUNTPOINT }}}" "{{{ MOUNTOPTION }}}"
 
-	ensure_partition_is_mounted "%MOUNTPOINT%"
+	ensure_partition_is_mounted "{{{ MOUNTPOINT }}}"
 }
 
 perform_remediation

--- a/shared/templates/template_BASH_mount_option_var
+++ b/shared/templates/template_BASH_mount_option_var
@@ -4,19 +4,19 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-populate %MOUNTPOINT%
+populate {{{ MOUNTPOINT }}}
 
 include_mount_options_functions
 
 function perform_remediation {
 	# test "$mount_has_to_exist" = 'yes'
-	if test "%MOUNT_HAS_TO_EXIST%" = 'yes'; then
-		assert_mount_point_in_fstab "$%MOUNTPOINT%" || { echo "Not remediating, because there is no record of $%MOUNTPOINT% in /etc/fstab" >&2; return 1; }
+	if test "{{{ MOUNT_HAS_TO_EXIST }}}" = 'yes'; then
+		assert_mount_point_in_fstab "${{{ MOUNTPOINT }}}" || { echo "Not remediating, because there is no record of ${{{ MOUNTPOINT }}} in /etc/fstab" >&2; return 1; }
 	fi
 
-	ensure_mount_option_in_fstab "$%MOUNTPOINT%" "%MOUNTOPTION%"
+	ensure_mount_option_in_fstab "${{{ MOUNTPOINT }}}" "{{{ MOUNTOPTION }}}"
 
-	ensure_partition_is_mounted "$%MOUNTPOINT%"
+	ensure_partition_is_mounted "${{{ MOUNTPOINT }}}"
 }
 
 perform_remediation

--- a/shared/templates/template_BASH_package_installed
+++ b/shared/templates/template_BASH_package_installed
@@ -6,4 +6,4 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-package_install %PKGNAME%
+package_install {{{ PKGNAME }}}

--- a/shared/templates/template_BASH_package_removed
+++ b/shared/templates/template_BASH_package_removed
@@ -5,12 +5,12 @@
 # disruption = low
 # Include source function library.
 
-# CAUTION: This remediation script will remove %PKGNAME%
+# CAUTION: This remediation script will remove {{{ PKGNAME }}}
 #	   from the system, and may remove any packages
-#	   that depend on %PKGNAME%. Execute this
+#	   that depend on {{{ PKGNAME }}}. Execute this
 #	   remediation AFTER testing on a non-production
 #	   system!
 
 . /usr/share/scap-security-guide/remediation_functions
 
-package_remove %PKGNAME%
+package_remove {{{ PKGNAME }}}

--- a/shared/templates/template_BASH_permissions
+++ b/shared/templates/template_BASH_permissions
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-chmod %FILEMODE% %FILEPATH%
+chmod {{{ FILEMODE }}} {{{ FILEPATH }}}

--- a/shared/templates/template_BASH_regex_permissions
+++ b/shared/templates/template_BASH_regex_permissions
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-find %FILEPATH% -regex '^%FILEPATH%/%FILENAME%' -exec chmod %FILEMODE% {} \;
+find {{{ FILEPATH }}} -regex '^{{{ FILEPATH }}}/{{{ FILENAME }}}' -exec chmod {{{ FILEMODE }}} {} \;

--- a/shared/templates/template_BASH_sebool
+++ b/shared/templates/template_BASH_sebool
@@ -5,4 +5,4 @@
 # disruption = low
 # Include source function library.
 
-setsebool -P %SEBOOLID% %SEBOOL_BOOL%
+setsebool -P {{{ SEBOOLID }}} {{{ SEBOOL_BOOL }}}

--- a/shared/templates/template_BASH_sebool_var
+++ b/shared/templates/template_BASH_sebool_var
@@ -6,6 +6,6 @@
 # Include source function library.
 
 . /usr/share/scap-security-guide/remediation_functions
-populate var_%SEBOOLID%
+populate var_{{{ SEBOOLID }}}
 
-setsebool -P %SEBOOLID% $var_%SEBOOLID%
+setsebool -P {{{ SEBOOLID }}} $var_{{{ SEBOOLID }}}

--- a/shared/templates/template_BASH_service_disabled
+++ b/shared/templates/template_BASH_service_disabled
@@ -6,18 +6,18 @@
 {{%- if init_system == "systemd" %}}
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
-"$SYSTEMCTL_EXEC" stop '%DAEMONNAME%.service'
-"$SYSTEMCTL_EXEC" disable '%DAEMONNAME%.service'
+"$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
 # Disable socket activation if we have a unit file for it
-"$SYSTEMCTL_EXEC" list-unit-files | grep -q '^%DAEMONNAME%.socket\>' && "$SYSTEMCTL_EXEC" disable '%DAEMONNAME%.socket'
+"$SYSTEMCTL_EXEC" list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket\>' && "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.socket'
 # The service may not be running because it has been started and failed,
 # so let's reset the state so OVAL checks pass.
 # Service should be 'inactive', not 'failed' after reboot though.
-"$SYSTEMCTL_EXEC" reset-failed '%DAEMONNAME%.service'
+"$SYSTEMCTL_EXEC" reset-failed '{{{ DAEMONNAME }}}.service'
 {{% elif init_system == "upstart" %}}
 
-/sbin/service '%DAEMONNAME%' disable
-/sbin/chkconfig --level 0123456 '%DAEMONNAME%' off
+/sbin/service '{{{ DAEMONNAME }}}' disable
+/sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' off
 {{% else %}}
 
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'

--- a/shared/templates/template_BASH_service_enabled
+++ b/shared/templates/template_BASH_service_enabled
@@ -6,12 +6,12 @@
 {{%- if init_system == "systemd" %}}
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
-"$SYSTEMCTL_EXEC" start '%DAEMONNAME%.service'
-"$SYSTEMCTL_EXEC" enable '%DAEMONNAME%.service'
+"$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
 {{% elif init_system == "upstart" %}}
 
-/sbin/service '%DAEMONNAME%' disable
-/sbin/chkconfig --level 0123456 '%DAEMONNAME%' off
+/sbin/service '{{{ DAEMONNAME }}}' disable
+/sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' off
 {{% else %}}
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
 {{%- endif %}}

--- a/shared/templates/template_BASH_sysctl
+++ b/shared/templates/template_BASH_sysctl
@@ -6,12 +6,12 @@
 . /usr/share/scap-security-guide/remediation_functions
 
 #
-# Set runtime for %SYSCTLVAR%
+# Set runtime for {{{ SYSCTLVAR }}}
 #
-/sbin/sysctl -q -n -w %SYSCTLVAR%=%SYSCTLVAL%
+/sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}={{{ SYSCTLVAL }}}
 
 #
-# If %SYSCTLVAR% present in /etc/sysctl.conf, change value to "%SYSCTLVAL%"
-#	else, add "%SYSCTLVAR% = %SYSCTLVAL%" to /etc/sysctl.conf
+# If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to "{{{ SYSCTLVAL }}}"
+#	else, add "{{{ SYSCTLVAR }}} = {{{ SYSCTLVAL }}}" to /etc/sysctl.conf
 #
-replace_or_append '/etc/sysctl.conf' '^%SYSCTLVAR%' "%SYSCTLVAL%" '@CCENUM@'
+replace_or_append '/etc/sysctl.conf' '^{{{ SYSCTLVAR }}}' "{{{ SYSCTLVAL }}}" '@CCENUM@'

--- a/shared/templates/template_BASH_sysctl_var
+++ b/shared/templates/template_BASH_sysctl_var
@@ -4,15 +4,15 @@
 # complexity = low
 # disruption = medium
 . /usr/share/scap-security-guide/remediation_functions
-populate sysctl_%SYSCTLID%_value
+populate sysctl_{{{ SYSCTLID }}}_value
 
 #
-# Set runtime for %SYSCTLVAR%
+# Set runtime for {{{ SYSCTLVAR }}}
 #
-/sbin/sysctl -q -n -w %SYSCTLVAR%=$sysctl_%SYSCTLID%_value
+/sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}=$sysctl_{{{ SYSCTLID }}}_value
 
 #
-# If %SYSCTLVAR% present in /etc/sysctl.conf, change value to appropriate value
-#	else, add "%SYSCTLVAR% = value" to /etc/sysctl.conf
+# If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to appropriate value
+#	else, add "{{{ SYSCTLVAR }}} = value" to /etc/sysctl.conf
 #
-replace_or_append '/etc/sysctl.conf' '^%SYSCTLVAR%' "$sysctl_%SYSCTLID%_value" '@CCENUM@'
+replace_or_append '/etc/sysctl.conf' '^{{{ SYSCTLVAR }}}' "$sysctl_{{{ SYSCTLID }}}_value" '@CCENUM@'

--- a/shared/templates/template_OVAL_accounts_password
+++ b/shared/templates/template_OVAL_accounts_password
@@ -1,61 +1,61 @@
 <def-group>
-  <definition class="compliance" id="accounts_password_pam_%VARIABLE%" version="3">
+  <definition class="compliance" id="accounts_password_pam_{{{ VARIABLE }}}" version="3">
     <metadata>
-      <title>Set Password %VARIABLE% Requirements</title>
+      <title>Set Password {{{ VARIABLE }}} Requirements</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
       </affected>
-      <description>The password %VARIABLE% should meet minimum requirements</description>
+      <description>The password {{{ VARIABLE }}} should meet minimum requirements</description>
     </metadata>
 {{% if product == "rhel6" %}}
     <criteria>
-        <criterion comment="rhel6 pam_cracklib %VARIABLE%" test_ref="test_password_pam_cracklib_%VARIABLE%" />
+        <criterion comment="rhel6 pam_cracklib {{{ VARIABLE }}}" test_ref="test_password_pam_cracklib_{{{ VARIABLE }}}" />
     </criteria>
 {{% else %}}
-    <criteria operator="AND" comment="conditions for %VARIABLE% are satisfied">
+    <criteria operator="AND" comment="conditions for {{{ VARIABLE }}} are satisfied">
       <extend_definition comment="pwquality.so exists in system-auth" definition_ref="accounts_password_pam_pwquality" />
-      <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_%VARIABLE%" />
+      <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}" />
     </criteria>
 {{% endif %}}
   </definition>
 
 {{# Only credit related variables allow negative values #}}
-{{% if "credit" in "%VARIABLE%" %}}
+{{% if "credit" in "{{{ VARIABLE }}}" %}}
   {{% set sign = "-?" %}}
 {{% else %}}
   {{% set sign = "" %}}
 {{% endif %}}
 
 {{% if product == "rhel6" %}}
-  <ind:textfilecontent54_test check="all" comment="check the configuration of /etc/pam.d/system-auth" id="test_password_pam_cracklib_%VARIABLE%" version="3">
-    <ind:object object_ref="obj_password_pam_cracklib_%VARIABLE%" />
-    <ind:state state_ref="state_password_pam_%VARIABLE%" />
+  <ind:textfilecontent54_test check="all" comment="check the configuration of /etc/pam.d/system-auth" id="test_password_pam_cracklib_{{{ VARIABLE }}}" version="3">
+    <ind:object object_ref="obj_password_pam_cracklib_{{{ VARIABLE }}}" />
+    <ind:state state_ref="state_password_pam_{{{ VARIABLE }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_password_pam_cracklib_%VARIABLE%" version="3">
+  <ind:textfilecontent54_object id="obj_password_pam_cracklib_{{{ VARIABLE }}}" version="3">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:required)|(?:requisite))\s+pam_cracklib\.so.*%VARIABLE%[\s]*=[\s]*({{{ sign }}}\d+)(?:[\s]|$)</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:required)|(?:requisite))\s+pam_cracklib\.so.*{{{ VARIABLE }}}[\s]*=[\s]*({{{ sign }}}\d+)(?:[\s]|$)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% else %}}
   <ind:textfilecontent54_test check="all"
   comment="check the configuration of /etc/security/pwquality.conf"
-  id="test_password_pam_pwquality_%VARIABLE%" version="3">
-    <ind:object object_ref="obj_password_pam_pwquality_%VARIABLE%" />
-    <ind:state state_ref="state_password_pam_%VARIABLE%" />
+  id="test_password_pam_pwquality_{{{ VARIABLE }}}" version="3">
+    <ind:object object_ref="obj_password_pam_pwquality_{{{ VARIABLE }}}" />
+    <ind:state state_ref="state_password_pam_{{{ VARIABLE }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_password_pam_pwquality_%VARIABLE%" version="3">
+  <ind:textfilecontent54_object id="obj_password_pam_pwquality_{{{ VARIABLE }}}" version="3">
     <ind:filepath>/etc/security/pwquality.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^%VARIABLE%[\s]*=[\s]*({{{ negative_symbol }}}\d+)(?:[\s]|$)</ind:pattern>
+    <ind:pattern operation="pattern match">^{{{ VARIABLE }}}[\s]*=[\s]*({{{ negative_symbol }}}\d+)(?:[\s]|$)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% endif %}}
 
-  <ind:textfilecontent54_state id="state_password_pam_%VARIABLE%" version="3">
-    <ind:subexpression datatype="int" operation="%OPERATION%" var_ref="var_password_pam_%VARIABLE%" />
+  <ind:textfilecontent54_state id="state_password_pam_{{{ VARIABLE }}}" version="3">
+    <ind:subexpression datatype="int" operation="{{{ OPERATION }}}" var_ref="var_password_pam_{{{ VARIABLE }}}" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for pam_%VARIABLE%" datatype="int" id="var_password_pam_%VARIABLE%" version="3" />
+  <external_variable comment="External variable for pam_{{{ VARIABLE }}}" datatype="int" id="var_password_pam_{{{ VARIABLE }}}" version="3" />
 </def-group>

--- a/shared/templates/template_OVAL_audit_rules_dac_modification
+++ b/shared/templates/template_OVAL_audit_rules_dac_modification
@@ -1,7 +1,7 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_dac_modification_%ATTR%" version="1">
+  <definition class="compliance" id="audit_rules_dac_modification_{{{ ATTR }}}" version="1">
     <metadata>
-      <title>Audit Discretionary Access Control Modification Events - %ATTR%</title>
+      <title>Audit Discretionary Access Control Modification Events - {{{ ATTR }}}</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
       </affected>
@@ -12,63 +12,63 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules 32-bit %ATTR%" test_ref="test_32bit_ardm_%ATTR%_augenrules" />
+        <criterion comment="audit augenrules 32-bit {{{ ATTR }}}" test_ref="test_32bit_ardm_{{{ ATTR }}}_augenrules" />
         <criteria operator="OR">
-          <!-- System either isn't 64-bit => we just check presence of 32-bit version of %ATTR% audit DAC rule -->
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of {{{ ATTR }}} audit DAC rule -->
           <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
-          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of %ATTR% audit DAC rule -->
-          <criterion comment="audit augenrules 64-bit %ATTR%" test_ref="test_64bit_ardm_%ATTR%_augenrules" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of {{{ ATTR }}} audit DAC rule -->
+          <criterion comment="audit augenrules 64-bit {{{ ATTR }}}" test_ref="test_64bit_ardm_{{{ ATTR }}}_augenrules" />
         </criteria>
       </criteria>
 
       <!-- OR test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl 32-bit %ATTR%" test_ref="test_32bit_ardm_%ATTR%_auditctl" />
+        <criterion comment="audit auditctl 32-bit {{{ ATTR }}}" test_ref="test_32bit_ardm_{{{ ATTR }}}_auditctl" />
         <criteria operator="OR">
-          <!-- System either isn't 64-bit => we just check presence of 32-bit version of %ATTR% audit DAC rule -->
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of {{{ ATTR }}} audit DAC rule -->
           <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
-          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of %ATTR% audit DAC rule -->
-          <criterion comment="audit auditctl 64-bit %ATTR%" test_ref="test_64bit_ardm_%ATTR%_auditctl" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of {{{ ATTR }}} audit DAC rule -->
+          <criterion comment="audit auditctl 64-bit {{{ ATTR }}}" test_ref="test_64bit_ardm_{{{ ATTR }}}_auditctl" />
         </criteria>
       </criteria>
 
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit %ATTR%" id="test_32bit_ardm_%ATTR%_augenrules" version="1">
-    <ind:object object_ref="object_32bit_ardm_%ATTR%_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit {{{ ATTR }}}" id="test_32bit_ardm_{{{ ATTR }}}_augenrules" version="1">
+    <ind:object object_ref="object_32bit_ardm_{{{ ATTR }}}_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_32bit_ardm_%ATTR%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_32bit_ardm_{{{ ATTR }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ ATTR }}}[\s]+|([\s]+|[,]){{{ ATTR }}}([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit %ATTR%" id="test_64bit_ardm_%ATTR%_augenrules" version="1">
-    <ind:object object_ref="object_64bit_ardm_%ATTR%_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit {{{ ATTR }}}" id="test_64bit_ardm_{{{ ATTR }}}_augenrules" version="1">
+    <ind:object object_ref="object_64bit_ardm_{{{ ATTR }}}_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_64bit_ardm_%ATTR%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_64bit_ardm_{{{ ATTR }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ ATTR }}}[\s]+|([\s]+|[,]){{{ ATTR }}}([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit %ATTR%" id="test_32bit_ardm_%ATTR%_auditctl" version="1">
-    <ind:object object_ref="object_32bit_ardm_%ATTR%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit {{{ ATTR }}}" id="test_32bit_ardm_{{{ ATTR }}}_auditctl" version="1">
+    <ind:object object_ref="object_32bit_ardm_{{{ ATTR }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_32bit_ardm_%ATTR%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_32bit_ardm_{{{ ATTR }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ ATTR }}}[\s]+|([\s]+|[,]){{{ ATTR }}}([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit %ATTR%" id="test_64bit_ardm_%ATTR%_auditctl" version="1">
-    <ind:object object_ref="object_64bit_ardm_%ATTR%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit {{{ ATTR }}}" id="test_64bit_ardm_{{{ ATTR }}}_auditctl" version="1">
+    <ind:object object_ref="object_64bit_ardm_{{{ ATTR }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_64bit_ardm_%ATTR%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_64bit_ardm_{{{ ATTR }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%ATTR%[\s]+|([\s]+|[,])%ATTR%([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ ATTR }}}[\s]+|([\s]+|[,]){{{ ATTR }}}([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/template_OVAL_audit_rules_file_deletion_events
+++ b/shared/templates/template_OVAL_audit_rules_file_deletion_events
@@ -1,7 +1,7 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_file_deletion_events_%NAME%" version="1">
+  <definition class="compliance" id="audit_rules_file_deletion_events_{{{ NAME }}}" version="1">
     <metadata>
-      <title>Audit File Deletion Events - %NAME%</title>
+      <title>Audit File Deletion Events - {{{ NAME }}}</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
@@ -14,63 +14,63 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules 32-bit %NAME%" test_ref="test_32bit_ardm_%NAME%_augenrules" />
+        <criterion comment="audit augenrules 32-bit {{{ NAME }}}" test_ref="test_32bit_ardm_{{{ NAME }}}_augenrules" />
         <criteria operator="OR">
-          <!-- System either isn't 64-bit => we just check presence of 32-bit version of %NAME% audit DAC rule -->
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of {{{ NAME }}} audit DAC rule -->
           <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
-          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of %NAME% audit DAC rule -->
-          <criterion comment="audit augenrules 64-bit %NAME%" test_ref="test_64bit_ardm_%NAME%_augenrules" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of {{{ NAME }}} audit DAC rule -->
+          <criterion comment="audit augenrules 64-bit {{{ NAME }}}" test_ref="test_64bit_ardm_{{{ NAME }}}_augenrules" />
         </criteria>
       </criteria>
 
       <!-- OR test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl 32-bit %NAME%" test_ref="test_32bit_ardm_%NAME%_auditctl" />
+        <criterion comment="audit auditctl 32-bit {{{ NAME }}}" test_ref="test_32bit_ardm_{{{ NAME }}}_auditctl" />
         <criteria operator="OR">
-          <!-- System either isn't 64-bit => we just check presence of 32-bit version of the %NAME% audit DAC rule -->
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of the {{{ NAME }}} audit DAC rule -->
           <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
-          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of %NAME% audit DAC rule -->
-          <criterion comment="audit auditctl 64-bit %NAME%" test_ref="test_64bit_ardm_%NAME%_auditctl" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of {{{ NAME }}} audit DAC rule -->
+          <criterion comment="audit auditctl 64-bit {{{ NAME }}}" test_ref="test_64bit_ardm_{{{ NAME }}}_auditctl" />
         </criteria>
       </criteria>
 
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit %NAME%" id="test_32bit_ardm_%NAME%_augenrules" version="1">
-    <ind:object object_ref="object_32bit_ardm_%NAME%_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit {{{ NAME }}}" id="test_32bit_ardm_{{{ NAME }}}_augenrules" version="1">
+    <ind:object object_ref="object_32bit_ardm_{{{ NAME }}}_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_32bit_ardm_%NAME%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_32bit_ardm_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit %NAME%" id="test_64bit_ardm_%NAME%_augenrules" version="1">
-    <ind:object object_ref="object_64bit_ardm_%NAME%_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit {{{ NAME }}}" id="test_64bit_ardm_{{{ NAME }}}_augenrules" version="1">
+    <ind:object object_ref="object_64bit_ardm_{{{ NAME }}}_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_64bit_ardm_%NAME%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_64bit_ardm_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit %NAME%" id="test_32bit_ardm_%NAME%_auditctl" version="1">
-    <ind:object object_ref="object_32bit_ardm_%NAME%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit {{{ NAME }}}" id="test_32bit_ardm_{{{ NAME }}}_auditctl" version="1">
+    <ind:object object_ref="object_32bit_ardm_{{{ NAME }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_32bit_ardm_%NAME%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_32bit_ardm_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit %NAME%" id="test_64bit_ardm_%NAME%_auditctl" version="1">
-    <ind:object object_ref="object_64bit_ardm_%NAME%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit {{{ NAME }}}" id="test_64bit_ardm_{{{ NAME }}}_auditctl" version="1">
+    <ind:object object_ref="object_64bit_ardm_{{{ NAME }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_64bit_ardm_%NAME%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_64bit_ardm_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+auid>=1000[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/template_OVAL_audit_rules_login_events
+++ b/shared/templates/template_OVAL_audit_rules_login_events
@@ -1,7 +1,7 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_login_events_%NAME%" version="2">
+  <definition class="compliance" id="audit_rules_login_events_{{{ NAME }}}" version="2">
     <metadata>
-      <title>Record Attempts to Alter Login and Logout Events - %NAME%</title>
+      <title>Record Attempts to Alter Login and Logout Events - {{{ NAME }}}</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
@@ -14,33 +14,33 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules %NAME%" test_ref="test_arle_%NAME%_augenrules" />
+        <criterion comment="audit augenrules {{{ NAME }}}" test_ref="test_arle_{{{ NAME }}}_augenrules" />
       </criteria>
 
       <!-- Test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl %NAME%" test_ref="test_arle_%NAME%_auditctl" />
+        <criterion comment="audit auditctl {{{ NAME }}}" test_ref="test_arle_{{{ NAME }}}_auditctl" />
       </criteria>
 
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules %NAME%" id="test_arle_%NAME%_augenrules" version="1">
-    <ind:object object_ref="object_arle_%NAME%_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules {{{ NAME }}}" id="test_arle_{{{ NAME }}}_augenrules" version="1">
+    <ind:object object_ref="object_arle_{{{ NAME }}}_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arle_%NAME%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_arle_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w\s+%PATH%\s+\-p\s+wa\s+(-k[\s]+|-F[\s]+key=)[-\w]+\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w\s+{{{ PATH }}}\s+\-p\s+wa\s+(-k[\s]+|-F[\s]+key=)[-\w]+\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl %NAME%" id="test_arle_%NAME%_auditctl" version="1">
-    <ind:object object_ref="object_arle_%NAME%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl {{{ NAME }}}" id="test_arle_{{{ NAME }}}_auditctl" version="1">
+    <ind:object object_ref="object_arle_{{{ NAME }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arle_%NAME%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_arle_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w\s+%PATH%\s+\-p\s+wa\s+(-k[\s]+|-F[\s]+key=)[-\w]+\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w\s+{{{ PATH }}}\s+\-p\s+wa\s+(-k[\s]+|-F[\s]+key=)[-\w]+\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/template_OVAL_audit_rules_privileged_commands
+++ b/shared/templates/template_OVAL_audit_rules_privileged_commands
@@ -1,12 +1,12 @@
 <def-group>
-  <definition class="compliance" id="%ID%" version="1">
+  <definition class="compliance" id="{{{ ID }}}" version="1">
     <metadata>
-      <title>%TITLE%</title>
+      <title>{{{ TITLE }}}</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
       </affected>
-      <description>Audit rules about the information on the use of %NAME% is enabled.</description>
+      <description>Audit rules about the information on the use of {{{ NAME }}} is enabled.</description>
     </metadata>
 
     <criteria operator="OR">
@@ -14,32 +14,32 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules %NAME%" test_ref="test_%ID%_augenrules" />
+        <criterion comment="audit augenrules {{{ NAME }}}" test_ref="test_{{{ ID }}}_augenrules" />
       </criteria>
 
       <!-- Test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl %NAME%" test_ref="test_%ID%_auditctl" />
+        <criterion comment="audit auditctl {{{ NAME }}}" test_ref="test_{{{ ID }}}_auditctl" />
       </criteria>
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="audit augenrules %NAME%" id="test_%ID%_augenrules" version="1">
-    <ind:object object_ref="object_%ID%_augenrules" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="audit augenrules {{{ NAME }}}" id="test_{{{ ID }}}_augenrules" version="1">
+    <ind:object object_ref="object_{{{ ID }}}_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_%ID%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_{{{ ID }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path=%PATH%[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>=1000[\s]+-F[\s]+auid!=4294967295[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>=1000[\s]+-F[\s]+auid!=4294967295[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="audit auditctl %NAME%" id="test_%ID%_auditctl" version="1">
-    <ind:object object_ref="object_%ID%_auditctl" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="audit auditctl {{{ NAME }}}" id="test_{{{ ID }}}_auditctl" version="1">
+    <ind:object object_ref="object_{{{ ID }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_%ID%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_{{{ ID }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path=%PATH%[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>=1000[\s]+-F[\s]+auid!=4294967295[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>=1000[\s]+-F[\s]+auid!=4294967295[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
@@ -1,7 +1,7 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_unsuccessful_file_modification_%NAME%" version="1">
+  <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ NAME }}}" version="1">
     <metadata>
-      <title>Ensure auditd Collects Unauthorized Access Attempts to Files (unsuccessful) - %NAME%</title>
+      <title>Ensure auditd Collects Unauthorized Access Attempts to Files (unsuccessful) - {{{ NAME }}}</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
@@ -14,15 +14,15 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules 32-bit file eacces" test_ref="test_32bit_arufm_eacces_%NAME%_augenrules" />
-        <criterion comment="audit augenrules 32-bit file eperm" test_ref="test_32bit_arufm_eperm_%NAME%_augenrules" />
+        <criterion comment="audit augenrules 32-bit file eacces" test_ref="test_32bit_arufm_eacces_{{{ NAME }}}_augenrules" />
+        <criterion comment="audit augenrules 32-bit file eperm" test_ref="test_32bit_arufm_eperm_{{{ NAME }}}_augenrules" />
         <criteria operator="OR">
           <!-- System either isn't 64-bit => we just check presence of the 32-bit version of the EACCES / EPERM rules-->
           <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
           <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit versions of the rules -->
           <criteria operator="AND">
-            <criterion comment="audit augenrules 64-bit file eacces" test_ref="test_64bit_arufm_eacces_%NAME%_augenrules" />
-            <criterion comment="audit augenrules 64-bit file eperm" test_ref="test_64bit_arufm_eperm_%NAME%_augenrules" />
+            <criterion comment="audit augenrules 64-bit file eacces" test_ref="test_64bit_arufm_eacces_{{{ NAME }}}_augenrules" />
+            <criterion comment="audit augenrules 64-bit file eperm" test_ref="test_64bit_arufm_eperm_{{{ NAME }}}_augenrules" />
           </criteria>
         </criteria>
       </criteria>
@@ -30,15 +30,15 @@
       <!-- OR test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl 32-bit file eacces" test_ref="test_32bit_arufm_eacces_%NAME%_auditctl" />
-        <criterion comment="audit auditctl 32-bit file eperm" test_ref="test_32bit_arufm_eperm_%NAME%_auditctl" />
+        <criterion comment="audit auditctl 32-bit file eacces" test_ref="test_32bit_arufm_eacces_{{{ NAME }}}_auditctl" />
+        <criterion comment="audit auditctl 32-bit file eperm" test_ref="test_32bit_arufm_eperm_{{{ NAME }}}_auditctl" />
         <criteria operator="OR">
           <!-- System either isn't 64-bit => we just check presence of the 32-bit version of the EACCES / EPERM rules -->
           <extend_definition comment="64-bit_system" definition_ref="system_info_architecture_64bit" negate="true" />
           <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit versions of the rules -->
           <criteria operator="AND">
-            <criterion comment="audit auditctl 64-bit file eacces" test_ref="test_64bit_arufm_eacces_%NAME%_auditctl" />
-            <criterion comment="audit auditctl 64-bit file eperm" test_ref="test_64bit_arufm_eperm_%NAME%_auditctl" />
+            <criterion comment="audit auditctl 64-bit file eacces" test_ref="test_64bit_arufm_eacces_{{{ NAME }}}_auditctl" />
+            <criterion comment="audit auditctl 64-bit file eperm" test_ref="test_64bit_arufm_eperm_{{{ NAME }}}_auditctl" />
           </criteria>
         </criteria>
       </criteria>
@@ -46,75 +46,75 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit file eacces" id="test_32bit_arufm_eacces_%NAME%_augenrules" version="1">
-    <ind:object object_ref="object_32bit_arufm_eacces_%NAME%_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit file eacces" id="test_32bit_arufm_eacces_{{{ NAME }}}_augenrules" version="1">
+    <ind:object object_ref="object_32bit_arufm_eacces_{{{ NAME }}}_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_32bit_arufm_eacces_%NAME%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_32bit_arufm_eacces_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit file eperm" id="test_32bit_arufm_eperm_%NAME%_augenrules" version="1">
-    <ind:object object_ref="object_32bit_arufm_eperm_%NAME%_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit file eperm" id="test_32bit_arufm_eperm_{{{ NAME }}}_augenrules" version="1">
+    <ind:object object_ref="object_32bit_arufm_eperm_{{{ NAME }}}_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_32bit_arufm_eperm_%NAME%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_32bit_arufm_eperm_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit file eacces" id="test_64bit_arufm_eacces_%NAME%_augenrules" version="1">
-    <ind:object object_ref="object_64bit_arufm_eacces_%NAME%_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit file eacces" id="test_64bit_arufm_eacces_{{{ NAME }}}_augenrules" version="1">
+    <ind:object object_ref="object_64bit_arufm_eacces_{{{ NAME }}}_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_64bit_arufm_eacces_%NAME%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_64bit_arufm_eacces_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit file eperm" id="test_64bit_arufm_eperm_%NAME%_augenrules" version="1">
-    <ind:object object_ref="object_64bit_arufm_eperm_%NAME%_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit file eperm" id="test_64bit_arufm_eperm_{{{ NAME }}}_augenrules" version="1">
+    <ind:object object_ref="object_64bit_arufm_eperm_{{{ NAME }}}_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_64bit_arufm_eperm_%NAME%_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_64bit_arufm_eperm_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit file eacces" id="test_32bit_arufm_eacces_%NAME%_auditctl" version="1">
-    <ind:object object_ref="object_32bit_arufm_eacces_%NAME%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit file eacces" id="test_32bit_arufm_eacces_{{{ NAME }}}_auditctl" version="1">
+    <ind:object object_ref="object_32bit_arufm_eacces_{{{ NAME }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_32bit_arufm_eacces_%NAME%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_32bit_arufm_eacces_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit file eperm" id="test_32bit_arufm_eperm_%NAME%_auditctl" version="1">
-    <ind:object object_ref="object_32bit_arufm_eperm_%NAME%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit file eperm" id="test_32bit_arufm_eperm_{{{ NAME }}}_auditctl" version="1">
+    <ind:object object_ref="object_32bit_arufm_eperm_{{{ NAME }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_32bit_arufm_eperm_%NAME%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_32bit_arufm_eperm_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit file eacces" id="test_64bit_arufm_eacces_%NAME%_auditctl" version="1">
-    <ind:object object_ref="object_64bit_arufm_eacces_%NAME%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit file eacces" id="test_64bit_arufm_eacces_{{{ NAME }}}_auditctl" version="1">
+    <ind:object object_ref="object_64bit_arufm_eacces_{{{ NAME }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_64bit_arufm_eacces_%NAME%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_64bit_arufm_eacces_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit file eperm" id="test_64bit_arufm_eperm_%NAME%_auditctl" version="1">
-    <ind:object object_ref="object_64bit_arufm_eperm_%NAME%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit file eperm" id="test_64bit_arufm_eperm_{{{ NAME }}}_auditctl" version="1">
+    <ind:object object_ref="object_64bit_arufm_eperm_{{{ NAME }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_64bit_arufm_eperm_%NAME%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_64bit_arufm_eperm_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+%NAME%[\s]+|([\s]+|[,])%NAME%([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=4294967295[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/template_OVAL_audit_rules_usergroup_modification
+++ b/shared/templates/template_OVAL_audit_rules_usergroup_modification
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_usergroup_modification_%NAME%" version="1">
+  <definition class="compliance" id="audit_rules_usergroup_modification_{{{ NAME }}}" version="1">
     <metadata>
       <title>Audit User/Group Modification</title>
       <affected family="unix">
@@ -11,30 +11,30 @@
     <criteria operator="OR">
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-	<criterion comment="audit %NAME%" test_ref="test_audit_rules_usergroup_modification_%NAME%_augen" />
+	<criterion comment="audit {{{ NAME }}}" test_ref="test_audit_rules_usergroup_modification_{{{ NAME }}}_augen" />
       </criteria>
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit %NAME%" test_ref="test_audit_rules_usergroup_modification_%NAME%_auditctl" />
+        <criterion comment="audit {{{ NAME }}}" test_ref="test_audit_rules_usergroup_modification_{{{ NAME }}}_auditctl" />
       </criteria>
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules %NAME%" id="test_audit_rules_usergroup_modification_%NAME%_augen" version="1">
-    <ind:object object_ref="object_audit_rules_usergroup_modification_%NAME%_augen" />
+  <ind:textfilecontent54_test check="all" comment="audit augenrules {{{ NAME }}}" id="test_audit_rules_usergroup_modification_{{{ NAME }}}_augen" version="1">
+    <ind:object object_ref="object_audit_rules_usergroup_modification_{{{ NAME }}}_augen" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_audit_rules_usergroup_modification_%NAME%_augen" version="1">
+  <ind:textfilecontent54_object id="object_audit_rules_usergroup_modification_{{{ NAME }}}_augen" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+%PATH%[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit %NAME%" id="test_audit_rules_usergroup_modification_%NAME%_auditctl" version="1">
-    <ind:object object_ref="object_audit_rules_usergroup_modification_%NAME%_auditctl" />
+  <ind:textfilecontent54_test check="all" comment="audit {{{ NAME }}}" id="test_audit_rules_usergroup_modification_{{{ NAME }}}_auditctl" version="1">
+    <ind:object object_ref="object_audit_rules_usergroup_modification_{{{ NAME }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_audit_rules_usergroup_modification_%NAME%_auditctl" version="1">
+  <ind:textfilecontent54_object id="object_audit_rules_usergroup_modification_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+%PATH%[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/template_OVAL_kernel_module_disabled
+++ b/shared/templates/template_OVAL_kernel_module_disabled
@@ -1,123 +1,123 @@
 <def-group>
   <definition class="compliance"
-  id="kernel_module_%KERNMODULE%_disabled" version="1">
+  id="kernel_module_{{{ KERNMODULE }}}_disabled" version="1">
     <metadata>
-      <title>Disable %KERNMODULE% Kernel Module</title>
+      <title>Disable {{{ KERNMODULE }}} Kernel Module</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The kernel module %KERNMODULE% should be disabled.</description>
+      <description>The kernel module {{{ KERNMODULE }}} should be disabled.</description>
     </metadata>
     <criteria operator="OR">
-      <criterion test_ref="test_kernmod_%KERNMODULE%_disabled" comment="kernel module %KERNMODULE% disabled in /etc/modprobe.d" />
-      <criterion test_ref="test_kernmod_%KERNMODULE%_modprobeconf" comment="kernel module %KERNMODULE% disabled in /etc/modprobe.conf" />
+      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.d" />
+      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" />
 
 {{% if product != "rhel6" %}}
 
-      <criterion test_ref="test_kernmod_%KERNMODULE%_etcmodules-load" comment="kernel module %KERNMODULE% disabled in /etc/modules-load.d" />
-      <criterion test_ref="test_kernmod_%KERNMODULE%_runmodules-load" comment="kernel module %KERNMODULE% disabled in /run/modules-load.d" />
-      <criterion test_ref="test_kernmod_%KERNMODULE%_libmodules-load" comment="kernel module %KERNMODULE% disabled in /usr/lib/modules-load.d" />
-      <criterion test_ref="test_kernmod_%KERNMODULE%_runmodprobed" comment="kernel module %KERNMODULE% disabled in /run/modprobe.d" />
-      <criterion test_ref="test_kernmod_%KERNMODULE%_libmodprobed" comment="kernel module %KERNMODULE% disabled in /usr/lib/modprobe.d" />
+      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_etcmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modules-load.d" />
+      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_runmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modules-load.d" />
+      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_libmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modules-load.d" />
+      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_runmodprobed" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modprobe.d" />
+      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_libmodprobed" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modprobe.d" />
 
 {{% endif %}}
 
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_disabled" version="1" check="all"
-  comment="kernel module %KERNMODULE% disabled">
-    <ind:object object_ref="obj_kernmod_%KERNMODULE%_disabled" />
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_disabled" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_disabled" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_modprobeconf" version="1" check="all"
-  comment="kernel module %KERNMODULE% disabled in /etc/modprobe.conf">
-    <ind:object object_ref="obj_kernmod_%KERNMODULE%_modprobeconf" />
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_modprobeconf" />
   </ind:textfilecontent54_test>
 
 {{% if product != "rhel6" %}}
 
-  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_etcmodules-load" version="1" check="all"
-  comment="kernel module %KERNMODULE% disabled in /etc/modules-load.d">
-    <ind:object object_ref="obj_kernmod_%KERNMODULE%_etcmodules-load" />
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_etcmodules-load" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modules-load.d">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_etcmodules-load" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_runmodules-load" version="1" check="all"
-  comment="kernel module %KERNMODULE% disabled in /run/modules-load.d">
-    <ind:object object_ref="obj_kernmod_%KERNMODULE%_runmodules-load" />
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_runmodules-load" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /run/modules-load.d">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_runmodules-load" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_libmodules-load" version="1" check="all"
-  comment="kernel module %KERNMODULE% disabled in /usr/lib/modules-load.d">
-    <ind:object object_ref="obj_kernmod_%KERNMODULE%_libmodules-load" />
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_libmodules-load" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modules-load.d">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_libmodules-load" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_runmodprobed" version="1" check="all"
-  comment="kernel module %KERNMODULE% disabled in /run/modprobe.d">
-    <ind:object object_ref="obj_kernmod_%KERNMODULE%_runmodprobed" />
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_runmodprobed" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /run/modprobe.d">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_runmodprobed" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test id="test_kernmod_%KERNMODULE%_libmodprobed" version="1" check="all"
-  comment="kernel module %KERNMODULE% disabled in /usr/lib/modprobe.d">
-    <ind:object object_ref="obj_kernmod_%KERNMODULE%_libmodprobed" />
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_libmodprobed" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modprobe.d">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_libmodprobed" />
   </ind:textfilecontent54_test>
 
 {{% endif %}}
 
-  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_disabled"
-  version="1" comment="kernel module %KERNMODULE% disabled">
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_disabled"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled">
     <ind:path>/etc/modprobe.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_modprobeconf"
-  version="1" comment="Check deprecated /etc/modprobe.conf for disablement of %KERNMODULE%">
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_modprobeconf"
+  version="1" comment="Check deprecated /etc/modprobe.conf for disablement of {{{ KERNMODULE }}}">
     <ind:filepath>/etc/modprobe.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
 {{% if product != "rhel6" %}}
 
-  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_etcmodules-load"
-  version="1" comment="kernel module %KERNMODULE% disabled in /etc/modules-load.d">
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_etcmodules-load"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modules-load.d">
     <ind:path>/etc/modules-load.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_runmodules-load"
-  version="1" comment="kernel module %KERNMODULE% disabled in /run/modules-load.d">
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_runmodules-load"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modules-load.d">
     <ind:path>/run/modules-load.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_libmodules-load"
-  version="1" comment="kernel module %KERNMODULE% disabled in /usr/lib/modules-load.d">
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_libmodules-load"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modules-load.d">
     <ind:path>/usr/lib/modules-load.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_runmodprobed"
-  version="1" comment="kernel module %KERNMODULE% disabled in /run/modprobe.d">
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_runmodprobed"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modprobe.d">
     <ind:path>/run/modprobe.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="obj_kernmod_%KERNMODULE%_libmodprobed"
-  version="1" comment="kernel module %KERNMODULE% disabled in /usr/lib/modprobe.d">
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_libmodprobed"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modprobe.d">
     <ind:path>/usr/lib/modprobe.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^\s*install\s+%KERNMODULE%\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/template_OVAL_mount
+++ b/shared/templates/template_OVAL_mount
@@ -1,25 +1,25 @@
 <def-group>
-  <definition class="compliance" id="partition_for%POINTID%" version="1">
+  <definition class="compliance" id="partition_for{{{ POINTID }}}" version="1">
     <metadata>
-      <title>Ensure %MOUNTPOINT% Located On Separate Partition</title>
+      <title>Ensure {{{ MOUNTPOINT }}} Located On Separate Partition</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
       <description>If stored locally, create a separate partition for
-      %MOUNTPOINT%. If %MOUNTPOINT% will be mounted from another
+      {{{ MOUNTPOINT }}}. If {{{ MOUNTPOINT }}} will be mounted from another
       system such as an NFS server, then creating a separate partition is not
       necessary at this time, and the mountpoint can instead be configured
       later.</description>
     </metadata>
     <criteria>
-      <criterion test_ref="test%POINTID%_partition" comment="%MOUNTPOINT% on own partition" />
+      <criterion test_ref="test{{{ POINTID }}}_partition" comment="{{{ MOUNTPOINT }}} on own partition" />
     </criteria>
   </definition>
   <linux:partition_test check="all" check_existence="all_exist"
-  id="test%POINTID%_partition" version="1" comment="%MOUNTPOINT% on own partition">
-    <linux:object object_ref="object_mount%POINTID%_own_partition" />
+  id="test{{{ POINTID }}}_partition" version="1" comment="{{{ MOUNTPOINT }}} on own partition">
+    <linux:object object_ref="object_mount{{{ POINTID }}}_own_partition" />
   </linux:partition_test>
-  <linux:partition_object id="object_mount%POINTID%_own_partition" version="1">
-    <linux:mount_point>%MOUNTPOINT%</linux:mount_point>
+  <linux:partition_object id="object_mount{{{ POINTID }}}_own_partition" version="1">
+    <linux:mount_point>{{{ MOUNTPOINT }}}</linux:mount_point>
   </linux:partition_object>
 </def-group>

--- a/shared/templates/template_OVAL_mount_option
+++ b/shared/templates/template_OVAL_mount_option
@@ -1,26 +1,26 @@
 <def-group>
-  <definition class="compliance" id="mount_option_%POINTID%_%MOUNTOPTION%" version="1">
+  <definition class="compliance" id="mount_option_{{{ POINTID }}}_{{{ MOUNTOPTION }}}" version="1">
     <metadata>
-      <title>Add %MOUNTOPTION% Option to %MOUNTPOINT%</title>
+      <title>Add {{{ MOUNTOPTION }}} Option to {{{ MOUNTPOINT }}}</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>%MOUNTPOINT% should be mounted with mount option %MOUNTOPTION%.</description>
+      <description>{{{ MOUNTPOINT }}} should be mounted with mount option {{{ MOUNTOPTION }}}.</description>
     </metadata>
     <criteria>
-      <criterion comment="%MOUNTOPTION% on %MOUNTPOINT%" test_ref="test_%POINTID%_partition_%MOUNTOPTION%" />
+      <criterion comment="{{{ MOUNTOPTION }}} on {{{ MOUNTPOINT }}}" test_ref="test_{{{ POINTID }}}_partition_{{{ MOUNTOPTION }}}" />
     </criteria>
   </definition>
 
   <linux:partition_test check="all" check_existence="all_exist"
-  id="test_%POINTID%_partition_%MOUNTOPTION%" version="1" comment="%MOUNTOPTION% on %MOUNTPOINT%">
-    <linux:object object_ref="object_%POINTID%_partition_%MOUNTOPTION%" />
-    <linux:state state_ref="state_%POINTID%_partition_%MOUNTOPTION%" />
+  id="test_{{{ POINTID }}}_partition_{{{ MOUNTOPTION }}}" version="1" comment="{{{ MOUNTOPTION }}} on {{{ MOUNTPOINT }}}">
+    <linux:object object_ref="object_{{{ POINTID }}}_partition_{{{ MOUNTOPTION }}}" />
+    <linux:state state_ref="state_{{{ POINTID }}}_partition_{{{ MOUNTOPTION }}}" />
   </linux:partition_test>
-  <linux:partition_object id="object_%POINTID%_partition_%MOUNTOPTION%" version="1">
-    <linux:mount_point>%MOUNTPOINT%</linux:mount_point>
+  <linux:partition_object id="object_{{{ POINTID }}}_partition_{{{ MOUNTOPTION }}}" version="1">
+    <linux:mount_point>{{{ MOUNTPOINT }}}</linux:mount_point>
   </linux:partition_object>
-  <linux:partition_state id="state_%POINTID%_partition_%MOUNTOPTION%" version="1">
-    <linux:mount_options datatype="string" entity_check="at least one" operation="equals">%MOUNTOPTION%</linux:mount_options>
+  <linux:partition_state id="state_{{{ POINTID }}}_partition_{{{ MOUNTOPTION }}}" version="1">
+    <linux:mount_options datatype="string" entity_check="at least one" operation="equals">{{{ MOUNTOPTION }}}</linux:mount_options>
   </linux:partition_state>
 </def-group>

--- a/shared/templates/template_OVAL_mount_option_remote_filesystems
+++ b/shared/templates/template_OVAL_mount_option_remote_filesystems
@@ -1,37 +1,37 @@
 <def-group>
-  <definition class="compliance" id="mount_option_%MOUNTOPTION%_remote_filesystems" version="1">
+  <definition class="compliance" id="mount_option_{{{ MOUNTOPTION }}}_remote_filesystems" version="1">
     <metadata>
-      <title>Mount Remote Filesystems with %MOUNTOPTION%</title>
+      <title>Mount Remote Filesystems with {{{ MOUNTOPTION }}}</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The %MOUNTOPTION% option should be enabled for all NFS mounts in /etc/fstab.</description>
+      <description>The {{{ MOUNTOPTION }}} option should be enabled for all NFS mounts in /etc/fstab.</description>
     </metadata>
     <criteria operator="XOR">
       <!-- these tests are designed to be mutually exclusive; either no nfs mounts exist in /etc/fstab -->
-      <!-- or all of the nfs mounts defined in /etc/fstab have the %MOUNTOPTION% mount option specified -->
-      <criterion comment="remote nfs filesystems" test_ref="test_no_nfs_defined_etc_fstab_%MOUNTOPTION%" />
-      <criterion comment="remote nfs filesystems" test_ref="test_nfs_%MOUNTOPTION%_etc_fstab" />
+      <!-- or all of the nfs mounts defined in /etc/fstab have the {{{ MOUNTOPTION }}} mount option specified -->
+      <criterion comment="remote nfs filesystems" test_ref="test_no_nfs_defined_etc_fstab_{{{ MOUNTOPTION }}}" />
+      <criterion comment="remote nfs filesystems" test_ref="test_nfs_{{{ MOUNTOPTION }}}_etc_fstab" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="all nfs has %MOUNTOPTION%" id="test_nfs_%MOUNTOPTION%_etc_fstab" version="1">
-    <ind:object object_ref="object_nfs_%MOUNTOPTION%_etc_fstab" />
-    <ind:state state_ref="state_remote_filesystem_%MOUNTOPTION%" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="all nfs has {{{ MOUNTOPTION }}}" id="test_nfs_{{{ MOUNTOPTION }}}_etc_fstab" version="1">
+    <ind:object object_ref="object_nfs_{{{ MOUNTOPTION }}}_etc_fstab" />
+    <ind:state state_ref="state_remote_filesystem_{{{ MOUNTOPTION }}}" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_nfs_%MOUNTOPTION%_etc_fstab" version="1">
+  <ind:textfilecontent54_object id="object_nfs_{{{ MOUNTOPTION }}}_etc_fstab" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
     <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+(.*)$</ind:pattern>
     <!-- the "not equal" operation essentially means all instances of the regexp -->
     <ind:instance datatype="int" operation="not equal">0</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_remote_filesystem_%MOUNTOPTION%" version="1">
-    <ind:subexpression operation="pattern match">^.*%MOUNTOPTION%.*$</ind:subexpression>
+  <ind:textfilecontent54_state id="state_remote_filesystem_{{{ MOUNTOPTION }}}" version="1">
+    <ind:subexpression operation="pattern match">^.*{{{ MOUNTOPTION }}}.*$</ind:subexpression>
   </ind:textfilecontent54_state>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="no nfs" id="test_no_nfs_defined_etc_fstab_%MOUNTOPTION%" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="no nfs" id="test_no_nfs_defined_etc_fstab_{{{ MOUNTOPTION }}}" version="1">
     <!-- this test returns 'true' if /etc/fstab does not contain nfs/nfs4 mounts -->
-    <ind:object object_ref="object_no_nfs_defined_etc_fstab_%MOUNTOPTION%" />
+    <ind:object object_ref="object_no_nfs_defined_etc_fstab_{{{ MOUNTOPTION }}}" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_no_nfs_defined_etc_fstab_%MOUNTOPTION%" version="1">
+  <ind:textfilecontent54_object id="object_no_nfs_defined_etc_fstab_{{{ MOUNTOPTION }}}" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
     <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+.*$</ind:pattern>
     <!-- the "not equal" operation below essentially means all instances of the regexp -->

--- a/shared/templates/template_OVAL_mount_option_removable_partitions
+++ b/shared/templates/template_OVAL_mount_option_removable_partitions
@@ -1,13 +1,13 @@
 <def-group>
-  <definition class="compliance" id="mount_option_%MOUNTOPTION%_removable_partitions" version="4">
+  <definition class="compliance" id="mount_option_{{{ MOUNTOPTION }}}_removable_partitions" version="4">
     <metadata>
-      <title>Add %MOUNTOPTION% Option to Removable Media Partitions</title>
+      <title>Add {{{ MOUNTOPTION }}} Option to Removable Media Partitions</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_wrlinux</platform>
       </affected>
-      <description>The %MOUNTOPTION% option should be enabled for all removable devices mounts in /etc/fstab.</description>
+      <description>The {{{ MOUNTOPTION }}} option should be enabled for all removable devices mounts in /etc/fstab.</description>
     </metadata>
     <criteria operator="OR">
       <!-- First check if specified removable partition truly exists on the system. If not, don't check /etc/fstab & runtime configuration
@@ -15,35 +15,35 @@
       <extend_definition comment="Check if removable partition really exists on the system"
       definition_ref="removable_partition_doesnt_exist" />
       <!-- Removable device exists. Check if it's CD/DVD drive. If so, verify that at least one from all of the possible its alternative
-           names in /etc/fstab & runtime configuration are configured with '%MOUNTOPTION%' option -->
+           names in /etc/fstab & runtime configuration are configured with '{{{ MOUNTOPTION }}}' option -->
       <criteria operator="AND">
         <extend_definition comment="Check if removable partition value represents CD/DVD drive"
         definition_ref="var_removable_partition_is_cd_dvd_drive" />
         <criteria operator="OR">
           <criteria operator="AND">
-            <criterion test_ref="test_%MOUNTOPTION%_etc_fstab_cd_dvd_drive"
-            comment="Check if at least one from CD/DVD drive alternative names is using '%MOUNTOPTION%' mount option in /etc/fstab" />
-            <criterion test_ref="test_%MOUNTOPTION%_runtime_cd_dvd_drive"
-            comment="Check if at least one from CD/DVD drive alternative names is using '%MOUNTOPTION%' mount option in runtime configuration" />
+            <criterion test_ref="test_{{{ MOUNTOPTION }}}_etc_fstab_cd_dvd_drive"
+            comment="Check if at least one from CD/DVD drive alternative names is using '{{{ MOUNTOPTION }}}' mount option in /etc/fstab" />
+            <criterion test_ref="test_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive"
+            comment="Check if at least one from CD/DVD drive alternative names is using '{{{ MOUNTOPTION }}}' mount option in runtime configuration" />
           </criteria>
           <extend_definition definition_ref="no_cd_dvd_drive_in_etc_fstab"
           comment="Check if CD/DVD drive is not configured to automount in /etc/fstab" />
         </criteria>
       </criteria>
-      <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with '%MOUNTOPTION%' mount option in both
+      <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with '{{{ MOUNTOPTION }}}' mount option in both
            /etc/fstab & runtime configuration -->
       <criteria operator="AND">
-        <criterion test_ref="test_%MOUNTOPTION%_etc_fstab_not_cd_dvd_drive"
-        comment="Check if removable partition is using '%MOUNTOPTION%' mount option in /etc/fstab" />
-        <criterion test_ref="test_%MOUNTOPTION%_runtime_not_cd_dvd_drive"
-        comment="Check if removable partition is using '%MOUNTOPTION%' mount option in runtime configuration" />
+        <criterion test_ref="test_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive"
+        comment="Check if removable partition is using '{{{ MOUNTOPTION }}}' mount option in /etc/fstab" />
+        <criterion test_ref="test_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive"
+        comment="Check if removable partition is using '{{{ MOUNTOPTION }}}' mount option in runtime configuration" />
       </criteria>
     </criteria>
   </definition>
 
   <!-- If specified removable partition represents CD / DVD drive, create a variable
        holding also alternative names for CD / DVD block special device as used by udev -->
-  <constant_variable id="variable_cd_dvd_drive_alternative_names_%MOUNTOPTION%" datatype="string" comment="CD/DVD drive alternative names whitelist" version="1">
+  <constant_variable id="variable_cd_dvd_drive_alternative_names_{{{ MOUNTOPTION }}}" datatype="string" comment="CD/DVD drive alternative names whitelist" version="1">
     <value>/dev/cdrom</value>
     <value>/dev/dvd</value>
     <value>/dev/scd0</value>
@@ -52,10 +52,10 @@
 
   <!-- For each of the CD / DVD drive alternative names create regular expression pattern
        to be used in textfilecontent54_object below -->
-  <local_variable id="variable_cd_dvd_drive_regex_pattern_%MOUNTOPTION%" datatype="string" comment="Regular expression pattern for CD / DVD drive alternative names" version="1">
+  <local_variable id="variable_cd_dvd_drive_regex_pattern_{{{ MOUNTOPTION }}}" datatype="string" comment="Regular expression pattern for CD / DVD drive alternative names" version="1">
     <concat>
       <literal_component>^[\s]*</literal_component>
-      <variable_component var_ref="variable_cd_dvd_drive_alternative_names_%MOUNTOPTION%" />
+      <variable_component var_ref="variable_cd_dvd_drive_alternative_names_{{{ MOUNTOPTION }}}" />
       <!-- Capture the mount options field (4-th column of /etc/fstab) -->
       <literal_component>[\s]+[/\w]+[\s]+[\w]+[\s]+([^\s]+)(?:[\s]+[\d]+){2}$</literal_component>
     </concat>
@@ -63,50 +63,50 @@
 
   <!-- If specified removable partition represents CD / DVD drive, use all alternative
        names to check /etc/fstab & runtime settings -->
-  <ind:textfilecontent54_test id="test_%MOUNTOPTION%_etc_fstab_cd_dvd_drive" check_existence="any_exist" check="all" comment="'%MOUNTOPTION%' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
-    <ind:object object_ref="object_%MOUNTOPTION%_etc_fstab_cd_dvd_drive" />
-    <ind:state state_ref="state_%MOUNTOPTION%_etc_fstab_cd_dvd_drive" />
+  <ind:textfilecontent54_test id="test_{{{ MOUNTOPTION }}}_etc_fstab_cd_dvd_drive" check_existence="any_exist" check="all" comment="'{{{ MOUNTOPTION }}}' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
+    <ind:object object_ref="object_{{{ MOUNTOPTION }}}_etc_fstab_cd_dvd_drive" />
+    <ind:state state_ref="state_{{{ MOUNTOPTION }}}_etc_fstab_cd_dvd_drive" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_%MOUNTOPTION%_etc_fstab_cd_dvd_drive" version="1">
+  <ind:textfilecontent54_object id="object_{{{ MOUNTOPTION }}}_etc_fstab_cd_dvd_drive" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match" datatype="string" var_ref="variable_cd_dvd_drive_regex_pattern_%MOUNTOPTION%" var_check="at least one" />
+    <ind:pattern operation="pattern match" datatype="string" var_ref="variable_cd_dvd_drive_regex_pattern_{{{ MOUNTOPTION }}}" var_check="at least one" />
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_%MOUNTOPTION%_etc_fstab_cd_dvd_drive" version="1">
-    <ind:subexpression operation="pattern match" datatype="string">^.*,?%MOUNTOPTION%,?.*$</ind:subexpression>
+  <ind:textfilecontent54_state id="state_{{{ MOUNTOPTION }}}_etc_fstab_cd_dvd_drive" version="1">
+    <ind:subexpression operation="pattern match" datatype="string">^.*,?{{{ MOUNTOPTION }}},?.*$</ind:subexpression>
   </ind:textfilecontent54_state>
 
-  <linux:partition_test id="test_%MOUNTOPTION%_runtime_cd_dvd_drive" check="all" comment="'%MOUNTOPTION%' mount option used for at least one CD / DVD drive alternative names in runtime configuration" version="1">
-    <linux:object object_ref="object_%MOUNTOPTION%_runtime_cd_dvd_drive" />
+  <linux:partition_test id="test_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive" check="all" comment="'{{{ MOUNTOPTION }}}' mount option used for at least one CD / DVD drive alternative names in runtime configuration" version="1">
+    <linux:object object_ref="object_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive" />
   </linux:partition_test>
 
-  <linux:partition_object id="object_%MOUNTOPTION%_runtime_cd_dvd_drive" version="1">
+  <linux:partition_object id="object_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive" version="1">
     <!-- CD / DVD drive can be mounted under any mount_point. We don't know ahead its exact name.
          => Capture all & filter out only the relevant ones via the corresponding state -->
     <linux:mount_point operation="pattern match">^.*$</linux:mount_point>
     <!-- Therefore from all the captured mount points select only those having
          device set to some CD / DVD drive alternative name and simultaneously
-         having '%MOUNTOPTION%' mount option used -->
-    <filter action="include">state_%MOUNTOPTION%_runtime_cd_dvd_drive</filter>
+         having '{{{ MOUNTOPTION }}}' mount option used -->
+    <filter action="include">state_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive</filter>
   </linux:partition_object>
 
-  <linux:partition_state id="state_%MOUNTOPTION%_runtime_cd_dvd_drive" version="1">
-    <linux:device datatype="string" operation="equals" var_ref="variable_cd_dvd_drive_alternative_names_%MOUNTOPTION%" var_check="at least one" />
-    <linux:mount_options datatype="string" entity_check="at least one" operation="equals">%MOUNTOPTION%</linux:mount_options>
+  <linux:partition_state id="state_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive" version="1">
+    <linux:device datatype="string" operation="equals" var_ref="variable_cd_dvd_drive_alternative_names_{{{ MOUNTOPTION }}}" var_check="at least one" />
+    <linux:mount_options datatype="string" entity_check="at least one" operation="equals">{{{ MOUNTOPTION }}}</linux:mount_options>
   </linux:partition_state>
 
   <!-- Specified removable partition exists & doesn't represent a CD/DVD drive.
-       Check if configured with '%MOUNTOPTION%' mount option in both /etc/fstab & runtime configuration -->
-  <ind:textfilecontent54_test id="test_%MOUNTOPTION%_etc_fstab_not_cd_dvd_drive" check="at least one" check_existence="all_exist" comment="Check if removable partition is configured with '%MOUNTOPTION%' mount option in /etc/fstab" version="1">
-    <ind:object object_ref="object_%MOUNTOPTION%_etc_fstab_not_cd_dvd_drive" />
-    <ind:state state_ref="state_%MOUNTOPTION%_etc_fstab_not_cd_dvd_drive" />
+       Check if configured with '{{{ MOUNTOPTION }}}' mount option in both /etc/fstab & runtime configuration -->
+  <ind:textfilecontent54_test id="test_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive" check="at least one" check_existence="all_exist" comment="Check if removable partition is configured with '{{{ MOUNTOPTION }}}' mount option in /etc/fstab" version="1">
+    <ind:object object_ref="object_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive" />
+    <ind:state state_ref="state_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive" />
   </ind:textfilecontent54_test>
 
   <!-- Create regular expression pattern for the device to be used in the
        textfilecontent54_object below -->
-  <local_variable id="variable_not_cd_dvd_drive_regex_pattern_%MOUNTOPTION%" datatype="string" comment="Regular expression pattern for removable block special device other than CD / DVD drive" version="1">
+  <local_variable id="variable_not_cd_dvd_drive_regex_pattern_{{{ MOUNTOPTION }}}" datatype="string" comment="Regular expression pattern for removable block special device other than CD / DVD drive" version="1">
     <concat>
       <literal_component>^[\s]*</literal_component>
       <variable_component var_ref="var_removable_partition" />
@@ -115,33 +115,33 @@
     </concat>
   </local_variable>
 
-  <ind:textfilecontent54_object id="object_%MOUNTOPTION%_etc_fstab_not_cd_dvd_drive" version="1">
+  <ind:textfilecontent54_object id="object_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match" datatype="string" var_ref="variable_not_cd_dvd_drive_regex_pattern_%MOUNTOPTION%" var_check="at least one" />
+    <ind:pattern operation="pattern match" datatype="string" var_ref="variable_not_cd_dvd_drive_regex_pattern_{{{ MOUNTOPTION }}}" var_check="at least one" />
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_%MOUNTOPTION%_etc_fstab_not_cd_dvd_drive" version="1">
-    <ind:subexpression operation="pattern match" datatype="string">^.*,?%MOUNTOPTION%,?.*</ind:subexpression>
+  <ind:textfilecontent54_state id="state_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive" version="1">
+    <ind:subexpression operation="pattern match" datatype="string">^.*,?{{{ MOUNTOPTION }}},?.*</ind:subexpression>
   </ind:textfilecontent54_state>
 
-  <linux:partition_test id="test_%MOUNTOPTION%_runtime_not_cd_dvd_drive" check="all" check_existence="all_exist" comment="'%MOUNTOPTION%' mount option used for removable partition in runtime configuration" version="1">
-    <linux:object object_ref="object_%MOUNTOPTION%_runtime_not_cd_dvd_drive" />
+  <linux:partition_test id="test_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive" check="all" check_existence="all_exist" comment="'{{{ MOUNTOPTION }}}' mount option used for removable partition in runtime configuration" version="1">
+    <linux:object object_ref="object_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive" />
   </linux:partition_test>
 
-  <linux:partition_object id="object_%MOUNTOPTION%_runtime_not_cd_dvd_drive" version="1">
+  <linux:partition_object id="object_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive" version="1">
     <!-- Removable partition can be mounted under any mount point. We don't know it's
          exact name ahead => Capture all & filter out only those relevant later via state -->
     <linux:mount_point operation="pattern match">^.*$</linux:mount_point>
     <!-- From all the captured mount points select only those having device equal
          to 'var_removable_partition' variable value and simultaneously having
-         '%MOUNTOPTION%' mount option set -->
-    <filter action="include">state_%MOUNTOPTION%_runtime_not_cd_dvd_drive</filter>
+         '{{{ MOUNTOPTION }}}' mount option set -->
+    <filter action="include">state_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive</filter>
   </linux:partition_object>
 
-  <linux:partition_state id="state_%MOUNTOPTION%_runtime_not_cd_dvd_drive" version="1">
+  <linux:partition_state id="state_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive" version="1">
     <linux:device datatype="string" operation="equals" var_ref="var_removable_partition" var_check="at least one" />
-    <linux:mount_options datatype="string" entity_check="at least one" operation="equals">%MOUNTOPTION%</linux:mount_options>
+    <linux:mount_options datatype="string" entity_check="at least one" operation="equals">{{{ MOUNTOPTION }}}</linux:mount_options>
   </linux:partition_state>
 
   <external_variable comment="removable partition" datatype="string" id="var_removable_partition" version="1" />

--- a/shared/templates/template_OVAL_package_installed
+++ b/shared/templates/template_OVAL_package_installed
@@ -1,50 +1,50 @@
 <def-group>
-  <definition class="compliance" id="package_%PKGNAME%_installed"
+  <definition class="compliance" id="package_{{{ PKGNAME }}}_installed"
   version="1">
     <metadata>
-      <title>Package %PKGNAME% Installed</title>
+      <title>Package {{{ PKGNAME }}} Installed</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The {{{ pkg_system|upper }}} package %PKGNAME% should be installed.</description>
+      <description>The {{{ pkg_system|upper }}} package {{{ PKGNAME }}} should be installed.</description>
     </metadata>
     <criteria>
-      <criterion comment="package %PKGNAME% is installed"
-      test_ref="test_package_%PKGNAME%_installed" />
+      <criterion comment="package {{{ PKGNAME }}} is installed"
+      test_ref="test_package_{{{ PKGNAME }}}_installed" />
     </criteria>
   </definition>
 {{% if pkg_system == "rpm" %}}
   <linux:rpminfo_test check="all" check_existence="all_exist"
-  id="test_package_%PKGNAME%_installed" version="1"
-  comment="package %PKGNAME% is installed">
-    <linux:object object_ref="obj_package_%PKGNAME%_installed" />
-    {{% if "%EVR%" %}}
-      <linux:state state_ref="ste_package_%PKGNAME%_installed" />
+  id="test_package_{{{ PKGNAME }}}_installed" version="1"
+  comment="package {{{ PKGNAME }}} is installed">
+    <linux:object object_ref="obj_package_{{{ PKGNAME }}}_installed" />
+    {{% if "{{{ EVR }}}" %}}
+      <linux:state state_ref="ste_package_{{{ PKGNAME }}}_installed" />
     {{% endif %}}
   </linux:rpminfo_test>
-  <linux:rpminfo_object id="obj_package_%PKGNAME%_installed" version="1">
-    <linux:name>%PKGNAME%</linux:name>
+  <linux:rpminfo_object id="obj_package_{{{ PKGNAME }}}_installed" version="1">
+    <linux:name>{{{ PKGNAME }}}</linux:name>
   </linux:rpminfo_object>
-  {{% if "%EVR%" %}}
-    <linux:rpminfo_state id="ste_package_%PKGNAME%_installed" version="1">
-      <linux:evr datatype="evr_string" operation="greater than or equal">%EVR%</linux:evr>
+  {{% if "{{{ EVR }}}" %}}
+    <linux:rpminfo_state id="ste_package_{{{ PKGNAME }}}_installed" version="1">
+      <linux:evr datatype="evr_string" operation="greater than or equal">{{{ EVR }}}</linux:evr>
     </linux:rpminfo_state>
   {{% endif %}}
 {{% elif pkg_system == "dpkg" %}}
   <linux:dpkginfo_test check="all" check_existence="all_exist"
-  id="test_package_%PKGNAME%_installed" version="1"
-  comment="package %PKGNAME% is installed">
-    <linux:object object_ref="obj_package_%PKGNAME%_installed" />
-    {{% if "%EVR%" %}}
-      <linux:state state_ref="ste_package_%PKGNAME%_installed" />
+  id="test_package_{{{ PKGNAME }}}_installed" version="1"
+  comment="package {{{ PKGNAME }}} is installed">
+    <linux:object object_ref="obj_package_{{{ PKGNAME }}}_installed" />
+    {{% if "{{{ EVR }}}" %}}
+      <linux:state state_ref="ste_package_{{{ PKGNAME }}}_installed" />
     {{% endif %}}
   </linux:dpkginfo_test>
-  <linux:dpkginfo_object id="obj_package_%PKGNAME%_installed" version="1">
-    <linux:name>%PKGNAME%</linux:name>
+  <linux:dpkginfo_object id="obj_package_{{{ PKGNAME }}}_installed" version="1">
+    <linux:name>{{{ PKGNAME }}}</linux:name>
   </linux:dpkginfo_object>
-  {{% if "%EVR%" %}}
-    <linux:dpkginfo_state id="ste_package_%PKGNAME%_installed" version="1">
-      <linux:evr datatype="evr_string" operation="greater than or equal">%EVR%</linux:evr>
+  {{% if "{{{ EVR }}}" %}}
+    <linux:dpkginfo_state id="ste_package_{{{ PKGNAME }}}_installed" version="1">
+      <linux:evr datatype="evr_string" operation="greater than or equal">{{{ EVR }}}</linux:evr>
     </linux:dpkginfo_state>
   {{% endif %}}
 {{% endif %}}

--- a/shared/templates/template_OVAL_package_removed
+++ b/shared/templates/template_OVAL_package_removed
@@ -1,35 +1,35 @@
 <def-group>
-  <definition class="compliance" id="package_%PKGNAME%_removed"
+  <definition class="compliance" id="package_{{{ PKGNAME }}}_removed"
   version="1">
     <metadata>
-      <title>Package %PKGNAME% Removed</title>
+      <title>Package {{{ PKGNAME }}} Removed</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The {{{ pkg_system|upper }}} package %PKGNAME% should be removed.</description>
+      <description>The {{{ pkg_system|upper }}} package {{{ PKGNAME }}} should be removed.</description>
     </metadata>
     <criteria>
-      <criterion comment="package %PKGNAME% is removed"
-      test_ref="test_package_%PKGNAME%_removed" />
+      <criterion comment="package {{{ PKGNAME }}} is removed"
+      test_ref="test_package_{{{ PKGNAME }}}_removed" />
     </criteria>
   </definition>
 {{% if pkg_system == "rpm" %}}
   <linux:rpminfo_test check="all" check_existence="none_exist"
-  id="test_package_%PKGNAME%_removed" version="1"
-  comment="package %PKGNAME% is removed">
-    <linux:object object_ref="obj_package_%PKGNAME%_removed" />
+  id="test_package_{{{ PKGNAME }}}_removed" version="1"
+  comment="package {{{ PKGNAME }}} is removed">
+    <linux:object object_ref="obj_package_{{{ PKGNAME }}}_removed" />
   </linux:rpminfo_test>
-  <linux:rpminfo_object id="obj_package_%PKGNAME%_removed" version="1">
-    <linux:name>%PKGNAME%</linux:name>
+  <linux:rpminfo_object id="obj_package_{{{ PKGNAME }}}_removed" version="1">
+    <linux:name>{{{ PKGNAME }}}</linux:name>
   </linux:rpminfo_object>
 {{% elif pkg_system == "dpkg" %}}
   <linux:dpkginfo_test check="all" check_existence="none_exist"
-  id="test_package_%PKGNAME%_removed" version="1"
-  comment="package %PKGNAME% is removed">
-    <linux:object object_ref="obj_package_%PKGNAME%_removed" />
+  id="test_package_{{{ PKGNAME }}}_removed" version="1"
+  comment="package {{{ PKGNAME }}} is removed">
+    <linux:object object_ref="obj_package_{{{ PKGNAME }}}_removed" />
   </linux:dpkginfo_test>
-  <linux:dpkginfo_object id="obj_package_%PKGNAME%_removed" version="1">
-    <linux:name>%PKGNAME%</linux:name>
+  <linux:dpkginfo_object id="obj_package_{{{ PKGNAME }}}_removed" version="1">
+    <linux:name>{{{ PKGNAME }}}</linux:name>
   </linux:dpkginfo_object>
 {{% endif %}}
 </def-group>

--- a/shared/templates/template_OVAL_permissions
+++ b/shared/templates/template_OVAL_permissions
@@ -1,33 +1,33 @@
 <def-group>
-  <definition class="compliance" id="file_permissions%FILEID%" version="1">
+  <definition class="compliance" id="file_permissions{{{ FILEID }}}" version="1">
     <metadata>
-      <title>Verify %FILEPATH% Permissions</title>
+      <title>Verify {{{ FILEPATH }}} Permissions</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>This test makes sure that %FILEPATH% is owned by %FILEUID%, group owned by %FILEGID%, and has mode %FILEMODE%. If
+      <description>This test makes sure that {{{ FILEPATH }}} is owned by {{{ FILEUID }}}, group owned by {{{ FILEGID }}}, and has mode {{{ FILEMODE }}}. If
       the target file or directory has an extended ACL then it will fail the mode check.</description>
     </metadata>
     <criteria>
-      <criterion test_ref="test%FILEID%" />
+      <criterion test_ref="test{{{ FILEID }}}" />
     </criteria>
   </definition>
-  <unix:file_test check="all" check_existence="all_exist" comment="%FILEPATH% mode and ownership" id="test%FILEID%" version="1">
-    <unix:object object_ref="object%FILEID%" />
-    <unix:state state_ref="%FILEID%_state_uid_%FILEUID%" />
-    <unix:state state_ref="%FILEID%_state_gid_%FILEGID%" />
-    <unix:state state_ref="%FILEID%_state_mode_%FILEMODE%" />
+  <unix:file_test check="all" check_existence="all_exist" comment="{{{ FILEPATH }}} mode and ownership" id="test{{{ FILEID }}}" version="1">
+    <unix:object object_ref="object{{{ FILEID }}}" />
+    <unix:state state_ref="{{{ FILEID }}}_state_uid_{{{ FILEUID }}}" />
+    <unix:state state_ref="{{{ FILEID }}}_state_gid_{{{ FILEGID }}}" />
+    <unix:state state_ref="{{{ FILEID }}}_state_mode_{{{ FILEMODE }}}" />
   </unix:file_test>
-  <unix:file_object comment="%FILEPATH%" id="object%FILEID%" version="1">
-    <unix:path>%FILEDIR%</unix:path>
-    %UNIX_FILENAME%
+  <unix:file_object comment="{{{ FILEPATH }}}" id="object{{{ FILEID }}}" version="1">
+    <unix:path>{{{ FILEDIR }}}</unix:path>
+    {{{ UNIX_FILENAME }}}
   </unix:file_object>
-  <unix:file_state id="%FILEID%_state_uid_%FILEUID%" version="1">
-    <unix:user_id datatype="int" operation="equals">%FILEUID%</unix:user_id>
+  <unix:file_state id="{{{ FILEID }}}_state_uid_{{{ FILEUID }}}" version="1">
+    <unix:user_id datatype="int" operation="equals">{{{ FILEUID }}}</unix:user_id>
   </unix:file_state>
-  <unix:file_state id="%FILEID%_state_gid_%FILEGID%" version="1">
-    <unix:group_id datatype="int" operation="equals">%FILEGID%</unix:group_id>
+  <unix:file_state id="{{{ FILEID }}}_state_gid_{{{ FILEGID }}}" version="1">
+    <unix:group_id datatype="int" operation="equals">{{{ FILEGID }}}</unix:group_id>
   </unix:file_state>
-  <unix:file_state id="%FILEID%_state_mode_%FILEMODE%" version="1">
-%STATEMODE%
+  <unix:file_state id="{{{ FILEID }}}_state_mode_{{{ FILEMODE }}}" version="1">
+{{{ STATEMODE }}}
 </def-group>

--- a/shared/templates/template_OVAL_sebool
+++ b/shared/templates/template_OVAL_sebool
@@ -1,30 +1,30 @@
 <def-group>
-  <definition class="compliance" id="sebool_%SEBOOLID%" version="1">
+  <definition class="compliance" id="sebool_{{{ SEBOOLID }}}" version="1">
     <metadata>
-      <title>SELinux "%SEBOOLID%" Boolean Check</title>
+      <title>SELinux "{{{ SEBOOLID }}}" Boolean Check</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
       </affected>
-      <description>The SELinux "%SEBOOLID%" boolean should be set in the system configuration.</description>
+      <description>The SELinux "{{{ SEBOOLID }}}" boolean should be set in the system configuration.</description>
     </metadata>
     <criteria>
-      <criterion comment="%SEBOOLID% is configured correctly" test_ref="test_sebool_%SEBOOLID%" />
+      <criterion comment="{{{ SEBOOLID }}} is configured correctly" test_ref="test_sebool_{{{ SEBOOLID }}}" />
     </criteria>
   </definition>
 
-  <linux:selinuxboolean_test check="all" check_existence="all_exist" comment="%SEBOOLID% is configured correctly" id="test_sebool_%SEBOOLID%" version="1">
-    <linux:object object_ref="object_sebool_%SEBOOLID%" />
-    <linux:state state_ref="state_sebool_%SEBOOLID%" />
+  <linux:selinuxboolean_test check="all" check_existence="all_exist" comment="{{{ SEBOOLID }}} is configured correctly" id="test_sebool_{{{ SEBOOLID }}}" version="1">
+    <linux:object object_ref="object_sebool_{{{ SEBOOLID }}}" />
+    <linux:state state_ref="state_sebool_{{{ SEBOOLID }}}" />
   </linux:selinuxboolean_test>
 
-  <linux:selinuxboolean_object id="object_sebool_%SEBOOLID%" version="1">
-    <linux:name>%SEBOOLID%</linux:name>
+  <linux:selinuxboolean_object id="object_sebool_{{{ SEBOOLID }}}" version="1">
+    <linux:name>{{{ SEBOOLID }}}</linux:name>
   </linux:selinuxboolean_object>
 
-  <linux:selinuxboolean_state id="state_sebool_%SEBOOLID%" version="1">
-    <linux:name>%SEBOOLID%</linux:name>
-    <linux:current_status datatype="boolean">%SEBOOL_BOOL%</linux:current_status>
-    <linux:pending_status datatype="boolean">%SEBOOL_BOOL%</linux:pending_status>
+  <linux:selinuxboolean_state id="state_sebool_{{{ SEBOOLID }}}" version="1">
+    <linux:name>{{{ SEBOOLID }}}</linux:name>
+    <linux:current_status datatype="boolean">{{{ SEBOOL_BOOL }}}</linux:current_status>
+    <linux:pending_status datatype="boolean">{{{ SEBOOL_BOOL }}}</linux:pending_status>
   </linux:selinuxboolean_state>
 </def-group>

--- a/shared/templates/template_OVAL_sebool_var
+++ b/shared/templates/template_OVAL_sebool_var
@@ -1,33 +1,33 @@
 <def-group>
-  <definition class="compliance" id="sebool_%SEBOOLID%" version="1">
+  <definition class="compliance" id="sebool_{{{ SEBOOLID }}}" version="1">
     <metadata>
-      <title>SELinux "%SEBOOLID%" Boolean Check</title>
+      <title>SELinux "{{{ SEBOOLID }}}" Boolean Check</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
       </affected>
-      <description>The SELinux "%SEBOOLID%" boolean should be set in the system configuration.</description>
+      <description>The SELinux "{{{ SEBOOLID }}}" boolean should be set in the system configuration.</description>
     </metadata>
     <criteria>
-      <criterion comment="%SEBOOLID% is configured correctly" test_ref="test_sebool_%SEBOOLID%" />
+      <criterion comment="{{{ SEBOOLID }}} is configured correctly" test_ref="test_sebool_{{{ SEBOOLID }}}" />
     </criteria>
   </definition>
 
-  <linux:selinuxboolean_test check="all" check_existence="all_exist" comment="%SEBOOLID% is configured correctly" id="test_sebool_%SEBOOLID%" version="1">
-    <linux:object object_ref="object_sebool_%SEBOOLID%" />
-    <linux:state state_ref="state_sebool_%SEBOOLID%" />
+  <linux:selinuxboolean_test check="all" check_existence="all_exist" comment="{{{ SEBOOLID }}} is configured correctly" id="test_sebool_{{{ SEBOOLID }}}" version="1">
+    <linux:object object_ref="object_sebool_{{{ SEBOOLID }}}" />
+    <linux:state state_ref="state_sebool_{{{ SEBOOLID }}}" />
   </linux:selinuxboolean_test>
 
-  <linux:selinuxboolean_object id="object_sebool_%SEBOOLID%" version="1">
-    <linux:name>%SEBOOLID%</linux:name>
+  <linux:selinuxboolean_object id="object_sebool_{{{ SEBOOLID }}}" version="1">
+    <linux:name>{{{ SEBOOLID }}}</linux:name>
   </linux:selinuxboolean_object>
 
-  <linux:selinuxboolean_state id="state_sebool_%SEBOOLID%" version="1">
-    <linux:name>%SEBOOLID%</linux:name>
-    <linux:current_status datatype="boolean" var_ref="var_%SEBOOLID%"/>
-    <linux:pending_status datatype="boolean" var_ref="var_%SEBOOLID%"/>
+  <linux:selinuxboolean_state id="state_sebool_{{{ SEBOOLID }}}" version="1">
+    <linux:name>{{{ SEBOOLID }}}</linux:name>
+    <linux:current_status datatype="boolean" var_ref="var_{{{ SEBOOLID }}}"/>
+    <linux:pending_status datatype="boolean" var_ref="var_{{{ SEBOOLID }}}"/>
   </linux:selinuxboolean_state>
 
-  <external_variable comment="external variable for %SEBOOLID%" datatype="boolean" id="var_%SEBOOLID%" version="1" />
+  <external_variable comment="external variable for {{{ SEBOOLID }}}" datatype="boolean" id="var_{{{ SEBOOLID }}}" version="1" />
 
 </def-group>

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -4,55 +4,55 @@
 
   {{# we are using systemd and our target OVAL version does support the systemd related tests #}}
 
-  <definition class="compliance" id="service_%SERVICENAME%_disabled" version="1">
+  <definition class="compliance" id="service_{{{ SERVICENAME }}}_disabled" version="1">
     <metadata>
-      <title>Service %SERVICENAME% Disabled</title>
+      <title>Service {{{ SERVICENAME }}} Disabled</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The %SERVICENAME% service should be disabled if possible.</description>
+      <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
     </metadata>
-    <criteria comment="package %PACKAGENAME% removed or service %SERVICENAME% is not configured to start" operator="OR">
-      <extend_definition comment="%PACKAGENAME% removed" definition_ref="package_%PACKAGENAME%_removed" />
-      <criteria operator="AND" comment="service %SERVICENAME% is not configured to start">
-        <criterion comment="%SERVICENAME% not wanted by multi-user.target" test_ref="test_%SERVICENAME%_not_wanted_by_multi_user_target" />
-        <criterion comment="%SERVICENAME% socket not wanted by multi-user.target" test_ref="test_%SERVICENAME%_socket_not_wanted_by_multi_user_target" />
-        <criterion comment="%SERVICENAME% is not running" test_ref="test_service_not_running_%SERVICENAME%" />
+    <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
+      <extend_definition comment="{{{ PACKAGENAME }}} removed" definition_ref="package_{{{ PACKAGENAME }}}_removed" />
+      <criteria operator="AND" comment="service {{{ SERVICENAME }}} is not configured to start">
+        <criterion comment="{{{ SERVICENAME }}} not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_not_wanted_by_multi_user_target" />
+        <criterion comment="{{{ SERVICENAME }}} socket not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_socket_not_wanted_by_multi_user_target" />
+        <criterion comment="{{{ SERVICENAME }}} is not running" test_ref="test_service_not_running_{{{ SERVICENAME }}}" />
       </criteria>
     </criteria>
   </definition>
 
-  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_%SERVICENAME%_not_wanted_by_multi_user_target" version="1">
-    <linux:object object_ref="object_multi_user_target_for_%SERVICENAME%_disabled" />
-    <linux:state state_ref="state_systemd_%SERVICENAME%_off"/>
+  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_{{{ SERVICENAME }}}_not_wanted_by_multi_user_target" version="1">
+    <linux:object object_ref="object_multi_user_target_for_{{{ SERVICENAME }}}_disabled" />
+    <linux:state state_ref="state_systemd_{{{ SERVICENAME }}}_off"/>
   </linux:systemdunitdependency_test>
-  <linux:systemdunitdependency_object id="object_multi_user_target_for_%SERVICENAME%_disabled" comment="list of dependencies of multi-user.target" version="1">
+  <linux:systemdunitdependency_object id="object_multi_user_target_for_{{{ SERVICENAME }}}_disabled" comment="list of dependencies of multi-user.target" version="1">
     <linux:unit>multi-user.target</linux:unit>
   </linux:systemdunitdependency_object>
-  <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_off" comment="%SERVICENAME% service is not listed in the dependencies" version="1">
-    <linux:dependency entity_check="none satisfy">%SERVICENAME%.service</linux:dependency>
+  <linux:systemdunitdependency_state id="state_systemd_{{{ SERVICENAME }}}_off" comment="{{{ SERVICENAME }}} service is not listed in the dependencies" version="1">
+    <linux:dependency entity_check="none satisfy">{{{ SERVICENAME }}}.service</linux:dependency>
   </linux:systemdunitdependency_state>
 
-  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_%SERVICENAME%_socket_not_wanted_by_multi_user_target" version="1">
-    <linux:object object_ref="object_multi_user_target_for_%SERVICENAME%_socket_disabled" />
-    <linux:state state_ref="state_systemd_%SERVICENAME%_socket_off"/>
+  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_{{{ SERVICENAME }}}_socket_not_wanted_by_multi_user_target" version="1">
+    <linux:object object_ref="object_multi_user_target_for_{{{ SERVICENAME }}}_socket_disabled" />
+    <linux:state state_ref="state_systemd_{{{ SERVICENAME }}}_socket_off"/>
   </linux:systemdunitdependency_test>
-  <linux:systemdunitdependency_object id="object_multi_user_target_for_%SERVICENAME%_socket_disabled" comment="list of dependencies of multi-user.target" version="1">
+  <linux:systemdunitdependency_object id="object_multi_user_target_for_{{{ SERVICENAME }}}_socket_disabled" comment="list of dependencies of multi-user.target" version="1">
     <linux:unit>multi-user.target</linux:unit>
   </linux:systemdunitdependency_object>
-  <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_socket_off" comment="%SERVICENAME% socket is not listed in the dependencies" version="1">
-    <linux:dependency entity_check="none satisfy">%SERVICENAME%.socket</linux:dependency>
+  <linux:systemdunitdependency_state id="state_systemd_{{{ SERVICENAME }}}_socket_off" comment="{{{ SERVICENAME }}} socket is not listed in the dependencies" version="1">
+    <linux:dependency entity_check="none satisfy">{{{ SERVICENAME }}}.socket</linux:dependency>
   </linux:systemdunitdependency_state>
 
-  <linux:systemdunitproperty_test id="test_service_not_running_%SERVICENAME%" check="all" check_existence="any_exist" comment="Test that the %SERVICENAME% service is not running" version="1">
-    <linux:object object_ref="obj_service_not_running_%SERVICENAME%"/>
-    <linux:state state_ref="state_service_not_running_%SERVICENAME%"/>
+  <linux:systemdunitproperty_test id="test_service_not_running_{{{ SERVICENAME }}}" check="all" check_existence="any_exist" comment="Test that the {{{ SERVICENAME }}} service is not running" version="1">
+    <linux:object object_ref="obj_service_not_running_{{{ SERVICENAME }}}"/>
+    <linux:state state_ref="state_service_not_running_{{{ SERVICENAME }}}"/>
   </linux:systemdunitproperty_test>
-  <linux:systemdunitproperty_object id="obj_service_not_running_%SERVICENAME%" comment="Retrieve the ActiveState property of %SERVICENAME%" version="1">
-    <linux:unit operation="pattern match">%SERVICENAME%\.(service|socket)</linux:unit>
+  <linux:systemdunitproperty_object id="obj_service_not_running_{{{ SERVICENAME }}}" comment="Retrieve the ActiveState property of {{{ SERVICENAME }}}" version="1">
+    <linux:unit operation="pattern match">{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_not_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is not running">
+  <linux:systemdunitproperty_state id="state_service_not_running_{{{ SERVICENAME }}}" version="1" comment="{{{ SERVICENAME }}} is not running">
       <linux:value>inactive</linux:value>
   </linux:systemdunitproperty_state>
 
@@ -60,136 +60,136 @@
 
   {{% if product == "ubuntu1404" %}}
 
-  <definition class="compliance" id="service_%SERVICENAME%_disabled"
+  <definition class="compliance" id="service_{{{ SERVICENAME }}}_disabled"
   version="1">
     <metadata>
-      <title>Service %SERVICENAME% Disabled</title>
+      <title>Service {{{ SERVICENAME }}} Disabled</title>
       <affected family="unix">
         <platform>Ubuntu 1404</platform>
       </affected>
-      <description>The %SERVICENAME% service should be disabled if possible.</description>
+      <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
     </metadata>
-   <criteria comment="package %PACKAGENAME% removed or service %SERVICENAME% is not configured to start" operator="OR">
-    <extend_definition comment="%PACKAGENAME% removed" definition_ref="package_%PACKAGENAME%_removed" />
+   <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
+    <extend_definition comment="{{{ PACKAGENAME }}} removed" definition_ref="package_{{{ PACKAGENAME }}}_removed" />
 
     <!-- OVAL <runlevel_test> is not implemented in OpenSCAP when compiled on Ubuntusystems yet:
          https://github.com/OpenSCAP/openscap/blob/maint-1.2/src/OVAL/probes/unix/runlevel.c#L210
 
          (attempt to use it will result into 'error' result), therefore we verify that there
          DOES NOT exist some "S\d{2}ssh" service record in all of "/etc/rc*.d/" subfolders -->
-    <criterion comment="%SERVICENAME% disabled in /etc/rc*.d" test_ref="test_%SERVICENAME%_disabled" />
+    <criterion comment="{{{ SERVICENAME }}} disabled in /etc/rc*.d" test_ref="test_{{{ SERVICENAME }}}_disabled" />
 
     </criteria>
   </definition>
 
   <!-- Verify there DOES NOT exist some 'S\d{2}ssh' service record in some of '/etc/rc*.d/' subfolders -->
-  <unix:file_test id="test_%SERVICENAME%_disabled" check="all" check_existence="none_exist"
-   comment="%SERVICENAME% disabled in /etc/rc*.d" version="1" >
-   <unix:object object_ref="object_%DAEMONNAME%_etc_rcd" />
+  <unix:file_test id="test_{{{ SERVICENAME }}}_disabled" check="all" check_existence="none_exist"
+   comment="{{{ SERVICENAME }}} disabled in /etc/rc*.d" version="1" >
+   <unix:object object_ref="object_{{{ DAEMONNAME }}}_etc_rcd" />
   </unix:file_test>
 
-  <unix:file_object id="object_%DAEMONNAME%_etc_rcd" comment="/etc/rc*.d/S\d{2}%DAEMONNAME%" version="1">
+  <unix:file_object id="object_{{{ DAEMONNAME }}}_etc_rcd" comment="/etc/rc*.d/S\d{2}{{{ DAEMONNAME }}}" version="1">
     <unix:path operation="pattern match">^/etc/rc[0-6S]\.d$</unix:path>
-    <unix:filename operation="pattern match">^S\d{2}%DAEMONNAME%$</unix:filename>
+    <unix:filename operation="pattern match">^S\d{2}{{{ DAEMONNAME }}}$</unix:filename>
   </unix:file_object>
 
   {{% elif init_system != "systemd" %}}
 
   {{# we are not using systemd, it doesn't matter if we can or cannot use OVAL 5.11, let us just use the runlevel test #}}
 
-  <definition class="compliance" id="service_%SERVICENAME%_disabled"
+  <definition class="compliance" id="service_{{{ SERVICENAME }}}_disabled"
   version="1">
     <metadata>
-      <title>Service %SERVICENAME% Disabled</title>
+      <title>Service {{{ SERVICENAME }}} Disabled</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The %SERVICENAME% service should be disabled if possible.</description>
+      <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
     </metadata>
-   <criteria comment="package %PACKAGENAME% removed or service %SERVICENAME% is not configured to start" operator="OR">
-    <extend_definition comment="%PACKAGENAME% removed" definition_ref="package_%PACKAGENAME%_removed" />
-    <criteria operator="AND" comment="service %SERVICENAME% is not configured to start">
-      <criterion comment="%SERVICENAME% runlevel 0" test_ref="test_runlevel0_%SERVICENAME%_off" />
-      <criterion comment="%SERVICENAME% runlevel 1" test_ref="test_runlevel1_%SERVICENAME%_off" />
-      <criterion comment="%SERVICENAME% runlevel 2" test_ref="test_runlevel2_%SERVICENAME%_off" />
-      <criterion comment="%SERVICENAME% runlevel 3" test_ref="test_runlevel3_%SERVICENAME%_off" />
-      <criterion comment="%SERVICENAME% runlevel 4" test_ref="test_runlevel4_%SERVICENAME%_off" />
-      <criterion comment="%SERVICENAME% runlevel 5" test_ref="test_runlevel5_%SERVICENAME%_off" />
-      <criterion comment="%SERVICENAME% runlevel 6" test_ref="test_runlevel6_%SERVICENAME%_off" />
+   <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
+    <extend_definition comment="{{{ PACKAGENAME }}} removed" definition_ref="package_{{{ PACKAGENAME }}}_removed" />
+    <criteria operator="AND" comment="service {{{ SERVICENAME }}} is not configured to start">
+      <criterion comment="{{{ SERVICENAME }}} runlevel 0" test_ref="test_runlevel0_{{{ SERVICENAME }}}_off" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 1" test_ref="test_runlevel1_{{{ SERVICENAME }}}_off" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 2" test_ref="test_runlevel2_{{{ SERVICENAME }}}_off" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 3" test_ref="test_runlevel3_{{{ SERVICENAME }}}_off" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 4" test_ref="test_runlevel4_{{{ SERVICENAME }}}_off" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 5" test_ref="test_runlevel5_{{{ SERVICENAME }}}_off" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 6" test_ref="test_runlevel6_{{{ SERVICENAME }}}_off" />
     </criteria>
     </criteria>
   </definition>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel0_%SERVICENAME%_off"
+  comment="Runlevel test" id="test_runlevel0_{{{ SERVICENAME }}}_off"
   version="2">
-    <unix:object object_ref="obj_runlevel0_%SERVICENAME%_off" />
-    <unix:state state_ref="state_service_%SERVICENAME%_off" />
+    <unix:object object_ref="obj_runlevel0_{{{ SERVICENAME }}}_off" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel1_%SERVICENAME%_off"
+  comment="Runlevel test" id="test_runlevel1_{{{ SERVICENAME }}}_off"
   version="2">
-    <unix:object object_ref="obj_runlevel1_%SERVICENAME%_off" />
-    <unix:state state_ref="state_service_%SERVICENAME%_off" />
+    <unix:object object_ref="obj_runlevel1_{{{ SERVICENAME }}}_off" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel2_%SERVICENAME%_off"
+  comment="Runlevel test" id="test_runlevel2_{{{ SERVICENAME }}}_off"
   version="2">
-    <unix:object object_ref="obj_runlevel2_%SERVICENAME%_off" />
-    <unix:state state_ref="state_service_%SERVICENAME%_off" />
+    <unix:object object_ref="obj_runlevel2_{{{ SERVICENAME }}}_off" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel3_%SERVICENAME%_off"
+  comment="Runlevel test" id="test_runlevel3_{{{ SERVICENAME }}}_off"
   version="2">
-    <unix:object object_ref="obj_runlevel3_%SERVICENAME%_off" />
-    <unix:state state_ref="state_service_%SERVICENAME%_off" />
+    <unix:object object_ref="obj_runlevel3_{{{ SERVICENAME }}}_off" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel4_%SERVICENAME%_off"
+  comment="Runlevel test" id="test_runlevel4_{{{ SERVICENAME }}}_off"
   version="2">
-    <unix:object object_ref="obj_runlevel4_%SERVICENAME%_off" />
-    <unix:state state_ref="state_service_%SERVICENAME%_off" />
+    <unix:object object_ref="obj_runlevel4_{{{ SERVICENAME }}}_off" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel5_%SERVICENAME%_off"
+  comment="Runlevel test" id="test_runlevel5_{{{ SERVICENAME }}}_off"
   version="2">
-    <unix:object object_ref="obj_runlevel5_%SERVICENAME%_off" />
-    <unix:state state_ref="state_service_%SERVICENAME%_off" />
+    <unix:object object_ref="obj_runlevel5_{{{ SERVICENAME }}}_off" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel6_%SERVICENAME%_off"
+  comment="Runlevel test" id="test_runlevel6_{{{ SERVICENAME }}}_off"
   version="2">
-    <unix:object object_ref="obj_runlevel6_%SERVICENAME%_off" />
-    <unix:state state_ref="state_service_%SERVICENAME%_off" />
+    <unix:object object_ref="obj_runlevel6_{{{ SERVICENAME }}}_off" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
   </unix:runlevel_test>
-  <unix:runlevel_object id="obj_runlevel0_%SERVICENAME%_off" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel0_{{{ SERVICENAME }}}_off" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">0</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel1_%SERVICENAME%_off" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel1_{{{ SERVICENAME }}}_off" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">1</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel2_%SERVICENAME%_off" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel2_{{{ SERVICENAME }}}_off" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">2</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel3_%SERVICENAME%_off" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel3_{{{ SERVICENAME }}}_off" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">3</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel4_%SERVICENAME%_off" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel4_{{{ SERVICENAME }}}_off" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">4</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel5_%SERVICENAME%_off" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel5_{{{ SERVICENAME }}}_off" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">5</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel6_%SERVICENAME%_off" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel6_{{{ SERVICENAME }}}_off" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">6</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_state comment="not configured to start" id="state_service_%SERVICENAME%_off" version="1">
+  <unix:runlevel_state comment="not configured to start" id="state_service_{{{ SERVICENAME }}}_off" version="1">
     <unix:start datatype="boolean">false</unix:start>
     <unix:kill datatype="boolean">true</unix:kill>
   </unix:runlevel_state>
@@ -198,48 +198,48 @@
 
   {{# fallback if we are using systemd but can't use the new systemd features of OVAL 5.11 #}}
 
-  <definition class="compliance" id="service_%SERVICENAME%_disabled" version="2">
+  <definition class="compliance" id="service_{{{ SERVICENAME }}}_disabled" version="2">
     <metadata>
-      <title>Service %SERVICENAME% Disabled</title>
+      <title>Service {{{ SERVICENAME }}} Disabled</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The %SERVICENAME% service should be disabled if possible.</description>
+      <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
     </metadata>
-    <criteria comment="package %PACKAGENAME% removed or service and socket %SERVICENAME% are not configured to start" operator="OR">
-      <extend_definition comment="%PACKAGENAME% removed" definition_ref="package_%PACKAGENAME%_removed" />
-      <criteria operator="AND" comment="service and socket %SERVICENAME% are disabled">
-        <criterion comment="%SERVICENAME% disabled in multi-user.target" test_ref="test_%SERVICENAME%_disabled_multi_user_target" />
-        <criterion comment="%SERVICENAME% socket disabled in sockets.target" test_ref="test_%SERVICENAME%_socket_disabled_sockets_target" />
+    <criteria comment="package {{{ PACKAGENAME }}} removed or service and socket {{{ SERVICENAME }}} are not configured to start" operator="OR">
+      <extend_definition comment="{{{ PACKAGENAME }}} removed" definition_ref="package_{{{ PACKAGENAME }}}_removed" />
+      <criteria operator="AND" comment="service and socket {{{ SERVICENAME }}} are disabled">
+        <criterion comment="{{{ SERVICENAME }}} disabled in multi-user.target" test_ref="test_{{{ SERVICENAME }}}_disabled_multi_user_target" />
+        <criterion comment="{{{ SERVICENAME }}} socket disabled in sockets.target" test_ref="test_{{{ SERVICENAME }}}_socket_disabled_sockets_target" />
       </criteria>
     </criteria>
   </definition>
 
   <unix:file_test check="all" check_existence="none_exist"
-   comment="look for %SERVICENAME%.service in /etc/systemd/system/multi-user.target.wants"
-   id="test_%SERVICENAME%_disabled_multi_user_target" version="1">
-    <unix:object object_ref="object_%SERVICENAME%_disabled_multi_user_target" />
+   comment="look for {{{ SERVICENAME }}}.service in /etc/systemd/system/multi-user.target.wants"
+   id="test_{{{ SERVICENAME }}}_disabled_multi_user_target" version="1">
+    <unix:object object_ref="object_{{{ SERVICENAME }}}_disabled_multi_user_target" />
   </unix:file_test>
 
-  <unix:file_object comment="look for %SERVICENAME%.service in /etc/systemd/system/multi-user.target.wants"
-   id="object_%SERVICENAME%_disabled_multi_user_target" version="1">
-    <unix:filepath>/etc/systemd/system/multi-user.target.wants/%SERVICENAME%.service</unix:filepath>
-    <filter action="include">unit_%SERVICENAME%_state_symlink</filter>
+  <unix:file_object comment="look for {{{ SERVICENAME }}}.service in /etc/systemd/system/multi-user.target.wants"
+   id="object_{{{ SERVICENAME }}}_disabled_multi_user_target" version="1">
+    <unix:filepath>/etc/systemd/system/multi-user.target.wants/{{{ SERVICENAME }}}.service</unix:filepath>
+    <filter action="include">unit_{{{ SERVICENAME }}}_state_symlink</filter>
   </unix:file_object>
 
   <unix:file_test check="all" check_existence="none_exist"
-   comment="look for %SERVICENAME%.socket in /etc/systemd/system/sockets.target.wants"
-   id="test_%SERVICENAME%_socket_disabled_sockets_target" version="1">
-    <unix:object object_ref="object_%SERVICENAME%_socket_disabled_sockets_target" />
+   comment="look for {{{ SERVICENAME }}}.socket in /etc/systemd/system/sockets.target.wants"
+   id="test_{{{ SERVICENAME }}}_socket_disabled_sockets_target" version="1">
+    <unix:object object_ref="object_{{{ SERVICENAME }}}_socket_disabled_sockets_target" />
   </unix:file_test>
 
-  <unix:file_object comment="look for %SERVICENAME%.socket in /etc/systemd/system/sockets.target.wants"
-   id="object_%SERVICENAME%_socket_disabled_sockets_target" version="1">
-    <unix:filepath>/etc/systemd/system/sockets.target.wants/%SERVICENAME%.socket</unix:filepath>
-    <filter action="include">unit_%SERVICENAME%_state_symlink</filter>
+  <unix:file_object comment="look for {{{ SERVICENAME }}}.socket in /etc/systemd/system/sockets.target.wants"
+   id="object_{{{ SERVICENAME }}}_socket_disabled_sockets_target" version="1">
+    <unix:filepath>/etc/systemd/system/sockets.target.wants/{{{ SERVICENAME }}}.socket</unix:filepath>
+    <filter action="include">unit_{{{ SERVICENAME }}}_state_symlink</filter>
   </unix:file_object>
 
-  <unix:file_state id="unit_%SERVICENAME%_state_symlink" version="1">
+  <unix:file_state id="unit_{{{ SERVICENAME }}}_state_symlink" version="1">
     <unix:type operation="equals">symbolic link</unix:type>
   </unix:file_state>
 

--- a/shared/templates/template_OVAL_service_enabled
+++ b/shared/templates/template_OVAL_service_enabled
@@ -2,155 +2,155 @@
 
 {{% if init_system == "systemd" and target_oval_version >= [5, 11] %}}
 
-  <definition class="compliance" id="service_%SERVICENAME%_enabled" version="1">
+  <definition class="compliance" id="service_{{{ SERVICENAME }}}_enabled" version="1">
     <metadata>
-      <title>Service %SERVICENAME% Enabled</title>
+      <title>Service {{{ SERVICENAME }}} Enabled</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The %SERVICENAME% service should be enabled if possible.</description>
+      <description>The {{{ SERVICENAME }}} service should be enabled if possible.</description>
     </metadata>
-    <criteria comment="package %PACKAGENAME% installed and service %SERVICENAME% is configured to start" operator="AND">
-    <extend_definition comment="%PACKAGENAME% installed" definition_ref="package_%PACKAGENAME%_installed" />
-      <criteria comment="service %SERVICENAME% is configured to start and is running" operator="AND">
-        <criterion comment="%SERVICENAME% is running" test_ref="test_service_running_%SERVICENAME%" />
-        <criteria operator="OR" comment="service %SERVICENAME% is configured to start">
-          <criterion comment="multi-user.target wants %SERVICENAME%" test_ref="test_multi_user_wants_%SERVICENAME%" />
-          <criterion comment="multi-user.target wants %SERVICENAME% socket" test_ref="test_multi_user_wants_%SERVICENAME%_socket" />
+    <criteria comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start" operator="AND">
+    <extend_definition comment="{{{ PACKAGENAME }}} installed" definition_ref="package_{{{ PACKAGENAME }}}_installed" />
+      <criteria comment="service {{{ SERVICENAME }}} is configured to start and is running" operator="AND">
+        <criterion comment="{{{ SERVICENAME }}} is running" test_ref="test_service_running_{{{ SERVICENAME }}}" />
+        <criteria operator="OR" comment="service {{{ SERVICENAME }}} is configured to start">
+          <criterion comment="multi-user.target wants {{{ SERVICENAME }}}" test_ref="test_multi_user_wants_{{{ SERVICENAME }}}" />
+          <criterion comment="multi-user.target wants {{{ SERVICENAME }}} socket" test_ref="test_multi_user_wants_{{{ SERVICENAME }}}_socket" />
         </criteria>
       </criteria>
     </criteria>
   </definition>
 
-  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_multi_user_wants_%SERVICENAME%" version="1">
-    <linux:object object_ref="object_multi_user_target_for_%SERVICENAME%_enabled" />
-    <linux:state state_ref="state_systemd_%SERVICENAME%_on"/>
+  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_multi_user_wants_{{{ SERVICENAME }}}" version="1">
+    <linux:object object_ref="object_multi_user_target_for_{{{ SERVICENAME }}}_enabled" />
+    <linux:state state_ref="state_systemd_{{{ SERVICENAME }}}_on"/>
   </linux:systemdunitdependency_test>
-  <linux:systemdunitdependency_object id="object_multi_user_target_for_%SERVICENAME%_enabled" comment="list of dependencies of multi-user.target" version="1">
+  <linux:systemdunitdependency_object id="object_multi_user_target_for_{{{ SERVICENAME }}}_enabled" comment="list of dependencies of multi-user.target" version="1">
     <linux:unit>multi-user.target</linux:unit>
   </linux:systemdunitdependency_object>
-  <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_on" comment="%SERVICENAME% listed at least once in the dependencies" version="1">
-    <linux:dependency entity_check="at least one">%SERVICENAME%.service</linux:dependency>
+  <linux:systemdunitdependency_state id="state_systemd_{{{ SERVICENAME }}}_on" comment="{{{ SERVICENAME }}} listed at least once in the dependencies" version="1">
+    <linux:dependency entity_check="at least one">{{{ SERVICENAME }}}.service</linux:dependency>
   </linux:systemdunitdependency_state>
 
-  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_multi_user_wants_%SERVICENAME%_socket" version="1">
-    <linux:object object_ref="object_multi_user_target_for_%SERVICENAME%_socket_enabled" />
-    <linux:state state_ref="state_systemd_%SERVICENAME%_socket_on"/>
+  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_multi_user_wants_{{{ SERVICENAME }}}_socket" version="1">
+    <linux:object object_ref="object_multi_user_target_for_{{{ SERVICENAME }}}_socket_enabled" />
+    <linux:state state_ref="state_systemd_{{{ SERVICENAME }}}_socket_on"/>
   </linux:systemdunitdependency_test>
-  <linux:systemdunitdependency_object id="object_multi_user_target_for_%SERVICENAME%_socket_enabled" comment="list of dependencies of multi-user.target" version="1">
+  <linux:systemdunitdependency_object id="object_multi_user_target_for_{{{ SERVICENAME }}}_socket_enabled" comment="list of dependencies of multi-user.target" version="1">
     <linux:unit>multi-user.target</linux:unit>
   </linux:systemdunitdependency_object>
-  <linux:systemdunitdependency_state id="state_systemd_%SERVICENAME%_socket_on" comment="%SERVICENAME% listed at least once in the dependencies" version="1">
-    <linux:dependency entity_check="at least one">%SERVICENAME%.socket</linux:dependency>
+  <linux:systemdunitdependency_state id="state_systemd_{{{ SERVICENAME }}}_socket_on" comment="{{{ SERVICENAME }}} listed at least once in the dependencies" version="1">
+    <linux:dependency entity_check="at least one">{{{ SERVICENAME }}}.socket</linux:dependency>
   </linux:systemdunitdependency_state>
 
-  <linux:systemdunitproperty_test id="test_service_running_%SERVICENAME%" check="at least one" check_existence="at_least_one_exists" comment="Test that the %SERVICENAME% service is running" version="1">
-    <linux:object object_ref="obj_service_running_%SERVICENAME%"/>
-    <linux:state state_ref="state_service_running_%SERVICENAME%"/>
+  <linux:systemdunitproperty_test id="test_service_running_{{{ SERVICENAME }}}" check="at least one" check_existence="at_least_one_exists" comment="Test that the {{{ SERVICENAME }}} service is running" version="1">
+    <linux:object object_ref="obj_service_running_{{{ SERVICENAME }}}"/>
+    <linux:state state_ref="state_service_running_{{{ SERVICENAME }}}"/>
   </linux:systemdunitproperty_test>
-  <linux:systemdunitproperty_object id="obj_service_running_%SERVICENAME%" comment="Retrieve the ActiveState property of %SERVICENAME%" version="1">
-    <linux:unit operation="pattern match">%SERVICENAME%\.(socket|service)</linux:unit>
+  <linux:systemdunitproperty_object id="obj_service_running_{{{ SERVICENAME }}}" comment="Retrieve the ActiveState property of {{{ SERVICENAME }}}" version="1">
+    <linux:unit operation="pattern match">{{{ SERVICENAME }}}\.(socket|service)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_running_%SERVICENAME%" version="1" comment="%SERVICENAME% is running">
+  <linux:systemdunitproperty_state id="state_service_running_{{{ SERVICENAME }}}" version="1" comment="{{{ SERVICENAME }}} is running">
       <linux:value>active</linux:value>
   </linux:systemdunitproperty_state>
 
 {{% else %}}
 
-  <definition class="compliance" id="service_%SERVICENAME%_enabled"
+  <definition class="compliance" id="service_{{{ SERVICENAME }}}_enabled"
   version="1">
     <metadata>
-      <title>Service %SERVICENAME% Enabled</title>
+      <title>Service {{{ SERVICENAME }}} Enabled</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The %SERVICENAME% service should be enabled if possible.</description>
+      <description>The {{{ SERVICENAME }}} service should be enabled if possible.</description>
     </metadata>
-    <criteria comment="package %PACKAGENAME% installed and service %SERVICENAME% is configured to start" operator="AND">
-    <extend_definition comment="%PACKAGENAME% installed" definition_ref="package_%PACKAGENAME%_installed" />
-    <criteria operator="OR" comment="service %SERVICENAME% is configured to start">
-      <criterion comment="%SERVICENAME% runlevel 0" test_ref="test_runlevel0_%SERVICENAME%_on" />
-      <criterion comment="%SERVICENAME% runlevel 1" test_ref="test_runlevel1_%SERVICENAME%_on" />
-      <criterion comment="%SERVICENAME% runlevel 2" test_ref="test_runlevel2_%SERVICENAME%_on" />
-      <criterion comment="%SERVICENAME% runlevel 3" test_ref="test_runlevel3_%SERVICENAME%_on" />
-      <criterion comment="%SERVICENAME% runlevel 4" test_ref="test_runlevel4_%SERVICENAME%_on" />
-      <criterion comment="%SERVICENAME% runlevel 5" test_ref="test_runlevel5_%SERVICENAME%_on" />
-      <criterion comment="%SERVICENAME% runlevel 6" test_ref="test_runlevel6_%SERVICENAME%_on" />
+    <criteria comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start" operator="AND">
+    <extend_definition comment="{{{ PACKAGENAME }}} installed" definition_ref="package_{{{ PACKAGENAME }}}_installed" />
+    <criteria operator="OR" comment="service {{{ SERVICENAME }}} is configured to start">
+      <criterion comment="{{{ SERVICENAME }}} runlevel 0" test_ref="test_runlevel0_{{{ SERVICENAME }}}_on" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 1" test_ref="test_runlevel1_{{{ SERVICENAME }}}_on" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 2" test_ref="test_runlevel2_{{{ SERVICENAME }}}_on" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 3" test_ref="test_runlevel3_{{{ SERVICENAME }}}_on" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 4" test_ref="test_runlevel4_{{{ SERVICENAME }}}_on" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 5" test_ref="test_runlevel5_{{{ SERVICENAME }}}_on" />
+      <criterion comment="{{{ SERVICENAME }}} runlevel 6" test_ref="test_runlevel6_{{{ SERVICENAME }}}_on" />
     </criteria>
     </criteria>
   </definition>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel0_%SERVICENAME%_on"
+  comment="Runlevel test" id="test_runlevel0_{{{ SERVICENAME }}}_on"
   version="2">
-    <unix:object object_ref="obj_runlevel0_%SERVICENAME%_on" />
-    <unix:state state_ref="state_service_%SERVICENAME%_on" />
+    <unix:object object_ref="obj_runlevel0_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel1_%SERVICENAME%_on"
+  comment="Runlevel test" id="test_runlevel1_{{{ SERVICENAME }}}_on"
   version="2">
-    <unix:object object_ref="obj_runlevel1_%SERVICENAME%_on" />
-    <unix:state state_ref="state_service_%SERVICENAME%_on" />
+    <unix:object object_ref="obj_runlevel1_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel2_%SERVICENAME%_on"
+  comment="Runlevel test" id="test_runlevel2_{{{ SERVICENAME }}}_on"
   version="2">
-    <unix:object object_ref="obj_runlevel2_%SERVICENAME%_on" />
-    <unix:state state_ref="state_service_%SERVICENAME%_on" />
+    <unix:object object_ref="obj_runlevel2_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel3_%SERVICENAME%_on"
+  comment="Runlevel test" id="test_runlevel3_{{{ SERVICENAME }}}_on"
   version="2">
-    <unix:object object_ref="obj_runlevel3_%SERVICENAME%_on" />
-    <unix:state state_ref="state_service_%SERVICENAME%_on" />
+    <unix:object object_ref="obj_runlevel3_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel4_%SERVICENAME%_on"
+  comment="Runlevel test" id="test_runlevel4_{{{ SERVICENAME }}}_on"
   version="2">
-    <unix:object object_ref="obj_runlevel4_%SERVICENAME%_on" />
-    <unix:state state_ref="state_service_%SERVICENAME%_on" />
+    <unix:object object_ref="obj_runlevel4_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel5_%SERVICENAME%_on"
+  comment="Runlevel test" id="test_runlevel5_{{{ SERVICENAME }}}_on"
   version="2">
-    <unix:object object_ref="obj_runlevel5_%SERVICENAME%_on" />
-    <unix:state state_ref="state_service_%SERVICENAME%_on" />
+    <unix:object object_ref="obj_runlevel5_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
   </unix:runlevel_test>
   <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel6_%SERVICENAME%_on"
+  comment="Runlevel test" id="test_runlevel6_{{{ SERVICENAME }}}_on"
   version="2">
-    <unix:object object_ref="obj_runlevel6_%SERVICENAME%_on" />
-    <unix:state state_ref="state_service_%SERVICENAME%_on" />
+    <unix:object object_ref="obj_runlevel6_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
   </unix:runlevel_test>
-  <unix:runlevel_object id="obj_runlevel0_%SERVICENAME%_on" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel0_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">0</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel1_%SERVICENAME%_on" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel1_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">1</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel2_%SERVICENAME%_on" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel2_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">2</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel3_%SERVICENAME%_on" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel3_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">3</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel4_%SERVICENAME%_on" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel4_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">4</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel5_%SERVICENAME%_on" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel5_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">5</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel6_%SERVICENAME%_on" version="1">
-    <unix:service_name>%SERVICENAME%</unix:service_name>
+  <unix:runlevel_object id="obj_runlevel6_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
     <unix:runlevel operation="equals">6</unix:runlevel>
   </unix:runlevel_object>
-  <unix:runlevel_state comment="configured to start" id="state_service_%SERVICENAME%_on" version="1">
+  <unix:runlevel_state comment="configured to start" id="state_service_{{{ SERVICENAME }}}_on" version="1">
     <unix:start datatype="boolean">true</unix:start>
     <unix:kill datatype="boolean">false</unix:kill>
   </unix:runlevel_state>

--- a/shared/templates/template_OVAL_sysctl
+++ b/shared/templates/template_OVAL_sysctl
@@ -1,15 +1,15 @@
 <def-group>
-  <definition class="compliance" id="sysctl_%SYSCTLID%" version="3">
+  <definition class="compliance" id="sysctl_{{{ SYSCTLID }}}" version="3">
     <metadata>
-      <title>Kernel "%SYSCTLVAR%" Parameter Configuration and Runtime Check</title>
+      <title>Kernel "{{{ SYSCTLVAR }}}" Parameter Configuration and Runtime Check</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The "%SYSCTLVAR%" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
+      <description>The "{{{ SYSCTLVAR }}}" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
     </metadata>
     <criteria operator="AND">
-      <extend_definition comment="%SYSCTLVAR% configuration setting check" definition_ref="sysctl_static_%SYSCTLID%" />
-      <extend_definition comment="%SYSCTLVAR% runtime setting check" definition_ref="sysctl_runtime_%SYSCTLID%" />
+      <extend_definition comment="{{{ SYSCTLVAR }}} configuration setting check" definition_ref="sysctl_static_{{{ SYSCTLID }}}" />
+      <extend_definition comment="{{{ SYSCTLVAR }}} runtime setting check" definition_ref="sysctl_runtime_{{{ SYSCTLID }}}" />
     </criteria>
   </definition>
 </def-group>

--- a/shared/templates/template_OVAL_sysctl_ipv6
+++ b/shared/templates/template_OVAL_sysctl_ipv6
@@ -1,21 +1,21 @@
 <def-group>
-  <definition class="compliance" id="sysctl_%SYSCTLID%" version="4">
+  <definition class="compliance" id="sysctl_{{{ SYSCTLID }}}" version="4">
     <metadata>
-      <title>Kernel "%SYSCTLVAR%" Parameter Configuration and Runtime Check</title>
+      <title>Kernel "{{{ SYSCTLVAR }}}" Parameter Configuration and Runtime Check</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The "%SYSCTLVAR%" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
+      <description>The "{{{ SYSCTLVAR }}}" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
     </metadata>
-    <criteria comment="IPv6 disabled or %SYSCTLVAR% set correctly" operator="OR">
+    <criteria comment="IPv6 disabled or {{{ SYSCTLVAR }}} set correctly" operator="OR">
 {{% if product in ["rhel6", "debian8", "ubuntu1404", "ubuntu1604"] %}}
       <extend_definition comment="is IPv6 enabled?" definition_ref="kernel_module_ipv6_option_disabled" />
 {{% else %}}
       <extend_definition comment="is IPv6 enabled?" definition_ref="sysctl_kernel_ipv6_disable" />
 {{% endif %}}
       <criteria operator="AND">
-        <extend_definition comment="%SYSCTLVAR% configuration setting check" definition_ref="sysctl_static_%SYSCTLID%" />
-        <extend_definition comment="%SYSCTLVAR% runtime setting check" definition_ref="sysctl_runtime_%SYSCTLID%" />
+        <extend_definition comment="{{{ SYSCTLVAR }}} configuration setting check" definition_ref="sysctl_static_{{{ SYSCTLID }}}" />
+        <extend_definition comment="{{{ SYSCTLVAR }}} runtime setting check" definition_ref="sysctl_runtime_{{{ SYSCTLID }}}" />
       </criteria>
     </criteria>
   </definition>

--- a/shared/templates/template_OVAL_sysctl_runtime
+++ b/shared/templates/template_OVAL_sysctl_runtime
@@ -1,27 +1,27 @@
 <def-group>
-  <definition class="compliance" id="sysctl_runtime_%SYSCTLID%" version="3">
+  <definition class="compliance" id="sysctl_runtime_{{{ SYSCTLID }}}" version="3">
     <metadata>
-      <title>Kernel "%SYSCTLVAR%" Parameter Runtime Check</title>
+      <title>Kernel "{{{ SYSCTLVAR }}}" Parameter Runtime Check</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The kernel "%SYSCTLVAR%" parameter should be set to "%SYSCTLVAL%" in system runtime.</description>
+      <description>The kernel "{{{ SYSCTLVAR }}}" parameter should be set to "{{{ SYSCTLVAL }}}" in system runtime.</description>
     </metadata>
     <criteria operator="AND">
-      <criterion comment="kernel runtime parameter %SYSCTLVAR% set to %SYSCTLVAL%" test_ref="test_sysctl_runtime_%SYSCTLID%" />
+      <criterion comment="kernel runtime parameter {{{ SYSCTLVAR }}} set to {{{ SYSCTLVAL }}}" test_ref="test_sysctl_runtime_{{{ SYSCTLID }}}" />
     </criteria>
   </definition>
 
-  <unix:sysctl_test check="all" check_existence="all_exist" comment="kernel runtime parameter %SYSCTLVAR% set to %SYSCTLVAL%" id="test_sysctl_runtime_%SYSCTLID%" version="1">
-    <unix:object object_ref="object_sysctl_runtime_%SYSCTLID%" />
-    <unix:state state_ref="state_sysctl_runtime_%SYSCTLID%" />
+  <unix:sysctl_test check="all" check_existence="all_exist" comment="kernel runtime parameter {{{ SYSCTLVAR }}} set to {{{ SYSCTLVAL }}}" id="test_sysctl_runtime_{{{ SYSCTLID }}}" version="1">
+    <unix:object object_ref="object_sysctl_runtime_{{{ SYSCTLID }}}" />
+    <unix:state state_ref="state_sysctl_runtime_{{{ SYSCTLID }}}" />
   </unix:sysctl_test>
 
-  <unix:sysctl_object id="object_sysctl_runtime_%SYSCTLID%" version="1">
-    <unix:name>%SYSCTLVAR%</unix:name>
+  <unix:sysctl_object id="object_sysctl_runtime_{{{ SYSCTLID }}}" version="1">
+    <unix:name>{{{ SYSCTLVAR }}}</unix:name>
   </unix:sysctl_object>
 
-  <unix:sysctl_state id="state_sysctl_runtime_%SYSCTLID%" version="1">
-    <unix:value datatype="int" operation="equals">%SYSCTLVAL%</unix:value>
+  <unix:sysctl_state id="state_sysctl_runtime_{{{ SYSCTLID }}}" version="1">
+    <unix:value datatype="int" operation="equals">{{{ SYSCTLVAL }}}</unix:value>
   </unix:sysctl_state>
 </def-group>

--- a/shared/templates/template_OVAL_sysctl_runtime_var
+++ b/shared/templates/template_OVAL_sysctl_runtime_var
@@ -1,29 +1,29 @@
 <def-group>
-  <definition class="compliance" id="sysctl_runtime_%SYSCTLID%" version="3">
+  <definition class="compliance" id="sysctl_runtime_{{{ SYSCTLID }}}" version="3">
     <metadata>
-      <title>Kernel "%SYSCTLVAR%" Parameter Runtime Check</title>
+      <title>Kernel "{{{ SYSCTLVAR }}}" Parameter Runtime Check</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The kernel "%SYSCTLVAR%" parameter should be set to the appropriate value in system runtime.</description>
+      <description>The kernel "{{{ SYSCTLVAR }}}" parameter should be set to the appropriate value in system runtime.</description>
     </metadata>
     <criteria operator="AND">
-      <criterion comment="kernel runtime parameter %SYSCTLVAR% set to the appropriate value" test_ref="test_sysctl_runtime_%SYSCTLID%" />
+      <criterion comment="kernel runtime parameter {{{ SYSCTLVAR }}} set to the appropriate value" test_ref="test_sysctl_runtime_{{{ SYSCTLID }}}" />
     </criteria>
   </definition>
 
-  <unix:sysctl_test check="all" check_existence="all_exist" comment="kernel runtime parameter %SYSCTLVAR% set to the appropriate value" id="test_sysctl_runtime_%SYSCTLID%" version="1">
-    <unix:object object_ref="object_sysctl_runtime_%SYSCTLID%" />
-    <unix:state state_ref="state_sysctl_runtime_%SYSCTLID%" />
+  <unix:sysctl_test check="all" check_existence="all_exist" comment="kernel runtime parameter {{{ SYSCTLVAR }}} set to the appropriate value" id="test_sysctl_runtime_{{{ SYSCTLID }}}" version="1">
+    <unix:object object_ref="object_sysctl_runtime_{{{ SYSCTLID }}}" />
+    <unix:state state_ref="state_sysctl_runtime_{{{ SYSCTLID }}}" />
   </unix:sysctl_test>
 
-  <unix:sysctl_object id="object_sysctl_runtime_%SYSCTLID%" version="1">
-    <unix:name>%SYSCTLVAR%</unix:name>
+  <unix:sysctl_object id="object_sysctl_runtime_{{{ SYSCTLID }}}" version="1">
+    <unix:name>{{{ SYSCTLVAR }}}</unix:name>
   </unix:sysctl_object>
 
-  <unix:sysctl_state id="state_sysctl_runtime_%SYSCTLID%" version="1">
-    <unix:value datatype="int" operation="equals" var_ref="sysctl_%SYSCTLID%_value" />
+  <unix:sysctl_state id="state_sysctl_runtime_{{{ SYSCTLID }}}" version="1">
+    <unix:value datatype="int" operation="equals" var_ref="sysctl_{{{ SYSCTLID }}}_value" />
   </unix:sysctl_state>
 
-  <external_variable comment="External variable for %SYSCTLVAR%" datatype="int" id="sysctl_%SYSCTLID%_value" version="1" />
+  <external_variable comment="External variable for {{{ SYSCTLVAR }}}" datatype="int" id="sysctl_{{{ SYSCTLID }}}_value" version="1" />
 </def-group>

--- a/shared/templates/template_OVAL_sysctl_static
+++ b/shared/templates/template_OVAL_sysctl_static
@@ -1,11 +1,11 @@
 <def-group>
-  <definition class="compliance" id="sysctl_static_%SYSCTLID%" version="3">
+  <definition class="compliance" id="sysctl_static_{{{ SYSCTLID }}}" version="3">
     <metadata>
-      <title>Kernel "%SYSCTLVAR%" Parameter Configuration Check</title>
+      <title>Kernel "{{{ SYSCTLVAR }}}" Parameter Configuration Check</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The kernel "%SYSCTLVAR%" parameter should be set to "%SYSCTLVAL%" in the system configuration.</description>
+      <description>The kernel "{{{ SYSCTLVAR }}}" parameter should be set to "{{{ SYSCTLVAL }}}" in the system configuration.</description>
     </metadata>
 
 {{% if product == "rhel6" %}}
@@ -24,124 +24,124 @@
            Since so far there isn't a way how to perform a lexicographic sort in OVAL, this OVAL check
            will behave as follows:
            * perform the verification in reversed order (check /etc/sysctl.d/* first, then /etc/sysctl.conf)
-           * if there's just one /etc/sysctl.d/* file containing the %SYSCTLVAR% directive, return PASS
+           * if there's just one /etc/sysctl.d/* file containing the {{{ SYSCTLVAR }}} directive, return PASS
              if the requirements are met, FAIL otherwise,
-           * if there are two or more /etc/sysctl.d/* files containing the %SYSCTLVAR% directive, return FAIL
+           * if there are two or more /etc/sysctl.d/* files containing the {{{ SYSCTLVAR }}} directive, return FAIL
              (since in this case we aren't able with absolute certainty to tell which /etc/sysctl.d/* file
              would be applied as the last one)
-           * if there's no /etc/sysctl.d/* file containing the %SYSCTLVAR% directive, and /etc/sysctl.conf
-             contains the %SYSCTLVAR% directive, return PASS if the requirements are met, FAIL otherwise. -->
+           * if there's no /etc/sysctl.d/* file containing the {{{ SYSCTLVAR }}} directive, and /etc/sysctl.conf
+             contains the {{{ SYSCTLVAR }}} directive, return PASS if the requirements are met, FAIL otherwise. -->
 
-      <criterion comment="Kernel static parameter %SYSCTLVAR% set to %SYSCTLVAL% in /etc/sysctl.d/*" test_ref="test_static_sysctld_%SYSCTLID%" />
+      <criterion comment="Kernel static parameter {{{ SYSCTLVAR }}} set to {{{ SYSCTLVAL }}} in /etc/sysctl.d/*" test_ref="test_static_sysctld_{{{ SYSCTLID }}}" />
       <criteria operator="AND">
-        <criterion comment="Kernel static paramater %SYSCTLVAR% set to %SYSCTLVAL% in /etc/sysctl.conf" test_ref="test_static_etc_sysctl_%SYSCTLID%" />
-        <criterion comment="Kernel static parameter %SYSCTLVAR% not present in some /etc/sysctl.d/* file" test_ref="test_static_sysctld_%SYSCTLID%_not_used" />
+        <criterion comment="Kernel static paramater {{{ SYSCTLVAR }}} set to {{{ SYSCTLVAL }}} in /etc/sysctl.conf" test_ref="test_static_etc_sysctl_{{{ SYSCTLID }}}" />
+        <criterion comment="Kernel static parameter {{{ SYSCTLVAR }}} not present in some /etc/sysctl.d/* file" test_ref="test_static_sysctld_{{{ SYSCTLID }}}_not_used" />
       </criteria>
     </criteria>
 {{% else %}}
     <criteria operator="OR">
-      <criterion comment="kernel static parameter %SYSCTLVAR% set to %SYSCTLVAL% in /etc/sysctl.conf" test_ref="test_static_sysctl_%SYSCTLID%" />
+      <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to {{{ SYSCTLVAL }}} in /etc/sysctl.conf" test_ref="test_static_sysctl_{{{ SYSCTLID }}}" />
       <!-- see sysctl.d(5) -->
-      <criterion comment="kernel static parameter %SYSCTLVAR% set to %SYSCTLVAL% in /etc/sysctl.d/*.conf" test_ref="test_static_etc_sysctld_%SYSCTLID%" />
-      <criterion comment="kernel static parameter %SYSCTLVAR% set to %SYSCTLVAL% in /run/sysctl.d/*.conf" test_ref="test_static_run_sysctld_%SYSCTLID%" />
-      <criterion comment="kernel static parameter %SYSCTLVAR% set to %SYSCTLVAL% in /usr/lib/sysctl.d/*.conf" test_ref="test_static_usr_lib_sysctld_%SYSCTLID%" />
+      <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to {{{ SYSCTLVAL }}} in /etc/sysctl.d/*.conf" test_ref="test_static_etc_sysctld_{{{ SYSCTLID }}}" />
+      <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to {{{ SYSCTLVAL }}} in /run/sysctl.d/*.conf" test_ref="test_static_run_sysctld_{{{ SYSCTLID }}}" />
+      <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to {{{ SYSCTLVAL }}} in /usr/lib/sysctl.d/*.conf" test_ref="test_static_usr_lib_sysctld_{{{ SYSCTLID }}}" />
     </criteria>
 {{% endif %}}
   </definition>
 
 {{% if product == "rhel6" %}}
   <!-- Check the /etc/sysctl.d/* configuration -->
-  <!-- Return PASS only in case there's only one /etc/sysctl.d/* file containing %SYSCTLVAR% set to %SYSCTLVAL%
+  <!-- Return PASS only in case there's only one /etc/sysctl.d/* file containing {{{ SYSCTLVAR }}} set to {{{ SYSCTLVAL }}}
        (otherwise we aren't able to reliably decide if the configuration is safe) -->
 
-  <ind:textfilecontent54_test id="test_static_sysctld_%SYSCTLID%" check="all" check_existence="only_one_exists" comment="Check %SYSCTLVAR% static configuration in /etc/sysctl.d/*" version="1">
-    <ind:object object_ref="object_static_sysctld_%SYSCTLID%" />
-    <ind:state state_ref="state_static_sysctld_%SYSCTLID%" />
+  <ind:textfilecontent54_test id="test_static_sysctld_{{{ SYSCTLID }}}" check="all" check_existence="only_one_exists" comment="Check {{{ SYSCTLVAR }}} static configuration in /etc/sysctl.d/*" version="1">
+    <ind:object object_ref="object_static_sysctld_{{{ SYSCTLID }}}" />
+    <ind:state state_ref="state_static_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_static_sysctld_%SYSCTLID%" version="1">
-    <!-- Read whole /etc/sysctl.d/* file as a single line so we can retrieve the last %SYSCTLVAR% directive instance -->
+  <ind:textfilecontent54_object id="object_static_sysctld_{{{ SYSCTLID }}}" version="1">
+    <!-- Read whole /etc/sysctl.d/* file as a single line so we can retrieve the last {{{ SYSCTLVAR }}} directive instance -->
     <ind:behaviors singleline="true" />
     <ind:path>/etc/sysctl.d</ind:path>
     <!-- apply_sysctl() routine from /etc/init.d/functions on RHEL-6 applies sysctl configuration from each /etc/sysctl.d/*
          file: https://git.fedorahosted.org/cgit/initscripts.git/tree/rc.d/init.d/functions?h=rhel6-branch#n646 -->
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*%SYSCTLVAR%[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
+    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_static_sysctld_%SYSCTLID%" version="1">
-    <ind:subexpression operation="equals" datatype="int">%SYSCTLVAL%</ind:subexpression>
+  <ind:textfilecontent54_state id="state_static_sysctld_{{{ SYSCTLID }}}" version="1">
+    <ind:subexpression operation="equals" datatype="int">{{{ SYSCTLVAL }}}</ind:subexpression>
   </ind:textfilecontent54_state>
 
   <!-- Check the /etc/sysctl.conf configuration -->
-  <!-- Return PASS only in case %SYSCTLVAR% is set to %SYSCTLVAL% in /etc/sysctl.conf and simultaneously %SYSCTLVAR% isn't used
-       in some /etc/sysctl.d/* file (otherwise the previous test_static_sysctld_%SYSCTLID% test would be applied) -->
+  <!-- Return PASS only in case {{{ SYSCTLVAR }}} is set to {{{ SYSCTLVAL }}} in /etc/sysctl.conf and simultaneously {{{ SYSCTLVAR }}} isn't used
+       in some /etc/sysctl.d/* file (otherwise the previous test_static_sysctld_{{{ SYSCTLID }}} test would be applied) -->
 
-  <!-- First check %SYSCTLVAR% set to %SYSCTLVAL% in /etc/sysctl.conf -->
-  <ind:textfilecontent54_test id="test_static_etc_sysctl_%SYSCTLID%" check="all" comment="Check %SYSCTLVAR% static configuration in /etc/sysctl.conf" version="1">
-    <ind:object object_ref="object_static_etc_sysctl_%SYSCTLID%" />
+  <!-- First check {{{ SYSCTLVAR }}} set to {{{ SYSCTLVAL }}} in /etc/sysctl.conf -->
+  <ind:textfilecontent54_test id="test_static_etc_sysctl_{{{ SYSCTLID }}}" check="all" comment="Check {{{ SYSCTLVAR }}} static configuration in /etc/sysctl.conf" version="1">
+    <ind:object object_ref="object_static_etc_sysctl_{{{ SYSCTLID }}}" />
     <!-- Re-use the above defined state (since the requirement is same for both locations) -->
-    <ind:state state_ref="state_static_sysctld_%SYSCTLID%" />
+    <ind:state state_ref="state_static_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_static_etc_sysctl_%SYSCTLID%" version="1">
-    <!-- Read whole /etc/sysctl.conf file as a single line so we can retrieve the last %SYSCTLVAR% directive instance -->
+  <ind:textfilecontent54_object id="object_static_etc_sysctl_{{{ SYSCTLID }}}" version="1">
+    <!-- Read whole /etc/sysctl.conf file as a single line so we can retrieve the last {{{ SYSCTLVAR }}} directive instance -->
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/sysctl.conf</ind:filepath>
-    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*%SYSCTLVAR%[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
+    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- Then ensure %SYSCTLVAR% is not listed in some /etc/sysctl.d/* file -->
-  <ind:textfilecontent54_test id="test_static_sysctld_%SYSCTLID%_not_used" check="all" check_existence="none_exist" comment="Check %SYSCTLVAR% is not used in some file from /etc/sysctl.d/* location" version="1">
-    <!-- Re-use the above defined object_static_sysctld_%SYSCTLID% object. We require object of same properties,
+  <!-- Then ensure {{{ SYSCTLVAR }}} is not listed in some /etc/sysctl.d/* file -->
+  <ind:textfilecontent54_test id="test_static_sysctld_{{{ SYSCTLID }}}_not_used" check="all" check_existence="none_exist" comment="Check {{{ SYSCTLVAR }}} is not used in some file from /etc/sysctl.d/* location" version="1">
+    <!-- Re-use the above defined object_static_sysctld_{{{ SYSCTLID }}} object. We require object of same properties,
          but this time we require no such object to exist in /etc/sysctl.d/* -->
-    <ind:object object_ref="object_static_sysctld_%SYSCTLID%" />
+    <ind:object object_ref="object_static_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
 {{% else %}}
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="%SYSCTLVAR% static configuration" id="test_static_sysctl_%SYSCTLID%" version="1">
-    <ind:object object_ref="object_static_sysctl_%SYSCTLID%" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="{{{ SYSCTLVAR }}} static configuration" id="test_static_sysctl_{{{ SYSCTLID }}}" version="1">
+    <ind:object object_ref="object_static_sysctl_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test check="all" comment="%SYSCTLVAR% static configuration in /etc/sysctl.d/*.conf" id="test_static_etc_sysctld_%SYSCTLID%" version="1">
-    <ind:object object_ref="object_static_etc_sysctld_%SYSCTLID%" />
+  <ind:textfilecontent54_test check="all" comment="{{{ SYSCTLVAR }}} static configuration in /etc/sysctl.d/*.conf" id="test_static_etc_sysctld_{{{ SYSCTLID }}}" version="1">
+    <ind:object object_ref="object_static_etc_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test check="all" comment="%SYSCTLVAR% static configuration in /etc/sysctl.d/*.conf" id="test_static_run_sysctld_%SYSCTLID%" version="1">
-    <ind:object object_ref="object_static_run_sysctld_%SYSCTLID%" />
+  <ind:textfilecontent54_test check="all" comment="{{{ SYSCTLVAR }}} static configuration in /etc/sysctl.d/*.conf" id="test_static_run_sysctld_{{{ SYSCTLID }}}" version="1">
+    <ind:object object_ref="object_static_run_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test check="all" comment="%SYSCTLVAR% static configuration in /etc/sysctl.d/*.conf" id="test_static_usr_lib_sysctld_%SYSCTLID%" version="1">
-    <ind:object object_ref="object_static_usr_lib_sysctld_%SYSCTLID%" />
+  <ind:textfilecontent54_test check="all" comment="{{{ SYSCTLVAR }}} static configuration in /etc/sysctl.d/*.conf" id="test_static_usr_lib_sysctld_{{{ SYSCTLID }}}" version="1">
+    <ind:object object_ref="object_static_usr_lib_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_static_sysctl_%SYSCTLID%" version="1">
+  <ind:textfilecontent54_object id="object_static_sysctl_{{{ SYSCTLID }}}" version="1">
     <ind:filepath>/etc/sysctl.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*%SYSCTLVAR%[\s]*=[\s]*%SYSCTLVAL%[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*{{{ SYSCTLVAR }}}[\s]*=[\s]*{{{ SYSCTLVAL }}}[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_static_etc_sysctld_%SYSCTLID%" version="1">
+  <ind:textfilecontent54_object id="object_static_etc_sysctld_{{{ SYSCTLID }}}" version="1">
     <ind:path>/etc/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^[\s]*%SYSCTLVAR%[\s]*=[\s]*%SYSCTLVAL%[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*{{{ SYSCTLVAR }}}[\s]*=[\s]*{{{ SYSCTLVAL }}}[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_static_run_sysctld_%SYSCTLID%" version="1">
+  <ind:textfilecontent54_object id="object_static_run_sysctld_{{{ SYSCTLID }}}" version="1">
     <ind:path>/run/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^[\s]*%SYSCTLVAR%[\s]*=[\s]*%SYSCTLVAL%[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*{{{ SYSCTLVAR }}}[\s]*=[\s]*{{{ SYSCTLVAL }}}[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_static_usr_lib_sysctld_%SYSCTLID%" version="1">
+  <ind:textfilecontent54_object id="object_static_usr_lib_sysctld_{{{ SYSCTLID }}}" version="1">
     <ind:path>/usr/lib/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^[\s]*%SYSCTLVAR%[\s]*=[\s]*%SYSCTLVAL%[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*{{{ SYSCTLVAR }}}[\s]*=[\s]*{{{ SYSCTLVAL }}}[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% endif %}}

--- a/shared/templates/template_OVAL_sysctl_static_var
+++ b/shared/templates/template_OVAL_sysctl_static_var
@@ -1,11 +1,11 @@
 <def-group>
-  <definition class="compliance" id="sysctl_static_%SYSCTLID%" version="3">
+  <definition class="compliance" id="sysctl_static_{{{ SYSCTLID }}}" version="3">
     <metadata>
-      <title>Kernel "%SYSCTLVAR%" Parameter Configuration Check</title>
+      <title>Kernel "{{{ SYSCTLVAR }}}" Parameter Configuration Check</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>The kernel "%SYSCTLVAR%" parameter should be set to the appropriate value in the system configuration.</description>
+      <description>The kernel "{{{ SYSCTLVAR }}}" parameter should be set to the appropriate value in the system configuration.</description>
     </metadata>
 {{% if product == "rhel6" %}}
     <criteria operator="OR">
@@ -24,135 +24,135 @@
            Since so far there isn't a way how to perform a lexicographic sort in OVAL, this OVAL check
            will behave as follows:
            * perform the verification in reversed order (check /etc/sysctl.d/* first, then /etc/sysctl.conf)
-           * if there's just one /etc/sysctl.d/* file containing the %SYSCTLVAR% directive, return PASS
+           * if there's just one /etc/sysctl.d/* file containing the {{{ SYSCTLVAR }}} directive, return PASS
              if the requirements are met, FAIL otherwise,
-           * if there are two or more /etc/sysctl.d/* files containing the %SYSCTLVAR% directive, return FAIL
+           * if there are two or more /etc/sysctl.d/* files containing the {{{ SYSCTLVAR }}} directive, return FAIL
              (since in this case we aren't able with absolute certainty to tell which /etc/sysctl.d/* file
              would be applied as the last one)
-           * if there's no /etc/sysctl.d/* file containing the %SYSCTLVAR% directive, and /etc/sysctl.conf
-             contains the %SYSCTLVAR% directive, return PASS if the requirements are met, FAIL otherwise. -->
+           * if there's no /etc/sysctl.d/* file containing the {{{ SYSCTLVAR }}} directive, and /etc/sysctl.conf
+             contains the {{{ SYSCTLVAR }}} directive, return PASS if the requirements are met, FAIL otherwise. -->
 
-      <criterion comment="Kernel static parameter %SYSCTLVAR% set to the appropriate value in /etc/sysctl.d/*" test_ref="test_static_sysctld_%SYSCTLID%" />
+      <criterion comment="Kernel static parameter {{{ SYSCTLVAR }}} set to the appropriate value in /etc/sysctl.d/*" test_ref="test_static_sysctld_{{{ SYSCTLID }}}" />
       <criteria operator="AND">
-        <criterion comment="Kernel static paramater %SYSCTLVAR% set to the appropriate value in /etc/sysctl.conf" test_ref="test_static_etc_sysctl_%SYSCTLID%" />
-        <criterion comment="Kernel static parameter %SYSCTLVAR% not present in some /etc/sysctl.d/* file" test_ref="test_static_sysctld_%SYSCTLID%_not_used" />
+        <criterion comment="Kernel static paramater {{{ SYSCTLVAR }}} set to the appropriate value in /etc/sysctl.conf" test_ref="test_static_etc_sysctl_{{{ SYSCTLID }}}" />
+        <criterion comment="Kernel static parameter {{{ SYSCTLVAR }}} not present in some /etc/sysctl.d/* file" test_ref="test_static_sysctld_{{{ SYSCTLID }}}_not_used" />
       </criteria>
     </criteria>
 {{% else %}}
     <criteria operator="OR">
-      <criterion comment="kernel static parameter %SYSCTLVAR% set to the appropriate value in /etc/sysctl.conf" test_ref="test_static_sysctl_%SYSCTLID%" />
+      <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to the appropriate value in /etc/sysctl.conf" test_ref="test_static_sysctl_{{{ SYSCTLID }}}" />
       <!-- see sysctl.d(5) -->
-      <criterion comment="kernel static parameter %SYSCTLVAR% set to the appropriate value in /etc/sysctl.d/*.conf" test_ref="test_static_etc_sysctld_%SYSCTLID%" />
-      <criterion comment="kernel static parameter %SYSCTLVAR% set to the appropriate value in /run/sysctl.d/*.conf" test_ref="test_static_run_sysctld_%SYSCTLID%" />
-      <criterion comment="kernel static parameter %SYSCTLVAR% set to the appropriate value in /usr/lib/sysctl.d/*.conf" test_ref="test_static_usr_lib_sysctld_%SYSCTLID%" />
+      <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to the appropriate value in /etc/sysctl.d/*.conf" test_ref="test_static_etc_sysctld_{{{ SYSCTLID }}}" />
+      <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to the appropriate value in /run/sysctl.d/*.conf" test_ref="test_static_run_sysctld_{{{ SYSCTLID }}}" />
+      <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to the appropriate value in /usr/lib/sysctl.d/*.conf" test_ref="test_static_usr_lib_sysctld_{{{ SYSCTLID }}}" />
     </criteria>
 {{% endif %}}
   </definition>
 
 {{% if product == "rhel6" %}}
   <!-- Check the /etc/sysctl.d/* configuration -->
-  <!-- Return PASS only in case there's only one /etc/sysctl.d/* file containing %SYSCTLVAR% set to the appropriate value
+  <!-- Return PASS only in case there's only one /etc/sysctl.d/* file containing {{{ SYSCTLVAR }}} set to the appropriate value
        (otherwise we aren't able to reliably decide if the configuration is safe) -->
 
-  <ind:textfilecontent54_test id="test_static_sysctld_%SYSCTLID%" check="all" check_existence="only_one_exists" comment="Check %SYSCTLVAR% static configuration in /etc/sysctl.d/*" version="1">
-    <ind:object object_ref="object_static_sysctld_%SYSCTLID%" />
-    <ind:state state_ref="state_static_sysctld_%SYSCTLID%" />
+  <ind:textfilecontent54_test id="test_static_sysctld_{{{ SYSCTLID }}}" check="all" check_existence="only_one_exists" comment="Check {{{ SYSCTLVAR }}} static configuration in /etc/sysctl.d/*" version="1">
+    <ind:object object_ref="object_static_sysctld_{{{ SYSCTLID }}}" />
+    <ind:state state_ref="state_static_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_static_sysctld_%SYSCTLID%" version="1">
-    <!-- Read whole /etc/sysctl.d/* file as a single line so we can retrieve the last %SYSCTLVAR% directive instance -->
+  <ind:textfilecontent54_object id="object_static_sysctld_{{{ SYSCTLID }}}" version="1">
+    <!-- Read whole /etc/sysctl.d/* file as a single line so we can retrieve the last {{{ SYSCTLVAR }}} directive instance -->
     <ind:behaviors singleline="true" />
     <ind:path>/etc/sysctl.d</ind:path>
     <!-- apply_sysctl() routine from /etc/init.d/functions on RHEL-6 applies sysctl configuration from each /etc/sysctl.d/*
          file: https://git.fedorahosted.org/cgit/initscripts.git/tree/rc.d/init.d/functions?h=rhel6-branch#n646 -->
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*%SYSCTLVAR%[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
+    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_static_sysctld_%SYSCTLID%" version="1">
-    <ind:subexpression operation="equals"  var_ref="sysctl_%SYSCTLID%_value" datatype="int" />
+  <ind:textfilecontent54_state id="state_static_sysctld_{{{ SYSCTLID }}}" version="1">
+    <ind:subexpression operation="equals"  var_ref="sysctl_{{{ SYSCTLID }}}_value" datatype="int" />
   </ind:textfilecontent54_state>
 
   <!-- Check the /etc/sysctl.conf configuration -->
-  <!-- Return PASS only in case %SYSCTLVAR% is set to the appropriate value in /etc/sysctl.conf and simultaneously %SYSCTLVAR% isn't used
-       in some /etc/sysctl.d/* file (otherwise the previous test_static_sysctld_%SYSCTLID% test would be applied) -->
+  <!-- Return PASS only in case {{{ SYSCTLVAR }}} is set to the appropriate value in /etc/sysctl.conf and simultaneously {{{ SYSCTLVAR }}} isn't used
+       in some /etc/sysctl.d/* file (otherwise the previous test_static_sysctld_{{{ SYSCTLID }}} test would be applied) -->
 
-  <!-- First check %SYSCTLVAR% set to the appropriate value in /etc/sysctl.conf -->
-  <ind:textfilecontent54_test id="test_static_etc_sysctl_%SYSCTLID%" check="all" comment="Check %SYSCTLVAR% static configuration in /etc/sysctl.conf" version="1">
-    <ind:object object_ref="object_static_etc_sysctl_%SYSCTLID%" />
+  <!-- First check {{{ SYSCTLVAR }}} set to the appropriate value in /etc/sysctl.conf -->
+  <ind:textfilecontent54_test id="test_static_etc_sysctl_{{{ SYSCTLID }}}" check="all" comment="Check {{{ SYSCTLVAR }}} static configuration in /etc/sysctl.conf" version="1">
+    <ind:object object_ref="object_static_etc_sysctl_{{{ SYSCTLID }}}" />
     <!-- Re-use the above defined state (since the requirement is same for both locations) -->
-    <ind:state state_ref="state_static_sysctld_%SYSCTLID%" />
+    <ind:state state_ref="state_static_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_static_etc_sysctl_%SYSCTLID%" version="1">
-    <!-- Read whole /etc/sysctl.conf file as a single line so we can retrieve the last %SYSCTLVAR% directive instance -->
+  <ind:textfilecontent54_object id="object_static_etc_sysctl_{{{ SYSCTLID }}}" version="1">
+    <!-- Read whole /etc/sysctl.conf file as a single line so we can retrieve the last {{{ SYSCTLVAR }}} directive instance -->
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/sysctl.conf</ind:filepath>
-    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*%SYSCTLVAR%[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
+    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- Then ensure %SYSCTLVAR% is not listed in some /etc/sysctl.d/* file -->
-  <ind:textfilecontent54_test id="test_static_sysctld_%SYSCTLID%_not_used" check="all" check_existence="none_exist" comment="Check %SYSCTLVAR% is not used in some file from /etc/sysctl.d/* location" version="1">
-    <!-- Re-use the above defined object_static_sysctld_%SYSCTLID% object. We require object of same properties,
+  <!-- Then ensure {{{ SYSCTLVAR }}} is not listed in some /etc/sysctl.d/* file -->
+  <ind:textfilecontent54_test id="test_static_sysctld_{{{ SYSCTLID }}}_not_used" check="all" check_existence="none_exist" comment="Check {{{ SYSCTLVAR }}} is not used in some file from /etc/sysctl.d/* location" version="1">
+    <!-- Re-use the above defined object_static_sysctld_{{{ SYSCTLID }}} object. We require object of same properties,
          but this time we require no such object to exist in /etc/sysctl.d/* -->
-    <ind:object object_ref="object_static_sysctld_%SYSCTLID%" />
+    <ind:object object_ref="object_static_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <external_variable comment="External variable for %SYSCTLVAR%" datatype="int" id="sysctl_%SYSCTLID%_value" version="1" />
+  <external_variable comment="External variable for {{{ SYSCTLVAR }}}" datatype="int" id="sysctl_{{{ SYSCTLID }}}_value" version="1" />
 {{% else %}}
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="%SYSCTLVAR% static configuration" id="test_static_sysctl_%SYSCTLID%" version="1">
-    <ind:object object_ref="object_static_sysctl_%SYSCTLID%" />
-    <ind:state state_ref="state_static_sysctld_%SYSCTLID%" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="{{{ SYSCTLVAR }}} static configuration" id="test_static_sysctl_{{{ SYSCTLID }}}" version="1">
+    <ind:object object_ref="object_static_sysctl_{{{ SYSCTLID }}}" />
+    <ind:state state_ref="state_static_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test check="all" comment="%SYSCTLVAR% static configuration in /etc/sysctl.d/*.conf" id="test_static_etc_sysctld_%SYSCTLID%" version="1">
-    <ind:object object_ref="object_static_etc_sysctld_%SYSCTLID%" />
-    <ind:state state_ref="state_static_sysctld_%SYSCTLID%" />
+  <ind:textfilecontent54_test check="all" comment="{{{ SYSCTLVAR }}} static configuration in /etc/sysctl.d/*.conf" id="test_static_etc_sysctld_{{{ SYSCTLID }}}" version="1">
+    <ind:object object_ref="object_static_etc_sysctld_{{{ SYSCTLID }}}" />
+    <ind:state state_ref="state_static_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test check="all" comment="%SYSCTLVAR% static configuration in /etc/sysctl.d/*.conf" id="test_static_run_sysctld_%SYSCTLID%" version="1">
-    <ind:object object_ref="object_static_run_sysctld_%SYSCTLID%" />
-    <ind:state state_ref="state_static_sysctld_%SYSCTLID%" />
+  <ind:textfilecontent54_test check="all" comment="{{{ SYSCTLVAR }}} static configuration in /etc/sysctl.d/*.conf" id="test_static_run_sysctld_{{{ SYSCTLID }}}" version="1">
+    <ind:object object_ref="object_static_run_sysctld_{{{ SYSCTLID }}}" />
+    <ind:state state_ref="state_static_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test check="all" comment="%SYSCTLVAR% static configuration in /etc/sysctl.d/*.conf" id="test_static_usr_lib_sysctld_%SYSCTLID%" version="1">
-    <ind:object object_ref="object_static_usr_lib_sysctld_%SYSCTLID%" />
-    <ind:state state_ref="state_static_sysctld_%SYSCTLID%" />
+  <ind:textfilecontent54_test check="all" comment="{{{ SYSCTLVAR }}} static configuration in /etc/sysctl.d/*.conf" id="test_static_usr_lib_sysctld_{{{ SYSCTLID }}}" version="1">
+    <ind:object object_ref="object_static_usr_lib_sysctld_{{{ SYSCTLID }}}" />
+    <ind:state state_ref="state_static_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_static_sysctl_%SYSCTLID%" version="1">
+  <ind:textfilecontent54_object id="object_static_sysctl_{{{ SYSCTLID }}}" version="1">
     <ind:filepath>/etc/sysctl.conf</ind:filepath>
-    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*%SYSCTLVAR%[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
+    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_static_etc_sysctld_%SYSCTLID%" version="1">
+  <ind:textfilecontent54_object id="object_static_etc_sysctld_{{{ SYSCTLID }}}" version="1">
     <ind:path>/etc/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*%SYSCTLVAR%[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
+    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_static_run_sysctld_%SYSCTLID%" version="1">
+  <ind:textfilecontent54_object id="object_static_run_sysctld_{{{ SYSCTLID }}}" version="1">
     <ind:path>/run/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*%SYSCTLVAR%[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
+    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_static_usr_lib_sysctld_%SYSCTLID%" version="1">
+  <ind:textfilecontent54_object id="object_static_usr_lib_sysctld_{{{ SYSCTLID }}}" version="1">
     <ind:path>/usr/lib/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*%SYSCTLVAR%[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
+    <ind:pattern operation="pattern match">(?:^|.*\n)[^#]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(\d+)[\s]*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_static_sysctld_%SYSCTLID%" version="1">
-    <ind:subexpression operation="equals"  var_ref="sysctl_%SYSCTLID%_value" datatype="int" />
+  <ind:textfilecontent54_state id="state_static_sysctld_{{{ SYSCTLID }}}" version="1">
+    <ind:subexpression operation="equals"  var_ref="sysctl_{{{ SYSCTLID }}}_value" datatype="int" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for %SYSCTLVAR%" datatype="int" id="sysctl_%SYSCTLID%_value" version="1" />
+  <external_variable comment="External variable for {{{ SYSCTLVAR }}}" datatype="int" id="sysctl_{{{ SYSCTLID }}}_value" version="1" />
 {{% endif %}}
 </def-group>

--- a/shared/templates/template_PUPPET_package_installed
+++ b/shared/templates/template_PUPPET_package_installed
@@ -3,10 +3,10 @@
 # strategy = enable
 # complexity = low
 # disruption = low
-include install_%PKGNAME%
+include install_{{{ PKGNAME }}}
 
-class install_%PKGNAME% {
-  package { '%PKGNAME%':
+class install_{{{ PKGNAME }}} {
+  package { '{{{ PKGNAME }}}':
     ensure => 'installed',
   }
 }

--- a/shared/templates/template_PUPPET_package_removed
+++ b/shared/templates/template_PUPPET_package_removed
@@ -3,10 +3,10 @@
 # strategy = disable
 # complexity = low
 # disruption = low
-include remove_%PKGNAME%
+include remove_{{{ PKGNAME }}}
 
-class remove_%PKGNAME% {
-  package { '%PKGNAME%':
+class remove_{{{ PKGNAME }}} {
+  package { '{{{ PKGNAME }}}':
     ensure => 'purged',
   }
 }

--- a/shared/templates/template_PUPPET_service_disabled
+++ b/shared/templates/template_PUPPET_service_disabled
@@ -3,10 +3,10 @@
 # strategy = enable
 # complexity = low
 # disruption = low
-include disable_%SERVICENAME%
+include disable_{{{ SERVICENAME }}}
 
-class disable_%SERVICENAME% {
-  service {'%DAEMONNAME%':
+class disable_{{{ SERVICENAME }}} {
+  service {'{{{ DAEMONNAME }}}':
     enable => false,
     ensure => 'stopped',
   }

--- a/shared/templates/template_PUPPET_service_enabled
+++ b/shared/templates/template_PUPPET_service_enabled
@@ -3,10 +3,10 @@
 # strategy = enable
 # complexity = low
 # disruption = low
-include enable_%SERVICENAME%
+include enable_{{{ SERVICENAME }}}
 
-class enable_%SERVICENAME% {
-  service {'%DAEMONNAME%':
+class enable_{{{ SERVICENAME }}} {
+  service {'{{{ DAEMONNAME }}}':
     enable => true,
     ensure => 'running',
   }

--- a/ssg/build_templates.py
+++ b/ssg/build_templates.py
@@ -32,12 +32,13 @@ from create_file_permissions import FilePermissionsGenerator
 
 
 class Builder(object):
-    def __init__(self):
+    def __init__(self, env_yaml):
         self.input_dir = None
         self.template_dir = None
         self.csv_dir = None
         self.output_dir = None
         self.ssg_shared = ""
+        self.env_yaml = env_yaml
 
         self.script_dict = {
             "sysctl_values.csv":                SysctlGenerator(),
@@ -123,6 +124,7 @@ class Builder(object):
             csv_filepath = os.path.join(self.csv_dir, csv_filename)
 
             generator.reset()
+            generator.env_yaml = self.env_yaml
             generator.output_dir = self.output_dir
             generator.action = ActionType.BUILD
             generator.product_input_dir = self.template_dir
@@ -146,6 +148,7 @@ class Builder(object):
                 list_.append(csv_filepath)
 
             generator.reset()
+            generator.env_yaml = self.env_yaml
             generator.output_dir = self.output_dir
             generator.action = action
             generator.product_input_dir = self.template_dir

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -88,5 +88,6 @@ def _rename_items(original_dict, renames):
 
 
 def process_file(filepath, substitutions_dict):
+    filepath = os.path.abspath(filepath)
     template = _get_jinja_environment(substitutions_dict).get_template(filepath)
     return template.render(substitutions_dict)

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -23,3 +23,15 @@ def get_cpu_count():
     except NotImplementedError:
         # 2 CPUs is the most probable
         return 2
+
+
+def merge_dicts(left, right):
+    """
+    Merges two dictionaries, keeing left and right as passed. If there are any
+    common keys between left and right, the value from right is use.
+
+    Returns the merger of the left and right dictionaries
+    """
+    result = left.copy()
+    result.update(right)
+    return result

--- a/tests/unit/ssg/test_utils.py
+++ b/tests/unit/ssg/test_utils.py
@@ -1,0 +1,16 @@
+import pytest
+
+import ssg.utils
+
+
+def test_merge_dicts():
+    left = {1: 2}
+    right = {"red fish": "blue fish"}
+    merged_expected = {1: 2, "red fish": "blue fish"}
+    merged_actual = ssg.utils.merge_dicts(left, right)
+
+    assert(merged_actual == merged_expected)
+    assert(1 in left)
+    assert("red fish" not in left)
+    assert("red fish" in right)
+    assert(1 not in right)


### PR DESCRIPTION
#### Description

 * Updates ssg build infrastructure to pass env_yaml into templates_common.py
 * Updates ssg.jinja.process_file to convert filepath to absolute
 * Converts all shared/templates/*.py to use JINJA variable names
 * Converts all shared/templates/template_* to ues JINJA macros

(The diff is a little messy as I removed trailing whitespace in the templates while I was editing them). 

#### TODO

*TODO* (separate PR): do not process generated artifacts twice. Note that these artifacts have jinja in them already (in the case of some OVALs). These would be ignored prior to this PR, and processed at a later time. This PR adds processing logic (+required variables) in `templates_common.py` here, but does not remove the other instance of processing later (as I do not know where that is :) ). 


#### Rationale

This PR unblocks a yet-unopened PR that blocks #3130 by allowing templated files to use JINJA instead of bulk replacement. This will allow that PR to simplify handling of templated owner/group/mode checks and generate a shared single shared check with all three used (or the subset of the three that are provide...hence the need for jinja). 

After this PR is merged, I can propose the other PR and let it merge, then #3130 -> #3126 -> #3129. :)