### PR TITLE
Py2py3 sanity

### DIFF
--- a/tests/python2_vs_python3_sanity.sh
+++ b/tests/python2_vs_python3_sanity.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+pushd "$DIR/.." > /dev/null
+
+rm -rf build-py2 build-py3
+
+mkdir -p build-py2
+pushd build-py2 > /dev/null
+rm -rf *
+cmake -G Ninja -DPYTHON_EXECUTABLE=/usr/bin/python2 ../
+ninja
+popd > /dev/null
+
+mkdir -p build-py3
+pushd build-py3 > /dev/null
+rm -rf *
+cmake -G Ninja -DPYTHON_EXECUTABLE=/usr/bin/python3 ../
+ninja
+popd > /dev/null
+
+./utils/compare_generated.sh ./build-py2 ./build-py3 ovals
+./utils/compare_generated.sh ./build-py2 ./build-py3 fixes
+
+popd > /dev/null


### PR DESCRIPTION
Build SSG with python2, then python3, in different build folders. Then compare results. This is using the compare_generated.sh script originally by @ybznek that I modified a bit.

This should help us catch any unexpected differences.

Since this is an integration test I haven't hooked it into cmake, I don't think that would make sense because we would be testing 2 different build folders with a context of yet another build folder.