### PR TITLE
Finish rule disable_host_auth in Fedora OSPP profile

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_all
 grep -q ^HostbasedAuthentication /etc/ssh/sshd_config && \
   sed -i "s/HostbasedAuthentication.*/HostbasedAuthentication no/g" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/oval/shared.xml
@@ -3,7 +3,7 @@
     <metadata>
       <title>Disable Host-Based Authentication</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>SSH host-based authentication should be disabled.</description>
     </metadata>

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_disable_host_auth/comment.pass.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_disable_host_auth/comment.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^HostbasedAuthentication" /etc/ssh/sshd_config; then
+	sed -i "s/^HostbasedAuthentication.*/# HostbasedAuthentication yes/" /etc/ssh/sshd_config
+else
+	echo "# HostbasedAuthentication yes" >> /etc/ssh/sshd_config
+fi

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_disable_host_auth/correct_value.pass.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_disable_host_auth/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^HostbasedAuthentication" /etc/ssh/sshd_config; then
+	sed -i "s/^HostbasedAuthentication.*/HostbasedAuthentication no/" /etc/ssh/sshd_config
+else
+	echo "HostbasedAuthentication no" >> /etc/ssh/sshd_config
+fi

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_disable_host_auth/line_not_there.pass.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_disable_host_auth/line_not_there.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+sed -i "/^HostbasedAuthentication.*/d" /etc/ssh/sshd_config

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_disable_host_auth/wrong_value.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_disable_host_auth/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^HostbasedAuthentication" /etc/ssh/sshd_config; then
+	sed -i "s/^HostbasedAuthentication.*/HostbasedAuthentication yes/" /etc/ssh/sshd_config
+else
+	echo "HostbasedAuthentication yes" >> /etc/ssh/sshd_config
+fi


### PR DESCRIPTION
#### Description:
This PR:
*   updates OVAL  and Bash remediation and Ansible remediation for rule disable_host_auth to be applicable on all platforms
*    adds test cases for  rule disable_host_auth

#### Rationale:
This rule is a part of Fedora OSPP profile.