### PR TITLE
Ignore .pytest_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ CMakeLists.txt.user
 
 # Ignore VIM's ropeproject files
 .ropeproject
+
+# Ignore pytest cache
+.pytest_cache/


### PR DESCRIPTION
Signed-off-by: Alexander Scheel <ascheel@redhat.com>

On pytest failure, this directory is left around. Ignore it. 