### PR TITLE
wrlinux -> linux_os guide merger

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed.rule
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed.rule
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora,ol7
-
 title: 'Verify All Account Password Hashes are Shadowed'
 
 description: |-

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords.rule
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords.rule
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora,ol7
-
 title: 'Prevent Log In to Accounts With Empty Password'
 
 description: |-

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files.rule
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files.rule
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
-
 title: 'Verify No netrc Files Exist'
 
 description: |-

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero.rule
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero.rule
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
-
 title: 'Verify Only Root Has UID 0'
 
 description: "If any account other than root has a UID of 0, this misconfiguration should \nbe investigated and the accounts other than root should be removed or \nhave their UID changed.\n<br />\nIf the account is associated with system commands or applications the UID should be changed\nto one greater than \"0\" but less than \"1000.\" Otherwise assign a UID greater than \"1000\" that\nhas not already been assigned."

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay.rule
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay.rule
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel7
-
 title: 'Ensure the Logon Failure Delay is Set Correctly in login.defs'
 
 description: |-

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions.rule
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions.rule
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
-
 title: 'Limit the Number of Concurrent Login Sessions Allowed Per User'
 
 description: |-

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_dirs.rule
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_dirs.rule
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
-
 title: 'Ensure that User Home Directories are not Group-Writable or World-Readable'
 
 description: |-

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write.rule
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write.rule
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora,ol7
-
 title: 'Ensure that Root''s Path Does Not Include World or Group-Writable Directories'
 
 description: |-

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot.rule
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot.rule
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora,ol7
-
 title: 'Ensure that Root''s Path Does Not Include Relative Paths or Null Directories'
 
 description: |-

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs.rule
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs.rule
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7
-
 title: 'Ensure the Default Umask is Set Correctly in login.defs'
 
 description: |-

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile.rule
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile.rule
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
-
 title: 'Ensure the Default Umask is Set Correctly in /etc/profile'
 
 description: |-

--- a/wrlinux/product.yml
+++ b/wrlinux/product.yml
@@ -2,7 +2,7 @@ product: wrlinux
 full_name: WRLinux
 type: platform
 
-benchmark_root: "./guide"
+benchmark_root: "../linux_os/guide"
 
 profiles_root: "./profiles"
 


### PR DESCRIPTION
#### Description

Most of the rules in the `wrlinux` guide are unused, and are at best copies of existing rules in `linux_os` or otherwise poorly modified. This is completely independent of the `debian8` merger (#3129), but I've not tested for cross-conflicts.

In essence, remove a bunch of prodtypes and then update the `product.yml` to point to `linux_os`. It should be simple to verify that all the existing rules are in `linux_os`, that the contents of differ only a little.

Easiest one yet!

#### Rationale

This reduces maintenance costs and unifies much product structure. This is the last remaining Linux product with a guide:

```
./wrlinux/guide
./firefox/guide
./linux_os/guide
./debian8/guide
./eap6/guide
./chromium/guide
./jre/guide
./fuse6/guide
```

So, since `debian8` is gone in #3151 and this one can be removed after a little more testing, we can now reorganize SSG content structure more easily and without having to do lots of duplicated actions.



(this one is much less epic as a PR, but is still good to have done... hence I'm not adding the EPIC label :)