### PR TITLE
Further improvement of the SSG test suite

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -57,6 +57,8 @@ starting with `ssg_`.
 - `--mode`: Can be either `online` or `offline`, which corresponds either to
   online or offline scanning mode. Online scanning mode uses `oscap-ssh`, while
   offline scanning is backend-specific.
+  As offline scanning examines the filesystem of the container or VM, it may require
+  extended privileges.
 - `--help`: This will get you the invocation help.
 
 VM-based tests:
@@ -166,12 +168,13 @@ You can also use the docker-based for running tests, just use the script with th
 You need to provide `--docker <base image name>` option on the command-line.
 
 To obtain the base image, you can use `test_suite-*` Dockerfiles in the `Dockerfiles` directory to build it.
-We recomend to use RHEL-based containers, as the test suite is optimized for testing the RHEL content.
+We recommend to use RHEL-based containers, as the test suite is optimized for testing the RHEL content.
 
 Build the image using this command:
 
 ```
-docker build --build-arg CLIENT_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1y...rJSs4BL me@localhost" -t ssg_test_suite -f test_suite-rhel .
+public_key="ssh-rsa AAAAB3NzaC1y...rJSs4BL me@localhost"
+docker build --build-arg CLIENT_PUBLIC_KEY="$public_key" -t ssg_test_suite -f test_suite-rhel .
 ```
 
 Run the test suite using this command:
@@ -184,18 +187,18 @@ On your side, you need to have
 - the [docker](https://pypi.org/project/docker/) Python module installed. You may have to use `pip` to install it on older distributions s.a. RHEL 7, running `pip install --user docker` as `root` will do the trick of installing it only for the `root` user.
 - the Docker service running, and
 - rights that allow you to start/stop containers and to create images.
-  This level of rights is considered to be insecure, so it is recomended to run the test suite in a VM.
+  This level of rights is considered to be insecure, so it is recommended to run the test suite in a VM.
   You can accomplish this by creating a `docker` group, then add yourself in it and restart `docker`.
 
 The Docker image you want to use with the tests needs to be prepared, so it can scan itself, and that it can accept connections and data.
 Following services need to be supported:
 
 - `sshd` (`openssh-server` needs to be installed, server host keys have to be in place, root's `.ssh/authorized_keys` are set up with correct permissions)
-- `scp` (`openssh-clients` need to be installed - scp requires more than a ssh server on the server-side)
+- `scp` (`openssh-clients` need to be installed - `scp` requires more than a ssh server on the server-side)
 - `oscap` (`openscap-scanner` - the container has to be able to scan itself)
 - You may want to include another packages, as base images tend to be bare-bone and tests may require more packages to be present.
 Also, as containers may get any IP address, a conflict may appear in your local client's `known_hosts` file.
-You might have a version of `oscap-ssh` that doesn't support ssh connetion customization at the client-side, so it may be a good idea to disable known hosts checks for all hosts if you are testing on a VM or under a separate user.
+You might have a version of `oscap-ssh` that doesn't support ssh connection customization at the client-side, so it may be a good idea to disable known hosts checks for all hosts if you are testing on a VM or under a separate user.
 You can do that by putting following lines in your `$HOME/.ssh/config` file:
 
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,6 +54,9 @@ starting with `ssg_`.
 - `--xccdf-id`: Also known as `Ref-ID`, it is the identifier of benchmark within
   the datastream.  It can be obtained by running `oscap info` over the
   datastream XML and searching for `Ref-ID` strings.
+- `--mode`: Can be either `online` or `offline`, which corresponds either to
+  online or offline scanning mode. Online scanning mode uses `oscap-ssh`, while
+  offline scanning is backend-specific.
 - `--help`: This will get you the invocation help.
 
 VM-based tests:
@@ -192,7 +195,7 @@ Following services need to be supported:
 - `oscap` (`openscap-scanner` - the container has to be able to scan itself)
 - You may want to include another packages, as base images tend to be bare-bone and tests may require more packages to be present.
 Also, as containers may get any IP address, a conflict may appear in your local client's `known_hosts` file.
-As `oscap-ssh` doesn't let you to switch known hosts checks off at the client-side, it may be a good idea to disable known hosts checks for all hosts if you are testing on a VM or under a separate user.
+You might have a version of `oscap-ssh` that doesn't support ssh connetion customization at the client-side, so it may be a good idea to disable known hosts checks for all hosts if you are testing on a VM or under a separate user.
 You can do that by putting following lines in your `$HOME/.ssh/config` file:
 
 ```

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -1,0 +1,36 @@
+import logging
+import subprocess
+
+
+IGNORE_KNOWN_HOSTS_OPTIONS = (
+    "-o", "StrictHostKeyChecking=no",
+    "-o", "UserKnownHostsFile=/dev/null",
+)
+
+
+def run_cmd_local(command, verbose_path, env=None):
+    command_string = ' '.join(command)
+    logging.debug('Running {}'.format(command_string))
+    returncode, output = _run_cmd(command, verbose_path, env)
+    return returncode, output
+
+
+def run_cmd_remote(command_string, domain_ip, verbose_path, env=None):
+    machine = 'root@{0}'.format(domain_ip)
+    remote_cmd = ['ssh'] + IGNORE_KNOWN_HOSTS_OPTIONS + [machine, command_string]
+    logging.debug('Running {}'.format(command_string))
+    returncode, output = _run_cmd(remote_cmd, verbose_path, env)
+    return returncode, output
+
+
+def _run_cmd(command_list, verbose_path, env=None):
+    returncode = 0
+    output = b""
+    try:
+        with open(verbose_path, 'w') as verbose_file:
+            output = subprocess.check_output(
+                command_list, stderr=verbose_file, env=env)
+    except subprocess.CalledProcessError as e:
+        returncode = e.returncode
+        output = e.output
+    return returncode, output.decode('utf-8')

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -273,17 +273,6 @@ class GenericRunner(object):
         ])
         self._filenames_to_clean_afterwards.add(self.report_path)
 
-    def prepare_oscap_docker_arguments(self):
-        self.command_base.extend(
-            ['oscap-docker', "xxx", 'xccdf', 'eval'])
-        self.command_options.extend([
-            '--benchmark-id', self.benchmark_id,
-            '--profile', self.profile,
-            '--verbose', 'DEVEL',
-            '--progress', '--oval-results',
-        ])
-        self.command_operands.append(self.datastream)
-
     def prepare_online_scanning_arguments(self):
         self.command_options.extend([
             '--benchmark-id', self.benchmark_id,

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -20,9 +20,9 @@ class ProfileChecker(ssg_test_suite.oscap.Checker):
     def _test_target(self, target):
         profiles = get_viable_profiles(
             target, self.datastream, self.benchmark_id)
-        self._test_by_profiles(profiles)
+        self.run_test_for_all_profiles(profiles)
 
-    def _run_test(self, profile, ** run_test_args):
+    def _run_test(self, profile, test_data):
         logging.info("Evaluation of profile {0}.".format(profile))
         self.executed_tests += 1
 

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -28,7 +28,7 @@ class ProfileChecker(ssg_test_suite.oscap.Checker):
 
         runner_cls = ssg_test_suite.oscap.REMEDIATION_PROFILE_RUNNERS[self.remediate_using]
         runner = runner_cls(
-            self.test_env.domain_ip, profile, self.datastream, self.benchmark_id)
+            self.test_env, profile, self.datastream, self.benchmark_id)
 
         for stage in ("initial", "remediation", "final"):
             result = runner.run_stage(stage)

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -3,45 +3,127 @@ from __future__ import print_function
 import contextlib
 import sys
 
+import time
+import logging
+
 import docker
 
 import ssg_test_suite
 from ssg_test_suite.virt import SnapshotStack
 
 
+class SavedState(object):
+    def __init__(self, environment, name):
+        self.name = name
+        self.environment = environment
+        self.initial_running_state = True
+
+    def map_on_top(self, function, args_list):
+        current_running_state = self.initial_running_state
+        function(* args_list[0])
+        for args in args_list[1:]:
+            current_running_state = self.environment.reset_state_to(self.name)
+            function(* args)
+
+    @classmethod
+    @contextlib.contextmanager
+    def create_from_environment(cls, environment, state_name):
+        state = cls(environment, state_name)
+
+        state_handle = environment._save_state(state_name)
+        exception_to_reraise = None
+        try:
+            yield state
+        except KeyboardInterrupt as exc:
+            print("Hang on for a minute, cleaning up the saved state '{0}'."
+                  .format(state_name), file=sys.stderr)
+            exception_to_reraise = exc
+        finally:
+            try:
+                environment._delete_saved_state(state_handle)
+            except KeyboardInterrupt as exc:
+                print("Hang on for a minute, cleaning up the saved state '{0}'."
+                      .format(state_name), file=sys.stderr)
+                environment._delete_saved_state(state_handle)
+            finally:
+                if exception_to_reraise:
+                    raise exception_to_reraise
+
+
 class TestEnv(object):
     def __init__(self):
-        self.domain_ip = ""
+        self.running_state_base = None
+        self.running_state = None
 
     def start(self):
+        """
+        Run the environment and
+        ensure that the environment will not be permanently modified
+        by subsequent procedures.
+        """
         pass
 
     def finalize(self):
+        """
+        Perform the environment cleanup and shut it down.
+        """
         pass
 
-    def _get_snapshot(self, snapshot_name):
+    def _save_state(self, state_name):
+        self.running_state_base = state_name
+        running_state = self.running_state
+
+        return None
+
+    def _delete_saved_state(self, state_name):
         raise NotImplementedError()
 
-    def _revert_snapshot(self, snapshot_name):
-        raise NotImplementedError()
+    def _stop_state(self, state):
+        pass
 
     @contextlib.contextmanager
-    def in_layer(self, snapshot_name, delete=True):
-        snapshot = self._get_snapshot(snapshot_name)
+    def run_state(self, state_name, try_to_use_current_state=True):
+        if try_to_use_current_state and state_name == self.running_state_base:
+            running_state = self.running_state
+            self.running_state_base = None
+        else:
+            self.running_state = None
+            running_state = self.get_running_state(state_name)
+
+        try:
+            yield running_state
+        except KeyboardInterrupt as exc:
+            print("Hang on for a minute, aborting the running state '{0}'."
+                  .format(state_name), file=sys.stderr)
+            exception_to_reraise = exc
+        finally:
+            try:
+                self._stop_state(running_state)
+            except KeyboardInterrupt as exc:
+                print("Hang on for a minute, aborting the running state '{0}'."
+                      .format(state_name), file=sys.stderr)
+                self._stop_state(running_state)
+            finally:
+                if exception_to_reraise:
+                    raise exception_to_reraise
+
+    @contextlib.contextmanager
+    def save_state(self, state_name):
+        snapshot = self._save_state(state_name)
         exception_to_reraise = None
         try:
             yield snapshot
         except KeyboardInterrupt as exc:
             print("Hang on for a minute, cleaning up the snapshot '{0}'."
-                  .format(snapshot_name), file=sys.stderr)
+                  .format(state_name), file=sys.stderr)
             exception_to_reraise = exc
         finally:
             try:
-                self._revert_snapshot(snapshot)
+                self._delete_saved_state(snapshot)
             except KeyboardInterrupt as exc:
                 print("Hang on for a minute, cleaning up the snapshot '{0}'."
-                      .format(snapshot_name), file=sys.stderr)
-                self._revert_snapshot(snapshot)
+                      .format(state_name), file=sys.stderr)
+                self._delete_saved_state(snapshot)
             finally:
                 if exception_to_reraise:
                     raise exception_to_reraise
@@ -52,23 +134,46 @@ class VMTestEnv(TestEnv):
 
     def __init__(self, hypervisor, domain_name):
         super(VMTestEnv, self).__init__()
+        self.domain = None
 
         self.hypervisor = hypervisor
         self.domain_name = domain_name
         self.snapshot_stack = None
 
+        self._origin = None
+
     def start(self):
-        dom = ssg_test_suite.virt.connect_domain(
+        self.domain = ssg_test_suite.virt.connect_domain(
             self.hypervisor, self.domain_name)
-        self.snapshot_stack = SnapshotStack(dom)
+        self.snapshot_stack = SnapshotStack(self.domain)
 
-        ssg_test_suite.virt.start_domain(dom)
-        self.domain_ip = ssg_test_suite.virt.determine_ip(dom)
+        ssg_test_suite.virt.start_domain(self.domain)
+        self.domain_ip = ssg_test_suite.virt.determine_ip(self.domain)
 
-    def _get_snapshot(self, snapshot_name):
-        return self.snapshot_stack.create(snapshot_name)
+        self._origin = self._save_state("origin")
 
-    def _revert_snapshot(self, snapshot):
+    def finalize(self):
+        self._delete_saved_state(self._origin)
+        # self.domain.shutdown()
+        # logging.debug('Shut the domain off')
+
+    def reset_state_to(self, state_name):
+        last_snapshot_name = self.snapshot_stack.snapshot_stack[-1].getName()
+        assert last_snapshot_name == state_name, (
+            "You can only revert to the last snapshot, which is {0}, not {1}"
+            .format(last_snapshot_name, state_name))
+        state = self.snapshot_stack.revert(delete=False)
+        return state
+
+    def discard_running_state(self, state_handle):
+        pass
+
+    def _save_state(self, state_name):
+        super(VMTestEnv, self)._save_state(state_name)
+        state = self.snapshot_stack.create(state_name)
+        return state
+
+    def _delete_saved_state(self, snapshot):
         self.snapshot_stack.revert()
 
 
@@ -90,9 +195,20 @@ class DockerTestEnv(TestEnv):
                 "and do you have rights to access it?"
                 .format(str(exc)))
             raise RuntimeError(msg)
+
         self.base_image = image_name
         self.created_images = []
         self.containers = []
+
+    def start(self):
+        self.run_container(self.base_image)
+
+    def finalize(self):
+        self._terminate_current_running_container_if_applicable()
+
+    def image_stem2fqn(self, stem):
+        image_name = "{0}_{1}".format(self.base_image, stem)
+        return image_name
 
     @property
     def current_container(self):
@@ -100,24 +216,27 @@ class DockerTestEnv(TestEnv):
             return self.containers[-1]
         return None
 
+    @property
+    def current_image(self):
+        if self.created_images:
+            return self.created_images[-1]
+        return self.base_image
+
     def _create_new_image(self, from_container, name):
-        new_image_name = "{0}_{1}".format(self.base_image, name)
+        new_image_name = self.image_stem2fqn(name)
+        if not from_container:
+            from_container = self.run_container(self.current_image)
         from_container.commit(repository=new_image_name)
         self.created_images.append(new_image_name)
         return new_image_name
 
-    def _new_container(self, name):
-        if self.containers:
-            img = self._create_new_image(self.containers[-1], name)
-        else:
-            img = self.base_image
-        return self.client.containers.run(
-            img, "/usr/sbin/sshd -D",
-            name="{0}_{1}".format(self._name_stem, name), ports={"22": None},
-            detach=True)
+    def _save_state(self, state_name):
+        super(DockerTestEnv, self)._save_state(state_name)
+        state = self._create_new_image(self.current_container, state_name)
+        return state
 
-    def _get_snapshot(self, snapshot_name):
-        new_container = self._new_container(snapshot_name)
+    def run_container(self, image_name, container_name="running"):
+        new_container = self._new_container_from_image(image_name, container_name)
         self.containers.append(new_container)
 
         new_container.reload()
@@ -125,12 +244,39 @@ class DockerTestEnv(TestEnv):
 
         return new_container
 
-    def _revert_snapshot(self, snapshot):
-        snapshot.stop()
-        snapshot.remove()
+    def reset_state_to(self, state_name):
+        self._terminate_current_running_container_if_applicable()
+        image_name = self.image_stem2fqn(state_name)
 
-        assert snapshot == self.containers.pop()
+        new_container = self.run_container(image_name)
 
-        if self.created_images:
-            associated_image = self.created_images.pop()
-            self.client.images.remove(associated_image)
+        return new_container
+
+    def _find_image_by_name(self, image_name):
+        return self.client.images.get(image_name)
+
+    def _new_container_from_image(self, image_name, container_name):
+        img = self._find_image_by_name(image_name)
+        result = self.client.containers.run(
+            img, "/usr/sbin/sshd -D",
+            name="{0}_{1}".format(self._name_stem, container_name), ports={"22": None},
+            detach=True)
+        return result
+
+    def _terminate_current_running_container_if_applicable(self):
+        if self.containers:
+            running_state = self.containers.pop()
+            running_state.stop()
+            running_state.remove()
+
+    def _delete_saved_state(self, image):
+        self._terminate_current_running_container_if_applicable()
+
+        assert self.created_images
+
+        associated_image = self.created_images.pop()
+        assert associated_image == image
+        self.client.images.remove(associated_image)
+
+    def discard_running_state(self, state_handle):
+        self._terminate_current_running_container_if_applicable()

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -92,9 +92,8 @@ class TestEnv(object):
         full_hostname = 'root@{}'.format(self.domain_ip)
         command_base = []
         command_base.extend(
-            ['oscap-ssh', full_hostname, '22'])
-        command_base.extend(
-            ['xccdf', 'eval'])
+            ['oscap-ssh', full_hostname, '22',
+             'xccdf', 'eval'])
         return command_base
 
     def scan(self, args, verbose_path):
@@ -165,16 +164,15 @@ class VMTestEnv(TestEnv):
     def _delete_saved_state(self, snapshot):
         self.snapshot_stack.revert()
 
-    def _oscap_docker_base_arguments(self):
+    def _local_oscap_check_base_arguments(self):
         command_base = []
         command_base.extend(
-            ['oscap-vm', "domain", self.domain_name])
-        command_base.extend(
-            ['xccdf', 'eval'])
+            ['oscap-vm', "domain", self.domain_name,
+             'xccdf', 'eval'])
         return command_base
 
     def offline_scan(self, args, verbose_path):
-        command_list = self._oscap_docker_base_arguments() + args
+        command_list = self._local_oscap_check_base_arguments() + args
 
         return common.run_cmd_local(command_list, verbose_path)
 
@@ -286,15 +284,14 @@ class DockerTestEnv(TestEnv):
     def discard_running_state(self, state_handle):
         self._terminate_current_running_container_if_applicable()
 
-    def _oscap_docker_base_arguments(self):
+    def _local_oscap_check_base_arguments(self):
         command_base = []
         command_base.extend(
-            ['oscap-docker', "container", self.current_container.id])
-        command_base.extend(
-            ['xccdf', 'eval'])
+            ['oscap-docker', "container", self.current_container.id,
+             'xccdf', 'eval'])
         return command_base
 
     def offline_scan(self, args, verbose_path):
-        command_list = self._oscap_docker_base_arguments() + args
+        command_list = self._local_oscap_check_base_arguments() + args
 
         return common.run_cmd_local(command_list, verbose_path)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -57,6 +57,15 @@ def parse_args():
                                help="Directory to which all output is saved")
 
     common_parser.add_argument(
+        "--mode",
+        dest="scanning_mode",
+        default="online",
+        choices=("online", "offline"),
+        help="What type of check to use: "
+        "Online check done by running oscap inside the concerned system, or "
+        "offline check that examines the filesystem from the host?")
+
+    common_parser.add_argument(
         "--remediate-using",
         dest="remediate_using",
         default="oscap",
@@ -141,14 +150,14 @@ def normalize_passed_arguments(options):
 
     if options.docker:
         options.test_env = ssg_test_suite.test_env.DockerTestEnv(
-            options.docker)
+            options.scanning_mode, options.docker)
         logging.info(
             "The base image option has been specified, "
             "choosing Docker-based test environment.")
     else:
         hypervisor, domain_name = options.libvirt
         options.test_env = ssg_test_suite.test_env.VMTestEnv(
-            hypervisor, domain_name)
+            options.scanning_mode, hypervisor, domain_name)
         logging.info(
             "The base image option has not been specified, "
             "choosing libvirt-based test environment.")

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -61,9 +61,10 @@ def parse_args():
         dest="scanning_mode",
         default="online",
         choices=("online", "offline"),
-        help="What type of check to use: "
+        help="What type of check to use - either "
         "Online check done by running oscap inside the concerned system, or "
-        "offline check that examines the filesystem from the host?")
+        "offline check that examines the filesystem from the host "
+        "(either may require extended privileges).")
 
     common_parser.add_argument(
         "--remediate-using",


### PR DESCRIPTION
This PR builds on top of #3179:

* With recent-enough `oscap-ssh`, execute SSH-based operations completely disregarding `known_hosts` - see also https://github.com/OpenSCAP/openscap/pull/1177.
* Refactored the state handling: There is a new class `SavedState` that maps to stored persistent state (docker image, VM snapshot). The class has a `map_on_top` method, that fits the purpose of starting from the defined state, performing state alternations and scan, and reverting to the original state to run another check.
* Introduced offline scanning for libvirt and docker backends using `oscap-vm` and `oscap-docker` respectively. `oscap-vm` doesn't work, which is a known issue, and `oscap-docker` may require the test suite to be executed by the root user.
* Introduced the `common` module with shared utility functions..
* Dropped usage of a `scenario` saved state that was not needed - we just need the state with all tests scripts uploaded.