### PR TITLE
Removed formatting leftovers.

### DIFF
--- a/chromium/guide/benchmark.yml
+++ b/chromium/guide/benchmark.yml
@@ -10,21 +10,21 @@ description: |
     configuration settings for {{{ full_name }}}. It is a rendering of
     content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
     in order to support security automation.  The SCAP content is
-    is available in the config_item="scap-security-guide" package which is developed at
+    is available in the <tt>scap-security-guide</tt> package which is developed at
     {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
     <br/><br/>
     Providing system administrators with such guidance informs them how to securely
     configure systems under their control in a variety of network roles. Policy
     makers and baseline creators can use this catalog of settings, with its
     associated references to higher-level security control catalogs, in order to
-    assist them in security baseline creation. This guide is a italics="catalog, not a
-    checklist," and satisfaction of every item is not likely to be possible or
+    assist them in security baseline creation. This guide is a <em>catalog, not a
+    checklist</em>, and satisfaction of every item is not likely to be possible or
     sensible in many operational scenarios. However, the XCCDF format enables
     granular selection and adjustment of settings, and their association with OVAL
     and OCIL content provides an automated checking capability. Transformations of
     this document, and its associated automated checking content, are capable of
     providing baselines that meet a diverse set of policy objectives. Some example
-    XCCDF italics="Profiles", which are selections of items that form checklists and
+    XCCDF <em>Profiles</em>, which are selections of items that form checklists and
     can be used as baselines, are available with this guide. They can be
     processed, in an automated fashion, with tools that support the Security
     Content Automation Protocol (SCAP). The DISA STIG for {{{ full_name }}},

--- a/debian8/guide/benchmark.yml
+++ b/debian8/guide/benchmark.yml
@@ -10,21 +10,21 @@ description: |
     configuration settings for {{{ full_name }}}. It is a rendering of
     content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
     in order to support security automation.  The SCAP content is
-    is available in the config_item="scap-security-guide" package which is developed at
+    is available in the <tt>scap-security-guide</tt> package which is developed at
     {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
     <br/><br/>
     Providing system administrators with such guidance informs them how to securely
     configure systems under their control in a variety of network roles. Policy
     makers and baseline creators can use this catalog of settings, with its
     associated references to higher-level security control catalogs, in order to
-    assist them in security baseline creation. This guide is a italics="catalog, not a
-    checklist," and satisfaction of every item is not likely to be possible or
+    assist them in security baseline creation. This guide is a <em>catalog, not a
+    checklist</em>, and satisfaction of every item is not likely to be possible or
     sensible in many operational scenarios. However, the XCCDF format enables
     granular selection and adjustment of settings, and their association with OVAL
     and OCIL content provides an automated checking capability. Transformations of
     this document, and its associated automated checking content, are capable of
     providing baselines that meet a diverse set of policy objectives. Some example
-    XCCDF italics="Profiles", which are selections of items that form checklists and
+    XCCDF <em>Profiles</em>, which are selections of items that form checklists and
     can be used as baselines, are available with this guide. They can be
     processed, in an automated fashion, with tools that support the Security
     Content Automation Protocol (SCAP). The DISA STIG for {{{ full_name }}},

--- a/eap6/guide/benchmark.yml
+++ b/eap6/guide/benchmark.yml
@@ -10,21 +10,21 @@ description: |
     configuration settings for {{{ full_name }}}. It is a rendering of
     content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
     in order to support security automation.  The SCAP content is
-    is available in the config_item="scap-security-guide" package which is developed at
+    is available in the <tt>scap-security-guide</tt> package which is developed at
     {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
     <br/><br/>
     Providing system administrators with such guidance informs them how to securely
     configure systems under their control in a variety of network roles. Policy
     makers and baseline creators can use this catalog of settings, with its
     associated references to higher-level security control catalogs, in order to
-    assist them in security baseline creation. This guide is a italics="catalog, not a
-    checklist," and satisfaction of every item is not likely to be possible or
+    assist them in security baseline creation. This guide is a <em>catalog, not a
+    checklist</em>, and satisfaction of every item is not likely to be possible or
     sensible in many operational scenarios. However, the XCCDF format enables
     granular selection and adjustment of settings, and their association with OVAL
     and OCIL content provides an automated checking capability. Transformations of
     this document, and its associated automated checking content, are capable of
     providing baselines that meet a diverse set of policy objectives. Some example
-    XCCDF italics="Profiles", which are selections of items that form checklists and
+    XCCDF <em>Profiles</em>, which are selections of items that form checklists and
     can be used as baselines, are available with this guide. They can be
     processed, in an automated fashion, with tools that support the Security
     Content Automation Protocol (SCAP). The DISA STIG for {{{ full_name }}},

--- a/firefox/guide/benchmark.yml
+++ b/firefox/guide/benchmark.yml
@@ -10,21 +10,21 @@ description: |
     configuration settings for {{{ full_name }}}. It is a rendering of
     content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
     in order to support security automation.  The SCAP content is
-    is available in the config_item="scap-security-guide" package which is developed at
+    is available in the <tt>scap-security-guide</tt> package which is developed at
     {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
     <br/><br/>
     Providing system administrators with such guidance informs them how to securely
     configure systems under their control in a variety of network roles. Policy
     makers and baseline creators can use this catalog of settings, with its
     associated references to higher-level security control catalogs, in order to
-    assist them in security baseline creation. This guide is a italics="catalog, not a
-    checklist," and satisfaction of every item is not likely to be possible or
+    assist them in security baseline creation. This guide is a <em>catalog, not a
+    checklist</em>, and satisfaction of every item is not likely to be possible or
     sensible in many operational scenarios. However, the XCCDF format enables
     granular selection and adjustment of settings, and their association with OVAL
     and OCIL content provides an automated checking capability. Transformations of
     this document, and its associated automated checking content, are capable of
     providing baselines that meet a diverse set of policy objectives. Some example
-    XCCDF italics="Profiles", which are selections of items that form checklists and
+    XCCDF <em>Profiles</em>, which are selections of items that form checklists and
     can be used as baselines, are available with this guide. They can be
     processed, in an automated fashion, with tools that support the Security
     Content Automation Protocol (SCAP). The DISA STIG for {{{ full_name }}},

--- a/fuse6/guide/benchmark.yml
+++ b/fuse6/guide/benchmark.yml
@@ -10,21 +10,21 @@ description: |
     configuration settings for {{{ full_name }}}. It is a rendering of
     content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
     in order to support security automation.  The SCAP content is
-    is available in the config_item="scap-security-guide" package which is developed at
+    is available in the <tt>scap-security-guide</tt> package which is developed at
     {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
     <br/><br/>
     Providing system administrators with such guidance informs them how to securely
     configure systems under their control in a variety of network roles. Policy
     makers and baseline creators can use this catalog of settings, with its
     associated references to higher-level security control catalogs, in order to
-    assist them in security baseline creation. This guide is a italics="catalog, not a
-    checklist," and satisfaction of every item is not likely to be possible or
+    assist them in security baseline creation. This guide is a <em>catalog, not a
+    checklist</em>, and satisfaction of every item is not likely to be possible or
     sensible in many operational scenarios. However, the XCCDF format enables
     granular selection and adjustment of settings, and their association with OVAL
     and OCIL content provides an automated checking capability. Transformations of
     this document, and its associated automated checking content, are capable of
     providing baselines that meet a diverse set of policy objectives. Some example
-    XCCDF italics="Profiles", which are selections of items that form checklists and
+    XCCDF <em>Profiles</em>, which are selections of items that form checklists and
     can be used as baselines, are available with this guide. They can be
     processed, in an automated fashion, with tools that support the Security
     Content Automation Protocol (SCAP). The DISA STIG for {{{ full_name }}},

--- a/jre/guide/benchmark.yml
+++ b/jre/guide/benchmark.yml
@@ -10,21 +10,21 @@ description: |
     configuration settings for {{{ full_name }}}. It is a rendering of
     content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
     in order to support security automation.  The SCAP content is
-    is available in the config_item="scap-security-guide" package which is developed at
+    is available in the <tt>scap-security-guide</tt> package which is developed at
     {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
     <br/><br/>
     Providing system administrators with such guidance informs them how to securely
     configure systems under their control in a variety of network roles. Policy
     makers and baseline creators can use this catalog of settings, with its
     associated references to higher-level security control catalogs, in order to
-    assist them in security baseline creation. This guide is a italics="catalog, not a
-    checklist," and satisfaction of every item is not likely to be possible or
+    assist them in security baseline creation. This guide is a <em>catalog, not a
+    checklist</em>, and satisfaction of every item is not likely to be possible or
     sensible in many operational scenarios. However, the XCCDF format enables
     granular selection and adjustment of settings, and their association with OVAL
     and OCIL content provides an automated checking capability. Transformations of
     this document, and its associated automated checking content, are capable of
     providing baselines that meet a diverse set of policy objectives. Some example
-    XCCDF italics="Profiles", which are selections of items that form checklists and
+    XCCDF <em>Profiles</em>, which are selections of items that form checklists and
     can be used as baselines, are available with this guide. They can be
     processed, in an automated fashion, with tools that support the Security
     Content Automation Protocol (SCAP). The DISA STIG for {{{ full_name }}},

--- a/linux_os/guide/benchmark.yml
+++ b/linux_os/guide/benchmark.yml
@@ -10,21 +10,21 @@ description: |
     configuration settings for {{{ full_name }}}. It is a rendering of
     content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
     in order to support security automation.  The SCAP content is
-    is available in the config_item="scap-security-guide" package which is developed at
+    is available in the <tt>scap-security-guide</tt> package which is developed at
     {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
     <br/><br/>
     Providing system administrators with such guidance informs them how to securely
     configure systems under their control in a variety of network roles. Policy
     makers and baseline creators can use this catalog of settings, with its
     associated references to higher-level security control catalogs, in order to
-    assist them in security baseline creation. This guide is a italics="catalog, not a
-    checklist," and satisfaction of every item is not likely to be possible or
+    assist them in security baseline creation. This guide is a <em>catalog, not a
+    checklist</em>, and satisfaction of every item is not likely to be possible or
     sensible in many operational scenarios. However, the XCCDF format enables
     granular selection and adjustment of settings, and their association with OVAL
     and OCIL content provides an automated checking capability. Transformations of
     this document, and its associated automated checking content, are capable of
     providing baselines that meet a diverse set of policy objectives. Some example
-    XCCDF italics="Profiles", which are selections of items that form checklists and
+    XCCDF <em>Profiles</em>, which are selections of items that form checklists and
     can be used as baselines, are available with this guide. They can be
     processed, in an automated fashion, with tools that support the Security
     Content Automation Protocol (SCAP). The DISA STIG for {{{ full_name }}},

--- a/wrlinux/guide/benchmark.yml
+++ b/wrlinux/guide/benchmark.yml
@@ -10,21 +10,21 @@ description: |
     configuration settings for {{{ full_name }}}. It is a rendering of
     content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
     in order to support security automation.  The SCAP content is
-    is available in the config_item="scap-security-guide" package which is developed at
+    is available in the <tt>scap-security-guide</tt> package which is developed at
     {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
     <br/><br/>
     Providing system administrators with such guidance informs them how to securely
     configure systems under their control in a variety of network roles. Policy
     makers and baseline creators can use this catalog of settings, with its
     associated references to higher-level security control catalogs, in order to
-    assist them in security baseline creation. This guide is a italics="catalog, not a
-    checklist," and satisfaction of every item is not likely to be possible or
+    assist them in security baseline creation. This guide is a <em>catalog, not a
+    checklist</em>, and satisfaction of every item is not likely to be possible or
     sensible in many operational scenarios. However, the XCCDF format enables
     granular selection and adjustment of settings, and their association with OVAL
     and OCIL content provides an automated checking capability. Transformations of
     this document, and its associated automated checking content, are capable of
     providing baselines that meet a diverse set of policy objectives. Some example
-    XCCDF italics="Profiles", which are selections of items that form checklists and
+    XCCDF <em>Profiles</em>, which are selections of items that form checklists and
     can be used as baselines, are available with this guide. They can be
     processed, in an automated fashion, with tools that support the Security
     Content Automation Protocol (SCAP). The DISA STIG for {{{ full_name }}},


### PR DESCRIPTION
Removed italics="..." and config_item="..." from where it was applicable.

Fixes: #3053