### PR TITLE
CMAKE_BUILD_TYPE support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,13 @@
 cmake_minimum_required(VERSION 2.8)
+
+# Inspired and referenced from https://blog.kitware.com/cmake-and-the-default-build-type
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+        "MinSizeRel" "RelWithDebInfo")
+endif()
+
 project(scap-security-guide NONE)
 
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ find_program(ANSIBLE_PLAYBOOK_EXECUTABLE NAMES ansible-playbook)
 configure_file("${CMAKE_SOURCE_DIR}/build_config.yml.in" "${CMAKE_BINARY_DIR}/build_config.yml" @ONLY)
 
 message(STATUS "CMake:")
+message(STATUS "build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "generator: ${CMAKE_GENERATOR}")
 message(STATUS "source directory: ${CMAKE_SOURCE_DIR}")
 message(STATUS "build directory: ${CMAKE_BINARY_DIR}")

--- a/build_config.yml.in
+++ b/build_config.yml.in
@@ -1,3 +1,5 @@
+cmake_build_type: "@CMAKE_BUILD_TYPE@"
+
 ssg_version: [@SSG_MAJOR_VERSION@, @SSG_MINOR_VERSION@, @SSG_PATCH_VERSION@]
 ssg_version_str: "@SSG_VERSION@"
 target_oval_version: [@SSG_TARGET_OVAL_MAJOR_VERSION@, @SSG_TARGET_OVAL_MINOR_VERSION@]

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -28,7 +28,7 @@ def _save_rename(result, stem, prefix):
     result["{0}_{1}".format(prefix, stem)] = stem
 
 
-def _open_yaml(stream, original_file=None):
+def _open_yaml(stream, original_file=None, substitutions_dict={}):
     """
     Open given file-like object and parse it as YAML.
 
@@ -40,7 +40,8 @@ def _open_yaml(stream, original_file=None):
     try:
         yaml_contents = yaml.load(stream, Loader=yaml_SafeLoader)
 
-        if yaml_contents.pop("documentation_complete", "true") == "false":
+        if yaml_contents.pop("documentation_complete", "true") == "false" and \
+                substitutions_dict.get("cmake_build_type") != "Debug":
             return None
 
         return yaml_contents
@@ -79,7 +80,7 @@ def open_and_expand(yaml_file, substitutions_dict=None):
         substitutions_dict = dict()
 
     expanded_template = process_file(yaml_file, substitutions_dict)
-    yaml_contents = _open_yaml(expanded_template, original_file=yaml_file)
+    yaml_contents = _open_yaml(expanded_template, yaml_file, substitutions_dict)
     return yaml_contents
 
 


### PR DESCRIPTION
The only thing that's different when using the Debug build type is the addition of documentation_complete=false content. That let's developers test work in progress content conveniently without flipping switches back and forth.

![image](https://user-images.githubusercontent.com/753153/44052011-707286f4-9f09-11e8-8b3f-f19b4de5e688.png)
