### PR TITLE
SSG test suite support for Docker.

### DIFF
--- a/Dockerfiles/test_suite-centos
+++ b/Dockerfiles/test_suite-centos
@@ -1,0 +1,20 @@
+# This Dockerfile is a minimal example for a RHEL-based SSG test suite target container.
+FROM centos
+
+ENV AUTH_KEYS=/root/.ssh/authorized_keys
+
+ARG CLIENT_PUBLIC_KEY
+ARG ADDITIONAL_PACKAGES
+
+RUN true \
+        && yum install -y openssh-clients openssh-server openscap-scanner $ADDITIONAL_PACKAGES \
+        && yum clean all \
+        && true
+
+RUN true \
+        && for key_type in rsa ecdsa ed25519; do sshd-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && mkdir -p /root/.ssh \
+        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+&& true
+

--- a/Dockerfiles/test_suite-rhel
+++ b/Dockerfiles/test_suite-rhel
@@ -1,0 +1,19 @@
+# This Dockerfile is a minimal example for a RHEL-based SSG test suite target container.
+FROM registry.access.redhat.com/rhel
+
+ENV AUTH_KEYS=/root/.ssh/authorized_keys
+
+ARG CLIENT_PUBLIC_KEY
+ARG ADDITIONAL_PACKAGES
+
+RUN true \
+        && yum install -y openssh-clients openssh-server openscap-scanner $ADDITIONAL_PACKAGES \
+        && yum clean all \
+        && true
+
+RUN true \
+        && for key_type in rsa ecdsa ed25519; do sshd-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && mkdir -p /root/.ssh \
+        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+&& true

--- a/tests/README.md
+++ b/tests/README.md
@@ -146,3 +146,23 @@ Now, you can perform validation check with command
 ```
 ./test_suite.py rule --hypervisor qemu:///system --domain ssg-test-suite-centos --datastream ./ssg-centos7-ds.xml rule_sshd_disable_kerb_auth
 ```
+
+## Docker backend
+
+You can use either docker-based or libvirt-based environment for running tests.
+If you provide `--base-image <image name>` option on the command-line, the docker-based environment will be picked, if not, you will end up with the libvirt-based environment.
+
+On your side, you need to have
+- the [docker](https://pypi.org/project/docker/) Python module installed. You may have to use `pip` to install it on older distributions s.a. RHEL 7, running `pip install --user docker` as `root` will do the trick of installing it only for the `root` user.
+- the Docker service running, and
+- rights that allow you to start/stop containers and to create images.
+- Insecure: create a `docker` group, add yourself in it and restart `docker`.
+
+The Docker image you want to use with the tests needs to be prepared, so it can scan itself, and that it can accept connections and data.
+Following services need to be supported:
+
+TLDR: `yum install openssh-clients openssh-server openscap-scanner`
+
+- `sshd` (`openssh-server` needs to be installed, server host keys have to be in place, root's `.ssh/authorized_keys` are set up with correct permissions)
+- `scp` (`openssh-clients` need to be installed - scp requires more than a ssh server on the server-side)
+- `oscap` (`openscap-scanner` - the container has to be able to scan itself)

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -1,25 +1,31 @@
 import os
 import os.path
 import tarfile
+import collections
 
 _DIR = os.path.dirname(__file__)
 _TAR_BASENAME = 'data.tar'
 _SSG_PREFIX = 'xccdf_org.ssgproject.content_'
+
+Rule = collections.namedtuple(
+    "Rule", ["directory", "id", "files"])
 
 
 def iterate_over_rules():
     """Iterate over directories beginning with "rule_".
 
     Returns:
-    dir_name -- absolute path to the rule directory
-    rule -- full rule id as it is present in datastream
-    files -- list of files in the directory
+        Named tuple having these fields:
+            directory -- absolute path to the rule directory
+            id -- full rule id as it is present in datastream
+            files -- list of files in the directory
     """
     for dir_name, directories, files in os.walk(_DIR):
         leaf_dir = os.path.basename(dir_name)
         rel_dir = '.' + dir_name[len(_DIR):]
         if leaf_dir.startswith('rule_'):
-            yield rel_dir, _SSG_PREFIX + leaf_dir, files
+            result = Rule(rel_dir, _SSG_PREFIX + leaf_dir, files)
+            yield result
 
 
 def _exclude_utils(file_name):

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -12,6 +12,11 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
 class ProfileChecker(ssg_test_suite.oscap.Checker):
+    """
+    Iterate over profiles in datastream and perform scanning of unaltered system
+    using every profile according to input. Also perform remediation run.
+    Return value not defined, textual output and generated reports is the result.
+    """
     def _test_target(self, target):
         profiles = get_viable_profiles(
             target, self.datastream, self.benchmark_id)

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -1,74 +1,39 @@
 #!/usr/bin/env python2
 from __future__ import print_function
 
-import atexit
 import logging
-import sys
+
 
 import ssg_test_suite.oscap
 import ssg_test_suite.virt
 from ssg_test_suite.rule import get_viable_profiles
-from ssg_test_suite.virt import SnapshotStack
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
-def perform_profile_check(options):
-    """Perform profile check.
+class ProfileChecker(ssg_test_suite.oscap.Checker):
+    def _test_target(self, target):
+        profiles = get_viable_profiles(
+            target, self.datastream, self.benchmark_id)
+        self._test_by_profiles(profiles)
 
-    Iterate over profiles in datastream and perform scanning of unaltered VM
-    using every profile according to input. Also perform remediation run.
-
-    Return value not defined, textual output and generated reports is the
-    result.
-    """
-    dom = ssg_test_suite.virt.connect_domain(options.hypervisor,
-                                             options.domain_name)
-    if dom is None:
-        sys.exit(1)
-    snapshot_stack = SnapshotStack(dom)
-    atexit.register(snapshot_stack.clear)
-
-    # create origin
-    snapshot_stack.create('origin')
-    ssg_test_suite.virt.start_domain(dom)
-    domain_ip = ssg_test_suite.virt.determine_ip(dom)
-
-    has_worked = False
-    profiles = get_viable_profiles(options.target,
-                                   options.datastream,
-                                   options.benchmark_id)
-    if len(profiles) > 1:
-        # create origin <- profile
-        snapshot_stack.create('profile')
-    for profile in profiles:
+    def _run_test(self, profile, ** run_test_args):
         logging.info("Evaluation of profile {0}.".format(profile))
-        has_worked = True
-        runner = options.remediate_using
-        ssg_test_suite.oscap.run_profile(domain_ip,
-                                         profile,
-                                         'initial',
-                                         options.datastream,
-                                         options.benchmark_id,
-                                         runner=runner)
-        ssg_test_suite.oscap.run_profile(domain_ip,
-                                         profile,
-                                         'remediation',
-                                         options.datastream,
-                                         options.benchmark_id,
-                                         runner=runner)
-        ssg_test_suite.oscap.run_profile(domain_ip,
-                                         profile,
-                                         'final',
-                                         options.datastream,
-                                         options.benchmark_id,
-                                         runner=runner)
-        # revert either profile (if created), or origin. Don't delete
-        snapshot_stack.revert(delete=False)
-    if not has_worked:
-        logging.error("Nothing has been tested!")
-        # Delete the reverted profile or origin.
-    snapshot_stack.delete()
-    # depending on number of profiles we have either "origin" snapshot
-    # still to be reverted (multiple profiles) or we are reverted
-    # completely (only one profile was run)
+        self.executed_tests += 1
+
+        runner_cls = ssg_test_suite.oscap.REMEDIATION_PROFILE_RUNNERS[self.remediate_using]
+        runner = runner_cls(
+            self.test_env.domain_ip, profile, self.datastream, self.benchmark_id)
+
+        for stage in ("initial", "remediation", "final"):
+            result = runner.run_stage(stage)
+
+
+def perform_profile_check(options):
+    checker = ProfileChecker(options.test_env)
+
+    checker.datastream = options.datastream
+    checker.benchmark_id = options.benchmark_id
+    checker.remediate_using = options.remediate_using
+
+    checker.test_target(options.target)

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -1,22 +1,24 @@
 #!/usr/bin/env python2
 from __future__ import print_function
 
-import atexit
 import logging
 import os
 import os.path
 import re
 import subprocess
-import sys
+import collections
 
 import ssg_test_suite.oscap as oscap
 import ssg_test_suite.virt
 from ssg_test_suite import xml_operations
-from ssg_test_suite.virt import SnapshotStack
 from ssg_test_suite.log import LogHelper
 import data
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+
+Scenario = collections.namedtuple(
+    "Scenario", ["script", "context", "script_params"])
 
 
 def _parse_parameters(script):
@@ -59,6 +61,7 @@ def get_viable_profiles(selected_profiles, datastream, benchmark):
 
 
 def _run_with_stdout_logging(command, log_file):
+    log_file.write(" ".join(command) + "\n")
     try:
         subprocess.check_call(command,
                               stdout=log_file,
@@ -101,8 +104,8 @@ def _apply_script(rule_dir, domain_ip, script):
     machine = "root@{0}".format(domain_ip)
     logging.debug("Applying script {0}".format(script))
     rule_name = os.path.basename(rule_dir)
-    log_file_name = os.path.join(LogHelper.LOG_DIR,
-                                 rule_name + ".prescripts.log")
+    log_file_name = os.path.join(
+        LogHelper.LOG_DIR, rule_name + ".prescripts.log")
 
     with open(log_file_name, 'a') as log_file:
         log_file.write('##### {0} / {1} #####\n'.format(rule_name, script))
@@ -113,9 +116,8 @@ def _apply_script(rule_dir, domain_ip, script):
                                   stdout=log_file,
                                   stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            logging.error(("Rule testing script {0} "
-                           "failed with exit code {1}").format(script,
-                                                               e.returncode))
+            logging.error("Rule testing script {0} failed with exit code {1}"
+                          .format(script, e.returncode))
             return False
     return True
 
@@ -149,141 +151,100 @@ def _get_scenarios(rule_dir, scripts):
         script_context = _get_script_context(script)
         if script_context is not None:
             script_params = _parse_parameters(os.path.join(rule_dir, script))
-            scenarios += [(script, script_context, script_params)]
+            scenarios += [Scenario(script, script_context, script_params)]
     return scenarios
 
 
-def perform_rule_check(options):
-    """Perform rule check.
+class RuleChecker(ssg_test_suite.oscap.Checker):
+    def _run_test(self, profile, ** run_test_args):
+        scenario = run_test_args["scenario"]
+        rule_id = run_test_args["rule_id"]
 
-    Iterate over rule-testing scenarios and utilize `oscap-ssh` to test every
-    scenario. Expected result is encoded in scenario file name. In case of
-    `fail` or `error` results expected, continue with remediation and
-    reevaluation. Revert system to clean state using snapshots.
+        LogHelper.preload_log(
+            logging.INFO, "Script {0} using profile {1} OK".format(scenario.script, profile),
+            log_target='pass')
+        LogHelper.preload_log(
+            logging.ERROR,
+            "Script {0} using profile {1} found issue:".format(scenario.script, profile),
+            log_target='fail')
 
-    Return value not defined, textual output and generated reports is the
-    result.
-    """
-    dom = ssg_test_suite.virt.connect_domain(options.hypervisor,
-                                             options.domain_name)
-    if dom is None:
-        sys.exit(1)
-    snapshot_stack = SnapshotStack(dom)
-    atexit.register(snapshot_stack.clear)
+        runner_cls = ssg_test_suite.oscap.REMEDIATION_RULE_RUNNERS[self.remediate_using]
+        runner = runner_cls(
+            self.test_env.domain_ip, profile, self.datastream, self.benchmark_id,
+            rule_id, scenario.script, self.dont_clean)
 
-    # create origin
-    snapshot_stack.create('origin')
-    ssg_test_suite.virt.start_domain(dom)
-    domain_ip = ssg_test_suite.virt.determine_ip(dom)
-    scanned_something = False
+        success = runner.run_stage_with_context("initial", scenario.context)
+        if not success:
+            msg = ("The initial scan failed for rule '{}'."
+                   .format(rule_id))
+            logging.error(msg)
+            return False
 
-    remote_dir = _send_scripts(domain_ip)
-    if not remote_dir:
-        return
+        is_supported = set(['all'])
+        is_supported.add(
+            oscap.REMEDIATION_RUNNER_TO_REMEDIATION_MEANS[self.remediate_using])
+        supported_and_available_remediations = set(
+            scenario.script_params['remediation']).intersection(is_supported)
 
-    for rule_dir, rule, scripts in data.iterate_over_rules():
-        remote_rule_dir = os.path.join(remote_dir, rule_dir)
-        local_rule_dir = os.path.join(data.DATA_DIR, rule_dir)
-        if not _matches_target(rule_dir, options.target):
-            continue
-        logging.info(rule)
-        scanned_something = True
-        logging.debug("Testing rule directory {0}".format(rule_dir))
+        if (scenario.context not in ['fail', 'error'] or
+                len(supported_and_available_remediations) == 0):
+            return success
 
-        for script, script_context, script_params in _get_scenarios(local_rule_dir, scripts):
-            logging.debug(('Using test script {0} '
-                           'with context {1}').format(script, script_context))
-            # create origin <- script
-            snapshot_stack.create('script')
-            has_worked = False
+        success = runner.run_stage_with_context('remediation', 'fixed')
+        if not success:
+            msg = ("The remediation failed for rule '{}'."
+                   .format(rule_id))
+            logging.error(msg)
+            return success
 
-            if not _apply_script(remote_rule_dir, domain_ip, script):
-                logging.error("Environment failed to prepare, skipping test")
-                # maybe revert script
-                snapshot_stack.revert()
+        success = runner.run_stage_with_context('final', 'pass')
+        if not success:
+            msg = ("The check after remediation failed for rule '{}'."
+                   .format(rule_id))
+            logging.error(msg)
+        return success
+
+    def _test_target(self, target):
+        remote_dir = _send_scripts(self.test_env.domain_ip)
+        if not remote_dir:
+            msg = "Unable to upload test scripts"
+            raise RuntimeError(msg)
+
+        matching_rule_found = False
+        for rule_dir, rule, scripts in data.iterate_over_rules():
+            remote_rule_dir = os.path.join(remote_dir, rule_dir)
+            local_rule_dir = os.path.join(data.DATA_DIR, rule_dir)
+            if not _matches_target(rule_dir, target):
                 continue
-            profiles = get_viable_profiles(script_params['profiles'],
-                                           options.datastream,
-                                           options.benchmark_id)
-            if len(profiles) > 1:
-                # create origin <- script <- profile
-                snapshot_stack.create('profile')
-            for profile in profiles:
-                LogHelper.preload_log(logging.INFO,
-                                      ("Script {0} "
-                                       "using profile {1} "
-                                       "OK").format(script,
-                                                    profile),
-                                      log_target='pass')
-                LogHelper.preload_log(logging.ERROR,
-                                      ("Script {0} "
-                                       "using profile {1} "
-                                       "found issue:").format(script,
-                                                              profile),
-                                      log_target='fail')
-                has_worked = True
-                run_rule_checks(
-                    domain_ip, profile, options.datastream,
-                    options.benchmark_id, rule, script_context,
-                    script, script_params, options.remediate_using,
-                    options.dont_clean,
-                )
-                # revert either profile (if created), or script. Don't delete
-                snapshot_stack.revert(delete=False)
-            if not has_worked:
-                logging.error("Nothing has been tested!")
-            # Delete the reverted profile or script.
-            snapshot_stack.delete()
-            if len(profiles) > 1:
-                # revert script (we have reverted profile before).
-                snapshot_stack.revert()
-    if not scanned_something:
-        logging.error("Rule {0} has not been found".format(options.target))
+            logging.info(rule)
+            matching_rule_found = True
+
+            logging.debug("Testing rule directory {0}".format(rule_dir))
+
+            for scenario in _get_scenarios(local_rule_dir, scripts):
+                logging.debug('Using test script {0} with context {1}'
+                              .format(scenario.script, scenario.context))
+                with self.test_env.in_layer('script'):
+                    if not _apply_script(
+                            remote_rule_dir, self.test_env.domain_ip, scenario.script):
+                        logging.error("Environment failed to prepare, skipping test")
+                        continue
+
+                    profiles = get_viable_profiles(
+                        scenario.script_params['profiles'], self.datastream, self.benchmark_id)
+                    self._test_by_profiles(profiles, scenario=scenario, rule_id=rule)
+                self.executed_tests += 1
+
+        if not matching_rule_found:
+            logging.error("No matching rule ID found for '{0}'".format(target))
 
 
-def run_rule_checks(
-        domain_ip, profile, datastream, benchmark_id, rule,
-        script_context, script_name, script_params, runner, dont_clean):
-    def oscap_run_rule(stage, context):
-        return oscap.run_rule(
-            domain_ip=domain_ip,
-            profile=profile,
-            stage=stage,
-            datastream=datastream,
-            benchmark_id=benchmark_id,
-            rule_id=rule,
-            context=context,
-            script_name=script_name,
-            runner=runner,
-            dont_clean=dont_clean)
+def perform_rule_check(options):
+    checker = RuleChecker(options.test_env)
 
-    success = oscap_run_rule('initial', script_context)
-    if not success:
-        msg = ("The initial scan failed for rule '{}'."
-               .format(rule))
-        logging.error(msg)
-        return False
+    checker.datastream = options.datastream
+    checker.benchmark_id = options.benchmark_id
+    checker.remediate_using = options.remediate_using
+    checker.dont_clean = options.dont_clean
 
-    is_supported = set(['all'])
-    is_supported.add(
-        oscap.REMEDIATION_RUNNER_TO_REMEDIATION_MEANS[runner])
-    supported_and_available_remediations = set(
-        script_params['remediation']).intersection(is_supported)
-
-    if (script_context not in ['fail', 'error'] or
-            len(supported_and_available_remediations) == 0):
-        return success
-
-    success = oscap_run_rule('remediation', 'fixed')
-    if not success:
-        msg = ("The remediation failed for rule '{}'."
-               .format(rule))
-        logging.error(msg)
-        return success
-
-    success = oscap_run_rule('final', 'pass')
-    if not success:
-        msg = ("The check after remediation failed for rule '{}'."
-               .format(rule))
-        logging.error(msg)
-    return success
+    checker.test_target(options.target)

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -1,0 +1,136 @@
+from __future__ import print_function
+
+import contextlib
+import sys
+
+import docker
+
+import ssg_test_suite
+from ssg_test_suite.virt import SnapshotStack
+
+
+class TestEnv(object):
+    def __init__(self):
+        self.domain_ip = ""
+
+    def start(self):
+        pass
+
+    def finalize(self):
+        pass
+
+    def _get_snapshot(self, snapshot_name):
+        raise NotImplementedError()
+
+    def _revert_snapshot(self, snapshot_name):
+        raise NotImplementedError()
+
+    @contextlib.contextmanager
+    def in_layer(self, snapshot_name, delete=True):
+        snapshot = self._get_snapshot(snapshot_name)
+        exception_to_reraise = None
+        try:
+            yield snapshot
+        except KeyboardInterrupt as exc:
+            print("Hang on for a minute, cleaning up the snapshot '{0}'."
+                  .format(snapshot_name), file=sys.stderr)
+            exception_to_reraise = exc
+        finally:
+            try:
+                self._revert_snapshot(snapshot)
+            except KeyboardInterrupt as exc:
+                print("Hang on for a minute, cleaning up the snapshot '{0}'."
+                      .format(snapshot_name), file=sys.stderr)
+                self._revert_snapshot(snapshot)
+            finally:
+                if exception_to_reraise:
+                    raise exception_to_reraise
+
+
+class VMTestEnv(TestEnv):
+    name = "libvirt-based"
+
+    def __init__(self, hypervisor, domain_name):
+        super(VMTestEnv, self).__init__()
+
+        self.hypervisor = hypervisor
+        self.domain_name = domain_name
+        self.snapshot_stack = None
+
+    def start(self):
+        dom = ssg_test_suite.virt.connect_domain(
+            self.hypervisor, self.domain_name)
+        self.snapshot_stack = SnapshotStack(dom)
+
+        ssg_test_suite.virt.start_domain(dom)
+        self.domain_ip = ssg_test_suite.virt.determine_ip(dom)
+
+    def _get_snapshot(self, snapshot_name):
+        return self.snapshot_stack.create(snapshot_name)
+
+    def _revert_snapshot(self, snapshot):
+        self.snapshot_stack.revert()
+
+
+class DockerTestEnv(TestEnv):
+    name = "container-based"
+
+    def __init__(self, image_name):
+        super(DockerTestEnv, self).__init__()
+
+        self._name_stem = "ssg_test"
+
+        try:
+            self.client = docker.from_env(version="auto")
+            self.client.ping()
+        except Exception as exc:
+            msg = (
+                "Unable to start the Docker test environment, "
+                "is the Docker service started "
+                "and do you have rights to access it?"
+                .format(str(exc)))
+            raise RuntimeError(msg)
+        self.base_image = image_name
+        self.created_images = []
+        self.containers = []
+
+    @property
+    def current_container(self):
+        if self.containers:
+            return self.containers[-1]
+        return None
+
+    def _create_new_image(self, from_container, name):
+        new_image_name = "{0}_{1}".format(self.base_image, name)
+        from_container.commit(repository=new_image_name)
+        self.created_images.append(new_image_name)
+        return new_image_name
+
+    def _new_container(self, name):
+        if self.containers:
+            img = self._create_new_image(self.containers[-1], name)
+        else:
+            img = self.base_image
+        return self.client.containers.run(
+            img, "/usr/sbin/sshd -D",
+            name="{0}_{1}".format(self._name_stem, name), ports={"22": None},
+            detach=True)
+
+    def _get_snapshot(self, snapshot_name):
+        new_container = self._new_container(snapshot_name)
+        self.containers.append(new_container)
+
+        new_container.reload()
+        self.domain_ip = new_container.attrs["NetworkSettings"]["Networks"]["bridge"]["IPAddress"]
+
+        return new_container
+
+    def _revert_snapshot(self, snapshot):
+        snapshot.stop()
+        snapshot.remove()
+
+        assert snapshot == self.containers.pop()
+
+        if self.created_images:
+            associated_image = self.created_images.pop()
+            self.client.images.remove(associated_image)

--- a/tests/ssg_test_suite/virt.py
+++ b/tests/ssg_test_suite/virt.py
@@ -136,7 +136,7 @@ def determine_ip(domain):
                             0)
 
     # get IPv4 address of the guest
-    for (name, val) in ifaces.iteritems():
+    for (name, val) in ifaces.items():
         if val['hwaddr'] == domain_mac and val['addrs']:
             for ipaddr in val['addrs']:
                 if ipaddr['type'] == libvirt.VIR_IP_ADDR_TYPE_IPV4:

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -10,7 +10,7 @@ import sys
 
 from ssg_test_suite.log import LogHelper
 import ssg_test_suite.oscap
-import ssg_test_suite.virt
+import ssg_test_suite.test_env
 import ssg_test_suite.profile
 import ssg_test_suite.rule
 from ssg_test_suite import xml_operations
@@ -20,6 +20,11 @@ def parse_args():
     parser = argparse.ArgumentParser()
 
     common_parser = argparse.ArgumentParser(add_help=False)
+    common_parser.set_defaults(test_env=None)
+    common_parser.add_argument("--base-image",
+                               dest="base_image",
+                               metavar="IMAGE",
+                               help="Use Docker test environment with this base image.")
     common_parser.add_argument("--hypervisor",
                                dest="hypervisor",
                                metavar="HYPERVISOR",
@@ -141,6 +146,19 @@ def normalize_passed_arguments(options):
         msg = "Error inferring benchmark ID from component refId: {}".format(str(exc))
         raise RuntimeError(msg)
 
+    if options.base_image:
+        options.test_env = ssg_test_suite.test_env.DockerTestEnv(
+            options.base_image)
+        logging.info(
+            "The base image option has been specified, "
+            "choosing Docker-based test environment.")
+    else:
+        options.test_env = ssg_test_suite.test_env.VMTestEnv(
+            options.hypervisor, options.domain_name)
+        logging.info(
+            "The base image option has not been specified, "
+            "choosing libvirt-based test environment.")
+
 
 def main():
     options = parse_args()
@@ -150,14 +168,14 @@ def main():
     # debug otherwise it cuts silently everything
     log.setLevel(logging.DEBUG)
 
+    LogHelper.add_console_logger(log, options.loglevel)
+
     try:
         normalize_passed_arguments(options)
     except RuntimeError as exc:
         msg = "Error occurred during options normalization: {}".format(str(exc))
         logging.error(msg)
         sys.exit(1)
-
-    LogHelper.add_console_logger(log, options.loglevel)
     # logging dir needs to be created based on other options
     # thus we have to postprocess it
 


### PR DESCRIPTION
This PR adds support for scanning Docker containers (as opposed to VM instances), together with some refactoring.

* Added Python3 compatibility.

* Got rid of `run_profile` and `run_rule` boilerplate functions. Introduced the `Checker` class that allows some code sharing between profile and rule checks.
* Relocated test environments-related code to the `test_env` submodule. This allows to use the snapshot-like functionality in form of context managers and to clearly separate libvirt-related code from the docker-related code.
* Implemented Docker test environment support, added support for it to the CLI and expanded the README accordingly.
* Introduced one test suite launcher for each backend - now there are `test_suite-docker.py` and `test_suite-vm.py`.

Known issues that are intentionally not part of this PR:
- The snapshot handling got a bit stupid - it can't do reverts without deleting the snapshot. This is a performance regression and can be fixed later.
- Terminating the program during snapshot creation/deletion may not delete them. It used to work somewhat better (but not perfectly) by using `atexit`, but that would be too hackish for both VMs and Docker images/containers at the same time. It can be fixed later.
- Plenty of tests don't work in containers (mounts, dbus, ...).