### PR TITLE
Ol7 pci-dss auditd service rules

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 
 if `grep -q ^log_group /etc/audit/auditd.conf` ; then
   GROUP=$(awk -F "=" '/log_group/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 
 if `grep -q ^log_group /etc/audit/auditd.conf` ; then
   GROUP=$(awk -F "=" '/log_group/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>Verify /var/log/audit Permissions</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Checks for correct permissions for all log files in /var/log/audit.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'System Audit Logs Must Have Mode 0640 or Less Permissive'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/bash/shared.sh
@@ -1,7 +1,7 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
+. /usr/share/scap-security-guide/remediation_functions
+var_syslog_active="yes"
 
-grep -q ^active /etc/audisp/plugins.d/syslog.conf && \
-  sed -i "s/active.*/active = yes/g" /etc/audisp/plugins.d/syslog.conf
-if ! [ $? -eq 0 ]; then
-    echo "active = yes" >> /etc/audisp/plugins.d/syslog.conf
-fi
+AUDISP_SYSLOGCONFIG=/etc/audisp/plugins.d/syslog.conf
+
+replace_or_append $AUDISP_SYSLOGCONFIG '^active' "$var_syslog_active" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/bash/shared.sh
@@ -1,11 +1,7 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_action_mail_acct
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-grep -q ^action_mail_acct $AUDITCONFIG && \
-  sed -i 's/^action_mail_acct.*/action_mail_acct = '"$var_auditd_action_mail_acct"'/g' $AUDITCONFIG
-if ! [ $? -eq 0 ]; then
-  echo "action_mail_acct = $var_auditd_action_mail_acct" >> $AUDITCONFIG
-fi
+replace_or_append $AUDITCONFIG '^action_mail_acct' "$var_auditd_action_mail_acct" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/rhel6.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/rhel6.sh
@@ -1,9 +1,0 @@
-# platform = Red Hat Enterprise Linux 6
-. /usr/share/scap-security-guide/remediation_functions
-populate var_auditd_admin_space_left_action
-
-grep -q ^admin_space_left_action /etc/audit/auditd.conf && \
-  sed -i "s/admin_space_left_action.*/admin_space_left_action = $var_auditd_admin_space_left_action/g" /etc/audit/auditd.conf
-if ! [ $? -eq 0 ]; then
-    echo "admin_space_left_action = $var_auditd_admin_space_left_action" >> /etc/audit/auditd.conf
-fi

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/rhel7.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/rhel7.sh
@@ -1,9 +1,0 @@
-# platform = Red Hat Enterprise Linux 7
-. /usr/share/scap-security-guide/remediation_functions
-populate var_auditd_admin_space_left_action
-
-grep -q ^admin_space_left_action /etc/audit/auditd.conf && \
-  sed -i "s/admin_space_left_action.*/admin_space_left_action = $var_auditd_admin_space_left_action/g" /etc/audit/auditd.conf
-if ! [ $? -eq 0 ]; then
-    echo "admin_space_left_action = $var_auditd_admin_space_left_action" >> /etc/audit/auditd.conf
-fi

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/shared.sh
@@ -1,0 +1,8 @@
+# platform = multi_platform_rhel,multi_platform_ol
+. /usr/share/scap-security-guide/remediation_functions
+
+populate var_auditd_admin_space_left_action
+
+AUDITCONFIG=/etc/audit/auditd.conf
+
+replace_or_append $AUDITCONFIG '^admin_space_left_action' "$var_auditd_admin_space_left_action" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/bash/shared.sh
@@ -4,8 +4,4 @@ populate var_auditd_max_log_file
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-grep -q ^max_log_file $AUDITCONFIG && \
-  sed -i 's/^max_log_file.*/max_log_file = '"$var_auditd_max_log_file"'/g' $AUDITCONFIG
-if ! [ $? -eq 0 ]; then
-  echo "max_log_file = $var_auditd_max_log_file" >> $AUDITCONFIG
-fi
+replace_or_append $AUDITCONFIG '^max_log_file' "$var_auditd_max_log_file" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_max_log_file
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/bash/shared.sh
@@ -4,8 +4,4 @@ populate var_auditd_max_log_file_action
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-grep -q ^max_log_file_action $AUDITCONFIG && \
-  sed -i 's/^max_log_file_action.*/max_log_file_action = '"$var_auditd_max_log_file_action"'/g' $AUDITCONFIG
-if ! [ $? -eq 0 ]; then
-  echo "max_log_file_action = $var_auditd_max_log_file_action" >> $AUDITCONFIG
-fi
+replace_or_append $AUDITCONFIG '^max_log_file_action' "$var_auditd_max_log_file_action" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_max_log_file_action
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_num_logs
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/bash/shared.sh
@@ -4,8 +4,4 @@ populate var_auditd_num_logs
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-grep -q ^num_logs $AUDITCONFIG && \
-  sed -i 's/^num_logs.*/num_logs = '"$var_auditd_num_logs"'/g' $AUDITCONFIG
-if ! [ $? -eq 0 ]; then
-  echo "num_logs = $var_auditd_num_logs" >> $AUDITCONFIG
-fi
+replace_or_append $AUDITCONFIG '^num_logs' "$var_auditd_num_logs" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_space_left_action
 
@@ -8,9 +8,6 @@ populate var_auditd_space_left_action
 # add "space_left_action = $var_auditd_space_left_action" to /etc/audit/auditd.conf
 #
 
-if grep --silent ^space_left_action /etc/audit/auditd.conf ; then
-        sed -i 's/^space_left_action.*/space_left_action = '"$var_auditd_space_left_action"'/g' /etc/audit/auditd.conf
-else
-        echo -e "\n# Set space_left_action to $var_auditd_space_left_action per security requirements" >> /etc/audit/auditd.conf
-        echo "space_left_action = $var_auditd_space_left_action" >> /etc/audit/auditd.conf
-fi
+AUDITCONFIG=/etc/audit/auditd.conf
+
+replace_or_append $AUDITCONFIG '^space_left_action' "$var_auditd_space_left_action" "@CCENUM@"

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -39,3 +39,4 @@ selections:
     - file_ownership_var_log_audit
     - auditd_data_retention_num_logs
     - auditd_data_retention_max_log_file
+    - auditd_data_retention_max_log_file_action

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -42,3 +42,4 @@ selections:
     - auditd_data_retention_max_log_file_action
     - auditd_data_retention_space_left_action
     - auditd_data_retention_admin_space_left_action
+    - auditd_data_retention_action_mail_acct

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -43,3 +43,4 @@ selections:
     - auditd_data_retention_space_left_action
     - auditd_data_retention_admin_space_left_action
     - auditd_data_retention_action_mail_acct
+    - auditd_audispd_syslog_plugin_activated

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -37,5 +37,5 @@ selections:
     - service_auditd_enabled
     - file_permissions_var_log_audit
     - file_ownership_var_log_audit
-    - var_auditd_num_logs=5
     - auditd_data_retention_num_logs
+    - auditd_data_retention_max_log_file

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -37,3 +37,5 @@ selections:
     - service_auditd_enabled
     - file_permissions_var_log_audit
     - file_ownership_var_log_audit
+    - var_auditd_num_logs=5
+    - auditd_data_retention_num_logs

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -35,3 +35,5 @@ selections:
     - aide_build_database
     - aide_periodic_cron_checking
     - service_auditd_enabled
+    - file_permissions_var_log_audit
+    - file_ownership_var_log_audit

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -40,3 +40,5 @@ selections:
     - auditd_data_retention_num_logs
     - auditd_data_retention_max_log_file
     - auditd_data_retention_max_log_file_action
+    - auditd_data_retention_space_left_action
+    - auditd_data_retention_admin_space_left_action

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -34,3 +34,4 @@ selections:
     - package_aide_installed
     - aide_build_database
     - aide_periodic_cron_checking
+    - service_auditd_enabled

--- a/ol7/templates/csv/packages_installed.csv
+++ b/ol7/templates/csv/packages_installed.csv
@@ -1,4 +1,5 @@
 aide
+audit
 openssh-server
 uuidd
 glibc,0:2.17-55.0.4.el7_0.3

--- a/ol7/templates/csv/services_enabled.csv
+++ b/ol7/templates/csv/services_enabled.csv
@@ -1,0 +1,1 @@
+auditd,audit,


### PR DESCRIPTION
#### Description:

- Added set of auditd service rules to OL7 pci-dss profile. Mostly added ol7 to supported platform in existing shared rules and checked to work.
- auditd_data_retention_admin_space_left_action.sh {rhel6,rhel7} scripts merged to shared one
- Fixed corresponding bash auditd_data_retention*.sh rules to use replace_or_append function from remediation_functions shared library

List of ol7 enabled rules:
- service_auditd_enabled
- file_permissions_var_log_audit
- file_ownership_var_log_audit
- auditd_data_retention_num_logs
- auditd_data_retention_max_log_file
- auditd_data_retention_max_log_file_action
- auditd_data_retention_space_left_action
- auditd_data_retention_admin_space_left_action
- auditd_data_retention_action_mail_acct
- auditd_audispd_syslog_plugin_activated

#### Testing (Oracle Linux 7):

- Checked OVAL and remediation scripts content
- Checked guide content
- Checked rules evaluation and remediation scripts results
