### PR TITLE
Added example profile with tested rule that uses filehash58

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/root_bashrc_not_modified.rule
+++ b/linux_os/guide/system/accounts/accounts-session/root_bashrc_not_modified.rule
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'Ensure that Root''s .bashrc was not modified.'
+
+description: |-
+    Check the file hash of the <tt>/root/.bashrc</tt> file to determine whether
+    it has not been modified.
+    Overlaps with the RPM verification, as it is provided by the 
+    <tt>rootfiles</tt> package.
+
+rationale: |-
+    Code in <tt>.bashrc</tt> is executed on each login, so contents of this
+    file have to be strictly controled.
+
+severity: unknown

--- a/rhel7/checks/oval/root_bashrc_not_modified.xml
+++ b/rhel7/checks/oval/root_bashrc_not_modified.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="root_bashrc_not_modified" version="1">
+    <metadata>
+      <title>Verify hash of the root's .bashrc file</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>This description in OVALs is mandatory, but the most important is to have description in XCCDF.</description>
+    </metadata>
+    <criteria>
+	    <criterion comment="Check file hash of /root/.bashrc" test_ref="test_root_bashrc_hash" />
+    </criteria>
+  </definition>
+  <ind:filehash58_test check="all" comment="Test that bashrc has a given hash." id="test_root_bashrc_hash" version="1">
+    <ind:object object_ref="concerned_file" />
+    <ind:state state_ref="hash_value" />
+  </ind:filehash58_test>
+  <ind:filehash58_object id="concerned_file" version="1">
+    <ind:filepath>/root/.bashrc</ind:filepath>
+    <ind:hash_type>SHA-512</ind:hash_type>
+  </ind:filehash58_object>
+  <ind:filehash58_state id="hash_value" version="1">
+    <ind:hash_type>SHA-512</ind:hash_type>
+    <ind:hash>5b559bb00d09275abf2fcb7b9a577b77557f338a2c18c9e370bf338db6aae2ae9ab814c790a207be4c2eb972f46c79fbc70819c8d1f0e682e00ebb8f5f45f74d</ind:hash>
+  </ind:filehash58_state>
+</def-group>
+

--- a/rhel7/fixes/bash/root_bashrc_not_modified.sh
+++ b/rhel7/fixes/bash/root_bashrc_not_modified.sh
@@ -1,0 +1,4 @@
+# platform = Red Hat Enterprise Linux 7
+
+rhel7_bashrc_base64_encoded="IyAuYmFzaHJjCgojIFVzZXIgc3BlY2lmaWMgYWxpYXNlcyBhbmQgZnVuY3Rpb25zCgphbGlhcyBybT0ncm0gLWknCmFsaWFzIGNwPSdjcCAtaScKYWxpYXMgbXY9J212IC1pJwoKIyBTb3VyY2UgZ2xvYmFsIGRlZmluaXRpb25zCmlmIFsgLWYgL2V0Yy9iYXNocmMgXTsgdGhlbgoJLiAvZXRjL2Jhc2hyYwpmaQo="
+printf "%s" "$rhel7_bashrc_base64_encoded" | base64 -d > /root/.bashrc

--- a/rhel7/profiles/example.profile
+++ b/rhel7/profiles/example.profile
@@ -1,0 +1,11 @@
+documentation_complete: true
+
+title: 'Example Profile for Red Hat Enterprise Linux 7'
+
+description: |-
+    This profile contains set of simple example rules to demonstrate how to create
+    custom security content.
+
+selections:
+    - root_bashrc_not_modified
+

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_root_bashrc_not_modified/bad_bashrc.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_root_bashrc_not_modified/bad_bashrc.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_example
+
+echo "###" >> /root/.bashrc


### PR DESCRIPTION
We need to test a rule that uses `filehash58` probe in the SSG suite.

I have added a rule that checks that RHEL7 `root`'s `.bashrc` hash matches a vanilla `.bashrc`. The rule has OVAL check and remediation, both can be tested by the SSG test suite.