### PR TITLE
Add prodtype: rhel6 to more grub_legacy rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/grub_legacy_disable_interactive_boot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub_legacy_disable_interactive_boot/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6
+
 title: 'Disable Interactive Boot'
 
 description: |-

--- a/linux_os/guide/system/auditing/grub_legacy_audit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub_legacy_audit_argument/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6
+
 title: 'Enable Auditing for Processes Which Start Prior to the Audit Daemon'
 
 description: |-

--- a/linux_os/guide/system/permissions/mounting/grub_legacy_nousb_argument/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/grub_legacy_nousb_argument/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6
+
 title: 'Disable Kernel Support for USB via Bootloader Configuration'
 
 description: |-

--- a/linux_os/guide/system/selinux/grub_legacy_enable_selinux/rule.yml
+++ b/linux_os/guide/system/selinux/grub_legacy_enable_selinux/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6
+
 title: 'Ensure SELinux Not Disabled in /etc/grub.conf'
 
 description: |-

--- a/linux_os/guide/system/software/integrity/fips/grub_legacy_enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub_legacy_enable_fips_mode/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6
+
 title: 'Enable FIPS Mode in GRUB Legacy'
 
 description: |-


### PR DESCRIPTION
Signed-off-by: Alexander Scheel <ascheel@redhat.com>

Per comments by @iokomin on #3196, there's a few `grub_legacy` rules which apply to all products. This fixes these and removes them from all other products but `rhel6`, which should be the only product we support which doesn't use grub2. 