### PR TITLE
Add remediation and tests for mount_option_krb_sec_emote_filesystems rule

### DIFF
--- a/shared/bash_remediation_functions/include_mount_options_functions.sh
+++ b/shared/bash_remediation_functions/include_mount_options_functions.sh
@@ -2,6 +2,18 @@ function include_mount_options_functions {
 	:
 }
 
+# $1: type of filesystem
+# $2: new mount point option
+function ensure_mount_option_for_vfstype {
+        local _vfstype="$1" _new_opt="$2" _vfstype_points=()
+        _vfstype_points=($(grep -E "[[:space:]]$_vfstype[[:space:]]" /etc/fstab | awk '{print $2}'))
+
+        for _vfstype_point in "${_vfstype_points[@]}"
+        do
+                ensure_mount_option_in_fstab "$_vfstype_point" "$_new_opt"
+        done
+}
+
 # $1: mount point
 # $2: new mount point option
 function ensure_mount_option_in_fstab {

--- a/shared/fixes/ansible/mount_option_krb_sec_remote_filesystems.yml
+++ b/shared/fixes/ansible/mount_option_krb_sec_remote_filesystems.yml
@@ -1,0 +1,19 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+- name: "Get nfs and nfs4 mount points, that don't have Kerberos security option"
+  shell: grep -E "[[:space:]]nfs[4]?[[:space:]]" /etc/fstab | grep -v "sec=krb5:krb5i:krb5p" | awk '{print $2}'
+  register: points_register
+  check_mode: no
+  tags:
+    @ANSIBLE_TAGS@
+
+- name: "Add Kerberos security to mount points"
+  shell: awk '$2=="{{ item }}"{$4=$4",sec=krb5:krb5i:krb5p"}1' /etc/fstab > fstab.tmp && mv fstab.tmp /etc/fstab
+  with_items:
+    - "{{ points_register.stdout_lines }}"
+  tags:
+    @ANSIBLE_TAGS@

--- a/shared/fixes/bash/mount_option_krb_sec_remote_filesystems.sh
+++ b/shared/fixes/bash/mount_option_krb_sec_remote_filesystems.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+. /usr/share/scap-security-guide/remediation_functions
+include_mount_options_functions
+
+ensure_mount_option_for_vfstype "nfs[4]?" "sec=krb5:krb5i:krb5p"

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/fstab
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/fstab
@@ -1,0 +1,8 @@
+# /etc/fstab: static file system information
+# Example fstab file with mounted NFS file systems
+# <file system>                   <mount point>   <type>  <options>                             <dump>  <pass>
+
+/tmp/folder0                        /folder0       ext4   defaults,sec=krb5:krb5:krb5i:krb5p              0  0
+some.server:/remote/folder1         /folder1       nfs    defaults,noexec,nosuid,sec=krb5:krb5i:krb5p     0  0
+/home/folder2                       /folder2       auto   defaults                                        0  0
+another.server:/remote/folder3      /folder3       nfs4   defaults,noexec,nosuid,sec=krb5:krb5i:krb5p     0  0

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/krb_sec_set.pass.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/krb_sec_set.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/missing_all_krb_sec.fail.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/missing_all_krb_sec.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/
+sed -i 's/,sec=krb5:krb5i:krb5p//' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/missing_krb_sec.fail.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/missing_krb_sec.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/
+# delete sec=.. only from nfs4
+sed -i 's|\(.*nfs4.*\),sec=krb5:krb5i:krb5p\(.*\)|\1\2|' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/no_nfs.pass.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/no_nfs.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/
+sed -i '/nfs/d' /etc/fstab


### PR DESCRIPTION
#### Description:
Add bash and ansible remediation with tests for Mount Remote Filesystems with Kerberos Security rule.
