### PR TITLE
Changing debian 8 package name syslogng to syslog-ng

### DIFF
--- a/debian8/templates/csv/packages_installed.csv
+++ b/debian8/templates/csv/packages_installed.csv
@@ -4,5 +4,5 @@ auditd
 cron
 ntp
 rsyslog
-syslogng
+syslog-ng
 openssh-server


### PR DESCRIPTION
#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
