### PR TITLE
Fix required_key usage on build-only key

### DIFF
--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -45,7 +45,7 @@ class AbsolutePathFileSystemLoader(jinja2.BaseLoader):
 def _get_jinja_environment(substitutions_dict):
     if _get_jinja_environment.env is None:
         bytecode_cache = None
-        if required_key(substitutions_dict, "jinja2_cache_enabled") == "true":
+        if substitutions_dict.get("jinja2_cache_enabled") == "true":
             bytecode_cache = jinja2.FileSystemBytecodeCache(
                 required_key(substitutions_dict, "jinja2_cache_dir")
             )


### PR DESCRIPTION
Not sure why we're using `required_key` on this... Thought I fixed it earlier. 

`jinja2_cache_dir` depends on `jinja2_cache_enabled` being true, so that makes sense to use a `required_key` there, but we should be perfectly fine if we don't have a `jinja2_cache_enabled` key--default to `False`!