### PR TITLE
Add multi_platform_fedora to AIDE and password hasing checks and fixes

### DIFF
--- a/shared/checks/oval/aide_periodic_cron_checking.xml
+++ b/shared/checks/oval/aide_periodic_cron_checking.xml
@@ -4,6 +4,7 @@
       <title>Configure Periodic Execution of AIDE</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>
       <description>By default, AIDE does not install itself for periodic
@@ -59,5 +60,5 @@
     <ind:pattern operation="pattern match">^\s*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-   
+
 </def-group>

--- a/shared/checks/oval/set_password_hashing_algorithm_libuserconf.xml
+++ b/shared/checks/oval/set_password_hashing_algorithm_libuserconf.xml
@@ -4,6 +4,7 @@
       <title>Set SHA512 Password Hashing Algorithm in /etc/libuser.conf</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>
       <description>The password hashing algorithm should be set correctly in /etc/libuser.conf.</description>
@@ -13,8 +14,8 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" 
-  comment="The password hashing algorithm should be set correctly in /etc/libuser.conf" 
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists"
+  comment="The password hashing algorithm should be set correctly in /etc/libuser.conf"
   id="test_etc_libuser_conf_cryptstyle" version="1">
     <ind:object object_ref="object_etc_libuser_conf_cryptstyle" />
   </ind:textfilecontent54_test>

--- a/shared/checks/oval/set_password_hashing_algorithm_systemauth.xml
+++ b/shared/checks/oval/set_password_hashing_algorithm_systemauth.xml
@@ -4,6 +4,7 @@
       <title>Set Password Hashing Algorithm in /etc/pam.d/system-auth</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>
       <description>The password hashing algorithm should be set correctly in /etc/pam.d/system-auth.</description>

--- a/shared/fixes/bash/aide_build_database.sh
+++ b/shared/fixes/bash/aide_build_database.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 package_install aide

--- a/shared/fixes/bash/aide_periodic_cron_checking.sh
+++ b/shared/fixes/bash/aide_periodic_cron_checking.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 package_install aide

--- a/shared/fixes/bash/set_password_hashing_algorithm_logindefs.sh
+++ b/shared/fixes/bash/set_password_hashing_algorithm_logindefs.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 if grep --silent ^ENCRYPT_METHOD /etc/login.defs ; then
 	sed -i 's/^ENCRYPT_METHOD.*/ENCRYPT_METHOD SHA512/g' /etc/login.defs
 else

--- a/shared/fixes/bash/set_password_hashing_algorithm_systemauth.sh
+++ b/shared/fixes/bash/set_password_hashing_algorithm_systemauth.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 AUTH_FILES[0]="/etc/pam.d/system-auth"
 AUTH_FILES[1]="/etc/pam.d/password-auth"


### PR DESCRIPTION
While reviewing #3189, I discovered that several of the updated checks and remediations should apply to Fedora as well. This updates them accordingly. 

Since they apply to rhel6, rhel7 and ol7, I'm fairly confident these will apply on Fedora. Further, the `aide` package exists on Fedora so this is valid.