### PR TITLE
Rule directory tools

### DIFF
--- a/ssg/oval.py
+++ b/ssg/oval.py
@@ -83,6 +83,24 @@ def _add_elements(body, header):
     return defname
 
 
+def applicable_platforms(oval_file):
+    """
+    Returns the applicable platforms for a given oval file
+    """
+
+    platforms = []
+    header = oval_generated_header("applicable_platforms", "5.11", "0.0.1")
+    body = read_ovaldefgroup_file(oval_file)
+    oval_tree = ET.fromstring(header + body + footer)
+
+    element_path = "./{%s}def-group/{%s}definition/{%s}metadata/{%s}affected/{%s}platform"
+    element_ns_path = element_path % (ovalns, ovalns, ovalns, ovalns, ovalns)
+    for node in oval_tree.findall(element_ns_path):
+        platforms.append(node.text)
+
+    return platforms
+
+
 def replace_external_vars(tree):
     """Replace external_variables with local_variables, so the definition can be
        tested independently of an XCCDF file"""

--- a/ssg/rule_dir_stats.py
+++ b/ssg/rule_dir_stats.py
@@ -1,0 +1,404 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+from collections import defaultdict
+
+from .build_remediations import REMEDIATION_TO_EXT_MAP as REMEDIATION_MAP
+from .utils import subset_dict
+
+
+def get_affected_products(rule_obj):
+    """
+    From a rule_obj, return the set of affected products from rule.yml
+    """
+    return set(rule_obj['products'])
+
+
+def get_all_affected_products(args, rule_obj):
+    """
+    From a rule_obj, return the set of affected products from rule.yml, and
+    all fixes and checks.
+
+    If args.strict is set, this function is equivalent to
+    get_affected_products. Otherwise, it includes ovals and fix content based
+    on the values of args.fixes_only and args.ovals_only.
+    """
+
+    affected_products = get_affected_products(rule_obj)
+
+    if args.strict:
+        return affected_products
+
+    if not args.fixes_only:
+        for product in rule_obj['oval_products']:
+            affected_products.add(product)
+
+    if not args.ovals_only:
+        for product in rule_obj['remediation_products']:
+            affected_products.add(product)
+
+    return affected_products
+
+
+def _walk_rule(args, rule_obj, oval_func, remediation_func, verbose_output):
+    """
+    Walks a single rule and updates verbose_output if visited. Returns visited
+    state as a boolean.
+
+    Internal function for walk_rules and walk_rules_parallel.
+    """
+
+    rule_id = rule_obj['id']
+
+    affected_products = get_all_affected_products(args, rule_obj)
+    if not affected_products.intersection(args.products):
+        return False
+    if args.query and rule_id not in args.query:
+        return False
+
+    if not args.fixes_only:
+        result = oval_func(args, rule_obj)
+        if result:
+            verbose_output[rule_id]['oval'] = result
+
+    if not args.ovals_only:
+        any_remediations = False
+        for r_type in REMEDIATION_MAP:
+            result = remediation_func(args, rule_obj, r_type)
+            if result:
+                verbose_output[rule_id][r_type] = result
+
+    return True
+
+def walk_rules(args, known_rules, oval_func, remediation_func):
+    """
+    Walk a dictionary of known_rules, returning the number of visited rules
+    and the output at each visited rule, conditionally calling oval_func and
+    remediation_func based on the values of args.fixes_only and
+    args.ovals_only. If the result of these functions are not Falsy, set the
+    appropriate output content.
+
+    The input rule_obj structure is the value of known_rules[rule_id].
+
+    The output structure is a dict as follows:
+    {
+        rule_id: {
+            "oval": oval_func(args, rule_obj),
+            "ansible": remediation_func(args, "ansible", rule_obj),
+            "anaconda": remediation_func(args, "anaconda", rule_obj),
+            "bash": remediation_func(args, "bash", rule_obj),
+            "puppet": remediation_func(args, "puppet", rule_obj)
+        },
+        ...
+    }
+
+    The arguments supplied to oval_func are args and rule_obj.
+    The arguments supplied to remediation_func are args, the remediation type,
+    and rule_obj.
+    """
+
+    affected_rules = 0
+    verbose_output = defaultdict(lambda: defaultdict(lambda: None))
+
+    for rule_id in known_rules:
+        rule_obj = known_rules[rule_id]
+        if _walk_rule(args, rule_obj, oval_func, remediation_func, verbose_output):
+            affected_rules += 1
+
+    return affected_rules, verbose_output
+
+
+def walk_rule_stats(rule_id, rule_output):
+    affected_ovals = 0
+    affected_remediations = 0
+    all_affected_remediations = 0
+    affected_remediations_type = defaultdict(lambda: 0)
+    all_output = []
+
+    affected_remediation = False
+    all_remedation = True
+
+    if 'oval' in rule_output:
+        affected_ovals += 1
+        all_output.append(rule_output['oval'])
+
+    for r_type in sorted(REMEDIATION_MAP):
+        if r_type in rule_output:
+            affected_remediation = True
+            affected_remediations_type[r_type] += 1
+            all_output.append(rule_output[r_type])
+        else:
+            all_remedation = False
+
+    if affected_remediation:
+        affected_remediations += 1
+    if all_remedation:
+        all_affected_remediations += 1
+
+    return (affected_ovals, affected_remediations, all_affected_remediations,
+            affected_remediations_type, all_output)
+
+
+def walk_rules_stats(args, known_rules, oval_func, remediation_func):
+    """
+    Walk a dictionary of known_rules and generate simple aggregate statistics
+    for all visited rules. The oval_func and remediation_func arguments behave
+    according to walk_rules().
+
+    Returned values are visited_rules, affected_ovals, affected_remediation,
+    a dictionary containing all fix types and the quantity of affected fixes,
+    and the ordered output of all functions.
+
+    An effort is made to provide consistently ordered verbose_output by
+    sorting all visited keys and the keys of
+    ssg.build_remediations.REMEDIATION_MAP.
+    """
+    affected_rules, verbose_output = walk_rules(args, known_rules, oval_func, remediation_func)
+
+    affected_ovals = 0
+    affected_remediations = 0
+    all_affected_remediations = 0
+    affected_remediations_type = defaultdict(lambda: 0)
+    all_output = []
+
+    for rule_id in sorted(verbose_output):
+        rule_output = verbose_output[rule_id]
+        results = walk_rule_stats(rule_id, rule_output)
+
+        affected_ovals += results[0]
+        affected_remediations += results[1]
+        all_affected_remediations += results[2]
+        for key in results[3]:
+            affected_remediations_type[key] += results[3][key]
+
+        all_output.extend(results[4])
+
+    return (affected_rules, affected_ovals, affected_remediations,
+            all_affected_remediations, affected_remediations_type, all_output)
+
+
+def walk_rules_parallel(args, left_rules, right_rules, oval_func, remediation_func):
+    """
+    Walks two sets of known_rules (left_rules and right_rules) with identical
+    keys and returns left_only, right_only, and common_only output from
+    _walk_rule. If the outputted data for a rule when called on left_rules and
+    right_rules is the same, it is added to common_only. Only rules which
+    output different data will have their data added to left_only and
+    right_only respectively.
+
+    Can assert.
+    """
+
+    left_affected_rules = 0
+    right_affected_rules = 0
+    common_affected_rules = 0
+
+    left_verbose_output = defaultdict(lambda: defaultdict(lambda: None))
+    right_verbose_output = defaultdict(lambda: defaultdict(lambda: None))
+    common_verbose_output = defaultdict(lambda: defaultdict(lambda: None))
+
+    assert(set(left_rules) == set(right_rules))
+
+    for rule_id in left_rules:
+        left_rule_obj = left_rules[rule_id]
+        right_rule_obj = right_rules[rule_id]
+
+        if left_rule_obj == right_rule_obj:
+            if _walk_rule(args, left_rule_obj, oval_func, remediation_func, common_verbose_output):
+                common_affected_rules += 1
+        else:
+            left_temp = defaultdict(lambda: defaultdict(lambda: None))
+            right_temp = defaultdict(lambda: defaultdict(lambda: None))
+
+            left_ret = _walk_rule(args, left_rule_obj, oval_func, remediation_func, left_temp)
+            right_ret = _walk_rule(args, right_rule_obj, oval_func, remediation_func, right_temp)
+
+            if left_ret == right_ret and left_temp == right_temp:
+                common_verbose_output.update(left_temp)
+                if left_ret:
+                    common_affected_rules += 1
+            else:
+                left_verbose_output.update(left_temp)
+                right_verbose_output.update(right_temp)
+                if left_ret:
+                    left_affected_rules += 1
+                if right_ret:
+                    right_affected_rules += 1
+
+    left_only = (left_affected_rules, left_verbose_output)
+    right_only = (right_affected_rules, right_verbose_output)
+    common_only = (common_affected_rules, common_verbose_output)
+
+    return left_only, right_only, common_only
+
+
+def walk_rules_diff(args, left_rules, right_rules, oval_func, remediation_func):
+    """
+    Walk a two dictionary of known_rules (left_rules and right_rules) and generate
+    five sets of output: left_only rules output, right_only rules output,
+    shared left output, shared right output, and shared common output, as a
+    five-tuple, where each tuple element is equivalent to walk_rules on the
+    appropriate set of rules.
+
+    Does not understand renaming of rule_ids as this would depend on disk
+    content to reflect these differences. Unless significantly more data is
+    added to the rule_obj structure (contents of rule.yml, ovals,
+    remediations, etc.), all information besides 'title' is not uniquely
+    identifying or could be easily updated.
+    """
+
+    left_rule_ids = set(left_rules)
+    right_rule_ids = set(right_rules)
+
+    left_only_rule_ids = left_rule_ids.difference(right_rule_ids)
+    right_only_rule_ids = right_rule_ids.difference(left_rule_ids)
+    common_rule_ids = left_rule_ids.intersection(right_rule_ids)
+
+    left_restricted = subset_dict(left_rules, left_only_rule_ids)
+    left_common = subset_dict(left_rules, common_rule_ids)
+    right_restricted = subset_dict(right_rules, right_only_rule_ids)
+    right_common = subset_dict(right_rules, common_rule_ids)
+
+    left_only_data = walk_rules(args, left_restricted, oval_func, remediation_func)
+    right_only_data = walk_rules(args, right_restricted, oval_func, remediation_func)
+    left_changed_data, right_changed_data, common_data = walk_rules_parallel(args, left_common, right_common, oval_func, remediation_func)
+
+    return (left_only_data, right_only_data, left_changed_data, right_changed_data, common_data)
+
+
+def walk_rules_diff_stats(args, results):
+    """
+    Takes the results of walk_rules_diff (results) and generates five sets of
+    output statistics: left_only rules output, right_only rules output,
+    shared left output, shared right output, and shared common output, as a
+    five-tuple, where each tuple element is equivalent to walk_rules_stats on
+    the appropriate set of rules.
+
+    Can assert.
+    """
+
+    assert(len(results) == 5)
+
+    output_data = []
+
+    for data in results:
+        affected_rules, verbose_output = data
+
+        affected_ovals = 0
+        affected_remediations = 0
+        all_affected_remediations = 0
+        affected_remediations_type = defaultdict(lambda: 0)
+        all_output = []
+
+        for rule_id in sorted(verbose_output):
+            rule_output = verbose_output[rule_id]
+            _results = walk_rule_stats(rule_id, rule_output)
+
+            affected_ovals += _results[0]
+            affected_remediations += _results[1]
+            all_affected_remediations += _results[2]
+            for key in _results[3]:
+                affected_remediations_type[key] += _results[3][key]
+
+            all_output.extend(_results[4])
+
+        output_data.append((affected_rules, affected_ovals,
+                            affected_remediations, all_affected_remediations,
+                            affected_remediations_type, all_output))
+
+    assert(len(output_data) == 5)
+
+    return tuple(output_data)
+
+
+
+
+def missing_oval(args, rule_obj):
+    rule_id = rule_obj['id']
+    check = len(rule_obj['ovals']) > 0
+    if not check:
+        return "\trule_id:%s is missing all OVALs" % rule_id
+
+
+def missing_remediation(args, rule_obj, r_type):
+    rule_id = rule_obj['id']
+    check = len(rule_obj['remediations'][r_type]) > 0
+    if not check:
+        return "\trule_id:%s is missing %s remediations" % (rule_id, r_type)
+
+
+def two_plus_oval(args, rule_obj):
+    rule_id = rule_obj['id']
+    check = len(rule_obj['ovals']) >= 2
+    if check:
+        return "\trule_id:%s has two or more OVALs: %s" % (rule_id, ','.join(rule_obj['ovals']))
+
+
+def two_plus_remediation(args, rule_obj, r_type):
+    rule_id = rule_obj['id']
+    check = len(rule_obj['remediations'][r_type]) >= 2
+    if check:
+        return "\trule_id:%s has two or more %s remediations: %s" % (rule_id, r_type, ','.join(rule_obj['remediations'][r_type]))
+
+
+def prodtypes_oval(args, rule_obj):
+    rule_id = rule_obj['id']
+
+    rule_products = set(rule_obj['products'])
+    if not rule_products:
+        return
+
+    oval_products = set()
+    for oval in rule_obj['ovals']:
+        oval_products.update(rule_obj['ovals'][oval]['products'])
+    if not oval_products:
+        return
+
+    sym_diff = sorted(rule_products.symmetric_difference(oval_products))
+    check = len(sym_diff) > 0
+    if check:
+        return "\trule_id:%s has a different prodtypes between YAML and OVALs: %s" % (rule_id, ','.join(sym_diff))
+
+
+def prodtypes_remediation(args, rule_obj, r_type):
+    rule_id = rule_obj['id']
+
+    rule_products = set(rule_obj['products'])
+    if not rule_products:
+        return
+
+    remediation_products = set()
+    for remediation in rule_obj['remediations'][r_type]:
+        remediation_products.update(rule_obj['remediations'][r_type][remediation]['products'])
+    if not remediation_products:
+        return
+
+    sym_diff = sorted(rule_products.symmetric_difference(remediation_products))
+    check = len(sym_diff) > 0 and rule_products and remediation_products
+    if check:
+        return "\trule_id:%s has a different prodtypes between YAML and %s remediations: %s" % (rule_id, r_type, ','.join(sym_diff))
+
+
+def product_names_oval(args, rule_obj):
+    rule_id = rule_obj['id']
+    for oval_name in rule_obj['ovals']:
+        if oval_name == "shared.xml":
+            continue
+
+        oval_product, _ = os.path.splitext(oval_name)
+        for product in rule_obj['ovals'][oval_name]['products']:
+            if product != oval_product:
+                return "\trule_id:%s has a different product and OVALs names: %s is not %s" % (rule_id, product, oval_product)
+
+
+def product_names_remediation(args, rule_obj, r_type):
+    rule_id = rule_obj['id']
+    for r_name in rule_obj['remediations'][r_type]:
+        r_product, _ = os.path.splitext(r_name)
+        if r_product == "shared":
+            continue
+
+        for product in rule_obj['remediations'][r_type][r_name]['products']:
+            if product != r_product:
+                return "\trule_id:%s has a different product and %s remediation names: %s is not %s" % (rule_id, r_type, product, r_product)

--- a/ssg/rule_dir_stats.py
+++ b/ssg/rule_dir_stats.py
@@ -331,6 +331,39 @@ def walk_rules_diff_stats(results):
     return tuple(output_data)
 
 
+def filter_rule_ids(all_keys, queries):
+    """
+    From a set of queries (a comma separated list of queries, where a query is either a
+    rule id or a substring thereof), return the set of matching keys from all_keys. When
+    queries is the literal string "all", return all of the keys.
+    """
+
+    if not queries:
+        return set()
+
+    if queries == 'all':
+        return set(all_keys)
+
+    # We assume that all_keys is much longer than queries; this allows us to do
+    # len(all_keys) iterations of size len(query_parts) instead of len(query_parts)
+    # queries of size len(all_keys) -- which hopefully should be a faster data access
+    # pattern due to caches but in reality shouldn't matter. Note that we have to iterate
+    # over the keys in all_keys either way, because we wish to check whether query is a
+    # substring of a key, not whether query is a key.
+    #
+    # This does have the side-effect of not having the results be ordered according to
+    # their order in query_parts, so we instead, we intentionally discard order by using
+    # a set. This also guarantees that our results are unique.
+    results = set()
+    query_parts = queries.split(',')
+    for key in all_keys:
+        for query in query_parts:
+            if query in key:
+                results.add(key)
+
+    return results
+
+
 def missing_oval(rule_obj):
     """
     For a rule object, check if it is missing an oval.

--- a/ssg/rules.py
+++ b/ssg/rules.py
@@ -5,6 +5,29 @@ import os
 
 
 from .build_remediations import REMEDIATION_TO_EXT_MAP as REMEDIATION_MAP
+from .build_remediations import is_applicable_for_product
+
+
+def is_applicable(platform, product):
+    """
+    Function to check if a platform is applicable for the product.
+    Handles when a platform is really a list of products, i.e., a
+    prodtype field from a rule.yml.
+
+    Returns true iff product is applicable for the platform or list
+    of products
+    """
+
+    if platform == 'all' or platform == 'multi_platform_all':
+        return True
+
+    if is_applicable_for_product(platform, product):
+        return True
+
+    if 'osp7' in product and 'osp7' in platform:
+        return True
+
+    return product in platform.split(',')
 
 
 def get_rule_dir_yaml(dir_path):

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -46,3 +46,17 @@ def merge_dicts(left, right):
     result = left.copy()
     result.update(right)
     return result
+
+
+def subset_dict(dictionary, keys):
+    """
+    Restricts dictionary to only have keys from keys. Does not modify either
+    dictionary or keys, returning the result instead.
+    """
+
+    result = dictionary.copy()
+    for original_key in dictionary:
+        if original_key not in keys:
+            del result[original_key]
+
+    return result

--- a/tests/unit/ssg/data/group_dir/rule_dir/oval/rhel.xml
+++ b/tests/unit/ssg/data/group_dir/rule_dir/oval/rhel.xml
@@ -1,0 +1,17 @@
+<def-group oval_version="5.11">
+  <definition class="compliance" id="service_chronyd_or_ntpd_enabled" version="1">
+    <metadata>
+      <title>Service chronyd Or Service ntpd Enabled</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>At least one of the chronyd or ntpd services should be enabled if possible.</description>
+    </metadata>
+
+    <criteria comment="chronyd or ntpd service enabled" operator="OR">
+      <extend_definition comment="service chronyd enabled" definition_ref="service_chronyd_enabled" />
+      <extend_definition comment="service ntpd enabled" definition_ref="service_ntpd_enabled" />
+    </criteria>
+
+  </definition>
+</def-group>

--- a/tests/unit/ssg/data/group_dir/rule_dir/oval/shared.xml
+++ b/tests/unit/ssg/data/group_dir/rule_dir/oval/shared.xml
@@ -1,0 +1,38 @@
+<def-group>
+  <definition class="compliance" id="sudo_remove_nopasswd" version="1">
+    <metadata>
+      <title>Ensure NOPASSWD Is Not Used in Sudo</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_debian</platform>
+        <platform>multi_platform_ubuntu</platform>
+      </affected>
+      <description>Checks sudo usage without password</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion comment="NOPASSWD is not configured in /etc/sudoers" test_ref="test_nopasswd_etc_sudoers" />
+      <criterion comment="NOPASSWD is not configured in /etc/sudoers.d" test_ref="test_nopasswd_etc_sudoers_d" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="NOPASSWD does not exist /etc/sudoers" id="test_nopasswd_etc_sudoers" version="1">
+    <ind:object object_ref="object_nopasswd_etc_sudoers" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_nopasswd_etc_sudoers" version="1">
+    <ind:filepath>/etc/sudoers</ind:filepath>
+    <ind:pattern operation="pattern match">^(?!#).*[\s]+NOPASSWD[\s]*\:.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="NOPASSWD does not exist in /etc/sudoers.d" id="test_nopasswd_etc_sudoers_d" version="1">
+    <ind:object object_ref="object_nopasswd_etc_sudoers_d" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_nopasswd_etc_sudoers_d" version="1">
+    <ind:path>/etc/sudoers.d</ind:path>
+    <ind:filename operation="pattern match">^.*$</ind:filename>
+    <ind:pattern operation="pattern match">^(?!#).*[\s]+NOPASSWD[\s]*\:.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/tests/unit/ssg/test_oval.py
+++ b/tests/unit/ssg/test_oval.py
@@ -1,6 +1,24 @@
 import pytest
 
+import os
 import ssg.oval
+
+data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
+rule_dir_oval = os.path.join(data_dir, "group_dir", "rule_dir", "oval")
+rhel_oval = os.path.join(rule_dir_oval, "rhel.xml")
+shared_oval = os.path.join(rule_dir_oval, "shared.xml")
+
+def test_applicable_platforms():
+    rap = ssg.oval.applicable_platforms(rhel_oval)
+    assert len(rap) == 1
+    assert 'Red Hat Enterprise Linux 7' in rap
+
+    sap = ssg.oval.applicable_platforms(shared_oval)
+    assert len(sap) == 4
+    assert 'multi_platform_rhel' in sap
+    assert 'multi_platform_fedora' in sap
+    assert 'multi_platform_debian' in sap
+    assert 'multi_platform_ubuntu' in sap
 
 
 def test_find_existing_testfile():

--- a/tests/unit/ssg/test_rules.py
+++ b/tests/unit/ssg/test_rules.py
@@ -7,6 +7,25 @@ data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
 rule_dir = os.path.join(data_dir, "group_dir", "rule_dir")
 
 
+def test_is_applicable():
+    assert ssg.rules.is_applicable('all', 'rhel7')
+    assert ssg.rules.is_applicable('multi_platform_all', 'rhel7')
+    assert ssg.rules.is_applicable('rhel7', 'rhel7')
+    assert ssg.rules.is_applicable('multi_platform_rhel', 'rhel7')
+    assert ssg.rules.is_applicable('Red Hat Enterprise Linux 7', 'rhel7')
+
+    assert ssg.rules.is_applicable('all', 'rhel-osp7')
+    assert ssg.rules.is_applicable('multi_platform_rhel-osp', 'rhel-osp7')
+    assert ssg.rules.is_applicable('rhel-osp7', 'rhel-osp7')
+    assert ssg.rules.is_applicable('Red Hat OpenStack Platform 7', 'rhel-osp7')
+    assert not ssg.rules.is_applicable('rhel7', 'rhel-osp7')
+
+    assert not ssg.rules.is_applicable('rhel-osp7', 'rhel7')
+    assert not ssg.rules.is_applicable('fedora,multi_platform_ubuntu', 'rhel7')
+    assert not ssg.rules.is_applicable('ol7', 'rhel7')
+    assert not ssg.rules.is_applicable('fedora,debian8', 'rhel7')
+
+
 def test_get_rule_dir_id():
     assert ssg.rules.get_rule_dir_id("/some/path/fix_all_vulns/rule.yml") == "fix_all_vulns"
     assert ssg.rules.get_rule_dir_id("/some/path/fix_all_vulns") == "fix_all_vulns"

--- a/tests/unit/ssg/test_utils.py
+++ b/tests/unit/ssg/test_utils.py
@@ -26,3 +26,16 @@ def test_required_key():
 
     with pytest.raises(ValueError):
         rk(_dict, 'not-in-dict')
+
+
+def test_subset_dict():
+    _dict = {1: 2, "red fish": "blue fish"}
+
+    _keys = [1]
+    assert ssg.utils.subset_dict(_dict, _keys) == {1: 2}
+    assert _keys == [1]
+    assert _dict == {1: 2, "red fish": "blue fish"}
+
+    assert ssg.utils.subset_dict(_dict, ["red fish"]) == {"red fish": "blue fish"}
+    assert ssg.utils.subset_dict(_dict, [1, "red fish"]) == _dict
+    assert ssg.utils.subset_dict(_dict, []) == dict()

--- a/utils/rule_dir_diff.py
+++ b/utils/rule_dir_diff.py
@@ -313,12 +313,10 @@ def main():
         args.products = args.products.split(',')
     args.products = set(args.products)
 
-    if isinstance(args.query, str):
-        args.query = args.query.split(',')
-        for rule_id in args.query:
-            if rule_id not in left_rules and rule_id not in right_rules:
-                print("Unknown rule_id:%s or rule_id appears only in left or right." % rule_id)
-                sys.exit(1)
+    left_query_keys = rds.filter_rule_ids(set(left_rules), args.query)
+    right_query_keys = rds.filter_rule_ids(set(right_rules), args.query)
+    args.query = left_query_keys.union(right_query_keys)
+    print("Total number of queried rules: %d\n" % len(args.query))
 
     if not args.missing and not args.two_plus and not args.prodtypes and not args.product_names:
         args.missing = True
@@ -327,6 +325,7 @@ def main():
 
     print("< Total number of known rule directories: %d" % len(left_rules))
     print("> Total number of known rule directories: %d\n" % len(right_rules))
+    print("= Total number of queried rules: %d\n" % len(args.query))
 
     if args.missing:
         process_diff_missing(args, left_rules, right_rules)

--- a/utils/rule_dir_diff.py
+++ b/utils/rule_dir_diff.py
@@ -96,9 +96,9 @@ def select_indices(data, indices):
     return [data[index] for index in indices]
 
 
-def process_missing(args, left_rules, right_rules):
+def process_diff_missing(args, left_rules, right_rules):
     data = rds.walk_rules_diff(args, left_rules, right_rules, rds.missing_oval, rds.missing_remediation)
-    result = rds.walk_rules_diff_stats(args, data)
+    result = rds.walk_rules_diff_stats(data)
     left_only_data, right_only_data, left_changed_data, right_changed_data, common_data = result
 
     statements = ["Missing Objects Summary",
@@ -144,9 +144,9 @@ def process_missing(args, left_rules, right_rules):
         print_summary(args, statements, r_d, '>')
 
 
-def process_two_plus(args, left_rules, right_rules):
+def process_diff_two_plus(args, left_rules, right_rules):
     data = rds.walk_rules_diff(args, left_rules, right_rules, rds.two_plus_oval, rds.two_plus_remediation)
-    result = rds.walk_rules_diff_stats(args, data)
+    result = rds.walk_rules_diff_stats(data)
     left_only_data, right_only_data, left_changed_data, right_changed_data, common_data = result
 
     statements = ["Two Plus Objects Summary:",
@@ -192,9 +192,9 @@ def process_two_plus(args, left_rules, right_rules):
         print_summary(args, statements, r_d, '>')
 
 
-def process_prodtypes(args, left_rules, right_rules):
+def process_diff_prodtypes(args, left_rules, right_rules):
     data = rds.walk_rules_diff(args, left_rules, right_rules, rds.prodtypes_oval, rds.prodtypes_remediation)
-    result = rds.walk_rules_diff_stats(args, data)
+    result = rds.walk_rules_diff_stats(data)
     left_only_data, right_only_data, left_changed_data, right_changed_data, common_data = result
 
     statements = ["Prodtypes Objects Summary",
@@ -240,9 +240,9 @@ def process_prodtypes(args, left_rules, right_rules):
         print_summary(args, statements, r_d, '>')
 
 
-def process_product_names(args, left_rules, right_rules):
+def process_diff_product_names(args, left_rules, right_rules):
     data = rds.walk_rules_diff(args, left_rules, right_rules, rds.product_names_oval, rds.product_names_remediation)
-    result = rds.walk_rules_diff_stats(args, data)
+    result = rds.walk_rules_diff_stats(data)
     left_only_data, right_only_data, left_changed_data, right_changed_data, common_data = result
 
     if not args.right_only:
@@ -329,13 +329,13 @@ def main():
     print("> Total number of known rule directories: %d\n" % len(right_rules))
 
     if args.missing:
-        process_missing(args, left_rules, right_rules)
+        process_diff_missing(args, left_rules, right_rules)
     if args.two_plus:
-        process_two_plus(args, left_rules, right_rules)
+        process_diff_two_plus(args, left_rules, right_rules)
     if args.prodtypes:
-        process_prodtypes(args, left_rules, right_rules)
+        process_diff_prodtypes(args, left_rules, right_rules)
     if args.product_names:
-        process_product_names(args, left_rules, right_rules)
+        process_diff_product_names(args, left_rules, right_rules)
 
 
 if __name__ == "__main__":

--- a/utils/rule_dir_diff.py
+++ b/utils/rule_dir_diff.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+import json
+import pprint
+
+import ssg.build_yaml
+import ssg.oval
+import ssg.build_remediations
+import ssg.rule_dir_stats as rds
+import ssg.rules
+import ssg.yaml
+
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--left", type=str, action="store", default="build/old_rule_dirs.json",
+                        help="File to read json output of rule_dir_json from (defaults to " +
+                             "build/old_rule_dirs.json); left such file for diffing")
+    parser.add_argument("--right", type=str, action="store", default="build/rule_dirs.json",
+                        help="File to read json output of rule_dir_json from (defaults to " +
+                             "build/rule_dirs.json); right such file for diffing")
+
+    parser.add_argument("-p", "--products", type=str, action="store", default="all",
+                        help="Products to inquire about, as a comma separated list")
+    parser.add_argument("-t", "--strict", action="store_true",
+                        help="Enforce strict --products checking against rule.yml prodtype only")
+    parser.add_argument("-q", "--query", type=str, action="store", default=None,
+                        help="Limit actions to only act on a comma separated list of rule_ids")
+
+    parser.add_argument("-m", "--missing", action="store_true",
+                        help="List rules which are missing OVALs or fixes")
+    parser.add_argument("-2", "--two-plus", action="store_true",
+                        help="List rules which have two or more OVALs or fixes")
+    parser.add_argument("-r", "--prodtypes", action="store_true",
+                        help="List rules which have different YAML prodtypes from checks+fix prodtypes")
+    parser.add_argument("-n", "--product-names", action="store_true",
+                        help="List rules which have product specific objects with broader accepted products")
+
+    parser.add_argument("-o", "--ovals-only", action="store_true",
+                        help="Only output information about OVALs")
+    parser.add_argument("-f", "--fixes-only", action="store_true",
+                        help="Only output information about fixes")
+
+    parser.add_argument("--left-only", action="store_true",
+                        help="Print only information from the left that is " +
+                             "not in the right")
+    parser.add_argument("--right-only", action="store_true",
+                        help="Print only information from the right that is " +
+                             "not in the left")
+    parser.add_argument("--show-common", action="store_true",
+                        help="Also print information that is common to both")
+
+    parser.add_argument("-s", "--summary-only", action="store_true",
+                        help="Only output summary information")
+
+    return parser.parse_args()
+
+
+def prefixed_print(statement, prefix):
+    print("%s %s" % (prefix, statement))
+
+
+def print_specifics(args, headline, data, prefix):
+    if not args.summary_only and data:
+        prefixed_print(headline, prefix)
+        for line in data:
+            prefixed_print(line, prefix)
+        print("\n")
+
+
+def print_summary(args, statements, data, prefix):
+    affected_rules, affected_ovals, affected_remediations, affected_remediations_type = data
+
+    prefixed_print(statements[0], prefix)
+    prefixed_print(statements[1] % affected_rules, prefix)
+    if not args.fixes_only:
+        prefixed_print(statements[2] % (affected_ovals, affected_rules), prefix)
+    if not args.ovals_only:
+        prefixed_print(statements[3] % (affected_remediations, affected_rules), prefix)
+        for r_type in ssg.build_remediations.REMEDIATION_TO_EXT_MAP:
+            r_missing = affected_remediations_type[r_type]
+            prefixed_print(statements[4] % (r_type, r_missing, affected_rules), prefix)
+    print("\n")
+
+
+def select_indices(data, indices):
+    return [data[index] for index in indices]
+
+
+def process_missing(args, left_rules, right_rules):
+    data = rds.walk_rules_diff(args, left_rules, right_rules, rds.missing_oval, rds.missing_remediation)
+    result = rds.walk_rules_diff_stats(args, data)
+    left_only_data, right_only_data, left_changed_data, right_changed_data, common_data = result
+
+    statements = ["Missing Objects Summary",
+                  "Total affected rules: %d",
+                  "Rules with no OVALs: %d / %d",
+                  "Rules without any remediations: %d / %d",
+                  "Rules with no %s remediations: %d / %d"]
+
+    if not args.right_only:
+        print_specifics(args, "Missing Objects Specifics - Left Only:", left_only_data[5], '<')
+        print_specifics(args, "Missing Objects Specifics - Left Changed:", left_changed_data[5], '<')
+
+    if args.show_common:
+        print_specifics(args, "Missing Objects Specifics - Common:", common_data[5], '=')
+
+    if not args.left_only:
+        print_specifics(args, "Missing Objects Specifics - Right Changed:", right_changed_data[5], '>')
+        print_specifics(args, "Missing Objects Specifics - Right Only:", right_only_data[5], '>')
+
+    data_indices = [0, 1, 3, 4]
+
+    if not args.right_only:
+        statements[0] = "Missing Objects Summary - Left Only:"
+        l_d = select_indices(left_only_data, data_indices)
+        print_summary(args, statements, l_d, '<')
+
+        statements[0] = "Missing Objects Summary - Left Changed:"
+        l_d = select_indices(left_changed_data, data_indices)
+        print_summary(args, statements, l_d, '<')
+
+    if args.show_common:
+        statements[0] = "Missing Objects Summary - Common:"
+        c_d = select_indices(common_data, data_indices)
+        print_summary(args, statements, c_d, '=')
+
+    if not args.left_only:
+        statements[0] = "Missing Objects Summary - Right Changed:"
+        r_d = select_indices(right_changed_data, data_indices)
+        print_summary(args, statements, r_d, '>')
+
+        statements[0] = "Missing Objects Summary - Right Only:"
+        r_d = select_indices(right_only_data, data_indices)
+        print_summary(args, statements, r_d, '>')
+
+
+def process_two_plus(args, left_rules, right_rules):
+    data = rds.walk_rules_diff(args, left_rules, right_rules, rds.two_plus_oval, rds.two_plus_remediation)
+    result = rds.walk_rules_diff_stats(args, data)
+    left_only_data, right_only_data, left_changed_data, right_changed_data, common_data = result
+
+    statements = ["Two Plus Objects Summary:",
+                  "Total affected rules: %d",
+                  "Rules with two or more OVALs: %d / %d",
+                  "Rules with two or more remediations: %d / %d",
+                  "Rules with two or more %s remediations: %d / %d"]
+
+    if not args.right_only:
+        print_specifics(args, "Two Plus Objects Specifics - Left Only:", left_only_data[5], '<')
+        print_specifics(args, "Two Plus Objects Specifics - Left Changed:", left_changed_data[5], '<')
+
+    if args.show_common:
+        print_specifics(args, "Two Plus Objects Specifics - Common:", common_data[5], '=')
+
+    if not args.left_only:
+        print_specifics(args, "Two Plus Objects Specifics - Right Changed:", right_changed_data[5], '>')
+        print_specifics(args, "Two Plus Objects Specifics - Right Only:", right_only_data[5], '>')
+
+    data_indices = [0, 1, 2, 4]
+
+    if not args.right_only:
+        statements[0] = "Two Plus Objects Summary - Left Only:"
+        l_d = select_indices(left_only_data, data_indices)
+        print_summary(args, statements, l_d, '<')
+
+        statements[0] = "Two Plus Objects Summary - Left Changed:"
+        l_d = select_indices(left_changed_data, data_indices)
+        print_summary(args, statements, l_d, '<')
+
+    if args.show_common:
+        statements[0] = "Two Plus Objects Summary - Common:"
+        c_d = select_indices(common_data, data_indices)
+        print_summary(args, statements, c_d, '=')
+
+    if not args.left_only:
+        statements[0] = "Two Plus Objects Summary - Right Changed:"
+        r_d = select_indices(right_changed_data, data_indices)
+        print_summary(args, statements, r_d, '>')
+
+        statements[0] = "Two Plus Objects Summary - Right Only:"
+        r_d = select_indices(right_only_data, data_indices)
+        print_summary(args, statements, r_d, '>')
+
+
+def process_prodtypes(args, left_rules, right_rules):
+    data = rds.walk_rules_diff(args, left_rules, right_rules, rds.prodtypes_oval, rds.prodtypes_remediation)
+    result = rds.walk_rules_diff_stats(args, data)
+    left_only_data, right_only_data, left_changed_data, right_changed_data, common_data = result
+
+    statements = ["Prodtypes Objects Summary",
+                  "Total affected rules: %d",
+                  "Rules with differing prodtypes between YAML and OVALs: %d / %d",
+                  "Rules with differing prodtypes between YAML and remediations: %d / %d",
+                  "Rules with differing prodtypes between YAML and %s remediations: %d / %d"]
+
+    if not args.right_only:
+        print_specifics(args, "Prodtypes Objects Specifics - Left Only:", left_only_data[5], '<')
+        print_specifics(args, "Prodtypes Objects Specifics - Left Changed:", left_changed_data[5], '<')
+
+    if args.show_common:
+        print_specifics(args, "Prodtypes Objects Specifics - Common:", common_data[5], '=')
+
+    if not args.left_only:
+        print_specifics(args, "Prodtypes Objects Specifics - Right Changed:", right_changed_data[5], '>')
+        print_specifics(args, "Prodtypes Objects Specifics - Right Only:", right_only_data[5], '>')
+
+    data_indices = [0, 1, 2, 4]
+
+    if not args.right_only:
+        statements[0] = "Prodtypes Objects Summary - Left Only:"
+        l_d = select_indices(left_only_data, data_indices)
+        print_summary(args, statements, l_d, '<')
+
+        statements[0] = "Prodtypes Objects Summary - Left Changed:"
+        l_d = select_indices(left_changed_data, data_indices)
+        print_summary(args, statements, l_d, '<')
+
+    if args.show_common:
+        statements[0] = "Prodtypes Objects Summary - Common:"
+        c_d = select_indices(common_data, data_indices)
+        print_summary(args, statements, c_d, '=')
+
+    if not args.left_only:
+        statements[0] = "Prodtypes Objects Summary - Right Changed:"
+        r_d = select_indices(right_changed_data, data_indices)
+        print_summary(args, statements, r_d, '>')
+
+        statements[0] = "Prodtypes Objects Summary - Right Only:"
+        r_d = select_indices(right_only_data, data_indices)
+        print_summary(args, statements, r_d, '>')
+
+
+def process_product_names(args, left_rules, right_rules):
+    data = rds.walk_rules_diff(args, left_rules, right_rules, rds.product_names_oval, rds.product_names_remediation)
+    result = rds.walk_rules_diff_stats(args, data)
+    left_only_data, right_only_data, left_changed_data, right_changed_data, common_data = result
+
+    if not args.right_only:
+        print_specifics(args, "Product Names Objects Specifics - Left Only:", left_only_data[5], '<')
+        print_specifics(args, "Product Names Objects Specifics - Left Changed:", left_changed_data[5], '<')
+
+    if args.show_common:
+        print_specifics(args, "Product Names Objects Specifics - Common:", common_data[5], '=')
+
+    if not args.left_only:
+        print_specifics(args, "Product Names Objects Specifics - Right Changed:", right_changed_data[5], '>')
+        print_specifics(args, "Product Names Objects Specifics - Right Only:", right_only_data[5], '>')
+
+    data_indices = [0, 1, 2, 4]
+    statements = ["Product Names Objects Summary:",
+                  "Total affected rules: %d",
+                  "Rules with differing products and OVAL names: %d / %d",
+                  "Rules with differing product and remediation names: %d / %d",
+                  "Rules with differing product and %s remediation names: %d / %d"]
+
+    if not args.right_only:
+        statements[0] = "Product Names Objects Summary - Left Only:"
+        l_d = select_indices(left_only_data, data_indices)
+        print_summary(args, statements, l_d, '<')
+
+        statements[0] = "Product Names Objects Summary - Left Changed:"
+        l_d = select_indices(left_changed_data, data_indices)
+        print_summary(args, statements, l_d, '<')
+
+    if args.show_common:
+        statements[0] = "Product Names Objects Summary - Common:"
+        c_d = select_indices(common_data, data_indices)
+        print_summary(args, statements, c_d, '=')
+
+    if not args.left_only:
+        statements[0] = "Product Names Objects Summary - Right Changed:"
+        r_d = select_indices(right_changed_data, data_indices)
+        print_summary(args, statements, r_d, '>')
+
+        statements[0] = "Product Names Objects Summary - Right Only:"
+        r_d = select_indices(right_only_data, data_indices)
+        print_summary(args, statements, r_d, '>')
+
+
+def main():
+    args = parse_args()
+
+    linux_products, other_products = ssg.products.get_all(SSG_ROOT)
+    all_products = linux_products.union(other_products)
+
+    left_file = open(args.left, 'r')
+    left_rules = json.load(left_file)
+
+    right_file = open(args.right, 'r')
+    right_rules = json.load(right_file)
+
+    if left_rules == right_rules:
+        print("No difference. Please use rule_dir_stats to inspect one of these files.")
+        sys.exit(0)
+
+    if args.products.lower() == 'all':
+        args.products = all_products
+    elif args.products.lower() == 'linux':
+        args.products = linux_products
+    elif args.products.lower() == 'other':
+        args.products = other_products
+    else:
+        args.products = args.products.split(',')
+    args.products = set(args.products)
+
+    if isinstance(args.query, str):
+        args.query = args.query.split(',')
+        for rule_id in args.query:
+            if rule_id not in left_rules and rule_id not in right_rules:
+                print("Unknown rule_id:%s or rule_id appears only in left or right." % rule_id)
+                sys.exit(1)
+
+    if not args.missing and not args.two_plus and not args.prodtypes and not args.product_names:
+        args.missing = True
+        args.two_plus = True
+        args.prodtypes = True
+
+    print("< Total number of known rule directories: %d" % len(left_rules))
+    print("> Total number of known rule directories: %d\n" % len(right_rules))
+
+    if args.missing:
+        process_missing(args, left_rules, right_rules)
+    if args.two_plus:
+        process_two_plus(args, left_rules, right_rules)
+    if args.prodtypes:
+        process_prodtypes(args, left_rules, right_rules)
+    if args.product_names:
+        process_product_names(args, left_rules, right_rules)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 
 import argparse
-import codecs
 import os
 import sys
 from collections import defaultdict

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+import codecs
+import os
+import sys
+from collections import defaultdict
+
+import json
+
+import ssg.build_yaml
+import ssg.oval
+import ssg.build_remediations
+import ssg.rules
+import ssg.yaml
+
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-r", "--root", type=str, action="store", default=SSG_ROOT,
+                   help="Path to SSG root directory (defaults to %s)" % SSG_ROOT)
+    parser.add_argument("-o", "--output", type=str, action="store", default="build/rule_dirs.json",
+                   help="File to write json output to (defaults to build/rule_dirs.json)")
+
+    return parser.parse_args()
+
+
+def walk_products(root, all_products):
+    visited_guide_dirs = set()
+
+    all_rule_dirs = []
+    product_yamls = {}
+    known_rules = set()
+
+    for product in all_products:
+        product_dir = os.path.join(root, product)
+        product_yaml_path = os.path.join(product_dir, "product.yml")
+        product_yaml = ssg.yaml.open_raw(product_yaml_path)
+        product_yaml.update(ssg.yaml._get_implied_properties(product_yaml))
+        product_yamls[product] = product_yaml
+
+        guide_dir = os.path.join(product_dir, product_yaml['benchmark_root'])
+        guide_dir = os.path.abspath(guide_dir)
+
+        if guide_dir in visited_guide_dirs:
+            continue
+
+        new_rule_dirs = sorted(ssg.rules.find_rule_dirs(guide_dir))
+        for rule_dir in new_rule_dirs:
+            rule_id = ssg.rules.get_rule_dir_id(rule_dir)
+            all_rule_dirs.append((rule_id, rule_dir, guide_dir, product))
+
+            if rule_id in known_rules:
+                exp = "Multiple rules with same rule_id: %s and %s" % \
+                      (known_rules[rule_id]['rule_dir'], rule_dir)
+                raise ValueError(exp)
+            known_rules.add(rule_id)
+
+        visited_guide_dirs.add(guide_dir)
+
+    return all_rule_dirs, product_yamls
+
+
+def handle_rule_yaml(product_list, product_yamls, rule_id, rule_dir, guide_dir):
+    rule_obj = {'id': rule_id, 'dir': rule_dir, 'guide': guide_dir}
+    rule_file = ssg.rules.get_rule_dir_yaml(rule_dir)
+
+    prod_type = product_list[0]
+    product_yaml = product_yamls[prod_type]
+
+    rule_yaml = ssg.build_yaml.Rule.from_yaml(rule_file, product_yaml)
+    rule_products = set()
+    for product in product_list:
+        if ssg.rules.is_applicable(rule_yaml.prodtype, product):
+            rule_products.add(product)
+
+    rule_products = sorted(rule_products)
+    rule_obj['products'] = rule_products
+    rule_obj['title'] = rule_yaml.title
+
+    return rule_obj
+
+
+def handle_ovals(product_list, product_yamls, rule_obj):
+    rule_dir = rule_obj['dir']
+
+    rule_ovals = {}
+    oval_products = defaultdict(set)
+
+    for oval_path in ssg.rules.get_rule_dir_ovals(rule_dir):
+        oval_name = os.path.basename(oval_path)
+        oval_product, _ = os.path.splitext(oval_name)
+        oval_obj = {'name': oval_name, 'product': oval_product}
+
+        platforms = ssg.oval.applicable_platforms(oval_path)
+        cs_platforms = ','.join(platforms)
+
+        oval_obj['platforms'] = platforms
+        oval_obj['products'] = set()
+        for product in product_list:
+            if ssg.rules.is_applicable(cs_platforms, product):
+                oval_products[product].add(oval_name)
+                oval_obj['products'].add(product)
+
+        oval_obj['products'] = sorted(oval_obj['products'])
+        rule_ovals[oval_name] = oval_obj
+
+    return rule_ovals, oval_products
+
+
+def handle_remediations(product_list, product_yamls, rule_obj):
+    rule_dir = rule_obj['dir']
+
+    rule_remediations = {}
+    r_products = defaultdict(set)
+    for r_type in ssg.build_remediations.REMEDIATION_TO_EXT_MAP:
+        rule_remediations[r_type] = {}
+        r_paths = ssg.rules.get_rule_dir_remediations(rule_dir, r_type)
+
+        for r_path in r_paths:
+            r_name = os.path.basename(r_path)
+            r_product, r_ext = os.path.splitext(r_name)
+            r_obj = {'type': r_type, 'name': r_name, 'product': r_product, 'ext': r_ext[1:]}
+
+            prod_type = product_list[0]
+            if r_product != 'shared' and r_product in product_list:
+                prod_type = r_product
+            product_yaml = product_yamls[prod_type]
+
+            _, config = ssg.build_remediations.parse_from_file(r_path, product_yaml)
+            platforms = config['platform']
+            if not platforms:
+                print(config['platform'])
+
+            r_obj['platforms'] = sorted(map(lambda x: x.strip(), platforms.split(',')))
+            r_obj['products'] = set()
+            for product in product_list:
+                if ssg.rules.is_applicable(platforms, product):
+                    r_products[product].add(r_name)
+                    r_obj['products'].add(product)
+
+            r_obj['products'] = sorted(r_obj['products'])
+            rule_remediations[r_type][r_name] = r_obj
+
+    return rule_remediations, r_products
+
+
+def main():
+    args = parse_args()
+
+    linux_products, other_products = ssg.products.get_all(args.root)
+    all_products = linux_products.union(other_products)
+
+    all_rule_dirs, product_yamls = walk_products(args.root, all_products)
+
+    known_rules = {}
+    for rule_id, rule_dir, guide_dir, given_product in all_rule_dirs:
+        product_list = sorted(linux_products)
+        if 'linux_os' not in guide_dir:
+            product_list = [given_product]
+
+        rule_obj = handle_rule_yaml(product_list, product_yamls, rule_id, rule_dir, guide_dir)
+        rule_obj['ovals'], oval_products = handle_ovals(product_list, product_yamls, rule_obj)
+        rule_obj['remediations'], r_products = handle_remediations(product_list, product_yamls, rule_obj)
+
+        # Validate oval products
+        for key in oval_products:
+            oval_products[key] = sorted(oval_products[key])
+            if len(oval_products[key]) > 1:
+                print("product has multiple ovals: %s - %s" % (key, ','.join(oval_products[key])), file=sys.stderr)
+
+        rule_obj['oval_products'] = oval_products
+
+        # Validate remediation products
+        for key in r_products:
+            r_products[key] = sorted(r_products[key])
+            if len(r_products[key]) > 1:
+                exts = sorted(map(lambda x: os.path.splitext(x)[1], r_products[key]))
+                if len(exts) != len(set(exts)):
+                    print("product has multiple remediations of the same type: %s - %s" % (key, ','.join(r_products[key])), file=sys.stderr)
+
+        rule_obj['remediation_products'] = r_products
+
+        known_rules[rule_id] = rule_obj
+
+    f = open(args.output, 'w')
+    j = json.dump(known_rules, f)
+    if not f.closed:
+        f.flush()
+        f.close()
+
+if __name__ == "__main__":
+    main()

--- a/utils/rule_dir_stats.py
+++ b/utils/rule_dir_stats.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+import json
+import pprint
+
+import ssg.build_yaml
+import ssg.oval
+import ssg.build_remediations
+import ssg.rule_dir_stats as rds
+import ssg.rules
+import ssg.yaml
+
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input", type=str, action="store", default="build/rule_dirs.json",
+                        help="File to read json output of rule_dir_json from (defaults to build/rule_dirs.json)")
+
+    parser.add_argument("-p", "--products", type=str, action="store", default="all",
+                        help="Products to inquire about, as a comma separated list")
+    parser.add_argument("-t", "--strict", action="store_true",
+                        help="Enforce strict --products checking against rule.yml prodtype only")
+    parser.add_argument("-q", "--query", type=str, action="store", default=None,
+                        help="Limit actions to only act on a comma separated list of rule_ids")
+
+    parser.add_argument("-m", "--missing", action="store_true",
+                        help="List rules which are missing OVALs or fixes")
+    parser.add_argument("-2", "--two-plus", action="store_true",
+                        help="List rules which have two or more OVALs or fixes")
+    parser.add_argument("-r", "--prodtypes", action="store_true",
+                        help="List rules which have different YAML prodtypes from checks+fix prodtypes")
+    parser.add_argument("-n", "--product-names", action="store_true",
+                        help="List rules which have product specific objects with broader accepted products")
+    parser.add_argument("-?", "--introspect", action="store_true",
+                        help="Dump raw objects for explicitly queried rule_ids")
+    parser.add_argument("-u", "--unassociated", action="store_true",
+                        help="Search for rules without any product association")
+
+    parser.add_argument("-o", "--ovals-only", action="store_true",
+                        help="Only output information about OVALs")
+    parser.add_argument("-f", "--fixes-only", action="store_true",
+                        help="Only output information about fixes")
+
+    parser.add_argument("-s", "--summary-only", action="store_true",
+                        help="Only output summary information")
+
+    return parser.parse_args()
+
+
+def process_missing(args, known_rules):
+    result = rds.walk_rules_stats(args, known_rules, rds.missing_oval, rds.missing_remediation)
+    affected_rules = result[0]
+    affected_ovals = result[1]
+    affected_remediations = result[3]
+    affected_remediations_type = result[4]
+    verbose_output = result[5]
+
+    if not args.summary_only:
+        print("Missing Objects Specifics:")
+        for line in verbose_output:
+            print(line)
+        print("\n")
+
+    print("Missing Objects Summary:")
+    print("Total affected rules: %d" % affected_rules)
+    if not args.fixes_only:
+        print("Rules with no OVALs: %d / %d" % (affected_ovals, affected_rules))
+    if not args.ovals_only:
+        print("Rules without any remediations: %d / %d" % (affected_remediations, affected_rules))
+        for r_type in ssg.build_remediations.REMEDIATION_TO_EXT_MAP:
+            r_missing = affected_remediations_type[r_type]
+            print("Rules with no %s remediations: %d / %d" % (r_type, r_missing, affected_rules))
+    print("\n")
+
+
+def process_two_plus(args, known_rules):
+    result = rds.walk_rules_stats(args, known_rules, rds.two_plus_oval, rds.two_plus_remediation)
+    affected_rules = result[0]
+    affected_ovals = result[1]
+    affected_remediations = result[2]
+    affected_remediations_type = result[4]
+    verbose_output = result[5]
+
+    if not args.summary_only:
+        print("Two Plus Object Specifics:")
+        for line in verbose_output:
+            print(line)
+        print("\n")
+
+    print("Two Plus Objects Summary:")
+    print("Total affected rules: %d" % affected_rules)
+    if not args.fixes_only:
+        print("Rules with two or more OVALs: %d / %d" % (affected_ovals, affected_rules))
+    if not args.ovals_only:
+        print("Rules with two or more remediations: %d / %d" % (affected_remediations, affected_rules))
+        for r_type in ssg.build_remediations.REMEDIATION_TO_EXT_MAP:
+            r_missing = affected_remediations_type[r_type]
+            print("Rules with two or more %s remediations: %d / %d" % (r_type, r_missing, affected_rules))
+
+    print("\n")
+
+
+def process_prodtypes(args, known_rules):
+    result = rds.walk_rules_stats(args, known_rules, rds.prodtypes_oval, rds.prodtypes_remediation)
+    affected_rules = result[0]
+    affected_ovals = result[1]
+    affected_remediations = result[2]
+    affected_remediations_type = result[4]
+    verbose_output = result[5]
+
+    if not args.summary_only:
+        print("Prodtypes Object Specifics:")
+        for line in verbose_output:
+            print(line)
+        print("\n")
+
+    print("Prodtypes Objects Summary:")
+    print("Total affected rules: %d" % affected_rules)
+    if not args.fixes_only:
+        print("Rules with differing prodtypes between YAML and OVALs: %d / %d" % (affected_ovals, affected_rules))
+    if not args.ovals_only:
+        print("Rules with differing prodtypes between YAML and remediations: %d / %d" % (affected_remediations, affected_rules))
+        for r_type in ssg.build_remediations.REMEDIATION_TO_EXT_MAP:
+            r_missing = affected_remediations_type[r_type]
+            print("Rules with differing prodtypes between YAML and %s remediations: %d / %d" % (r_type, r_missing, affected_rules))
+
+    print("\n")
+
+
+def process_product_names(args, known_rules):
+    result = rds.walk_rules_stats(args, known_rules, rds.product_names_oval, rds.product_names_remediation)
+    affected_rules = result[0]
+    affected_ovals = result[1]
+    affected_remediations = result[2]
+    affected_remediations_type = result[4]
+    verbose_output = result[5]
+
+    if not args.summary_only:
+        print("Product Names Specifics:")
+        for line in verbose_output:
+            print(line)
+        print("\n")
+
+    print("Product Names Summary:")
+    print("Total affected rules: %d" % affected_rules)
+    if not args.fixes_only:
+        print("Rules with differing products and OVAL names: %d / %d" % (affected_ovals, affected_rules))
+    if not args.ovals_only:
+        print("Rules with differing product and remediation names: %d / %d" % (affected_remediations, affected_rules))
+        for r_type in ssg.build_remediations.REMEDIATION_TO_EXT_MAP:
+            r_missing = affected_remediations_type[r_type]
+            print("Rules with differing product and %s remediation names: %d / %d" % (r_type, r_missing, affected_rules))
+
+    print("\n")
+
+
+def process_introspection(args, known_rules):
+    for rule_id in args.query:
+        if not args.summary_only:
+            pprint.pprint(known_rules[rule_id])
+            print("\n")
+        else:
+            print(rule_id)
+
+
+def process_unassociated(args, known_rules, all_products):
+    save_ovals_only = args.ovals_only
+    save_fixes_only = args.fixes_only
+    save_strict = args.strict
+
+    args.ovals_only = False
+    args.fixes_only = False
+    args.strict = False
+
+    for rule_id in known_rules:
+        rule_obj = known_rules[rule_id]
+        affected_products = rds.get_all_affected_products(args, rule_obj)
+        if affected_products.intersection(all_products):
+            continue
+
+        print("Unassociated Rule: rule_id:%s" % rule_id)
+
+    args.ovals_only = save_ovals_only
+    args.fixes_only = save_fixes_only
+    args.stict = save_strict
+
+
+def main():
+    args = parse_args()
+
+    linux_products, other_products = ssg.products.get_all(SSG_ROOT)
+    all_products = linux_products.union(other_products)
+
+    json_file = open(args.input, 'r')
+    known_rules = json.load(json_file)
+
+    if args.products.lower() == 'all':
+        args.products = all_products
+    elif args.products.lower() == 'linux':
+        args.products = linux_products
+    elif args.products.lower() == 'other':
+        args.products = other_products
+    else:
+        args.products = args.products.split(',')
+    args.products = set(args.products)
+
+    if isinstance(args.query, str):
+        args.query = args.query.split(',')
+        for rule_id in args.query:
+            if not rule_id in known_rules:
+                print("Unknown rule_id:%s" % rule_id)
+                sys.exit(1)
+
+    if not args.missing and not args.two_plus and not args.prodtypes and not args.introspect and not args.unassociated and not args.product_names:
+        args.missing = True
+        args.two_plus = True
+        args.prodtypes = True
+
+    print("Total number of known rule directories: %d\n" % len(known_rules))
+
+    if args.missing:
+        process_missing(args, known_rules)
+    if args.two_plus:
+        process_two_plus(args, known_rules)
+    if args.prodtypes:
+        process_prodtypes(args, known_rules)
+    if args.product_names:
+        process_product_names(args, known_rules)
+    if args.introspect and args.query:
+        process_introspection(args, known_rules)
+    if args.unassociated:
+        process_unassociated(args, known_rules, all_products)
+
+if __name__ == "__main__":
+    main()

--- a/utils/rule_dir_stats.py
+++ b/utils/rule_dir_stats.py
@@ -213,19 +213,15 @@ def main():
         args.products = args.products.split(',')
     args.products = set(args.products)
 
-    if isinstance(args.query, str):
-        args.query = args.query.split(',')
-        for rule_id in args.query:
-            if not rule_id in known_rules:
-                print("Unknown rule_id:%s" % rule_id)
-                sys.exit(1)
+    args.query = rds.filter_rule_ids(set(known_rules), args.query)
 
     if not args.missing and not args.two_plus and not args.prodtypes and not args.introspect and not args.unassociated and not args.product_names:
         args.missing = True
         args.two_plus = True
         args.prodtypes = True
 
-    print("Total number of known rule directories: %d\n" % len(known_rules))
+    print("Total number of known rule directories: %d" % len(known_rules))
+    print("Total number of queried rules: %d\n" % len(args.query))
 
     if args.missing:
         process_missing(args, known_rules)


### PR DESCRIPTION
This is a WIP PR dependent upon several others, but is opened to provide visibility.

#### Dependencies:

Currently several commits from other PRs are carried here. This PR will be rebased as necessary.

 - ~#3188 - To add build support~ -- merged, thanks @matejak!
 - ~#3178 - To reorganize rules so this has something to use~ -- merged, thanks @mpreisler! 
 - ~#3191~ - Because I'm not parsing rules as part of the build system -- merged, thanks @mpreisler!
 - ~#3198~ - Because this is a useful function -- merged, thanks @matejak!

#### Description:

This PR adds tools for inspecting the source SSG content from the perspective of rule directories. This adds three main utilities:

 - `rule_dir_json` -- builds a JSON object that represents the state of the SSG content. This allows the FS to be walked once for all of SSG, parses `product_yaml` files, understands `prodtype`s, and creates one large object which can be walked. While the order of the keys are not necessarily stable, all lists are sorted. providing relatively stable output.
 - `rule_dir_stats` -- interacts with the JSON object from `rule_dir_json`  to display useful information. This'll include filtering by product, listing rules without OVALs/remediations, listing rules with too many OVALs/remediations. faulty prodtypes, and other sanity checks. ~**WIP**~ Done! See output below. 
- `rule_dir_diff` -- interacts with two JSON objects and diffs the objects, but otherwise provides a similar functionality as `rule_dir_stats`. ~**WIP**~ -- Done! See output below.

Hopefully these will prove useful long term in addition to me during the migration. My thought is that `rule_dir_stats` might be useful to find places to contribute, and `rule_dir_diff` might be useful for reviewing large PRs. 

**To be clear:** these operate on the source content artifacts (of `linux_os/guide`, etc.), not on the built content. Hence they are different than `profile-stats` or `stats` in the build system. 

#### rule_dir_json

Help Text:
```
usage: rule_dir_json.py [-h] [-r ROOT] [-o OUTPUT]

optional arguments:
  -h, --help            show this help message and exit
  -r ROOT, --root ROOT  Path to SSG root directory (defaults to pwd)
  -o OUTPUT, --output OUTPUT
                        File to write json output to (defaults to output.json)
```

Description (from commit d1536884f101f855dd09848ed3f8731f66e016fd):
```
Add tool to walk rule directories and output json

The new utils/rule_dir_json.py walks the SSG root and
locates all rule directories across all products. These
rule directories are parsed for check and fix content,
and a JSON object is outputted containing all known
rules and associated data.
```

#### rule_dir_stats

Help Text:
```
usage: rule_dir_stats.py [-h] [-i INPUT] [-p PRODUCTS] [-m] [-2] [-r] [-n]
                         [-?] [-u] [-q QUERY] [-o] [-f] [-s]

optional arguments:
  -h, --help            show this help message and exit
  -i INPUT, --input INPUT
                        File to read json output of rule_dir_json from
                        (defaults to output.json)
  -p PRODUCTS, --products PRODUCTS
                        Products to inquire about, as a comma separated list
  -m, --missing         List rules which are missing OVALs or fixes
  -2, --two-plus        List rules which have two or more OVALs or fixes
  -r, --prodtypes       List rules which have different YAML prodtypes from
                        checks+fix prodtypes
  -n, --product-names   List rules which have product specific objects with
                        broader accepted products
  -?, --introspect      Dump raw objects for explicitly queried rule_ids
  -u, --unassociated    Search for rules without any product association
  -q QUERY, --query QUERY
                        Limit actions to only act on a comma separated list of
                        rule_ids
  -o, --ovals-only      Only output information about OVALs
  -f, --fixes-only      Only output information about fixes
  -s, --summary-only    Only output summary information
```

Description (from commit bd8d0a8c4d865b53c95050e3165e8d306679afb2):
```
Add rule_dir_stats utility for analyzing rule directories

The utils/rule_dir_stats.py function analyzes the output
from utils/rule_dir_json.py and provides several useful
functions for analyzing the state of the content of rule
directories. Among these are:

 - Listing rules missing checks and fixes
 - Listing rules with two or more of a check or fix
 - Listing rules which differ in prodtypes between the rule.yml and check/fix content
 - Listing rules which have different prodtypes within a check/fix as their name
 - Introspecting a single rule within the JSON output
 - Look for rules which are unassociated to any product

These can be filtered by a list of products and/or by a list of rule_ids,
with the output being limited to checking only OVALs or fixes. Summary
statistics can also be provided.
```


#### Rule Dir Diff

Help Text:
```
usage: rule_dir_diff.py [-h] [--left LEFT] [--right RIGHT] [-p PRODUCTS] [-t]
                        [-q QUERY] [-m] [-2] [-r] [-n] [-o] [-f] [--left-only]
                        [--right-only] [--show-common] [-s]

optional arguments:
  -h, --help            show this help message and exit
  --left LEFT           File to read json output of rule_dir_json from
                        (defaults to build/old_rule_dirs.json); left such file
                        for diffing
  --right RIGHT         File to read json output of rule_dir_json from
                        (defaults to build/rule_dirs.json); right such file
                        for diffing
  -p PRODUCTS, --products PRODUCTS
                        Products to inquire about, as a comma separated list
  -t, --strict          Enforce strict --products checking against rule.yml
                        prodtype only
  -q QUERY, --query QUERY
                        Limit actions to only act on a comma separated list of
                        rule_ids
  -m, --missing         List rules which are missing OVALs or fixes
  -2, --two-plus        List rules which have two or more OVALs or fixes
  -r, --prodtypes       List rules which have different YAML prodtypes from
                        checks+fix prodtypes
  -n, --product-names   List rules which have product specific objects with
                        broader accepted products
  -o, --ovals-only      Only output information about OVALs
  -f, --fixes-only      Only output information about fixes
  --left-only           Print only information from the left that is not in
                        the right
  --right-only          Print only information from the right that is not in
                        the left
  --show-common         Also print information that is common to both
  -s, --summary-only    Only output summary information

```

Description from commit (ffc848a1b7584c804811d2d52233a4369324fcd0):
```
    Add rule_dir_diff utility for diffing statistics
    
    The utils/rule_dir_diff.py utility analyzes the output
    of utils/rule_dir_json.py at two points in time and provides
    interfaces for diffing the output in a semantic way. This
    utility provides the same interface as utils/rule_dir_stats.py,
    with additional arguments specific to diffing. These are:
    
     - Show only fixed/left-only information
     - Show only new/right-only information
     - Show information common to both
    
    But otherwise has the same queries and command line options
    as utils/rule_dir_stats.py.
    
    Signed-off-by: Alexander Scheel <ascheel@redhat.com>
```
