### PR TITLE
Fix utils/move_rules.py

### DIFF
--- a/utils/move_rules.py
+++ b/utils/move_rules.py
@@ -155,7 +155,7 @@ def move_rule_other(ssg_root, current_product, path, obj_name):
 
     assert not os.path.exists(new_rule_dir)
 
-    sub_dirs = ['oval', 'bash', 'ansible', 'puppet', 'anaconda']
+    sub_dirs = ['oval', 'bash', 'ansible', 'anaconda', 'puppet']
     new_rule_subdirs = [abs_join(new_rule_dir, j) for j in sub_dirs]
 
     move_templates = [


### PR DESCRIPTION
This did not affect our movement because none of the non-Linux OS guide products have anaconda or puppet remediations. However...

Technically these were wrong in the script and their order needed to be swapped. This was fixed for the Linux OS function as a result of #3193, but I forgot to make the symmetrical change for non-Linux OS guide products.

I checked this by pulling master, adding this fix, reverting 78aa4de88079cfc0138fa567bf0f947503a18f94, regenerating all moves, and copying all product folders to a clean master tree and checking the results.

So this is purely a cosmetic fix for the future. 