### PR TITLE
OL7 pci-dss aide and password hashing rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Set Password Hashing Algorithm in /etc/libuser.conf'
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Set Password Hashing Algorithm in /etc/login.defs'
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth.rule
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Set PAM''s Password Hashing Algorithm'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking.rule
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Configure Periodic Execution of AIDE'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed.rule
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed.rule
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Install AIDE'
 

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -31,3 +31,6 @@ selections:
     - set_password_hashing_algorithm_systemauth
     - set_password_hashing_algorithm_logindefs
     - set_password_hashing_algorithm_libuserconf
+    - package_aide_installed
+    - aide_build_database
+    - aide_periodic_cron_checking

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -28,3 +28,6 @@ selections:
     - file_owner_grub2_cfg
     - file_groupowner_grub2_cfg
     - package_libreswan_installed
+    - set_password_hashing_algorithm_systemauth
+    - set_password_hashing_algorithm_logindefs
+    - set_password_hashing_algorithm_libuserconf

--- a/ol7/templates/csv/packages_installed.csv
+++ b/ol7/templates/csv/packages_installed.csv
@@ -1,3 +1,4 @@
+aide
 openssh-server
 uuidd
 glibc,0:2.17-55.0.4.el7_0.3

--- a/shared/checks/oval/aide_build_database.xml
+++ b/shared/checks/oval/aide_build_database.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The aide database must be initialized.</description>
     </metadata>

--- a/shared/checks/oval/aide_periodic_cron_checking.xml
+++ b/shared/checks/oval/aide_periodic_cron_checking.xml
@@ -4,6 +4,7 @@
       <title>Configure Periodic Execution of AIDE</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>By default, AIDE does not install itself for periodic
       execution. Periodically running AIDE is necessary to reveal

--- a/shared/checks/oval/set_password_hashing_algorithm_libuserconf.xml
+++ b/shared/checks/oval/set_password_hashing_algorithm_libuserconf.xml
@@ -4,6 +4,7 @@
       <title>Set SHA512 Password Hashing Algorithm in /etc/libuser.conf</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The password hashing algorithm should be set correctly in /etc/libuser.conf.</description>
     </metadata>

--- a/shared/checks/oval/set_password_hashing_algorithm_logindefs.xml
+++ b/shared/checks/oval/set_password_hashing_algorithm_logindefs.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The password hashing algorithm should be set correctly in /etc/login.defs.</description>
     </metadata>

--- a/shared/checks/oval/set_password_hashing_algorithm_systemauth.xml
+++ b/shared/checks/oval/set_password_hashing_algorithm_systemauth.xml
@@ -4,6 +4,7 @@
       <title>Set Password Hashing Algorithm in /etc/pam.d/system-auth</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The password hashing algorithm should be set correctly in /etc/pam.d/system-auth.</description>
     </metadata>

--- a/shared/fixes/ansible/set_password_hashing_algorithm_libuserconf.yml
+++ b/shared/fixes/ansible/set_password_hashing_algorithm_libuserconf.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/shared/fixes/ansible/set_password_hashing_algorithm_logindefs.yml
+++ b/shared/fixes/ansible/set_password_hashing_algorithm_logindefs.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/shared/fixes/bash/aide_build_database.sh
+++ b/shared/fixes/bash/aide_build_database.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 package_install aide

--- a/shared/fixes/bash/aide_periodic_cron_checking.sh
+++ b/shared/fixes/bash/aide_periodic_cron_checking.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 package_install aide

--- a/shared/fixes/bash/set_password_hashing_algorithm_libuserconf.sh
+++ b/shared/fixes/bash/set_password_hashing_algorithm_libuserconf.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 
 LIBUSER_CONF="/etc/libuser.conf"
 CRYPT_STYLE_REGEX='[[:space:]]*\[defaults](.*(\n)+)+?[[:space:]]*crypt_style[[:space:]]*'

--- a/shared/fixes/bash/set_password_hashing_algorithm_logindefs.sh
+++ b/shared/fixes/bash/set_password_hashing_algorithm_logindefs.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 if grep --silent ^ENCRYPT_METHOD /etc/login.defs ; then
 	sed -i 's/^ENCRYPT_METHOD.*/ENCRYPT_METHOD SHA512/g' /etc/login.defs
 else

--- a/shared/fixes/bash/set_password_hashing_algorithm_systemauth.sh
+++ b/shared/fixes/bash/set_password_hashing_algorithm_systemauth.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 
 AUTH_FILES[0]="/etc/pam.d/system-auth"
 AUTH_FILES[1]="/etc/pam.d/password-auth"


### PR DESCRIPTION
#### Description:

Simple PR to add OL7 support for existing aide and password hashing pci-dss rules

#### Rationale:

Add more ol7 pci-dss rules

#### Testing (Oracle Linux 7):
- Checked OVAL and remediation scripts content
- Checked guide content
- Checked  rules evaluation an remediation scripts results

