### PR TITLE
Fix running of SSG TS

### DIFF
--- a/tests/kickstarts/rhel_centos_7.cfg
+++ b/tests/kickstarts/rhel_centos_7.cfg
@@ -79,6 +79,7 @@ logvol swap --name=lv_swap --vgname=VolGroup --size=2016
 %packages
 
 openscap-scanner
+tar
 
 # requirement of SSG Test Suite
 qemu-guest-agent

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -64,12 +64,8 @@ def get_viable_profiles(selected_profiles, datastream, benchmark):
 
 def _run_with_stdout_logging(command, args, log_file):
     log_file.write("{0} {1}\n".format(command, " ".join(args)))
-    try:
-        subprocess.check_call(
-            (command,) + args, stdout=log_file, stderr=subprocess.STDOUT)
-        return 0
-    except subprocess.CalledProcessError as e:
-        return e.returncode
+    subprocess.check_call(
+        (command,) + args, stdout=log_file, stderr=subprocess.STDOUT)
 
 
 def _send_scripts(domain_ip):


### PR DESCRIPTION
#### Description:

Install tar package on SSG TS VM

Do not ignore failures of external commands

#### Rationale:

On Fedora 28 Server the 'tar' package is not installed by default
which means that SSG test suite is not able to extract the archive
with test cases.

The CalledProcessError exception was caught and the return value of
this function was ignored. That meant if some command went wrong
(eg. uploading the tarball to the VM was not successful or extraction
of the tarball was not successful) it was ignored and the test suite
continued happily, without letting the user know. We need to terminate
if some of the test harness setup tasks went wrong.