### PR TITLE
Add fedora platform and tests for selinux_policytype rule

### DIFF
--- a/linux_os/guide/system/selinux/selinux_policytype/bash/shared.sh
+++ b/linux_os/guide/system/selinux/selinux_policytype/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_fedora
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/selinux/selinux_policytype/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_policytype/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>Enable SELinux</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+	<platform>multi_platform_fedora</platform>
       </affected>
       <description>The SELinux policy should be set appropriately.</description>
     </metadata>

--- a/tests/data/group_system/group_selinux/rule_selinux_policytype/selinuxtype_missing.fail.sh
+++ b/tests/data/group_system/group_selinux/rule_selinux_policytype/selinuxtype_missing.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_ospp
+
+SELINUX_FILE='/etc/selinux/config'
+sed -i '/^[[:space:]]*SELINUXTYPE/d' $SELINUX_FILE

--- a/tests/data/group_system/group_selinux/rule_selinux_policytype/selinuxtype_targeted.pass.sh
+++ b/tests/data/group_system/group_selinux/rule_selinux_policytype/selinuxtype_targeted.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_ospp
+
+SELINUX_FILE='/etc/selinux/config'
+
+if grep -s '^[[:space:]]*SELINUXTYPE' $SELINUX_FILE; then
+	sed -i 's/^\([[:space:]]SELINUXTYPE[[:space:]]*=[[:space:]]*\).*/\1targeted/' $SELINUX_FILE
+else
+	echo 'SELINUXTYPE=targeted' >> $SELINUX_FILE
+fi


### PR DESCRIPTION
#### Description:
Changes platform at OVAL, adds fedora platform at bash remediation and adds simple tests for rule_selinux_policytype.
