### PR TITLE
Fix linkchecker - disable ssl verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,8 @@ matrix:
             - docker build --no-cache --tag ssg_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
           script:
             - docker run ssg_$BASE_IMAGE:latest
+        - env: BASE_IMAGE="fedora_linkchecker"
+          before_install:
+            - docker build --no-cache --tag ssg_$BASE_IMAGE:latest -f Dockerfiles/$BASE_IMAGE .
+          script:
+            - docker run ssg_$BASE_IMAGE:latest

--- a/Dockerfiles/centos6
+++ b/Dockerfiles/centos6
@@ -20,4 +20,4 @@ RUN rm -rf $OSCAP_DIR/build/*
 
 WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
 
-CMD cmake -DPYTHON_EXECUTABLE=/usr/bin/python2 .. && make -j $BUILD_JOBS && ctest -j $BUILD_JOBS
+CMD cmake -DPYTHON_EXECUTABLE=/usr/bin/python2 .. && make -j $BUILD_JOBS && ctest --output-on-failure -j $BUILD_JOBS

--- a/Dockerfiles/fedora_linkchecker
+++ b/Dockerfiles/fedora_linkchecker
@@ -1,0 +1,23 @@
+FROM fedora:28
+
+ENV OSCAP_USERNAME oscap
+ENV OSCAP_DIR scap-security-guide
+ENV BUILD_JOBS 4
+
+RUN dnf -y upgrade && \
+    dnf -y install cmake ninja-build openscap-utils python3-jinja2 python3-PyYAML ansible linkchecker && \
+    mkdir -p /home/$OSCAP_USERNAME && \
+    dnf clean all && \
+    rm -rf /usr/share/doc /usr/share/doc-base \
+        /usr/share/man /usr/share/locale /usr/share/zoneinfo
+
+WORKDIR /home/$OSCAP_USERNAME
+
+COPY . $OSCAP_DIR/
+
+# clean the build dir in case the user is also building SSG locally
+RUN rm -rf $OSCAP_DIR/build/*
+
+WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
+
+CMD cmake -G Ninja .. && ninja -j $BUILD_JOBS && ctest --output-on-failure -R linkcheck

--- a/Dockerfiles/fedora_python2
+++ b/Dockerfiles/fedora_python2
@@ -20,4 +20,4 @@ RUN rm -rf $OSCAP_DIR/build/*
 
 WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
 
-CMD cmake -DPYTHON_EXECUTABLE=/usr/bin/python2 -G Ninja .. && ninja -j $BUILD_JOBS && ctest -j $BUILD_JOBS
+CMD cmake -DPYTHON_EXECUTABLE=/usr/bin/python2 -G Ninja .. && ninja -j $BUILD_JOBS && ctest --output-on-failure -j $BUILD_JOBS

--- a/Dockerfiles/fedora_python3
+++ b/Dockerfiles/fedora_python3
@@ -20,4 +20,4 @@ RUN rm -rf $OSCAP_DIR/build/*
 
 WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
 
-CMD cmake -G Ninja .. && ninja -j $BUILD_JOBS && ctest -j $BUILD_JOBS
+CMD cmake -G Ninja .. && ninja -j $BUILD_JOBS && ctest --output-on-failure -j $BUILD_JOBS

--- a/Dockerfiles/ubuntu
+++ b/Dockerfiles/ubuntu
@@ -19,4 +19,4 @@ RUN rm -rf $OSCAP_DIR/build/*
 
 WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
 
-CMD cmake -G Ninja .. && ninja -j $BUILD_JOBS && ctest -j $BUILD_JOBS
+CMD cmake -G Ninja .. && ninja -j $BUILD_JOBS && ctest --output-on-failure -j $BUILD_JOBS

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1040,12 +1040,12 @@ macro(ssg_define_guide_and_table_tests)
     if (SSG_LINKCHECKER_VALIDATION_ENABLED AND LINKCHECKER_EXECUTABLE)
         add_test(
             NAME "linkchecker-ssg-guides"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" --check-extern ${SSG_HTML_GUIDE_FILE_LIST}
+            COMMAND "${LINKCHECKER_EXECUTABLE}" --config "${CMAKE_SOURCE_DIR}/tests/linkcheckerrc" --check-extern ${SSG_HTML_GUIDE_FILE_LIST}
         )
 
         add_test(
             NAME "linkchecker-ssg-tables"
-            COMMAND "${LINKCHECKER_EXECUTABLE}" --check-extern ${SSG_HTML_TABLE_FILE_LIST}
+            COMMAND "${LINKCHECKER_EXECUTABLE}" --config "${CMAKE_SOURCE_DIR}/tests/linkcheckerrc" --check-extern ${SSG_HTML_TABLE_FILE_LIST}
         )
     endif()
 

--- a/tests/linkcheckerrc
+++ b/tests/linkcheckerrc
@@ -1,0 +1,2 @@
+[checking]
+sslverify=0


### PR DESCRIPTION
Add linkcheckerrc to set sslverify=0

This prevents us from validating the certificates of the links we check.
Because https://pcisecuritystandards.org does not serve the intermediate
certificate chain, we won't pass linkchecker tests with sslverify=1 (the
default). On the other hand, most browsers will cache intermediate CA
certs, letting the user access this website. Maintaining our own CA chain
just to add the GoDaddy intermediate cert we need is both fragile and
too much work for the little value it provides, so this is a better
compromise.

Also adds a docker image to run just the linkchecker test and adds it to travis-ci. Since we're waiting on other container builds anyways, we might as well run it here too. An alternative would be to add linkchecker to an existing run, but this way, hopefully it'll be done in parallel versus in series. :)

Also adds `--output-on-failure` to all Docker images to give useful output on test failures.