### PR TITLE
Html table tests and fixes

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -855,7 +855,9 @@ macro(ssg_build_html_table_by_ref PRODUCT REF)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-by-ref-${REF})
 
     # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
-    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${REF}refs.html" PARENT_SCOPE)
+    # also needs to set the variable in local scope for next macro tables
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${REF}refs.html")
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST}" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${REF}refs.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -878,7 +880,9 @@ macro(ssg_build_html_nistrefs_table PRODUCT PROFILE)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-nistrefs-${PROFILE})
 
     # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
-    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-nistrefs-${PROFILE}.html" PARENT_SCOPE)
+    # also needs to set the variable in local scope for next macro tables
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-nistrefs-${PROFILE}.html")
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST}" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-nistrefs-${PROFILE}.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -899,6 +903,11 @@ macro(ssg_build_html_anssirefs_table PRODUCT PROFILE)
         DEPENDS "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-anssirefs-${PROFILE}.html"
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-anssirefs-${PROFILE})
+
+    # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
+    # also needs to set the variable in local scope for next macro tables
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-anssirefs-${PROFILE}.html")
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST}" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-anssirefs-${PROFILE}.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -921,7 +930,9 @@ macro(ssg_build_html_cce_table PRODUCT)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-cces)
 
     # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
-    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html" PARENT_SCOPE)
+    # also needs to set the variable in local scope for next macro tables
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html")
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST}" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-cces.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -961,7 +972,9 @@ macro(ssg_build_html_srgmap_tables PRODUCT DISA_SRG_TYPE)
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-srg)
 
     # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
-    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html;${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" PARENT_SCOPE)
+    # also needs to set the variable in local scope for next macro tables
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html;${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html")
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST}" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")
@@ -1012,7 +1025,10 @@ macro(ssg_build_html_stig_tables PRODUCT STIG_PROFILE)
     )
     add_dependencies(${PRODUCT}-tables generate-${PRODUCT}-table-stig)
 
-    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html;${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html" PARENT_SCOPE)
+    # needs PARENT_SCOPE because this is done across different cmake files via add_directory(..)
+    # also needs to set the variable in local scope for next macro tables
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST};${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html;${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html;${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-testinfo.html")
+    set(SSG_HTML_TABLE_FILE_LIST "${SSG_HTML_TABLE_FILE_LIST}" PARENT_SCOPE)
 
     install(FILES "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig.html"
         DESTINATION "${SSG_TABLE_INSTALL_DIR}")

--- a/rhel6/CMakeLists.txt
+++ b/rhel6/CMakeLists.txt
@@ -12,7 +12,7 @@ ssg_build_html_table_by_ref(${PRODUCT} "nist")
 ssg_build_html_table_by_ref(${PRODUCT} "cis")
 ssg_build_html_table_by_ref(${PRODUCT} "pcidss")
 
-ssg_build_html_nistrefs_table(${PRODUCT} "common")
+ssg_build_html_nistrefs_table(${PRODUCT} "standard")
 ssg_build_html_nistrefs_table(${PRODUCT} "C2S")
 
 ssg_build_html_cce_table(${PRODUCT})

--- a/rhel7/CMakeLists.txt
+++ b/rhel7/CMakeLists.txt
@@ -14,8 +14,8 @@ ssg_build_html_table_by_ref(${PRODUCT} "cui")
 ssg_build_html_table_by_ref(${PRODUCT} "pcidss")
 ssg_build_html_table_by_ref(${PRODUCT} "anssi")
 
-ssg_build_html_nistrefs_table(${PRODUCT} "common")
-ssg_build_html_nistrefs_table(${PRODUCT} "ospp-${PRODUCT}")
+ssg_build_html_nistrefs_table(${PRODUCT} "standard")
+ssg_build_html_nistrefs_table(${PRODUCT} "ospp")
 ssg_build_html_nistrefs_table(${PRODUCT} "C2S")
 ssg_build_html_nistrefs_table(${PRODUCT} "stig-${PRODUCT}-disa")
 

--- a/rhel7/CMakeLists.txt
+++ b/rhel7/CMakeLists.txt
@@ -19,10 +19,11 @@ ssg_build_html_nistrefs_table(${PRODUCT} "ospp")
 ssg_build_html_nistrefs_table(${PRODUCT} "C2S")
 ssg_build_html_nistrefs_table(${PRODUCT} "stig-${PRODUCT}-disa")
 
-ssg_build_html_anssirefs_table(${PRODUCT} "nt28_minimal")
-ssg_build_html_anssirefs_table(${PRODUCT} "nt28_intermediary")
-ssg_build_html_anssirefs_table(${PRODUCT} "nt28_enhanced")
-ssg_build_html_anssirefs_table(${PRODUCT} "nt28_high")
+# Uncomment when anssi profiles are marked documentation_complete: true
+#ssg_build_html_anssirefs_table(${PRODUCT} "nt28_minimal")
+#ssg_build_html_anssirefs_table(${PRODUCT} "nt28_intermediary")
+#ssg_build_html_anssirefs_table(${PRODUCT} "nt28_enhanced")
+#ssg_build_html_anssirefs_table(${PRODUCT} "nt28_high")
 
 ssg_build_html_cce_table(${PRODUCT})
 

--- a/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -1,3 +1,4 @@
+# Don't forget to enable build of tables in rhel7CMakeLists.txt when setting to true
 documentation_complete: false
 
 title: 'DRAFT - ANSSI DAT-NT28 (enhanced)'

--- a/rhel7/profiles/anssi_nt28_high.profile
+++ b/rhel7/profiles/anssi_nt28_high.profile
@@ -1,3 +1,4 @@
+# Don't forget to enable build of tables in rhel7CMakeLists.txt when setting to true
 documentation_complete: false
 
 title: 'DRAFT - ANSSI DAT-NT28 (high)'

--- a/rhel7/profiles/anssi_nt28_intermediary.profile
+++ b/rhel7/profiles/anssi_nt28_intermediary.profile
@@ -1,3 +1,4 @@
+# Don't forget to enable build of tables in rhel7CMakeLists.txt when setting to true
 documentation_complete: false
 
 title: 'DRAFT - ANSSI DAT-NT28 (intermediary)'

--- a/rhel7/profiles/anssi_nt28_minimal.profile
+++ b/rhel7/profiles/anssi_nt28_minimal.profile
@@ -1,3 +1,4 @@
+# Don't forget to enable build of tables in rhel7CMakeLists.txt when setting to true
 documentation_complete: false
 
 title: 'DRAFT - ANSSI DAT-NT28 (minimal)'


### PR DESCRIPTION
#### Description:

- Fix accumulation of tables to test in variable `SSG_HTML_TABLE_FILE_LIST`.
- Fix Profile IDs in `rhel6` and `rhel7` `CMakeLists.txt`
- Comment generation of ANSSI references table.

#### Rationale:

- In SSG-0.1.39 tables `table-rhel6-nistrefs-common.html`, `table-rhel7-nistrefs-common.html` and `table-rhel7-nistrefs-ospp-rhel7.html` are empty, and were not caught by `ctest sanity-ssg-table tests`.
- ANSSI Profiles are not complete, so there is no need to build these tables.
