### PR TITLE
Update Ansible syntax

### DIFF
--- a/shared/fixes/ansible/accounts_passwords_pam_faillock_deny.yml
+++ b/shared/fixes/ansible/accounts_passwords_pam_faillock_deny.yml
@@ -18,7 +18,7 @@
     new_module_path: pam_faillock.so
     module_arguments: 'preauth
         silent
-        deny={{ var_accounts_passwords_pam_faillock_deny }}
+        deny: {{ var_accounts_passwords_pam_faillock_deny }}
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: before
@@ -36,7 +36,7 @@
     new_module_path: pam_faillock.so
     module_arguments: 'preauth
         silent
-        deny={{ var_accounts_passwords_pam_faillock_deny }}
+        deny: {{ var_accounts_passwords_pam_faillock_deny }}
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: after

--- a/shared/fixes/ansible/accounts_passwords_pam_faillock_deny_root.yml
+++ b/shared/fixes/ansible/accounts_passwords_pam_faillock_deny_root.yml
@@ -19,7 +19,7 @@
     module_arguments: 'preauth
         silent
         even_deny_root
-        deny={{ var_accounts_passwords_pam_faillock_deny }}
+        deny: {{ var_accounts_passwords_pam_faillock_deny }}
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: before
@@ -38,7 +38,7 @@
     module_arguments: 'preauth
         silent
         even_deny_root
-        deny={{ var_accounts_passwords_pam_faillock_deny }}
+        deny: {{ var_accounts_passwords_pam_faillock_deny }}
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: after

--- a/shared/fixes/ansible/aide_build_database.yml
+++ b/shared/fixes/ansible/aide_build_database.yml
@@ -5,8 +5,8 @@
 # disruption = low
 - name: "Ensure AIDE is installed"
   package:
-    name="{{item}}"
-    state=present
+    name: "{{item}}"
+    state: present
   with_items:
     - aide
   tags:

--- a/shared/fixes/ansible/aide_periodic_cron_checking.yml
+++ b/shared/fixes/ansible/aide_periodic_cron_checking.yml
@@ -5,8 +5,8 @@
 # disruption = low
 - name: "Ensure AIDE is installed"
   package:
-    name="{{item}}"
-    state=present
+    name: "{{item}}"
+    state: present
   with_items:
     - aide
   tags:

--- a/shared/fixes/ansible/disable_prelink.yml
+++ b/shared/fixes/ansible/disable_prelink.yml
@@ -5,7 +5,7 @@
 # disruption = low
 - name: Does prelink file exist
   stat:
-    path=/etc/sysconfig/prelink
+    path: /etc/sysconfig/prelink
   register: prelink_exists
   tags:
     @ANSIBLE_TAGS@  

--- a/shared/fixes/ansible/firewalld_sshd_port_enabled.yml
+++ b/shared/fixes/ansible/firewalld_sshd_port_enabled.yml
@@ -6,8 +6,8 @@
 
 - name: Ensure firewalld is installed
   package:
-    name="{{item}}"
-    state=present
+    name: "{{item}}"
+    state: present
   with_items:
     - firewalld
   tags:

--- a/shared/templates/template_ANSIBLE_accounts_password
+++ b/shared/templates/template_ANSIBLE_accounts_password
@@ -16,10 +16,10 @@
     module_args: '{{{ VARIABLE }}} = {{ var_password_pam_{{{ VARIABLE }}} }}'
 {{% else %}}
   lineinfile:
-    create=yes
-    dest="/etc/security/pwquality.conf"
-    regexp="^#?\s*{{{ VARIABLE }}}"
-    line="{{{ VARIABLE }}} = {{ var_password_pam_{{{ VARIABLE }}} }}"
+    create: yes
+    dest: "/etc/security/pwquality.conf"
+    regexp: '^#?\s*{{{ VARIABLE }}}'
+    line: "{{{ VARIABLE }}} = {{ var_password_pam_{{{ VARIABLE }}} }}"
 {{% endif %}}
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_kernel_module_disabled
+++ b/shared/templates/template_ANSIBLE_kernel_module_disabled
@@ -5,10 +5,10 @@
 # disruption = medium
 - name: Ensure kernel module '{{{ KERNMODULE }}}' is disabled
   lineinfile:
-    create=yes
-    dest="/etc/modprobe.d/{{item}}.conf"
-    regexp="{{item}}"
-    line="install {{item}} /bin/true"
+    create: yes
+    dest: "/etc/modprobe.d/{{item}}.conf"
+    regexp: '{{item}}'
+    line: "install {{item}} /bin/true"
   with_items:
     - {{{ KERNMODULE }}}
   tags:

--- a/shared/templates/template_ANSIBLE_package_installed
+++ b/shared/templates/template_ANSIBLE_package_installed
@@ -5,8 +5,8 @@
 # disruption = low
 - name: Ensure {{{ PKGNAME }}} is installed
   package:
-    name="{{item}}"
-    state=present
+    name: "{{item}}"
+    state: present
   with_items:
     - {{{ PKGNAME }}}
   tags:

--- a/shared/templates/template_ANSIBLE_package_removed
+++ b/shared/templates/template_ANSIBLE_package_removed
@@ -5,8 +5,8 @@
 # disruption = low
 - name: Ensure {{{ PKGNAME }}} is removed
   package:
-    name="{{item}}"
-    state=absent
+    name: "{{item}}"
+    state: absent
   with_items:
     - {{{ PKGNAME }}}
   tags:

--- a/shared/templates/template_ANSIBLE_permissions
+++ b/shared/templates/template_ANSIBLE_permissions
@@ -5,8 +5,8 @@
 # disruption = low
 - name: Ensure permission {{{ FILEMODE }}} on {{{ FILEPATH }}}
   file:
-    path="{{item}}"
-    mode={{{ FILEMODE }}}
+    path: "{{item}}"
+    mode: {{{ FILEMODE }}}
   with_items:
     - {{{ FILEPATH }}}
   tags:

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -5,9 +5,9 @@
 # disruption = low
 - name: Disable service {{{ SERVICENAME }}}
   service:
-    name="{{item}}"
-    enabled="no"
-    state="stopped"
+    name: "{{item}}"
+    enabled: "no"
+    state: "stopped"
   register: service_result
   failed_when: "service_result is failed and ('Could not find the requested service' not in service_result.msg)"
   with_items:
@@ -18,9 +18,9 @@
 {{% if init_system == "systemd" %}}
 - name: Disable socket of service {{{ SERVICENAME }}} if applicable
   service:
-    name="{{item}}"
-    enabled="no"
-    state="stopped"
+    name: "{{item}}"
+    enabled: "no"
+    state: "stopped"
   register: socket_result
   failed_when: "socket_result is failed and ('Could not find the requested service' not in socket_result.msg)"
   with_items:

--- a/shared/templates/template_ANSIBLE_service_enabled
+++ b/shared/templates/template_ANSIBLE_service_enabled
@@ -5,9 +5,9 @@
 # disruption = low
 - name: Enable service {{{ SERVICENAME }}}
   service:
-    name="{{item}}"
-    enabled="yes"
-    state="started"
+    name: "{{item}}"
+    enabled: "yes"
+    state: "started"
   with_items:
     - {{{ DAEMONNAME }}}
   tags:


### PR DESCRIPTION
Several of the Ansible remediations and templates used non-standard syntax. While valid YAML, this was not in the preferred [syntax](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html).

This was found by @yuumasato in #3146, and is now updated globally. I'm delaying this until 0.1.41 milestone so it will hopefully get merged after #3146, but I can update either PR as necessary if it causes conflicts. 