### PR TITLE
Remote <tt> elements from title

### DIFF
--- a/jre/guide/java/java_jre_deployment_config_configured/group.yml
+++ b/jre/guide/java/java_jre_deployment_config_configured/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Configure the <tt>deployment.config</tt> File'
+title: 'Configure the deployment.config File'
 
 description: |-
     The <tt>deployment.config</tt> file if used for specifying the System-level

--- a/jre/guide/java/java_jre_deployment_config_configured/java_jre_deployment_config_properties/rule.yml
+++ b/jre/guide/java/java_jre_deployment_config_configured/java_jre_deployment_config_properties/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Configure the <tt>deployment.properties</tt> File Path'
+title: 'Configure the deployment.properties File Path'
 
 description: |-
     To ensure that the Java properties file is set in

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Verify Group Who Owns <tt>/etc/cron.allow</tt> file'
+title: 'Verify Group Who Owns /etc/cron.allow file'
 
 description: |-
     If <tt>/etc/cron.allow</tt> exists, it must be group-owned by <tt>root</tt>.

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Verify User Who Owns <tt>/etc/cron.allow</tt> file'
+title: 'Verify User Who Owns /etc/cron.allow file'
 
 description: |-
     If <tt>/etc/cron.allow</tt> exists, it must be owned by <tt>root</tt>.

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_chroot/group.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_chroot/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Run <tt>httpd</tt> in a <tt>chroot</tt> Jail if Practical'
+title: 'Run httpd in a chroot Jail if Practical'
 
 description: |-
     Running <tt>httpd</tt> inside a <tt>chroot</tt> jail is designed to isolate the

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_etc_httpd_conf/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_etc_httpd_conf/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7
 
-title: 'Set Permissions on the <tt>/etc/httpd/conf/</tt> Directory'
+title: 'Set Permissions on the /etc/httpd/conf/ Directory'
 
 description: '{{{ describe_file_permissions(file="/etc/http/conf", perms="0750") }}}'
 

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_var_log_httpd/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_var_log_httpd/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7
 
-title: 'Set Permissions on the <tt>/var/log/httpd/</tt> Directory'
+title: 'Set Permissions on the /var/log/httpd/ Directory'
 
 description: |-
     Ensure that the permissions on the web server log directory is set to 700:

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Set Permissions on All Configuration Files Inside <tt>/etc/httpd/conf.d/</tt>'
+title: 'Set Permissions on All Configuration Files Inside /etc/httpd/conf.d/'
 
 description: '{{{ describe_file_permissions(file="/etc/http/conf.d/*", perms="0640") }}}'
 

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7
 
-title: 'Set Permissions on All Configuration Files Inside <tt>/etc/httpd/conf/</tt>'
+title: 'Set Permissions on All Configuration Files Inside /etc/httpd/conf/'
 
 description: '{{{ describe_file_permissions(file="/etc/http/conf/*", perms="0640") }}}'
 

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Set Permissions on All Configuration Files Inside <tt>/etc/httpd/conf.modules.d/</tt>'
+title: 'Set Permissions on All Configuration Files Inside /etc/httpd/conf.modules.d/'
 
 description: '{{{ describe_file_permissions(file="/etc/http/conf.modules.d/*", perms="0640") }}}'
 

--- a/linux_os/guide/services/http/securing_httpd/httpd_minimize_loadable_modules/httpd_core_modules/group.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_minimize_loadable_modules/httpd_core_modules/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: '<tt>httpd</tt> Core Modules'
+title: 'httpd Core Modules'
 
 description: |-
     These modules comprise a basic subset of modules that are likely needed for base <tt>httpd</tt>

--- a/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/group.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Use Appropriate Modules to Improve <tt>httpd</tt>''s Security'
+title: 'Use Appropriate Modules to Improve httpd''s Security'
 
 description: |-
     Among the modules available for <tt>httpd</tt> are several whose use may improve the

--- a/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_security/group.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_security/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Deploy <tt>mod_security</tt>'
+title: 'Deploy mod_security'
 
 description: |-
     The <tt>security</tt> module provides an application level firewall for <tt>httpd</tt>.

--- a/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_security/httpd_install_mod_security/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_security/httpd_install_mod_security/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7
 
-title: 'Install <tt>mod_security</tt>'
+title: 'Install mod_security'
 
 description: |-
     Install the <tt>security</tt> module:

--- a/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_ssl/group.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_ssl/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Deploy <tt>mod_ssl</tt>'
+title: 'Deploy mod_ssl'
 
 description: |-
     Because HTTP is a plain text protocol, all traffic is susceptible to passive

--- a/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_ssl/httpd_install_mod_ssl/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_ssl/httpd_install_mod_ssl/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7
 
-title: 'Install <tt>mod_ssl</tt>'
+title: 'Install mod_ssl'
 
 description: |-
     Install the <tt>mod_ssl</tt> module:

--- a/linux_os/guide/services/http/securing_httpd/httpd_restrict_info_leakage/httpd_serversignature_off/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_restrict_info_leakage/httpd_serversignature_off/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7
 
-title: 'Set httpd <tt>ServerSignature</tt> Directive to <tt>Off</tt>'
+title: 'Set httpd ServerSignature Directive to Off'
 
 description: |-
     <tt>ServerSignature Off</tt> restricts <tt>httpd</tt> from displaying server version number

--- a/linux_os/guide/services/http/securing_httpd/httpd_restrict_info_leakage/httpd_servertokens_prod/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_restrict_info_leakage/httpd_servertokens_prod/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7
 
-title: 'Set httpd <tt>ServerTokens</tt> Directive to <tt>Prod</tt>'
+title: 'Set httpd ServerTokens Directive to Prod'
 
 description: |-
     <tt>ServerTokens Prod</tt> restricts information in page headers, returning only the word "Apache."

--- a/linux_os/guide/services/imap/configure_dovecot/dovecot_enabling_ssl/dovecot_enable_ssl/rule.yml
+++ b/linux_os/guide/services/imap/configure_dovecot/dovecot_enabling_ssl/dovecot_enable_ssl/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7
 
-title: 'Enable the SSL flag in <tt>/etc/dovecot.conf</tt>'
+title: 'Enable the SSL flag in /etc/dovecot.conf'
 
 description: |-
     To allow clients to make encrypted connections the <tt>ssl</tt>

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_all_machines/nfs_configure_fixed_ports/nfs_fixed_lockd_tcp_port/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_all_machines/nfs_configure_fixed_ports/nfs_fixed_lockd_tcp_port/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Configure <tt>lockd</tt> to use static TCP port'
+title: 'Configure lockd to use static TCP port'
 
 description: |-
     Configure the <tt>lockd</tt> daemon to use a static TCP port as

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_all_machines/nfs_configure_fixed_ports/nfs_fixed_lockd_udp_port/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_all_machines/nfs_configure_fixed_ports/nfs_fixed_lockd_udp_port/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Configure <tt>lockd</tt> to use static UDP port'
+title: 'Configure lockd to use static UDP port'
 
 description: |-
     Configure the <tt>lockd</tt> daemon to use a static UDP port as

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_all_machines/nfs_configure_fixed_ports/nfs_fixed_mountd_port/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_all_machines/nfs_configure_fixed_ports/nfs_fixed_mountd_port/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Configure <tt>mountd</tt> to use static port'
+title: 'Configure mountd to use static port'
 
 description: |-
     Configure the <tt>mountd</tt> daemon to use a static port as

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_all_machines/nfs_configure_fixed_ports/nfs_fixed_statd_port/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_all_machines/nfs_configure_fixed_ports/nfs_fixed_statd_port/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Configure <tt>statd</tt> to use static port'
+title: 'Configure statd to use static port'
 
 description: |-
     Configure the <tt>statd</tt> daemon to use a static port as

--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7
 
-title: 'Ensure <tt>tftp</tt> Daemon Uses Secure Mode'
+title: 'Ensure tftp Daemon Uses Secure Mode'
 
 description: |-
     If running the <tt>tftp</tt> service is necessary, it should be configured

--- a/linux_os/guide/services/smb/configuring_samba/require_smb_client_signing/rule.yml
+++ b/linux_os/guide/services/smb/configuring_samba/require_smb_client_signing/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7
 
-title: 'Require Client SMB Packet Signing, if using <tt>smbclient</tt>'
+title: 'Require Client SMB Packet Signing, if using smbclient'
 
 description: |-
     To require samba clients running <tt>smbclient</tt> to use

--- a/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Uninstall <tt>net-snmp</tt> Package'
+title: 'Uninstall net-snmp Package'
 
 description: |-
     The <tt>net-snmp</tt> package provides the snmpd service.

--- a/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7
 
-title: 'Disable <tt>snmpd</tt> Service'
+title: 'Disable snmpd Service'
 
 description: '{{{ describe_service_disable(service="snmpd") }}}'
 

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify Permissions on SSH Server Private <tt>*_key</tt> Key Files'
+title: 'Verify Permissions on SSH Server Private *_key Key Files'
 
 description: '{{{ describe_file_permissions(file="/etc/ssh/*_key", perms="0640") }}}'
 

--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify Permissions on SSH Server Public <tt>*.pub</tt> Key Files'
+title: 'Verify Permissions on SSH Server Public *.pub Key Files'
 
 description: '{{{ describe_file_permissions(file="/etc/ssh/*.pub", perms="0644") }}}'
 

--- a/linux_os/guide/services/ssh/firewalld_sshd_disabled/rule.yml
+++ b/linux_os/guide/services/ssh/firewalld_sshd_disabled/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Remove SSH Server <tt>firewalld</tt> Firewall exception (Unusual)'
+title: 'Remove SSH Server firewalld Firewall exception (Unusual)'
 
 description: |-
     By default, inbound connections to SSH's port are allowed. If

--- a/linux_os/guide/services/ssh/iptables_sshd_disabled/rule.yml
+++ b/linux_os/guide/services/ssh/iptables_sshd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Remove SSH Server <tt>iptables</tt> Firewall exception (Unusual)'
+title: 'Remove SSH Server iptables Firewall exception (Unusual)'
 
 description: "By default, inbound connections to SSH's port are allowed. If \nthe SSH server is not being used, this exception should be removed from the\nfirewall configuration.\n<br /><br />\nEdit the files <tt>/etc/sysconfig/iptables</tt> and <tt>/etc/sysconfig/ip6tables</tt>\n(if IPv6 is in use). In each file, locate and delete the line:\n<pre>-A INPUT -m state --state NEW -m tcp -p tcp --dport 22 -j ACCEPT</pre>\nThis is unusual, as SSH is a common method for encrypted and authenticated\nremote access."
 

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Enable SSH Server <tt>firewalld</tt> Firewall exception'
+title: 'Enable SSH Server firewalld Firewall exception'
 
 description: |-
     By default, inbound connections to SSH's port are allowed. If

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Disable Compression Or Set Compression to <tt>delayed</tt>'
+title: 'Disable Compression Or Set Compression to delayed'
 
 description: |-
     Compression is useful for slow network connections over long

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Configure the <tt>root</tt> Account for Failed Password Attempts'
+title: 'Configure the root Account for Failed Password Attempts'
 
 description: "To configure the system to lock out the <tt>root</tt> account after a number of incorrect login\nattempts using <tt>pam_faillock.so</tt>, modify the content of both\n<tt>/etc/pam.d/system-auth</tt> and <tt>/etc/pam.d/password-auth</tt> as follows:\n<br /><br />\n<ul> \n<li>Modify the following line in the <tt>AUTH</tt> section to add <tt>even_deny_root</tt>:\n<pre>auth required pam_faillock.so preauth silent <b>even_deny_root</b> deny=<sub idref=\"var_accounts_passwords_pam_faillock_deny\" /> unlock_time=<sub idref=\"var_accounts_passwords_pam_faillock_unlock_time\" /> fail_interval=<sub idref=\"var_accounts_passwords_pam_faillock_fail_interval\" /></pre></li>\n<li>Modify the following line in the <tt>AUTH</tt> section to add <tt>even_deny_root</tt>:\n<pre>auth [default=die] pam_faillock.so authfail <b>even_deny_root</b> deny=<sub idref=\"var_accounts_passwords_pam_faillock_deny\" /> unlock_time=<sub idref=\"var_accounts_passwords_pam_faillock_unlock_time\" /> fail_interval=<sub\
     \ idref=\"var_accounts_passwords_pam_faillock_fail_interval\" /></pre></li>\n</ul>"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Record Any Attempts to Run <tt>chcon</tt>'
+title: 'Record Any Attempts to Run chcon'
 
 description: |-
     At a minimum, the audit system should collect any execution attempt

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Record Any Attempts to Run <tt>restorecon</tt>'
+title: 'Record Any Attempts to Run restorecon'
 
 description: |-
     At a minimum, the audit system should collect any execution attempt

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Record Any Attempts to Run <tt>semanage</tt>'
+title: 'Record Any Attempts to Run semanage'
 
 description: |-
     At a minimum, the audit system should collect any execution attempt

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Record Any Attempts to Run <tt>setfiles</tt>'
+title: 'Record Any Attempts to Run setfiles'
 
 description: |-
     At a minimum, the audit system should collect any execution attempt

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Record Any Attempts to Run <tt>setsebool</tt>'
+title: 'Record Any Attempts to Run setsebool'
 
 description: |-
     At a minimum, the audit system should collect any execution attempt

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Ensure <tt>auditd</tt> Collects File Deletion Events by User'
+title: 'Ensure auditd Collects File Deletion Events by User'
 
 description: |-
     At a minimum the audit system should collect file deletion events

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects File Deletion Events by User - rename'
+title: 'Ensure auditd Collects File Deletion Events by User - rename'
 
 description: |-
     At a minimum, the audit system should collect file deletion events

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects File Deletion Events by User - renameat'
+title: 'Ensure auditd Collects File Deletion Events by User - renameat'
 
 description: |-
     At a minimum, the audit system should collect file deletion events

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects File Deletion Events by User - rmdir'
+title: 'Ensure auditd Collects File Deletion Events by User - rmdir'
 
 description: |-
     At a minimum, the audit system should collect file deletion events

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects File Deletion Events by User - unlink'
+title: 'Ensure auditd Collects File Deletion Events by User - unlink'
 
 description: |-
     At a minimum, the audit system should collect file deletion events

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects File Deletion Events by User - unlinkat'
+title: 'Ensure auditd Collects File Deletion Events by User - unlinkat'
 
 description: |-
     At a minimum, the audit system should collect file deletion events

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Ensure <tt>auditd</tt> Collects Information on Kernel Module Loading and Unloading'
+title: 'Ensure auditd Collects Information on Kernel Module Loading and Unloading'
 
 description: |-
     To capture kernel module loading and unloading events, use following lines, setting ARCH to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on Kernel Module Loading - create_module'
+title: 'Ensure auditd Collects Information on Kernel Module Loading - create_module'
 
 description: |-
     To capture kernel module loading events, use following line, setting ARCH to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on Kernel Module Unloading - delete_module'
+title: 'Ensure auditd Collects Information on Kernel Module Unloading - delete_module'
 
 description: |-
     To capture kernel module unloading events, use following line, setting ARCH to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Ensure <tt>auditd</tt> Collects Information on Kernel Module Loading and Unloading - finit_module'
+title: 'Ensure auditd Collects Information on Kernel Module Loading and Unloading - finit_module'
 
 description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt> program

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on Kernel Module Loading - init_module'
+title: 'Ensure auditd Collects Information on Kernel Module Loading - init_module'
 
 description: |-
     To capture kernel module loading events, use following line, setting ARCH to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_insmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_insmod/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on Kernel Module Loading - insmod'
+title: 'Ensure auditd Collects Information on Kernel Module Loading - insmod'
 
 description: |-
     To capture invocation of insmod, utility used to insert modules into kernel,

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_modprobe/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_modprobe/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on Kernel Module Loading and Unloading - modprobe'
+title: 'Ensure auditd Collects Information on Kernel Module Loading and Unloading - modprobe'
 
 description: |-
     To capture invocation of modprobe, utility used to insert / remove modules from kernel,

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_rmmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_rmmod/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on Kernel Module Unloading - rmmod'
+title: 'Ensure auditd Collects Information on Kernel Module Unloading - rmmod'
 
 description: |-
     To capture invocation of rmmod, utility used to remove modules from kernel,

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - chage'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - chage'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - chsh'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - chsh'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - crontab'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - crontab'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - gpasswd'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - gpasswd'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - newgrp'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - newgrp'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - pam_timestamp_check'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - pam_timestamp_check'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - passwd'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - passwd'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - postdrop'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - postdrop'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - postqueue'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - postqueue'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - pt_chown'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - pt_chown'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - ssh-keysign'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - ssh-keysign'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - su'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - su'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - sudo'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sudo'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - sudoedit'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sudoedit'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - umount'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - umount'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - unix_chkpwd'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - unix_chkpwd'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure <tt>auditd</tt> Collects Information on the Use of Privileged Commands - userhelper'
+title: 'Ensure auditd> Collects Information on the Use of Privileged Commands - userhelper'
 
 description: |-
     At a minimum, the audit system should collect the execution of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Make the <tt>auditd</tt> Configuration Immutable'
+title: 'Make the auditd Configuration Immutable'
 
 description: |-
     If the <tt>auditd</tt> daemon is configured to use the

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Ensure <tt>auditd</tt> Collects Information on Exporting to Media (successful)'
+title: 'Ensure auditd Collects Information on Exporting to Media (successful)'
 
 description: |-
     At a minimum, the audit system should collect media exportation

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Ensure <tt>auditd</tt> Collects System Administrator Actions'
+title: 'Ensure auditd Collects System Administrator Actions'
 
 description: |-
     At a minimum, the audit system should collect administrator actions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Ensure <tt>auditd</tt> Collects Unauthorized Access Attempts to Files (unsuccessful)'
+title: 'Ensure auditd Collects Unauthorized Access Attempts to Files (unsuccessful)'
 
 description: |-
     At a minimum the audit system should collect unauthorized file

--- a/linux_os/guide/system/auditing/auditd_configure_rules/group.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Configure <tt>auditd</tt> Rules for Comprehensive Auditing'
+title: 'Configure auditd Rules for Comprehensive Auditing'
 
 description: |-
     The <tt>auditd</tt> program can perform comprehensive

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/group.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Configure <tt>auditd</tt> Data Retention'
+title: 'Configure auditd Data Retention'
 
 description: |-
     The audit system writes data to <tt>/var/log/audit/audit.log</tt>. By default,

--- a/linux_os/guide/system/auditing/group.yml
+++ b/linux_os/guide/system/auditing/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'System Accounting with <tt>auditd</tt>'
+title: 'System Accounting with auditd'
 
 description: |-
     The audit service provides substantial capabilities

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7,fedora
 
-title: 'Ensure <tt>cron</tt> Is Logging To Rsyslog'
+title: 'Ensure cron Is Logging To Rsyslog'
 
 description: |-
     Cron logging must be implemented to spot intrusions or trace

--- a/linux_os/guide/system/logging/log_rotation/group.yml
+++ b/linux_os/guide/system/logging/log_rotation/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Ensure All Logs are Rotated by <tt>logrotate</tt>'
+title: 'Ensure All Logs are Rotated by logrotate'
 
 description: |-
     {{% if product in ['debian8', 'ubuntu14.04', 'ubuntu16.04'] %}}

--- a/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/group.yml
+++ b/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Configure <tt>rsyslogd</tt> to Accept Remote Messages If Acting as a Log Server'
+title: 'Configure rsyslogd to Accept Remote Messages If Acting as a Log Server'
 
 description: |-
     By default, <tt>rsyslog</tt> does not listen over the network

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify Group Who Owns <tt>group</tt> File'
+title: 'Verify Group Who Owns group File'
 
 description: '{{{ describe_file_group_owner(file="/etc/group", group="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify Group Who Owns <tt>gshadow</tt> File'
+title: 'Verify Group Who Owns gshadow File'
 
 description: '{{{ describe_file_group_owner(file="/etc/gshadow", group="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify Group Who Owns <tt>passwd</tt> File'
+title: 'Verify Group Who Owns passwd File'
 
 description: '{{{ describe_file_group_owner(file="/etc/passwd", group="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify Group Who Owns <tt>shadow</tt> File'
+title: 'Verify Group Who Owns shadow File'
 
 description: '{{{ describe_file_group_owner(file="/etc/shadow", group="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify User Who Owns <tt>group</tt> File'
+title: 'Verify User Who Owns group File'
 
 description: '{{{ describe_file_owner(file="/etc/group", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify User Who Owns <tt>gshadow</tt> File'
+title: 'Verify User Who Owns gshadow File'
 
 description: '{{{ describe_file_owner(file="/etc/gshadow", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify User Who Owns <tt>passwd</tt> File'
+title: 'Verify User Who Owns passwd File'
 
 description: '{{{ describe_file_owner(file="/etc/passwd", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify User Who Owns <tt>shadow</tt> File'
+title: 'Verify User Who Owns shadow File'
 
 description: '{{{ describe_file_owner(file="/etc/shadow", owner="root") }}}'
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify Permissions on <tt>group</tt> File'
+title: 'Verify Permissions on group File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/passwd", perms="0644") }}}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify Permissions on <tt>gshadow</tt> File'
+title: 'Verify Permissions on gshadow File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/gshadow", perms="0000") }}}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify Permissions on <tt>passwd</tt> File'
+title: 'Verify Permissions on passwd File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/passwd", perms="0644") }}}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify Permissions on <tt>shadow</tt> File'
+title: 'Verify Permissions on shadow File'
 
 description:  |-
     {{{ describe_file_permissions(file="/etc/shadow", perms="0640") }}}

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Disable Mounting of <tt>cramfs</tt>'
+title: 'Disable Mounting of cramfs'
 
 description: |-
     {{{ describe_module_disable(module="cramfs") }}}

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Disable Mounting of <tt>freevxfs</tt>'
+title: 'Disable Mounting of freevxfs'
 
 description: |-
     {{{ describe_module_disable(module="freevxfs") }}}

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Disable Mounting of <tt>hfs</tt>'
+title: 'Disable Mounting of hfs'
 
 description: |-
     {{{ describe_module_disable(module="hfs") }}}

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Disable Mounting of <tt>hfsplus</tt>'
+title: 'Disable Mounting of hfsplus'
 
 description: |-
     {{{ describe_module_disable(module="hfsplus") }}}

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Disable Mounting of <tt>jffs2</tt>'
+title: 'Disable Mounting of jffs2'
 
 description: |-
     {{{ describe_module_disable(module="jffs2") }}}

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Disable Mounting of <tt>squashfs</tt>'
+title: 'Disable Mounting of squashfs'
 
 description: |-
     {{{ describe_module_disable(module="squashfs") }}}

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora
 
-title: 'Disable Mounting of <tt>udf</tt>'
+title: 'Disable Mounting of udf'
 
 description: |-
     {{{ describe_module_disable(module="udf") }}}


### PR DESCRIPTION
#### Description:

- Remove `<tt>` elements from title. The elements don't seem to be consistently used and reports and tables either don't implement them or are inconsistently inplemented.
