### PR TITLE
Add ssg.products.get_all to return linux_os, other products

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -4,6 +4,10 @@ from __future__ import print_function
 import datetime
 import os.path
 
+product_directories = ['debian8', 'fedora', 'ol7', 'opensuse', 'rhel6',
+                       'rhel7', 'sle11', 'sle12', 'ubuntu1404',
+                       'ubuntu1604', 'wrlinux', 'rhel-osp7', 'chromium',
+                       'eap6', 'firefox', 'fuse6', 'jre', 'ocp3']
 
 JINJA_MACROS_BASE_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros.jinja")

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -2,6 +2,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import re
+import os
+from collections import namedtuple
+
+from .constants import product_directories
+from .yaml import open_raw
+
 
 # SSG Makefile to official product name mapping
 _version_name_map = {
@@ -38,6 +44,33 @@ def parse_name(product):
         _product_version = match.group(2)
 
     return _product, _product_version
+
+
+def get_all(ssg_root):
+    """
+    Analyzes all products in the SSG root and sorts them into two categories:
+    those which use linux_os and those which use their own directory. Returns
+    a namedtuple of sets, (linux, other).
+    """
+
+    linux_products = set()
+    other_products = set()
+
+    for product in product_directories:
+        product_dir = os.path.join(ssg_root, product)
+        product_yaml_path = os.path.join(product_dir, "product.yml")
+        product_yaml = open_raw(product_yaml_path)
+
+        guide_dir = os.path.join(product_dir, product_yaml['benchmark_root'])
+        guide_dir = os.path.abspath(guide_dir)
+
+        if 'linux_os' in guide_dir:
+            linux_products.add(product)
+        else:
+            other_products.add(product)
+
+    products = namedtuple('products', ['linux', 'other'])
+    return products(linux_products, other_products)
 
 
 def map_name(version):

--- a/tests/unit/ssg/test_products.py
+++ b/tests/unit/ssg/test_products.py
@@ -1,0 +1,19 @@
+import os
+
+import pytest
+
+import ssg.products
+
+
+def test_get_all():
+    ssg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+    products = ssg.products.get_all(ssg_root)
+
+    assert "fedora" in products.linux
+    assert "fedora" not in products.other
+
+    assert "rhel7" in products.linux
+    assert "rhel7" not in products.other
+
+    assert "jre" in products.other
+    assert "jre" not in products.linux


### PR DESCRIPTION
This function has been helpful in both #3178 and #3193, so I've decided to split it off as a separate commit.

In essence, we wish to figure out which products belong to the `linux_os` shared guide and which have their own guides. Since this is an expensive operation (and changes based on the contents of the `product.yml`), it makes sense to have this be a function vs either storing the results as constants, or having these be static constants.