### PR TITLE
Refactor and update template generation restrictions

### DIFF
--- a/rhel6/templates/csv/sysctl_values.csv
+++ b/rhel6/templates/csv/sysctl_values.csv
@@ -21,8 +21,8 @@ net.ipv4.ip_forward,0
 net.ipv4.tcp_syncookies,
 net.ipv6.conf.default.accept_ra,
 net.ipv6.conf.default.accept_redirects,
-net.ipv6.conf.all.accept_ra,#only-for:oval
-net.ipv6.conf.all.accept_redirects,#only-for:oval
-net.ipv6.conf.default.accept_source_route,#only-for:oval
-net.ipv6.conf.all.accept_source_route,#only-for:oval
-net.ipv6.conf.all.forwarding,#only-for:oval
+net.ipv6.conf.all.accept_ra,
+net.ipv6.conf.all.accept_redirects,
+net.ipv6.conf.default.accept_source_route,
+net.ipv6.conf.all.accept_source_route,
+net.ipv6.conf.all.forwarding,

--- a/rhel7/templates/csv/mount_options.csv
+++ b/rhel7/templates/csv/mount_options.csv
@@ -6,9 +6,11 @@
 #     '$' to reference a variable, e.g. var_removable_partition,nodev)
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
 #  add the 'create_fstab_entry_if_needed' literal string as the third argument.
-/dev/shm,nodev
-/dev/shm,noexec
-/dev/shm,nosuid
+
+# /dev/shm is created by systemd and is not available at install time
+/dev/shm,nodev #except-for:anaconda
+/dev/shm,noexec #except-for:anaconda
+/dev/shm,nosuid #except-for:anaconda
 /home,nosuid
 /home,nodev
 /tmp,nodev

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -36,7 +36,7 @@ class TemplateNotFoundError(RuntimeError):
 
 
 TEMPLATED_LANGUAGES = ["bash", "ansible", "oval", "anaconda", "puppet"]
-TARGET_REGEX = re.compile(r"#\s*only-for:([\s\w,]*)")
+TARGET_EXCLUDE_REGEX = re.compile(r"#\s*except-for:([\s\w,]*)")
 
 
 class FilesGenerator(object):
@@ -113,13 +113,13 @@ class FilesGenerator(object):
         """
 
         if target is not None:
-            match = TARGET_REGEX.search(line)
+            exclude_match = TARGET_EXCLUDE_REGEX.search(line)
 
-            if match:
-                # if line contains restriction to target, check it
-                supported_targets = \
-                    [x.strip() for x in match.group(1).split(",")]
-                if target not in supported_targets:
+            if exclude_match:
+                # Check if line contains restriction to target
+                unsupported_targets = \
+                    [x.strip() for x in exclude_match.group(1).split(",")]
+                if target in unsupported_targets:
                     return None
 
         # get part before comment

--- a/sle12/templates/csv/sysctl_values.csv
+++ b/sle12/templates/csv/sysctl_values.csv
@@ -1,7 +1,6 @@
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 fs.suid_dumpable,0
-kernel.dmesg_restrict,1#only-for:bash,ansible
 #kernel.exec-shield,1
 kernel.randomize_va_space,2
 net.ipv4.conf.all.accept_redirects,


### PR DESCRIPTION
#### Description:

- Generation of templated content for a target language can be restricted via `#only-for: ` comments on csv line.
- Lets flips the logic to exclude when necessary. It is easier to assume that we build everything and the exceptions are visible in comments.
- Drop unnecessary restrictions
- Restrict generation of Anaconda remediations for mount point options of `/dev/shm`.

#### Rationale:


- Fixes [rhbz#1570956](https://bugzilla.redhat.com/show_bug.cgi?id=1570956)
