### PR TITLE
Avoid jinja eating the whitespace after the platform identifier in fixes

### DIFF
--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -144,9 +144,10 @@ def main():
                             remediation_functions
                         )
                 else:
-                    sys.stderr.write("Skipping '%s' remediation script. "
-                                     "The platform identifier in the "
-                                     "script is missing!\n" % (filename))
+                    raise RuntimeError(
+                        "The '%s' remediation script does not contain the "
+                        "platform identifier!" % (filename))
+
     sys.stderr.write("Merged %d %s remediations.\n"
                      % (included_fixes_count, args.remediation_type))
     tree = ssg.xml.ElementTree.ElementTree(fixcontent)

--- a/shared/fixes/bash/enable_selinux_bootloader.sh
+++ b/shared/fixes/bash/enable_selinux_bootloader.sh
@@ -1,5 +1,6 @@
 # platform = multi_platform_rhel
-{{%- if product == "rhel7" -%}}
+
+{{% if product == "rhel7" -%}}
 sed -i --follow-symlinks "s/selinux=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*
 sed -i --follow-symlinks "s/enforcing=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*
 {{%- elif product == "rhel6" -%}}

--- a/shared/fixes/bash/require_singleuser_auth.sh
+++ b/shared/fixes/bash/require_singleuser_auth.sh
@@ -1,5 +1,6 @@
 # platform = multi_platform_rhel
-{{%- if init_system == "systemd" -%}}
+
+{{% if init_system == "systemd" -%}}
 grep -q "^ExecStart=\-.*/sbin/sulogin" /usr/lib/systemd/system/rescue.service
 if ! [ $? -eq 0 ]; then
     sed -i "s/ExecStart=-.*-c \"/&\/sbin\/sulogin; /g" /usr/lib/systemd/system/rescue.service


### PR DESCRIPTION
I have caused 2 regressions while unshadowing the bash fixes. The platform line was being joined with the next line, the resulting bash fix was therefore not valid and even the platform comment couldn't be parsed. This fixes that. I also made the build script fatal error when the platform identifier is missing. This is the only thing that works because we can't always rely on a thorough review.