### PR TITLE
Fix template_OVAL_package_installed

### DIFF
--- a/shared/templates/template_OVAL_package_installed
+++ b/shared/templates/template_OVAL_package_installed
@@ -18,14 +18,14 @@
   id="test_package_{{{ PKGNAME }}}_installed" version="1"
   comment="package {{{ PKGNAME }}} is installed">
     <linux:object object_ref="obj_package_{{{ PKGNAME }}}_installed" />
-    {{% if "{{{ EVR }}}" %}}
+    {{% if EVR %}}
       <linux:state state_ref="ste_package_{{{ PKGNAME }}}_installed" />
     {{% endif %}}
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_package_{{{ PKGNAME }}}_installed" version="1">
     <linux:name>{{{ PKGNAME }}}</linux:name>
   </linux:rpminfo_object>
-  {{% if "{{{ EVR }}}" %}}
+  {{% if EVR %}}
     <linux:rpminfo_state id="ste_package_{{{ PKGNAME }}}_installed" version="1">
       <linux:evr datatype="evr_string" operation="greater than or equal">{{{ EVR }}}</linux:evr>
     </linux:rpminfo_state>
@@ -35,14 +35,14 @@
   id="test_package_{{{ PKGNAME }}}_installed" version="1"
   comment="package {{{ PKGNAME }}} is installed">
     <linux:object object_ref="obj_package_{{{ PKGNAME }}}_installed" />
-    {{% if "{{{ EVR }}}" %}}
+    {{% if EVR %}}
       <linux:state state_ref="ste_package_{{{ PKGNAME }}}_installed" />
     {{% endif %}}
   </linux:dpkginfo_test>
   <linux:dpkginfo_object id="obj_package_{{{ PKGNAME }}}_installed" version="1">
     <linux:name>{{{ PKGNAME }}}</linux:name>
   </linux:dpkginfo_object>
-  {{% if "{{{ EVR }}}" %}}
+  {{% if EVR %}}
     <linux:dpkginfo_state id="ste_package_{{{ PKGNAME }}}_installed" version="1">
       <linux:evr datatype="evr_string" operation="greater than or equal">{{{ EVR }}}</linux:evr>
     </linux:dpkginfo_state>


### PR DESCRIPTION
In #3135, a regression was introduced regarding variables inside
jinja macros. This fixes the other regression not fixed in #3157.

Signed-off-by: Alexander Scheel <ascheel@redhat.com>