### PR TITLE
Add remediation and tests for mount_option_noexec_remote_filesystems rule

### DIFF
--- a/shared/fixes/ansible/mount_option_noexec_remote_filesystems.yml
+++ b/shared/fixes/ansible/mount_option_noexec_remote_filesystems.yml
@@ -1,0 +1,19 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+- name: "Get nfs and nfs4 mount points, that don't have noexec option"
+  shell: grep -E "[[:space:]]nfs[4]?[[:space:]]" /etc/fstab | grep -v "noexec" | awk '{print $2}'
+  register: no_noexec_points_register
+  check_mode: no
+  tags:
+    @ANSIBLE_TAGS@
+
+- name: "Add noexec to mount points"
+  shell: awk '$2=="{{ item }}"{$4=$4",noexec"}1' /etc/fstab > fstab.tmp && mv fstab.tmp /etc/fstab
+  with_items:
+    - "{{ no_noexec_points_register.stdout_lines }}"
+  tags:
+    @ANSIBLE_TAGS@

--- a/shared/fixes/bash/mount_option_noexec_remote_filesystems.sh
+++ b/shared/fixes/bash/mount_option_noexec_remote_filesystems.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+. /usr/share/scap-security-guide/remediation_functions
+include_mount_options_functions
+
+ensure_mount_option_for_vfstype "nfs[4]?" "noexec"

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_all_noexec.fail.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_all_noexec.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/
+sed -i 's/,noexec//' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_noexec.fail.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_noexec.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/
+sed -i 's|\(.*nfs4.*\),noexec\(.*\)|\1\2|' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/no_nfs.pass.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/no_nfs.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/
+sed -i '/nfs/d' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/noexec_set.pass.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/noexec_set.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/


### PR DESCRIPTION
#### Description:
Add bash and ansible remediation with tests for Mount Remote Filesystems with noexec rule.

Similar to #3180 PR. The only difference is that this checks `noexec` option.