### PR TITLE
Enable rsyslog_remote_loghost OVAL on Fedora

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>Send Logs to a Remote Loghost</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
         <platform>multi_platform_debian</platform>
         <platform>multi_platform_ubuntu</platform>
       </affected>


### PR DESCRIPTION
Bash and Ansible already being there this seems like it's just an oversight that it wasn't already enabled.