### PR TITLE
Jinja cleanup + tests

### DIFF
--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -68,7 +68,12 @@ def _get_jinja_environment(substitutions_dict):
 _get_jinja_environment.env = None
 
 
-def _extract_substitutions_dict_from_template(filename, substitutions_dict):
+def extract_substitutions_dict_from_template(filename, substitutions_dict):
+    """
+    Treat the given filename as a jinja2 file containing macro definitions,
+    and export definitions that don't start with _ as a name->macro dictionary.
+    During macro compilation, symbols from substitutions_dict may be used in those definitions.
+    """
     template = _get_jinja_environment(substitutions_dict).get_template(filename)
     all_symbols = template.make_module(substitutions_dict).__dict__
     symbols_to_export = dict()
@@ -77,14 +82,6 @@ def _extract_substitutions_dict_from_template(filename, substitutions_dict):
             continue
         symbols_to_export[name] = symbol
     return symbols_to_export
-
-
-def _rename_items(original_dict, renames):
-    renamed_macros = dict()
-    for rename_from, rename_to in renames.items():
-        if rename_from in original_dict:
-            renamed_macros[rename_to] = original_dict[rename_from]
-    return renamed_macros
 
 
 def process_file(filepath, substitutions_dict):

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -5,9 +5,7 @@ import codecs
 import yaml
 import sys
 
-from .jinja import _extract_substitutions_dict_from_template
-from .jinja import _rename_items
-from .jinja import process_file
+from .jinja import extract_substitutions_dict_from_template, process_file
 from .constants import (PKG_MANAGER_TO_SYSTEM,
                         JINJA_MACROS_BASE_DEFINITIONS, JINJA_MACROS_HIGHLEVEL_DEFINITIONS)
 from .constants import DEFAULT_UID_MIN
@@ -94,9 +92,9 @@ def open_and_macro_expand(yaml_file, substitutions_dict=None):
         substitutions_dict = dict()
 
     try:
-        macro_definitions = _extract_substitutions_dict_from_template(
+        macro_definitions = extract_substitutions_dict_from_template(
             JINJA_MACROS_BASE_DEFINITIONS, substitutions_dict)
-        macro_definitions.update(_extract_substitutions_dict_from_template(
+        macro_definitions.update(extract_substitutions_dict_from_template(
             JINJA_MACROS_HIGHLEVEL_DEFINITIONS, substitutions_dict))
     except Exception as exc:
         msg = ("Error extracting macro definitions: {0}"

--- a/tests/unit/ssg/data/definitions.jinja
+++ b/tests/unit/ssg/data/definitions.jinja
@@ -1,0 +1,8 @@
+{{% macro expand_to_bar() -%}}
+bar
+{{%- endmacro %}}
+
+
+{{% macro expand_to_global_var() -%}}
+{{{ global_var }}}
+{{%- endmacro %}}

--- a/tests/unit/ssg/test_jinja.py
+++ b/tests/unit/ssg/test_jinja.py
@@ -1,0 +1,29 @@
+import os
+
+import pytest
+
+import ssg.jinja
+
+
+def get_definitions_with_substitution(subs_dict=None):
+    if subs_dict is None:
+        subs_dict = dict()
+    subs_dict["jinja2_cache_enabled"] = "false"
+
+    definitions = os.path.join(os.path.dirname(__file__), "data", "definitions.jinja")
+    defs = ssg.jinja.extract_substitutions_dict_from_template(definitions, subs_dict)
+    return defs
+
+
+def test_macro_presence():
+    actual_defs = get_definitions_with_substitution()
+    assert "expand_to_bar" in actual_defs
+    assert actual_defs["expand_to_bar"]() == "bar"
+
+
+def test_macro_expansion():
+    incomplete_defs = get_definitions_with_substitution()
+    assert incomplete_defs["expand_to_global_var"]() == ""
+
+    complete_defs = get_definitions_with_substitution(dict(global_var="value"))
+    assert complete_defs["expand_to_global_var"]() == "value"


### PR DESCRIPTION
* Removed no longer used _rename_items
* Made `_extract_substitutions_dict_from_template` a public function with docstring.
* Added tests for using external symbols in jinja macros.