### PR TITLE
Ol7 pci dss audit dac rules

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/bash/rhel6.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/bash/rhel6.sh
@@ -1,7 +1,0 @@
-# platform = Red Hat Enterprise Linux 6
-
-# Include source function library.
-. /usr/share/scap-security-guide/remediation_functions
-
-# Perform the remediation
-fix_audit_watch_rule "auditctl" "/etc/selinux/" "wa" "MAC-policy"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/bash/shared.sh
@@ -1,5 +1,4 @@
-# platform = Red Hat Enterprise Linux 7
-
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Audit rules that detect changes to the system's mandatory access controls (SELinux) are enabled.</description>
     </metadata>

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -55,3 +55,17 @@ selections:
     - audit_rules_usergroup_modification_passwd
     - audit_rules_usergroup_modification_shadow
     - audit_rules_networkconfig_modification
+    - audit_rules_mac_modification
+    - audit_rules_dac_modification_chmod
+    - audit_rules_dac_modification_chown
+    - audit_rules_dac_modification_fchmod
+    - audit_rules_dac_modification_fchmodat
+    - audit_rules_dac_modification_fchown
+    - audit_rules_dac_modification_fchownat
+    - audit_rules_dac_modification_fremovexattr
+    - audit_rules_dac_modification_fsetxattr
+    - audit_rules_dac_modification_lchown
+    - audit_rules_dac_modification_lremovexattr
+    - audit_rules_dac_modification_lsetxattr
+    - audit_rules_dac_modification_removexattr
+    - audit_rules_dac_modification_setxattr

--- a/shared/templates/template_ANSIBLE_audit_rules_dac_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_dac_modification
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/shared/templates/template_BASH_audit_rules_dac_modification
+++ b/shared/templates/template_BASH_audit_rules_dac_modification
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/shared/templates/template_OVAL_audit_rules_dac_modification
+++ b/shared/templates/template_OVAL_audit_rules_dac_modification
@@ -4,6 +4,7 @@
       <title>Audit Discretionary Access Control Modification Events - {{{ ATTR }}}</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The changing of file permissions and attributes should be audited.</description>
     </metadata>


### PR DESCRIPTION
#### Description:

Set of audit MAC and DAC rules to be added to ol7 pci-dss.
Note: Easy fix as all DAC rules generated from templates

- Merged audit_rules_mac_modification bash scripts to shared
- Added ol7 to audit_rules_dac_modification ansible, bash and OVAL templates
- Enabled rules:
    - audit_rules_mac_modification
    - audit_rules_dac_modification_chmod
    - audit_rules_dac_modification_chown
    - audit_rules_dac_modification_fchmod
    - audit_rules_dac_modification_fchmodat
    - audit_rules_dac_modification_fchown
    - audit_rules_dac_modification_fchownat
    - audit_rules_dac_modification_fremovexattr
    - audit_rules_dac_modification_fsetxattr
    - audit_rules_dac_modification_lchown
    - audit_rules_dac_modification_lremovexattr
    - audit_rules_dac_modification_lsetxattr
    - audit_rules_dac_modification_removexattr
    - audit_rules_dac_modification_setxattr

Testing successful on Oracle Linux 7
