### PR TITLE
Fix grub2 conf rules

### DIFF
--- a/fedora/templates/csv/file_dir_permissions.csv
+++ b/fedora/templates/csv/file_dir_permissions.csv
@@ -8,4 +8,4 @@
 /etc/ssh,*.pub,,,0644,sshd_pub_key
 /etc/ssh,*_key,,,0600,sshd_private_key
 /etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
-/boot/grub,grub.conf,0,0,600,grub_conf
+/boot/grub2,grub.cfg,0,0,600,grub2_cfg

--- a/linux_os/guide/system/bootloader-grub-legacy/file_groupowner_grub_conf.rule
+++ b/linux_os/guide/system/bootloader-grub-legacy/file_groupowner_grub_conf.rule
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6
+
 title: 'Verify /etc/grub.conf Group Ownership'
 
 description: "The file <tt>/etc/grub.conf</tt> should \nbe group-owned by the <tt>root</tt> group to prevent \ndestruction or modification of the file.\n{{{ describe_file_group_owner(file="/etc/grub.conf", group="root") }}}"

--- a/linux_os/guide/system/bootloader-grub-legacy/file_owner_grub_conf.rule
+++ b/linux_os/guide/system/bootloader-grub-legacy/file_owner_grub_conf.rule
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6
+
 title: 'Verify /etc/grub.conf User Ownership'
 
 description: "The file <tt>/etc/grub.conf</tt> should \nbe owned by the <tt>root</tt> user to prevent destruction \nor modification of the file.\n{{{ describe_file_owner(file="/etc/grub.conf", owner="root") }}}"

--- a/linux_os/guide/system/bootloader-grub-legacy/file_permissions_grub_conf.rule
+++ b/linux_os/guide/system/bootloader-grub-legacy/file_permissions_grub_conf.rule
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6
+
 title: 'Verify /boot/grub/grub.conf Permissions'
 
 description: |-

--- a/linux_os/guide/system/bootloader-grub-legacy/grub_legacy_password.rule
+++ b/linux_os/guide/system/bootloader-grub-legacy/grub_legacy_password.rule
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6
+
 title: 'Set Boot Loader Password in grub.conf'
 
 description: |-

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg.rule
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg.rule
@@ -5,7 +5,7 @@ prodtype: rhel7
 title: 'Verify /boot/efi/EFI/redhat/grub.cfg Permissions'
 
 description: |-
-    File permissions for <tt>/boot/efi/EFI/redhat/grub.cfg</tt> should be set to 600.
+    File permissions for <tt>/boot/efi/EFI/redhat/grub.cfg</tt> should be set to 700.
     {{{ describe_file_permissions(file="/boot/efi/EFI/redhat/grub.cfg", perms="700") }}}
 
 rationale: |-

--- a/ol7/templates/csv/file_dir_permissions.csv
+++ b/ol7/templates/csv/file_dir_permissions.csv
@@ -1,4 +1,5 @@
 /etc,shadow,0,0,0000
 /etc,group,0,0,0644
 /etc,passwd,0,0,0644
-/boot/grub,grub.conf,0,0,600,grub_conf
+/boot/grub2,grub.cfg,0,0,600,grub2_cfg
+/boot/efi/EFI/redhat,grub.cfg,0,0,,efi_grub2_cfg

--- a/rhel7/templates/csv/file_dir_permissions.csv
+++ b/rhel7/templates/csv/file_dir_permissions.csv
@@ -8,4 +8,5 @@
 /etc/ssh,*.pub,,,0644,sshd_pub_key
 /etc/ssh,*_key,,,0600,sshd_private_key
 /etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
-/boot/grub,grub.conf,0,0,600,grub_conf
+/boot/grub2,grub.cfg,0,0,600,grub2_cfg
+/boot/efi/EFI/redhat,grub.cfg,0,0,700,efi_grub2_cfg

--- a/shared/fixes/bash/file_permissions_grub2_cfg.sh
+++ b/shared/fixes/bash/file_permissions_grub2_cfg.sh
@@ -1,2 +1,0 @@
-# platform = Red Hat Enterprise Linux 7
-chmod 600 /boot/grub2/grub.cfg


### PR DESCRIPTION
#### Description:
Fixing grub2 conf permissions/ownership build warnings introduced in latest templates unification.
grub2 grub.cfg file path updated in corresponding rhel7, fedora and ol7 templates.

Corresponding build warnings:
`
WARNING: OVAL check 'file_owner_efi_grub2_cfg' was not found, removing <check-content> element from the XCCDF rule.
WARNING: OVAL check 'file_groupowner_efi_grub2_cfg' was not found, removing <check-content> element from the XCCDF rule.
WARNING: OVAL check 'file_groupowner_grub2_cfg' was not found, removing <check-content> element from the XCCDF rule.
WARNING: OVAL check 'file_owner_grub2_cfg' was not found, removing <check-content> element from the XCCDF rule.
WARNING: OVAL check 'file_permissions_grub2_cfg' was not found, removing <check-content> element from the XCCDF rule.
`
#### Testing:
- Checked generated oval definitions, bash and ansible remediation scripts content
- Checked non-efi grub2 rules to pass on OL7, checked bash remediation scripts to work
- Checked mentioned OVAL check warnings fixed in rhel7, ol7 and fedora builds