### PR TITLE
Add missing OCIL Clause in file permission rules

### DIFF
--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow.rule
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow.rule
@@ -23,4 +23,6 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: "021120"
 
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.allow", group="root") }}}'
+
 ocil: '{{{ ocil_file_group_owner(file="/etc/cron.allow", group="root") }}}'

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow.rule
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow.rule
@@ -23,4 +23,6 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: "021110"
 
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.allow", owner="root") }}}'
+
 ocil: '{{{ ocil_file_owner(file="/etc/cron.allow", owner="root") }}}'

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files.rule
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files.rule
@@ -18,4 +18,6 @@ identifiers:
 references:
     nist: CM-7
 
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/http/conf.d/*", perms="-rw-r-----") }}}'
+
 ocil: '{{{ ocil_file_permissions(file="/etc/http/conf.d/*", perms="-rw-r-----") }}}'

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files.rule
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files.rule
@@ -19,4 +19,6 @@ identifiers:
 references:
     nist: CM-7
 
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/http/conf/*", perms="-rw-r-----") }}}'
+
 ocil: '{{{ ocil_file_permissions(file="/etc/http/conf/*", perms="-rw-r-----") }}}'

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files.rule
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files.rule
@@ -18,4 +18,6 @@ identifiers:
 references:
     nist: CM-7
 
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/http/conf.modules.d/*", perms="-rw-r-----") }}}'
+
 ocil: '{{{ ocil_file_permissions(file="/etc/http/conf.modules.d/*", perms="-rw-r-----") }}}'

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key.rule
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key.rule
@@ -20,4 +20,6 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: "040420"
 
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}'
+
 ocil: '{{{ ocil_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}'

--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key.rule
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key.rule
@@ -20,4 +20,6 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: "040410"
 
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/ssh/*.pub", perms="-rw-r--r--") }}}'
+
 ocil: '{{{ ocil_file_permissions(file="/etc/ssh/*.pub", perms="-rw-r--r--") }}}'

--- a/linux_os/guide/system/bootloader-grub-legacy/file_groupowner_grub_conf.rule
+++ b/linux_os/guide/system/bootloader-grub-legacy/file_groupowner_grub_conf.rule
@@ -20,4 +20,6 @@ references:
     srg@rhel6: SRG-OS-999999
     stigid@rhel6: RHEL-06-000066
 
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/grub.conf", group="root") }}}'
+
 ocil: '{{{ ocil_file_group_owner(file="/etc/grub.conf", group="root") }}}'

--- a/linux_os/guide/system/bootloader-grub-legacy/file_owner_grub_conf.rule
+++ b/linux_os/guide/system/bootloader-grub-legacy/file_owner_grub_conf.rule
@@ -18,4 +18,6 @@ references:
     srg@rhel6: SRG-OS-999999
     stigid@rhel6: RHEL-06-000065
 
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/grub.conf", owner="root") }}}'
+
 ocil: '{{{ ocil_file_owner(file="/etc/grub.conf", owner="root") }}}'

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg.rule
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg.rule
@@ -24,4 +24,6 @@ references:
     nist: AC-6(7)
     pcidss: Req-7.1
 
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}'
+
 ocil: '{{{ ocil_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}'

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_cfg.rule
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_cfg.rule
@@ -28,4 +28,6 @@ references:
     nist: AC-6(7)
     pcidss: Req-7.1
 
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}'
+
 ocil: '{{{ ocil_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}'

--- a/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg.rule
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg.rule
@@ -22,4 +22,6 @@ references:
     nist: AC-6(7)
     pcidss: Req-7.1
 
+ocil_clause: '{{{ ocil_clause_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}'
+
 ocil: '{{{ ocil_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}'

--- a/linux_os/guide/system/bootloader-grub2/file_owner_grub2_cfg.rule
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_grub2_cfg.rule
@@ -26,4 +26,6 @@ references:
     nist: AC-6(7)
     pcidss: Req-7.1
 
+ocil_clause: '{{{ ocil_clause_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}'
+
 ocil: '{{{ ocil_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid.rule
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid.rule
@@ -27,6 +27,8 @@ references:
     cis: 6.1.13
     nist: AC-6(1)
 
+ocil_clause: 'only authorized files appear in the output of the find command'
+
 ocil: |-
     To find world-writable files, run the following command:
     <pre>$ sudo find / -xdev -type f -perm -002</pre>

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group.rule
@@ -25,4 +25,6 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/group", group="root") }}}'
+
 ocil: '{{{ ocil_file_group_owner(file="/etc/group", group="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow.rule
@@ -23,4 +23,6 @@ references:
     cis: 6.1.5
     nist: AC-6
 
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/gshadow", group="root") }}}'
+
 ocil: '{{{ ocil_file_group_owner(file="/etc/gshadow", group="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd.rule
@@ -25,4 +25,6 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/passwd", group="root") }}}'
+
 ocil: '{{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow.rule
@@ -25,4 +25,6 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/shadow", group="root") }}}'
+
 ocil: '{{{ ocil_file_group_owner(file="/etc/shadow", group="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group.rule
@@ -24,4 +24,6 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/group", owner="root") }}}'
+
 ocil: '{{{ ocil_file_owner(file="/etc/group", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow.rule
@@ -23,4 +23,6 @@ references:
     cis: 6.1.5
     nist: AC-6
 
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/gshadow", owner="root") }}}'
+
 ocil: '{{{ ocil_file_owner(file="/etc/gshadow", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd.rule
@@ -25,4 +25,6 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/passwd", owner="root") }}}'
+
 ocil: '{{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow.rule
@@ -28,4 +28,6 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/shadow", owner="root") }}}'
+
 ocil: '{{{ ocil_file_owner(file="/etc/shadow", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group.rule
@@ -25,4 +25,6 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/group", perms="-rw-r--r--") }}}'
+
 ocil: '{{{ ocil_file_permissions(file="/etc/group", perms="-rw-r--r--") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow.rule
@@ -23,4 +23,6 @@ references:
     cis: 6.1.5
     nist: AC-6
 
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/gshadow", perms="----------") }}}'
+
 ocil: '{{{ ocil_file_permissions(file="/etc/gshadow", perms="----------") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd.rule
@@ -27,4 +27,6 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}'
+
 ocil: '{{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow.rule
@@ -28,4 +28,6 @@ references:
     nist: AC-6
     pcidss: Req-8.7.c
 
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/shadow", perms="----------") }}}'
+
 ocil: '{{{ ocil_file_permissions(file="/etc/shadow", perms="----------") }}}'

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -484,6 +484,17 @@ ocil_clause: "{{{ sebool }}} is not enabled"
     <code>{{{ group }}}</code>
 {{%- endmacro %}}
 
+{{%- macro ocil_clause_file_permissions(file, perms) %}}
+{{{ file }}} has unix mode {{{ perms }}}
+{{%- endmacro %}}
+
+{{%- macro ocil_clause_file_owner(file, owner) %}}
+{{{ file }}} has owner {{{ owner }}}
+{{%- endmacro %}}
+
+{{%- macro ocil_clause_file_group_owner(file, group) %}}
+{{{ file }}} has group owner {{{ group }}}
+{{%- endmacro %}}
 
 {{%- macro check_file_permissions(file, perms) %}}
     To check the permissions of <code>{{{ file }}}</code>, run the command:

--- a/utils/fix_file_ocilclause.py
+++ b/utils/fix_file_ocilclause.py
@@ -1,0 +1,248 @@
+import sys
+import os
+import argparse
+import subprocess
+import jinja2
+import yaml
+
+import ssg
+
+
+def _create_profile_cache(ssg_root):
+    profile_cache = {}
+
+    product_list = ['debian8', 'fedora', 'ol7', 'opensuse', 'rhel6', 'rhel7',
+                    'sle11', 'sle12', 'ubuntu1404', 'ubuntu1604', 'wrlinux']
+
+    for product in product_list:
+        found_obj_name = False
+        prod_profiles_dir = os.path.join(ssg_root, product, "profiles")
+        for _, _, files in os.walk(prod_profiles_dir):
+            for filename in files:
+                profile_path = os.path.join(prod_profiles_dir, filename)
+                parsed_profile = yaml.load(open(profile_path, 'r'))
+                for _obj in parsed_profile['selections']:
+                    obj = _obj
+                    if '=' in obj:
+                        # is a var with non-default value
+                        obj = _obj[:_obj.index('=')]
+                    if not obj[0].isalpha():
+                        obj = obj[1:]
+
+                    if obj not in profile_cache:
+                        profile_cache[obj] = set()
+
+                    profile_cache[obj].add(product)
+
+    return profile_cache
+
+
+def read_file(path):
+    file_contents = open(path, 'r').read().split("\n")
+    if file_contents[-1] == '':
+        file_contents = file_contents[:-1]
+    return file_contents
+
+
+def write_file(path, contents):
+    _f = open(path, 'w')
+    for line in contents:
+        _f.write(line + "\n")
+
+    _f.flush()
+    _f.close()
+
+
+def find_section_lines(file_contents, sec):
+    # Hack to find a global key ("section"/sec) in a YAML-like file.
+    # All indented lines until the next global key are included in the range.
+    # For example:
+    #
+    # 0: not_it:
+    # 1:     - value
+    # 2: this_one:
+    # 3:      - 2
+    # 4:      - 5
+    # 5:
+    # 6: nor_this:
+    #
+    # for the section "this_one", the result [(2, 5)] will be returned.
+    # Note that multiple sections may exist in a file and each will be
+    # identified and returned.
+    sec_ranges = []
+
+    sec_id = sec + ":"
+    sec_len = len(sec_id)
+    end_num = len(file_contents)
+    line_num = 0
+
+    while line_num < end_num:
+        if len(file_contents[line_num]) >= sec_len:
+            if file_contents[line_num][0:sec_len] == sec_id:
+                begin = line_num
+                line_num += 1
+                while line_num < end_num:
+                    if len(file_contents[line_num]) > 0 and file_contents[line_num][0] != ' ':
+                        break
+                    line_num += 1
+
+                end = line_num - 1
+                sec_ranges.append((begin, end))
+        line_num += 1
+    return sec_ranges
+
+
+def update_key_value(contents, key, old_value, new_value):
+    new_contents = contents[:]
+    old_line = key + ": " + old_value
+    updated = False
+
+    for line_num in range(0, len(new_contents)):
+        line = new_contents[line_num]
+        if line == old_line:
+            new_contents[line_num] = key + ": " + new_value
+            updated = True
+            break
+
+    if not updated:
+        assert(False)
+
+    return new_contents
+
+
+def update_subkey_value(contents, key, subkey, old_value, new_value):
+    new_contents = contents[:]
+    old_line = "    " + subkey + ": " + old_value
+    key_range = find_section_lines(contents, key)[0]
+    updated = False
+
+    for line_num in range(key_range[0], key_range[1] + 1):
+        line = new_contents[line_num]
+        if line == old_line:
+            new_contents[line_num] = "    " + subkey + ": "
+            updated = True
+
+    if not updated:
+        print(key)
+        print(subkey)
+        print(old_value)
+        print(new_value)
+        print(contents[key_range[0]:key_range[1]+1])
+        assert(False)
+
+    return new_contents
+
+
+def add_key_subkey(contents, key, subkey, value):
+    new_line = "    " + subkey + ": " + value
+    key_range = find_section_lines(contents, key)[0]
+
+    # Since there is always at least one line in the key_range (when [0] == [1]),
+    # it is always safe to add the new value right after the key header.
+    start_line = key_range[0] + 1
+    new_contents = contents[0:start_line]
+    new_contents.append(new_line)
+    new_contents.extend(contents[start_line:])
+    return new_contents
+
+
+def get_key(line):
+    if ':' in line and line[0].isalpha():
+        char_index = 0
+        _ll = len(line)
+        while char_index < _ll-1 and (line[char_index].isalpha() or
+                                      line[char_index] == '_'):
+            char_index += 1
+        if line[char_index] == ':':
+            return line[0:char_index]
+    return None
+
+
+def get_sections(file_contents):
+    global_sections = set()
+    for line in file_contents:
+        key = get_key(line)
+        if key:
+            global_sections.add(key)
+    return global_sections
+
+
+def range_has_jinja(file_contents, range):
+    return '{{' and '}}' in "\n".join(file_contents[range[0]:range[1]+1])
+
+
+def fix_ocil_clause(ssg_root, path, obj_name):
+    is_file_templated = obj_name[0:4] == 'file'
+    is_permissions = '_permissions_' in obj_name
+    is_groupowner = '_groupowner_' in obj_name
+    is_owner = '_owner_' in obj_name
+
+    if not is_file_templated or not (is_permissions or is_groupowner or is_owner):
+        return
+
+    loaded_file = read_file(path)
+    sections = get_sections(loaded_file)
+    if not 'ocil_clause' in sections:
+        ocil_lines = find_section_lines(loaded_file, 'ocil')
+        assert(len(ocil_lines) == 1)
+        ocil_lines = ocil_lines[0]
+
+        ocil = parse_from_yaml(loaded_file, ocil_lines)['ocil']
+        if '{{{' not in ocil:
+            print(path)
+
+        ocil_clause_str = ocil.replace('ocil_', 'ocil_clause_')
+        new_line = "ocil_clause: '%s'" % ocil_clause_str
+        new_file = loaded_file[:ocil_lines[0]]
+        new_file.extend([new_line, ''])
+        new_file.extend(loaded_file[ocil_lines[0]:])
+        write_file(path, new_file)
+
+
+def parse_from_yaml(file_contents, lines):
+    new_file_arr = file_contents[lines[0]:lines[1] + 1]
+    new_file = "\n".join(new_file_arr)
+    return yaml.load(new_file)
+
+
+def print_file(file_contents):
+    for line_num in range(0, len(file_contents)):
+        print("%d: %s" % (line_num, file_contents[line_num]))
+
+
+def walk_dir(ssg_root, function):
+    product_guide = os.path.join(ssg_root, 'linux_os', 'guide')
+    _pgl = len(product_guide)
+
+    data = None
+    for root, dirs, files in os.walk(product_guide):
+        for filename in files:
+            path = os.path.join(root, filename)
+
+            obj_name = filename
+            is_rule = len(path) >= 5 and path[-5:] == '.rule'
+
+            if is_rule:
+                obj_name = filename[:-5]
+                function(ssg_root, path, obj_name)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     description="Utility for finding similar guide rules")
+    parser.add_argument("ssg_root", help="Path to root of ssg git directory")
+    return parser.parse_args()
+
+
+def __main__():
+    args = parse_args()
+
+    pc = _create_profile_cache(args.ssg_root)
+    global profile_cache
+    profile_cache = pc
+
+    walk_dir(args.ssg_root, fix_ocil_clause)
+
+
+if __name__ == "__main__":
+    __main__()


### PR DESCRIPTION
Per report from @jan-cerny, a lot of the file permission rules lack OCIL clauses. This implements a new `jinja` macros to template the clause and adds them to a lot of missing rules in `linux_os/guide`.

This adds the python utility I wrote to automatically add these and then fixes #3150. Since this utility is based off a lot of common code and is not part of the build system, I'd prefer to just add it and review it later when I finish #3014.