### PR TITLE
Move signal logic from template to generator

### DIFF
--- a/shared/templates/create_accounts_password.py
+++ b/shared/templates/create_accounts_password.py
@@ -28,9 +28,12 @@ class AccountsPasswordGenerator(FilesGenerator):
                 "./ansible/accounts_password_pam_{0}.yml", VARIABLE
             )
         elif target == "oval":
+            # Only credit related variables allow negative values
+            SIGN = "-?" if VARIABLE.endswith("credit") else ""
             self.file_from_template(
                 "./template_OVAL_accounts_password",
                 {
+                    "SIGN": SIGN,
                     "VARIABLE": VARIABLE,
                     "OPERATION": OPERATION
                 },

--- a/shared/templates/template_OVAL_accounts_password
+++ b/shared/templates/template_OVAL_accounts_password
@@ -20,13 +20,6 @@
 {{% endif %}}
   </definition>
 
-{{# Only credit related variables allow negative values #}}
-{{% if "credit" in "{{{ VARIABLE }}}" %}}
-  {{% set sign = "-?" %}}
-{{% else %}}
-  {{% set sign = "" %}}
-{{% endif %}}
-
 {{% if product == "rhel6" %}}
   <ind:textfilecontent54_test check="all" comment="check the configuration of /etc/pam.d/system-auth" id="test_password_pam_cracklib_{{{ VARIABLE }}}" version="3">
     <ind:object object_ref="obj_password_pam_cracklib_{{{ VARIABLE }}}" />
@@ -35,7 +28,7 @@
 
   <ind:textfilecontent54_object id="obj_password_pam_cracklib_{{{ VARIABLE }}}" version="3">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:required)|(?:requisite))\s+pam_cracklib\.so.*{{{ VARIABLE }}}[\s]*=[\s]*({{{ sign }}}\d+)(?:[\s]|$)</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:required)|(?:requisite))\s+pam_cracklib\.so.*{{{ VARIABLE }}}[\s]*=[\s]*({{{ SIGN }}}\d+)(?:[\s]|$)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% else %}}
@@ -48,7 +41,7 @@
 
   <ind:textfilecontent54_object id="obj_password_pam_pwquality_{{{ VARIABLE }}}" version="3">
     <ind:filepath>/etc/security/pwquality.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^{{{ VARIABLE }}}[\s]*=[\s]*({{{ negative_symbol }}}\d+)(?:[\s]|$)</ind:pattern>
+    <ind:pattern operation="pattern match">^{{{ VARIABLE }}}[\s]*=[\s]*({{{ SIGN }}}\d+)(?:[\s]|$)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- Moves logic of credit sign from template to generator
- Also fix a wrong template substitution

#### Rationale:

- Logic stopped working after we stopped using [custom string-replacement in templates ](https://github.com/OpenSCAP/scap-security-guide/pull/3135/files#diff-24dbdafa7989c5054be38a4c4bbf50f9L24)

- Fixes #3155 (thanks @mako7c4 for filing the issue)