### PR TITLE
Add OVAL and Bash for auditd_audispd_encrypt_sent_records

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/bash/shared.sh
@@ -1,0 +1,8 @@
+# platform = multi_platform_all
+. /usr/share/scap-security-guide/remediation_functions
+
+var_enable_krb5="yes"
+
+AUDISP_REMOTE_CONFIG="/etc/audisp/audisp-remote.conf"
+
+replace_or_append $AUDISP_REMOTE_CONFIG '^enable_krb5' "$var_enable_krb5" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/oval/shared.xml
@@ -1,0 +1,29 @@
+<def-group>
+  <definition class="compliance" id="auditd_audispd_encrypt_sent_records" version="1">
+    <metadata>
+      <title>Kerberos 5 Authentication and Encryption in Audit Event Multiplexor (audispd) Is Activated</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>enable_krb5 setting in /etc/audisp/audisp-remote.conf is set to 'yes'</description>
+    </metadata>
+
+    <criteria>
+      <criterion comment="enable_krb5 setting in audisp-remote.conf" test_ref="test_auditd_audispd_encrypt_sent_records" />
+    </criteria>
+
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="enable_krb5 setting in audisp-remote.conf" id="test_auditd_audispd_encrypt_sent_records" version="1">
+    <ind:object object_ref="object_auditd_audispd_encrypt_sent_records" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_auditd_audispd_encrypt_sent_records" version="1">
+    <ind:filepath>/etc/audisp/audisp-remote.conf</ind:filepath>
+    <!-- Allow only space (exactly) as delimiter -->
+    <!-- Require at least one space before and after the equal sign -->
+    <ind:pattern operation="pattern match">^[ ]*enable_krb5[ ]+=[ ]+yes[ ]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa, xccdf_org.ssgproject.content_profile_ospp
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_activated.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_activated.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa, xccdf_org.ssgproject.content_profile_ospp
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa, xccdf_org.ssgproject.content_profile_ospp
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment


### PR DESCRIPTION
#### Description:
This PR:
* adds OVAL
* adds Bash remediation
* adds OSPP profile to the test cases

#### Rationale:

This rule is a part of Fedora OSPP profile.