### PR TITLE
Fix ansible for set_password_hashing_algorithm_libuserconf

### DIFF
--- a/shared/fixes/ansible/set_password_hashing_algorithm_libuserconf.yml
+++ b/shared/fixes/ansible/set_password_hashing_algorithm_libuserconf.yml
@@ -6,7 +6,7 @@
 - name: Set Password Hashing Algorithm in /etc/libuser.conf
   lineinfile:
     dest: /etc/libuser.conf
-    insertafter: "^.default]"
+    insertafter: '^\s*\[defaults]'
     regexp: ^#?crypt_style
     line: crypt_style = sha512
     state: present


### PR DESCRIPTION
#### Description:
Fix regex in `insertafter`. If ansible doesn't find `crypt_style` line in file, then it inserts it after `.default]` (old regex) line, but according to `man libuser.conf`, that section is called `[defaults]` and there can be leading and trailing white spaces, so the old regex won't match correct cases (`[defaults]`, `  [defaults] ` etc.) and adds `crypt_style = sha512` to the end of file.