### PR TITLE
Drop anaconda fix for /dev/cdrom mount points

### DIFF
--- a/shared/templates/csv/mount_options.csv
+++ b/shared/templates/csv/mount_options.csv
@@ -7,9 +7,9 @@
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
 #  add the 'create_fstab_entry_if_needed' literal string as the third argument.
 
-var_removable_partition,nodev,create_fstab_entry_if_needed
-var_removable_partition,nosuid,create_fstab_entry_if_needed
-var_removable_partition,noexec,create_fstab_entry_if_needed
+var_removable_partition,nodev,create_fstab_entry_if_needed #except-for:anaconda
+var_removable_partition,nosuid,create_fstab_entry_if_needed #except-for:anaconda
+var_removable_partition,noexec,create_fstab_entry_if_needed #except-for:anaconda
 remote_filesystems,nodev,create_fstab_entry_if_needed
 remote_filesystems,nosuid,create_fstab_entry_if_needed
 remote_filesystems,noexec,create_fstab_entry_if_needed


### PR DESCRIPTION
#### Description:

- Stop generation Anaconda remediation for 
  - `mount_option_nodev_removable_partitions`
  - `mount_option_nosuid_removable_partitions`
  - `mount_option_noexec_removable_partitions`

#### Rationale:

- The existance of the fix itself, is causing `oscap-anaconda-addon` to require the
partition `/dev/cdrom` to exist. This should not the use case for this rule.

- [rhbz#1618840](https://bugzilla.redhat.com/show_bug.cgi?id=1618840)
